### PR TITLE
Add checks to some operators in the predicate constructor

### DIFF
--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/dictionarymatcher/DictionaryPredicate.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/dictionarymatcher/DictionaryPredicate.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonUnwrapped;
 
 import edu.uci.ics.texera.api.dataflow.IOperator;
+import edu.uci.ics.texera.api.exception.TexeraException;
 import edu.uci.ics.texera.dataflow.common.PredicateBase;
 import edu.uci.ics.texera.dataflow.common.PropertyNameConstants;
 import edu.uci.ics.texera.dataflow.keywordmatcher.KeywordMatchingType;
@@ -42,6 +43,11 @@ public class DictionaryPredicate extends PredicateBase {
             KeywordMatchingType keywordMatchingType,
             @JsonProperty(value = PropertyNameConstants.SPAN_LIST_NAME, required = false)
             String spanListName) {
+        
+        if (dictionary.isEmpty()) {
+            throw new TexeraException("dictionary should not be empty");
+        }
+        
         this.dictionary = dictionary;
         this.luceneAnalyzerStr = luceneAnalyzerStr;
         this.attributeNames = attributeNames;

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/dictionarymatcher/DictionaryPredicate.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/dictionarymatcher/DictionaryPredicate.java
@@ -44,10 +44,6 @@ public class DictionaryPredicate extends PredicateBase {
             @JsonProperty(value = PropertyNameConstants.SPAN_LIST_NAME, required = false)
             String spanListName) {
         
-        if (dictionary.isEmpty()) {
-            throw new TexeraException("dictionary should not be empty");
-        }
-        
         this.dictionary = dictionary;
         this.luceneAnalyzerStr = luceneAnalyzerStr;
         this.attributeNames = attributeNames;

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/fuzzytokenmatcher/FuzzyTokenPredicate.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/fuzzytokenmatcher/FuzzyTokenPredicate.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.uci.ics.texera.api.dataflow.IOperator;
+import edu.uci.ics.texera.api.exception.TexeraException;
 import edu.uci.ics.texera.dataflow.common.PredicateBase;
 import edu.uci.ics.texera.dataflow.common.PropertyNameConstants;
 import edu.uci.ics.texera.dataflow.utils.DataflowUtils;
@@ -42,6 +43,14 @@ public class FuzzyTokenPredicate extends PredicateBase {
             Double thresholdRatio,
             @JsonProperty(value = PropertyNameConstants.SPAN_LIST_NAME, required = true)
             String spanListName) {
+        
+        if (query.trim().isEmpty()) {
+            throw new TexeraException("query should not be empty");
+        }
+        if (thresholdRatio < 0.0 || thresholdRatio > 1.0) {
+            throw new TexeraException("threshold ratio should be between 0.0 and 1.0");
+        }
+        
         this.query = query;
         this.attributeNames = attributeNames;
         this.luceneAnalyzerStr = luceneAnalyzerStr;

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/keywordmatcher/KeywordPredicate.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/keywordmatcher/KeywordPredicate.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.uci.ics.texera.api.dataflow.IOperator;
+import edu.uci.ics.texera.api.exception.TexeraException;
 import edu.uci.ics.texera.dataflow.common.PredicateBase;
 import edu.uci.ics.texera.storage.constants.LuceneAnalyzerConstants;
 import edu.uci.ics.texera.dataflow.common.PropertyNameConstants;
@@ -102,6 +103,10 @@ public class KeywordPredicate extends PredicateBase {
             KeywordMatchingType matchingType,
             @JsonProperty(value = PropertyNameConstants.SPAN_LIST_NAME, required = false)
             String spanListName) {
+        
+        if (query.trim().isEmpty()) {
+            throw new TexeraException("query should not be empty");
+        }
         
         this.query = query;
         this.attributeNames = Collections.unmodifiableList(attributeNames);

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/nlp/entity/NlpEntityPredicate.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/nlp/entity/NlpEntityPredicate.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.uci.ics.texera.api.dataflow.IOperator;
+import edu.uci.ics.texera.api.exception.TexeraException;
 import edu.uci.ics.texera.dataflow.common.PredicateBase;
 import edu.uci.ics.texera.dataflow.common.PropertyNameConstants;
 
@@ -24,6 +25,11 @@ public class NlpEntityPredicate extends PredicateBase {
             List<String> attributeNames,
             @JsonProperty(value = PropertyNameConstants.SPAN_LIST_NAME, required = true)
             String spanListName) {
+        
+        if (attributeNames.isEmpty()) {
+            throw new TexeraException("attributes should not be empty");
+        }
+        
         this.nlpEntityType = nlpEntityType;
         this.attributeNames = attributeNames;
         if (spanListName == null || spanListName.trim().isEmpty()) {

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/regexmatcher/RegexPredicate.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/regexmatcher/RegexPredicate.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.uci.ics.texera.api.dataflow.IOperator;
+import edu.uci.ics.texera.api.exception.TexeraException;
 import edu.uci.ics.texera.dataflow.common.PredicateBase;
 import edu.uci.ics.texera.dataflow.common.PropertyNameConstants;
 
@@ -50,6 +51,11 @@ public class RegexPredicate extends PredicateBase {
             Boolean ignoreCase,
             @JsonProperty(value = PropertyNameConstants.SPAN_LIST_NAME, required = true)
             String spanListName) {
+        
+        if (regex.trim().isEmpty()) {
+            throw new TexeraException("regex should not be empty");
+        }
+        
         this.regex = regex;
         this.attributeNames = attributeNames;
         if (ignoreCase == null) {

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/sink/tuple/TupleSinkPredicate.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/sink/tuple/TupleSinkPredicate.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.uci.ics.texera.api.dataflow.IOperator;
+import edu.uci.ics.texera.api.exception.TexeraException;
 import edu.uci.ics.texera.dataflow.common.PredicateBase;
 import edu.uci.ics.texera.dataflow.common.PropertyNameConstants;
 
@@ -24,6 +25,14 @@ public class TupleSinkPredicate extends PredicateBase {
             @JsonProperty(value = PropertyNameConstants.OFFSET, required = false)
             Integer offset
             ) {
+        
+        if (limit != null && limit < 0) {
+            throw new TexeraException("limit must be greater than 0");
+        }
+        if (offset != null && offset < 0) {
+            throw new TexeraException("offset must be greater than 0");
+        }
+        
         this.limit = limit;
         if (this.limit == null) {
             this.limit = Integer.MAX_VALUE;


### PR DESCRIPTION
This PR adds checks to some operators in the predicate constructor. An example check is:
```java
if (query == null || query.trim().isEmpty()) {
    throw new TexeraException("query is null");
}
```

The reason behind this is that we want the backend checks to happen as early as possible. Instead of letting the operator run with the invalid properties, we want to throw exception when at the predicate's constructor.