### PR TITLE
[Issue #471] fix the result bar window error when multiple query is run

### DIFF
--- a/textdb/textdb-angular-gui/app/resultbar/result-bar.component.ts
+++ b/textdb/textdb-angular-gui/app/resultbar/result-bar.component.ts
@@ -64,6 +64,7 @@ export class ResultBarComponent {
         // stop the loading animation of the run button
         jQuery('.navigation-btn').button('reset');
         this.attribute = [];
+        this.result = [];
         // check if the result is valid
         if (data.code === 0) {
           var ResultDisplay = (data.result.length < 20) ? data.result.length : this.ResultDisplayLimit;


### PR DESCRIPTION
The result now refreshes after 2nd query is run and the quantity stays at 20 at most.

![im1](https://user-images.githubusercontent.com/19577058/30738841-3c48b91c-9f40-11e7-9e04-4bf992bf62a0.png)
![im2](https://user-images.githubusercontent.com/19577058/30738840-3c36e2dc-9f40-11e7-9f63-60b05ea382e4.png)
