### PR TITLE
Fix a bug in maven pom.xml that causes build problem under CentOS

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -17,18 +17,6 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
     </properties>
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>junit</groupId>
-                <artifactId>junit</artifactId>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.lucene</groupId>
-                <artifactId>lucene-core</artifactId>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
     <build>
         <plugins>


### PR DESCRIPTION
As I was setting up a Texera instance on CentOS, the maven build command gives an error: `junit does not have a version number`

This PR fixes it by removing the dependency section (which contains two un-versioned dependencies: junit and lucene) on the root `pom.xml`. The junit dependency exists under the `texera-api` project, the lucene dependency exists under the `texera-storage` project, so this deletion doesn't affect anything.