### PR TITLE
[Issue #471.1] new advanced button feature to display hidden fields in the sidebar

### DIFF
--- a/textdb/textdb-angular-gui/app/sidebar/side-bar.component.html
+++ b/textdb/textdb-angular-gui/app/sidebar/side-bar.component.html
@@ -92,6 +92,9 @@
                 <input *ngIf="checkInSelector(attribute) === -1" [(ngModel)]="data.properties.attributes[attribute]" (ngModelChange)="onFormChange(attribute)" name="{{attribute}}" type="text" class="form-control" id="{{attribute}}" defaultValue="{{data.properties.attributes[attribute]}}" #{{attribute}}="ngModel" required>
             </div>
             <button type="button" class="btn btn-default" (click) = "onDelete()">Delete</button>
+            <button *ngIf="!advancedPressed" type="button" class="btn btn-default" (click) = "onAdvanced()">Advanced</button>
+            <button *ngIf="advancedPressed" type="button" class="btn btn-default" (click) = "hideAdvance()">Hide Advanced</button>
+
         </form>
     </div>
 </div>

--- a/textdb/textdb-angular-gui/app/sidebar/side-bar.component.ts
+++ b/textdb/textdb-angular-gui/app/sidebar/side-bar.component.ts
@@ -23,11 +23,14 @@ export class SideBarComponent {
     operatorId: number;
     operatorTitle: string;
 
+    advancedPressed: boolean = false;
+
     hiddenList: string[] = ["operatorType", "luceneAnalyzer", "matchingType"];
 
-    selectorList: string[] = ["dictionaryEntries", "password", "matchingType",
-        "nlpEntityType", "splitType", "splitOption", "sampleType", "comparisonType",
-        "aggregationType", "attributes", "tableName", "attribute", "keywordList", "languageList", "locationList","customerKey","customerSecret","token","tokenSecret"].concat(this.hiddenList);
+    selectorList: string[] = ["dictionaryEntries", "password", "nlpEntityType",
+        "splitType", "splitOption", "sampleType", "comparisonType",
+        "aggregationType", "attributes", "tableName", "attribute", "keywordList",
+        "languageList", "locationList","customerKey","customerSecret","token","tokenSecret"];
 
     matcherList: string[] = ["conjunction", "phrase", "substring"];
     nlpEntityList: string[] = ["noun", "verb", "adjective", "adverb", "ne_all",
@@ -64,10 +67,19 @@ export class SideBarComponent {
     optionalTwitterList: Array<string> = ["customerKey","customerSecret","token","tokenSecret"];
 
     checkInHidden(name: string) {
-        return jQuery.inArray(name, this.hiddenList);
+      if (this.advancedPressed){
+        var hideItem = ["operatorType"];
+        return jQuery.inArray(name, hideItem);
+      }
+      return jQuery.inArray(name, this.hiddenList);
     }
     checkInSelector(name: string) {
-        return jQuery.inArray(name, this.selectorList);
+      if (this.advancedPressed){
+        var selectList = this.selectorList.concat(["operatorType"]);
+        return jQuery.inArray(name, selectList);
+      }
+      var selectList = this.selectorList.concat(this.hiddenList);
+      return jQuery.inArray(name, selectList);
     }
 
     checkInOptionalTwitter(name: string){
@@ -93,7 +105,8 @@ export class SideBarComponent {
                 for (var attribute in data.operatorData.properties.attributes) {
                     this.attributes.push(attribute);
                 }
-
+                // initialize the advanced button
+                this.advancedPressed = false;
                 // initialize selected attributes
                 this.selectedAttributeMulti = "";
                 this.selectedAttributeSingle = "";
@@ -247,6 +260,13 @@ export class SideBarComponent {
     this.currentDataService.setAllOperatorData(jQuery('#the-flowchart').flowchart('getData'));
   }
 
+  onAdvanced() {
+    this.advancedPressed = true;
+  }
+
+  hideAdvance() {
+    this.advancedPressed = false;
+  }
 
 
 


### PR DESCRIPTION
Default sidebar with a new button for displaying advanced properties for each operator
![c1](https://user-images.githubusercontent.com/19577058/30766440-ef8107a0-9fa9-11e7-9b97-77300c80463c.JPG)
Advanced sidebar with some pre-hidden properties for user to change
![c2](https://user-images.githubusercontent.com/19577058/30766441-f0bab044-9fa9-11e7-8da5-25d201ea1da3.JPG)
