### PR TITLE
Fix a bug that SpanList is not deserialized properly

### DIFF
--- a/core/api/src/main/java/edu/uci/ics/texera/api/field/ListField.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/field/ListField.java
@@ -5,11 +5,13 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.collect.ImmutableList;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import edu.uci.ics.texera.api.constants.JsonConstants;
 
+@JsonDeserialize(using = ListFieldJsonDeserializer.class)
 public class ListField<T> implements IField {
 
     private ImmutableList<T> list;

--- a/core/api/src/main/java/edu/uci/ics/texera/api/field/ListFieldJsonDeserializer.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/field/ListFieldJsonDeserializer.java
@@ -1,0 +1,44 @@
+package edu.uci.ics.texera.api.field;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+
+import edu.uci.ics.texera.api.constants.JsonConstants;
+import edu.uci.ics.texera.api.span.Span;
+
+// TODO: currently all List<T> are SpanList. In the future maybe 
+//   either change List<T> to SpanList, or support generic list
+public class ListFieldJsonDeserializer extends StdDeserializer<ListField<?>> {
+
+    private static final long serialVersionUID = 6079052875639039779L;
+    
+    public ListFieldJsonDeserializer() {
+        this(null);
+    }
+
+    protected ListFieldJsonDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public ListField<Span> deserialize(JsonParser p, DeserializationContext ctxt)
+            throws IOException, JsonProcessingException {
+        JsonNode node = p.getCodec().readTree(p);
+        JsonNode fieldValueNode = node.get(JsonConstants.FIELD_VALUE);
+        
+        ArrayList<Span> spanList = new ArrayList<>();
+        for (int i = 0; i < fieldValueNode.size(); i++) {
+            JsonNode spanValueNode = fieldValueNode.get(i);
+            spanList.add(new ObjectMapper().convertValue(spanValueNode, Span.class));
+        }
+        return new ListField<Span>(spanList);
+    }
+
+}

--- a/core/api/src/main/java/edu/uci/ics/texera/api/field/ListFieldJsonDeserializer.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/field/ListFieldJsonDeserializer.java
@@ -13,8 +13,14 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import edu.uci.ics.texera.api.constants.JsonConstants;
 import edu.uci.ics.texera.api.span.Span;
 
-// TODO: currently all List<T> are SpanList. In the future maybe 
-//   either change List<T> to SpanList, or support generic list
+/**
+ * When the ListField<Span> is serialized to a Json String, the generic type (Span) information is lost.
+ * When the same Json string is deserialized back to ListField, the value cannot be correctly converted to a Span 
+ *   because Jackson doesn't know it should be mapped to the Span Class.
+ * 
+ * Since we only have Span List, this PR adds a custom deserializer to map any value to Span class, 
+ *   so we can always get ListField<Span>.
+ */
 public class ListFieldJsonDeserializer extends StdDeserializer<ListField<?>> {
 
     private static final long serialVersionUID = 6079052875639039779L;
@@ -27,6 +33,8 @@ public class ListFieldJsonDeserializer extends StdDeserializer<ListField<?>> {
         super(vc);
     }
 
+    // TODO: currently all List<T> are SpanList. In the future maybe 
+    //  either change List<T> to SpanList, or support generic list
     @Override
     public ListField<Span> deserialize(JsonParser p, DeserializationContext ctxt)
             throws IOException, JsonProcessingException {

--- a/core/api/src/main/java/edu/uci/ics/texera/api/utils/TestUtils.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/utils/TestUtils.java
@@ -135,6 +135,7 @@ public class TestUtils {
                 System.out.println(resultJson);
             }
             
+            Assert.assertEquals(object, resultObject);
             Assert.assertEquals(jsonNode, resultJsonNode);
             return jsonNode;
         } catch (IOException e) {

--- a/core/api/src/test/java/edu/uci/ics/texera/api/JsonSerializationTest.java
+++ b/core/api/src/test/java/edu/uci/ics/texera/api/JsonSerializationTest.java
@@ -97,6 +97,17 @@ public class JsonSerializationTest {
         TestUtils.testJsonSerialization(tuple);
     }
     
+    @Test
+    public void testTupleWithSpanlist() {
+        Tuple tuple = new Tuple.Builder()
+                .add("attr1", AttributeType.TEXT, new TextField("test"))
+                .add("spanList", AttributeType.LIST, new ListField<Span>(Arrays.asList(
+                        new Span("attr1", 0, 4, "test", "test"))))
+                .build();
+        
+        TestUtils.testJsonSerialization(tuple);
+    }
+    
     
     
 }

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/dictionarymatcher/Dictionary.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/dictionarymatcher/Dictionary.java
@@ -3,6 +3,9 @@ package edu.uci.ics.texera.dataflow.dictionarymatcher;
 import java.util.*;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -84,7 +87,7 @@ public class Dictionary {
         return null;
     }
 
-
+    @JsonIgnore
     public boolean isEmpty() {
         return (dictionaryEntries == null || dictionaryEntries.isEmpty());
     }
@@ -94,7 +97,7 @@ public class Dictionary {
      * of duplicate tokens in the setup() of DictionaryMather for conjunction matching type.
      * @param luceneAnalyzerStr
      */
-
+    @JsonIgnore
     public void setDictionaryTokenSetList(String luceneAnalyzerStr) {
         this.tokenSetsNoStopwords = new ArrayList<>();
         for (int i = 0; i < dictionaryEntries.size(); i++) {
@@ -109,6 +112,7 @@ public class Dictionary {
      *
      * @param luceneAnalyzerStr
      */
+    @JsonIgnore
     public void setDictionaryTokenListWithStopwords(String luceneAnalyzerStr) {
         this.tokenListsWithStopwords = new ArrayList<>();
         this.tokenListsNoStopwords = new ArrayList<>();
@@ -118,6 +122,7 @@ public class Dictionary {
         }
     }
 
+    @JsonIgnore
     public void setPatternList(){
         this.patternList = new ArrayList<>();
         for(int i = 0; i < dictionaryEntries.size(); i++) {
@@ -149,8 +154,26 @@ public class Dictionary {
     @JsonIgnore
     public void resetCursor() {
         dictionaryIterator = dictionaryEntries.iterator();
-        ;
     }
+    
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this.getDictionaryEntries());
+    }
+    
+    @Override
+    public boolean equals(Object that) {
+        if (that == null) return false;
+        if (! (that instanceof Dictionary)) return false;
+        
+        return Objects.equals(this.dictionaryEntries, ((Dictionary) that).dictionaryEntries);
+    }
+    
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
+    }
+    
 }
 
 

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/plangen/OperatorLink.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/plangen/OperatorLink.java
@@ -1,5 +1,9 @@
 package edu.uci.ics.texera.dataflow.plangen;
 
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -34,6 +38,21 @@ public class OperatorLink {
     @JsonProperty(value = PropertyNameConstants.DESTINATION_OPERATOR_ID)
     public String getDestination() {
         return this.destination;
+    }
+    
+    @Override
+    public int hashCode() {
+        return HashCodeBuilder.reflectionHashCode(this);
+    }
+    
+    @Override
+    public boolean equals(Object that) {
+        return EqualsBuilder.reflectionEquals(this, that);
+    }
+    
+    @Override
+    public String toString() {
+        return ToStringBuilder.reflectionToString(this);
     }
 
 }


### PR DESCRIPTION
This PR fixes a bug that SpanList is not deserialized properly.

Currently in Texera, we have a generic `ListField<T>`, however, the sole usage of this `ListField` is a Span List, which is `ListField<Span>`. 

When the `ListField<Span>` is serialized to a Json String, the generic type (`Span`) information is lost. 
When the same Json string is deserialized back to `ListField`, the value cannot be correctly converted to a `Span` because Jackson doesn't know it should be mapped to the `Span` Class.

Since we only have Span List, this PR adds a custom deserializer to map any value to `Span` class, so we can always get `ListField<Span>`. 

This PR also modifies how Json serialization test cases work. Previously they only check after converting object to json back and forth, if the json results are equal. Now they also check if the actual Java objects are also equal. As a result of this update, two more Json serialization errors are fixed.

However, this is a temporary solution. A better solution is to either:
1. Get rid of generic `ListField<T>` completely, make it `SpanList` since we only allow spans.
2. Support any generic `ListField`, but store the generic type information in Json.
