### PR TITLE
[Issue #471.2] Fix front-end issue when 'previous and next' appears on error modal as well

### DIFF
--- a/textdb/textdb-angular-gui/app/resultbar/result-bar.component.html
+++ b/textdb/textdb-angular-gui/app/resultbar/result-bar.component.html
@@ -35,8 +35,8 @@
     <div id="ResultElem"></div>
 	</modal-body>
 	<modal-footer>
-    <button id="ModalPreviousButton" type="button" (click)="PreviousModal()" class="btn btn-default">Previous</button>
-    <button id="ModalNextButton" type="button" (click)="NextModal()" class="btn btn-default">Next</button>
+    <button *ngIf="checkErrorOrDetail === 1" id="ModalPreviousButton" type="button" (click)="PreviousModal()" class="btn btn-default">Previous</button>
+    <button *ngIf="checkErrorOrDetail === 1" id="ModalNextButton" type="button" (click)="NextModal()" class="btn btn-default">Next</button>
 		<button type="button" (click)="ModalClose()" class="btn btn-default">X</button>
 	</modal-footer>
 <modal>


### PR DESCRIPTION
Previously, the previous and next buttons we added appear on the error modal as well, which will create a potential bug to the UI

![b1](https://user-images.githubusercontent.com/19577058/30766984-c187310e-9fad-11e7-8d95-916bc89bc0c0.JPG)

Now, there is an IF statement that stops this from happening

![b2](https://user-images.githubusercontent.com/19577058/30766986-c37ccfbe-9fad-11e7-873c-b94e987bcd3f.JPG)

