### PR TITLE
Modify the bugs related to DateField

### DIFF
--- a/core/api/src/main/java/edu/uci/ics/texera/api/constants/test/TestConstants.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/constants/test/TestConstants.java
@@ -45,33 +45,31 @@ public class TestConstants {
     public static List<Tuple> getSamplePeopleTuples() {
         
         try {
-            IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
+            IField[] fields0 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
                     new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
                     new TextField("Tall Angry") };
-            IField[] fields2 = { new StringField("tom hanks"), new StringField("cruise"), new IntegerField(45),
+            IField[] fields1 = { new StringField("tom hanks"), new StringField("cruise"), new IntegerField(45),
                     new DoubleField(5.95), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1971")),
                     new TextField("Short Brown") };
-            IField[] fields3 = { new StringField("brad lie angelina"), new StringField("pitt"), new IntegerField(44),
+            IField[] fields2 = { new StringField("brad lie angelina"), new StringField("pitt"), new IntegerField(44),
                     new DoubleField(6.10), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-12-1972")),
                     new TextField("White Angry") };
-            IField[] fields4 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
+            IField[] fields3 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
                     new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
                     new TextField("Lin Clooney is Short and lin clooney is Angry") };
-            IField[] fields5 = { new StringField("christian john wayne"), new StringField("rock bale"),
-                    new IntegerField(42), new DoubleField(5.99),
-                    new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair") };
-            IField[] fields6 = { new StringField("Mary brown"), new StringField("Lake Forest"),
-                    new IntegerField(42), new DoubleField(5.99),
-                    new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Short angry") };
+            IField[] fields4 = { new StringField("christian john wayne"), new StringField("rock bale"), new IntegerField(42), 
+                    new DoubleField(5.99), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair") };
+            IField[] fields5 = { new StringField("Mary brown"), new StringField("Lake Forest"), new IntegerField(42), 
+                    new DoubleField(5.99), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Short angry") };
 
+            Tuple tuple0 = new Tuple(SCHEMA_PEOPLE, fields0);
             Tuple tuple1 = new Tuple(SCHEMA_PEOPLE, fields1);
             Tuple tuple2 = new Tuple(SCHEMA_PEOPLE, fields2);
             Tuple tuple3 = new Tuple(SCHEMA_PEOPLE, fields3);
             Tuple tuple4 = new Tuple(SCHEMA_PEOPLE, fields4);
             Tuple tuple5 = new Tuple(SCHEMA_PEOPLE, fields5);
-            Tuple tuple6 = new Tuple(SCHEMA_PEOPLE, fields6);
 
-            return Arrays.asList(tuple1, tuple2, tuple3, tuple4, tuple5, tuple6);   
+            return Arrays.asList(tuple0, tuple1, tuple2, tuple3, tuple4, tuple5);   
         } catch (ParseException e) {
             // exception should not happen because we know the data is correct
             e.printStackTrace();

--- a/core/api/src/main/java/edu/uci/ics/texera/api/constants/test/TestConstantsRegexSplit.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/constants/test/TestConstantsRegexSplit.java
@@ -1,11 +1,10 @@
 package edu.uci.ics.texera.api.constants.test;
 
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
-import edu.uci.ics.texera.api.field.DateField;
+import edu.uci.ics.texera.api.field.DateTimeField;
 import edu.uci.ics.texera.api.field.DoubleField;
 import edu.uci.ics.texera.api.field.IField;
 import edu.uci.ics.texera.api.field.IntegerField;
@@ -35,7 +34,7 @@ public class TestConstantsRegexSplit {
     public static final Attribute LAST_NAME_ATTR = new Attribute(LAST_NAME, AttributeType.STRING);
     public static final Attribute AGE_ATTR = new Attribute(AGE, AttributeType.INTEGER);
     public static final Attribute HEIGHT_ATTR = new Attribute(HEIGHT, AttributeType.DOUBLE);
-    public static final Attribute DATE_OF_BIRTH_ATTR = new Attribute(DATE_OF_BIRTH, AttributeType.DATE);
+    public static final Attribute DATE_OF_BIRTH_ATTR = new Attribute(DATE_OF_BIRTH, AttributeType.DATETIME);
     public static final Attribute DESCRIPTION_ATTR = new Attribute(DESCRIPTION, AttributeType.TEXT);
 
     // Sample Schema
@@ -45,23 +44,17 @@ public class TestConstantsRegexSplit {
 
     public static List<Tuple> constructSamplePeopleTuples() {
         
-        try {
-            IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
-                    new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
-                    new TextField("banana") };
-            IField[] fields2 = { new StringField("tom hanks"), new StringField("cruise"), new IntegerField(45),
-                    new DoubleField(5.95), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1971")),
-                    new TextField("mississippi") };
-            
-            Tuple tuple1 = new Tuple(SCHEMA_PEOPLE, fields1);
-            Tuple tuple2 = new Tuple(SCHEMA_PEOPLE, fields2);
-            
-            return Arrays.asList(tuple1, tuple2);   
-        } catch (ParseException e) {
-            // exception should not happen because we know the data is correct
-            e.printStackTrace();
-            return Arrays.asList();
-        }
+        IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
+                new DoubleField(5.50), new DateTimeField(LocalDateTime.parse("1970-01-01T11:11:11")),
+                new TextField("banana") };
+        IField[] fields2 = { new StringField("tom hanks"), new StringField("cruise"), new IntegerField(45),
+                new DoubleField(5.95), new DateTimeField(LocalDateTime.parse("1980-01-02T13:14:15")),
+                new TextField("mississippi") };
+        
+        Tuple tuple1 = new Tuple(SCHEMA_PEOPLE, fields1);
+        Tuple tuple2 = new Tuple(SCHEMA_PEOPLE, fields2);
+        
+        return Arrays.asList(tuple1, tuple2);   
 
     }
 }

--- a/core/api/src/main/java/edu/uci/ics/texera/api/field/DateField.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/field/DateField.java
@@ -1,8 +1,15 @@
 package edu.uci.ics.texera.api.field;
 
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import static com.google.common.base.Preconditions.checkNotNull;
 
@@ -10,27 +17,49 @@ import edu.uci.ics.texera.api.constants.JsonConstants;
 
 public class DateField implements IField {
 
-    private Date value;
-
-    //TODO: current json serialization converts DateField to an int, which is not user friendly
-    @JsonCreator
-    public DateField(
-            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true)
-            Date value) {
-        checkNotNull(value);
-        this.value = value;
+    public static void main(String[] args) {
+        LocalDate localDate = LocalDate.parse("2017-06-03");
+        ZonedDateTime zonedDateTime = ZonedDateTime.parse("1999-06-02T19:24:01.000Z", DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.systemDefault()));
+        
+        System.out.println(localDate);
+        System.out.println(zonedDateTime.toLocalDateTime().toString());
+        System.out.println(localDate.compareTo(zonedDateTime.toLocalDate()));
     }
 
+    private String localDateTimeString;
+
+    public DateField(@JsonProperty(value = JsonConstants.FIELD_VALUE, required = true) Date value) {
+        checkNotNull(value);
+        this.localDateTimeString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'").format(value);
+    }
+
+    public DateField(LocalDateTime localDateTime) {
+        checkNotNull(localDateTime);
+        this.localDateTimeString = localDateTime.toString();
+    }
+
+    @JsonCreator
+    public DateField(@JsonProperty(value = JsonConstants.FIELD_VALUE, required = true) String localDateTimeString) {
+        checkNotNull(localDateTimeString);
+        this.localDateTimeString = localDateTimeString;
+    }
+
+    @JsonProperty(value = JsonConstants.FIELD_VALUE)
+    public String getDateString() {
+        return this.localDateTimeString;
+    }
+
+    @JsonIgnore
     @Override
-    public Date getValue() {
-        return value;
+    public LocalDateTime getValue() {
+        return LocalDateTime.parse(this.localDateTimeString);
     }
 
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((value == null) ? 0 : value.hashCode());
+        result = prime * result + ((localDateTimeString == null) ? 0 : localDateTimeString.hashCode());
         return result;
     }
 
@@ -43,17 +72,17 @@ public class DateField implements IField {
         if (getClass() != obj.getClass())
             return false;
         DateField other = (DateField) obj;
-        if (value == null) {
-            if (other.value != null)
+        if (localDateTimeString == null) {
+            if (other.localDateTimeString != null)
                 return false;
-        } else if (!value.equals(other.value))
+        } else if (!localDateTimeString.equals(other.localDateTimeString))
             return false;
         return true;
     }
 
     @Override
     public String toString() {
-        return "DateField [value=" + value + "]";
+        return "DateField [value=" + localDateTimeString + "]";
     }
 
 }

--- a/core/api/src/main/java/edu/uci/ics/texera/api/field/DateField.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/field/DateField.java
@@ -1,11 +1,7 @@
 package edu.uci.ics.texera.api.field;
 
 import java.text.SimpleDateFormat;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
 import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -17,20 +13,11 @@ import edu.uci.ics.texera.api.constants.JsonConstants;
 
 public class DateField implements IField {
 
-    public static void main(String[] args) {
-        LocalDate localDate = LocalDate.parse("2017-06-03");
-        ZonedDateTime zonedDateTime = ZonedDateTime.parse("1999-06-02T19:24:01.000Z", DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.systemDefault()));
-        
-        System.out.println(localDate);
-        System.out.println(zonedDateTime.toLocalDateTime().toString());
-        System.out.println(localDate.compareTo(zonedDateTime.toLocalDate()));
-    }
-
     private String localDateTimeString;
 
     public DateField(@JsonProperty(value = JsonConstants.FIELD_VALUE, required = true) Date value) {
         checkNotNull(value);
-        this.localDateTimeString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm'Z'").format(value);
+        this.localDateTimeString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm").format(value);
     }
 
     public DateField(LocalDateTime localDateTime) {

--- a/core/api/src/main/java/edu/uci/ics/texera/api/field/DateField.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/field/DateField.java
@@ -1,7 +1,7 @@
 package edu.uci.ics.texera.api.field;
 
-import java.text.SimpleDateFormat;
-import java.time.LocalDateTime;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.Date;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -13,43 +13,44 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import edu.uci.ics.texera.api.constants.JsonConstants;
 
 public class DateField implements IField {
+    
+    private LocalDate localDate;
 
-    private String localDateTimeString;
 
-    public DateField(Date value) {
-        checkNotNull(value);
-        this.localDateTimeString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm").format(value);
+    public DateField(Date date) {
+        checkNotNull(date);
+        this.localDate = date.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
     }
 
-    public DateField(LocalDateTime localDateTime) {
-        checkNotNull(localDateTime);
-        this.localDateTimeString = localDateTime.toString();
+    public DateField(LocalDate localDate) {
+        checkNotNull(localDate);
+        this.localDate = localDate;
     }
 
     @JsonCreator
     public DateField(
             @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true) 
-            String localDateTimeString) {
-        checkNotNull(localDateTimeString);
-        this.localDateTimeString = localDateTimeString;
+            String localDateString) {
+        checkNotNull(localDateString);
+        this.localDate = LocalDate.parse(localDateString);
     }
 
     @JsonProperty(value = JsonConstants.FIELD_VALUE)
     public String getDateString() {
-        return this.localDateTimeString;
+        return this.localDate.toString();
     }
 
     @JsonIgnore
     @Override
-    public LocalDateTime getValue() {
-        return LocalDateTime.parse(this.localDateTimeString);
+    public LocalDate getValue() {
+        return this.localDate;
     }
 
     @Override
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((localDateTimeString == null) ? 0 : localDateTimeString.hashCode());
+        result = prime * result + ((localDate == null) ? 0 : localDate.hashCode());
         return result;
     }
 
@@ -62,17 +63,17 @@ public class DateField implements IField {
         if (getClass() != obj.getClass())
             return false;
         DateField other = (DateField) obj;
-        if (localDateTimeString == null) {
-            if (other.localDateTimeString != null)
+        if (localDate == null) {
+            if (other.localDate != null)
                 return false;
-        } else if (!localDateTimeString.equals(other.localDateTimeString))
+        } else if (!localDate.equals(other.localDate))
             return false;
         return true;
     }
 
     @Override
     public String toString() {
-        return "DateField [value=" + localDateTimeString + "]";
+        return "DateField [value=" + localDate.toString() + "]";
     }
 
 }

--- a/core/api/src/main/java/edu/uci/ics/texera/api/field/DateField.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/field/DateField.java
@@ -7,6 +7,7 @@ import java.util.Date;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import edu.uci.ics.texera.api.constants.JsonConstants;
@@ -15,7 +16,7 @@ public class DateField implements IField {
 
     private String localDateTimeString;
 
-    public DateField(@JsonProperty(value = JsonConstants.FIELD_VALUE, required = true) Date value) {
+    public DateField(Date value) {
         checkNotNull(value);
         this.localDateTimeString = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm").format(value);
     }
@@ -26,7 +27,9 @@ public class DateField implements IField {
     }
 
     @JsonCreator
-    public DateField(@JsonProperty(value = JsonConstants.FIELD_VALUE, required = true) String localDateTimeString) {
+    public DateField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true) 
+            String localDateTimeString) {
         checkNotNull(localDateTimeString);
         this.localDateTimeString = localDateTimeString;
     }

--- a/core/api/src/main/java/edu/uci/ics/texera/api/field/DateTimeField.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/field/DateTimeField.java
@@ -1,0 +1,71 @@
+package edu.uci.ics.texera.api.field;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import edu.uci.ics.texera.api.constants.JsonConstants;
+
+public class DateTimeField implements IField {
+    
+    private LocalDateTime localDateTime;
+
+    public DateTimeField(LocalDateTime localDateTime) {
+        checkNotNull(localDateTime);
+        this.localDateTime = localDateTime;
+    }
+
+    @JsonCreator
+    public DateTimeField(
+            @JsonProperty(value = JsonConstants.FIELD_VALUE, required = true) 
+            String localDateTimeString) {
+        checkNotNull(localDateTimeString);
+        this.localDateTime = LocalDateTime.parse(localDateTimeString);
+    }
+
+    @JsonProperty(value = JsonConstants.FIELD_VALUE)
+    public String getDateTimeString() {
+        return this.localDateTime.toString();
+    }
+
+    @JsonIgnore
+    @Override
+    public LocalDateTime getValue() {
+        return this.localDateTime;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((localDateTime == null) ? 0 : localDateTime.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        DateTimeField other = (DateTimeField) obj;
+        if (localDateTime == null) {
+            if (other.localDateTime != null)
+                return false;
+        } else if (!localDateTime.equals(other.localDateTime))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return "DateTimeField [value=" + localDateTime.toString() + "]";
+    }
+
+}

--- a/core/api/src/main/java/edu/uci/ics/texera/api/schema/AttributeType.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/schema/AttributeType.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 import edu.uci.ics.texera.api.exception.TexeraException;
 import edu.uci.ics.texera.api.field.DateField;
+import edu.uci.ics.texera.api.field.DateTimeField;
 import edu.uci.ics.texera.api.field.DoubleField;
 import edu.uci.ics.texera.api.field.IDField;
 import edu.uci.ics.texera.api.field.IField;
@@ -21,6 +22,7 @@ public enum AttributeType {
     INTEGER("integer", IntegerField.class), 
     DOUBLE("double", DoubleField.class), 
     DATE("date", DateField.class),
+    DATETIME("datetime", DateTimeField.class),
 
     _ID_TYPE("_id", IDField.class),
     // A field that is the list of values

--- a/core/api/src/main/java/edu/uci/ics/texera/api/tuple/Tuple.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/tuple/Tuple.java
@@ -9,9 +9,9 @@ import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
@@ -140,7 +140,8 @@ public class Tuple {
     public ObjectNode getReadableJson() {
         ObjectNode objectNode = new ObjectMapper().createObjectNode();
         for (String attrName : this.schema.getAttributeNames()) {
-            objectNode.set(attrName, JsonNodeFactory.instance.pojoNode(this.getField(attrName).getValue()));
+            JsonNode valueNode = new ObjectMapper().convertValue(this.getField(attrName), JsonNode.class).get(JsonConstants.FIELD_VALUE);
+            objectNode.set(attrName, valueNode);
         }
         return objectNode;
     }

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/comparablematcher/ComparableMatcher.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/comparablematcher/ComparableMatcher.java
@@ -1,7 +1,8 @@
 package edu.uci.ics.texera.dataflow.comparablematcher;
 
-import java.text.DateFormat;
-import java.util.Date;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 
 import edu.uci.ics.texera.api.exception.DataflowException;
 import edu.uci.ics.texera.api.exception.TexeraException;
@@ -81,10 +82,10 @@ public class ComparableMatcher extends AbstractSingleInputOperator {
         if (predicate.getCompareToValue().getClass().equals(String.class)) {
             try {
                 String compareTo = (String) predicate.getCompareToValue();
-                Date compareToDate = DateFormat.getDateInstance(DateFormat.MEDIUM).parse(compareTo);
-                Date date = inputTuple.getField(predicate.getAttributeName(), DateField.class).getValue();
-                return compareValues(date, compareToDate, predicate.getComparisonType());
-            } catch (java.text.ParseException e) {
+                LocalDate compareToDate = LocalDate.parse(compareTo);
+                LocalDateTime dateTime = inputTuple.getField(predicate.getAttributeName(), DateField.class).getValue();
+                return compareValues(dateTime.toLocalDate(), compareToDate, predicate.getComparisonType());
+            } catch (DateTimeParseException e) {
                 throw new DataflowException("Unable to parse date: " + e.getMessage());
             }
         } else {
@@ -149,22 +150,22 @@ public class ComparableMatcher extends AbstractSingleInputOperator {
             }
             break;
         case GREATER_THAN:
-            if (compareResult == 1) {
+            if (compareResult > 0) {
                 return true;
             }
             break;
         case GREATER_THAN_OR_EQUAL_TO:
-            if (compareResult == 0 || compareResult == 1) {
+            if (compareResult >= 0) {
                 return true;
             }
             break;
         case LESS_THAN:
-            if (compareResult == -1) {
+            if (compareResult < 0) {
                 return true;
             }
             break;
         case LESS_THAN_OR_EQUAL_TO:
-            if (compareResult == 0 || compareResult == -1) {
+            if (compareResult <= 0) {
                 return true;
             }
             break;

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/comparablematcher/ComparablePredicate.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/comparablematcher/ComparablePredicate.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.uci.ics.texera.api.dataflow.IOperator;
+import edu.uci.ics.texera.api.exception.TexeraException;
 import edu.uci.ics.texera.dataflow.common.PredicateBase;
 import edu.uci.ics.texera.dataflow.common.PropertyNameConstants;
 
@@ -26,6 +27,9 @@ public class ComparablePredicate extends PredicateBase {
             ComparisonType matchingType,
             @JsonProperty(value = PropertyNameConstants.COMPARE_TO_VALUE, required = true)
             Object compareToValue) {
+        if (attributeName == null || attributeName.trim().isEmpty()) {
+            throw new TexeraException("attribute cannot be empty");
+        }
         this.compareToValue = compareToValue;
         this.attributeName = attributeName;
         this.matchingType = matchingType;

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/comparablematcher/ComparablePredicate.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/comparablematcher/ComparablePredicate.java
@@ -3,7 +3,6 @@ package edu.uci.ics.texera.dataflow.comparablematcher;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-import edu.uci.ics.texera.api.dataflow.IOperator;
 import edu.uci.ics.texera.api.exception.TexeraException;
 import edu.uci.ics.texera.dataflow.common.PredicateBase;
 import edu.uci.ics.texera.dataflow.common.PropertyNameConstants;
@@ -51,7 +50,7 @@ public class ComparablePredicate extends PredicateBase {
     }
 
     @Override
-    public IOperator newOperator() {
+    public ComparableMatcher newOperator() {
         return new ComparableMatcher(this);
     }
 

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/sink/excel/ExcelSink.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/sink/excel/ExcelSink.java
@@ -194,7 +194,7 @@ public class ExcelSink implements ISink {
     	} else if (field instanceof IntegerField) {
     	    cell.setCellValue((double) (int) field.getValue());
     	} else if(field instanceof DateField){
-    		cell.setCellValue((Date) field.getValue());
+    		cell.setCellValue(field.getValue().toString());
     	} else{
     		cell.setCellValue(field.getValue().toString());
     	}

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/sink/tuple/TupleSinkPredicate.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/sink/tuple/TupleSinkPredicate.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.uci.ics.texera.api.dataflow.IOperator;
+import edu.uci.ics.texera.api.exception.TexeraException;
 import edu.uci.ics.texera.dataflow.common.PredicateBase;
 import edu.uci.ics.texera.dataflow.common.PropertyNameConstants;
 
@@ -27,6 +28,9 @@ public class TupleSinkPredicate extends PredicateBase {
         this.limit = limit;
         if (this.limit == null) {
             this.limit = Integer.MAX_VALUE;
+        }
+        if (this.limit <= 0) {
+            throw new TexeraException("limit must > 0");
         }
         this.offset = offset;
         if (this.offset == null) {

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/twitter/TwitterConverter.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/twitter/TwitterConverter.java
@@ -1,5 +1,8 @@
 package edu.uci.ics.texera.dataflow.twitter;
 
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -12,6 +15,7 @@ import edu.uci.ics.texera.api.constants.ErrorMessages;
 import edu.uci.ics.texera.api.dataflow.IOperator;
 import edu.uci.ics.texera.api.exception.DataflowException;
 import edu.uci.ics.texera.api.exception.TexeraException;
+import edu.uci.ics.texera.api.field.DateField;
 import edu.uci.ics.texera.api.field.IField;
 import edu.uci.ics.texera.api.field.IntegerField;
 import edu.uci.ics.texera.api.field.StringField;
@@ -93,7 +97,10 @@ public class TwitterConverter implements IOperator {
             String county = geoTagNode.get("countyName").asText();
             String city = geoTagNode.get("cityName").asText();
             String createAt = tweet.get("create_at").asText();
+            ZonedDateTime zonedCreateAt = ZonedDateTime.parse(createAt, DateTimeFormatter.ISO_INSTANT.withZone(ZoneId.systemDefault()));
+
             return Arrays.asList(
+                    new StringField(id.toString()),
                     new TextField(text),
                     new StringField(tweetLink),
                     new StringField(userLink),
@@ -105,7 +112,7 @@ public class TwitterConverter implements IOperator {
                     new TextField(state),
                     new TextField(county),
                     new TextField(city),
-                    new StringField(createAt));
+                    new DateField(zonedCreateAt.toLocalDateTime()));
         } catch (Exception e) {
             return Arrays.asList();
         }

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/twitter/TwitterConverter.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/twitter/TwitterConverter.java
@@ -15,7 +15,7 @@ import edu.uci.ics.texera.api.constants.ErrorMessages;
 import edu.uci.ics.texera.api.dataflow.IOperator;
 import edu.uci.ics.texera.api.exception.DataflowException;
 import edu.uci.ics.texera.api.exception.TexeraException;
-import edu.uci.ics.texera.api.field.DateField;
+import edu.uci.ics.texera.api.field.DateTimeField;
 import edu.uci.ics.texera.api.field.IField;
 import edu.uci.ics.texera.api.field.IntegerField;
 import edu.uci.ics.texera.api.field.StringField;
@@ -112,7 +112,7 @@ public class TwitterConverter implements IOperator {
                     new TextField(state),
                     new TextField(county),
                     new TextField(city),
-                    new DateField(zonedCreateAt.toLocalDateTime()));
+                    new DateTimeField(zonedCreateAt.toLocalDateTime()));
         } catch (Exception e) {
             return Arrays.asList();
         }

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/twitter/TwitterConverterConstants.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/twitter/TwitterConverterConstants.java
@@ -45,7 +45,7 @@ public class TwitterConverterConstants {
     public static Attribute CITY_ATTRIBUTE = new Attribute(CITY, AttributeType.TEXT);
     
     public static String CREATE_AT = "create_at";
-    public static Attribute CREATE_AT_ATTRIBUTE = new Attribute(CREATE_AT, AttributeType.DATE);
+    public static Attribute CREATE_AT_ATTRIBUTE = new Attribute(CREATE_AT, AttributeType.DATETIME);
     
     public static List<Attribute> additionalAttributes = Arrays.asList(
             TWEET_ID_ATTRIBUTE, TEXT_ATTRIBUTE, TWEET_LINK_ATTRIBUTE, USER_LINK_ATTRIBUTE, 

--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/twitter/TwitterConverterConstants.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/twitter/TwitterConverterConstants.java
@@ -8,6 +8,9 @@ import edu.uci.ics.texera.api.schema.AttributeType;
 
 public class TwitterConverterConstants {
     
+    public static String TWEET_ID = "tweet_id";
+    public static Attribute TWEET_ID_ATTRIBUTE = new Attribute(TWEET_ID, AttributeType.STRING);
+    
     public static String TEXT = "text";
     public static Attribute TEXT_ATTRIBUTE = new Attribute(TEXT, AttributeType.TEXT);
     
@@ -42,10 +45,10 @@ public class TwitterConverterConstants {
     public static Attribute CITY_ATTRIBUTE = new Attribute(CITY, AttributeType.TEXT);
     
     public static String CREATE_AT = "create_at";
-    public static Attribute CREATE_AT_ATTRIBUTE = new Attribute(CREATE_AT, AttributeType.STRING);
+    public static Attribute CREATE_AT_ATTRIBUTE = new Attribute(CREATE_AT, AttributeType.DATE);
     
     public static List<Attribute> additionalAttributes = Arrays.asList(
-            TEXT_ATTRIBUTE, TWEET_LINK_ATTRIBUTE, USER_LINK_ATTRIBUTE, 
+            TWEET_ID_ATTRIBUTE, TEXT_ATTRIBUTE, TWEET_LINK_ATTRIBUTE, USER_LINK_ATTRIBUTE, 
             USER_SCREEN_NAME_ATTRIBUTE, USER_NAME_ATTRIBUTE, USER_DESCRIPTION_ATTRIBUTE, 
             USER_FOLLOWERS_COUNT_ATTRIBUTE, USER_FRIENDS_COUNT_ATTRIBUTE, 
             STATE_ATTRIBUTE, COUNTY_ATTRIBUTE, CITY_ATTRIBUTE, CREATE_AT_ATTRIBUTE);

--- a/core/dataflow/src/test/java/edu/uci/ics/texera/dataflow/comparablematcher/ComparableMatcherTest.java
+++ b/core/dataflow/src/test/java/edu/uci/ics/texera/dataflow/comparablematcher/ComparableMatcherTest.java
@@ -2,12 +2,6 @@ package edu.uci.ics.texera.dataflow.comparablematcher;
 
 import edu.uci.ics.texera.api.constants.test.TestConstants;
 import edu.uci.ics.texera.api.exception.TexeraException;
-import edu.uci.ics.texera.api.field.DateField;
-import edu.uci.ics.texera.api.field.DoubleField;
-import edu.uci.ics.texera.api.field.IField;
-import edu.uci.ics.texera.api.field.IntegerField;
-import edu.uci.ics.texera.api.field.StringField;
-import edu.uci.ics.texera.api.field.TextField;
 import edu.uci.ics.texera.api.schema.Attribute;
 import edu.uci.ics.texera.api.tuple.Tuple;
 import edu.uci.ics.texera.api.utils.TestUtils;
@@ -22,7 +16,6 @@ import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -54,20 +47,11 @@ public class ComparableMatcherTest {
         RelationManager relationManager = RelationManager.getInstance();
         relationManager.deleteTable(PEOPLE_TABLE);
     }
-
-    public List<Tuple> getDoubleQueryResults(String attributeName, ComparisonType matchingType, double threshold)
+    
+    public List<Tuple> getQueryResults(String attributeName, ComparisonType matchingType, Object compareToValue)
             throws TexeraException {
         // Perform the query
-        ComparablePredicate comparablePredicate = new ComparablePredicate(attributeName, matchingType, threshold);
-        ComparableMatcher comparableMatcher = new ComparableMatcher(comparablePredicate);
-        setDefaultMatcherConfig(comparableMatcher);
-        return getQueryResults(comparableMatcher);
-    }
-
-    public List<Tuple> getIntegerQueryResults(String attributeName, ComparisonType matchingType, int threshold)
-            throws TexeraException {
-        // Perform the query
-        ComparablePredicate comparablePredicate = new ComparablePredicate(attributeName, matchingType, threshold);
+        ComparablePredicate comparablePredicate = new ComparablePredicate(attributeName, matchingType, compareToValue);
         ComparableMatcher comparableMatcher = new ComparableMatcher(comparablePredicate);
         setDefaultMatcherConfig(comparableMatcher);
         return getQueryResults(comparableMatcher);
@@ -107,20 +91,14 @@ public class ComparableMatcherTest {
         ComparisonType matchingType = ComparisonType.GREATER_THAN;
 
         // Perform the query
-        List<Tuple> returnedResults = getDoubleQueryResults(attributeName, matchingType, threshold);
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, threshold);
 
         // check the results
-        IField[] fields1 = {new StringField("brad lie angelina"), new StringField("pitt"), new IntegerField(44),
-                new DoubleField(6.10), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-12-1972")),
-                new TextField("White Angry")};
-        IField[] fields2 = {new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
-                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
-                new TextField("Lin Clooney is Short and lin clooney is Angry")};
         List<Tuple> expectedResults = new ArrayList<>();
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields1));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields2));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(2));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(3));
 
-        Assert.assertEquals(2, returnedResults.size());
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
         Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
     }
 
@@ -138,16 +116,13 @@ public class ComparableMatcherTest {
         ComparisonType matchingType = ComparisonType.LESS_THAN;
 
         // Perform the query
-        List<Tuple> returnedResults = getDoubleQueryResults(attributeName, matchingType, threshold);
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, threshold);
 
-        IField[] fields1 = {new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
-                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
-                new TextField("Tall Angry")};
         List<Tuple> expectedResults = new ArrayList<>();
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields1));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(0));
 
         // check the results
-        Assert.assertEquals(1, returnedResults.size());
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
         Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
     }
 
@@ -165,20 +140,14 @@ public class ComparableMatcherTest {
         ComparisonType matchingType = ComparisonType.LESS_THAN_OR_EQUAL_TO;
 
         // Perform the query
-        List<Tuple> returnedResults = getDoubleQueryResults(attributeName, matchingType, threshold);
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, threshold);
 
-        IField[] fields1 = {new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
-                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
-                new TextField("Tall Angry")};
-        IField[] fields2 = {new StringField("tom hanks"), new StringField("cruise"), new IntegerField(45),
-                new DoubleField(5.95), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1971")),
-                new TextField("Short Brown")};
         List<Tuple> expectedResults = new ArrayList<>();
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields1));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields2));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(0));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(1));
 
         // check the results
-        Assert.assertEquals(2, returnedResults.size());
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
         Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
     }
 
@@ -196,32 +165,18 @@ public class ComparableMatcherTest {
         ComparisonType matchingType = ComparisonType.GREATER_THAN_OR_EQUAL_TO;
 
         // Perform the query
-        List<Tuple> returnedResults = getDoubleQueryResults(attributeName, matchingType, threshold);
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, threshold);
 
-        IField[] fields1 = {new StringField("tom hanks"), new StringField("cruise"), new IntegerField(45),
-                new DoubleField(5.95), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1971")),
-                new TextField("Short Brown")};
-        IField[] fields2 = {new StringField("brad lie angelina"), new StringField("pitt"), new IntegerField(44),
-                new DoubleField(6.10), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-12-1972")),
-                new TextField("White Angry")};
-        IField[] fields3 = {new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
-                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
-                new TextField("Lin Clooney is Short and lin clooney is Angry")};
-        IField[] fields4 = {new StringField("christian john wayne"), new StringField("rock bale"),
-                new IntegerField(42), new DoubleField(5.99),
-                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair")};
-        IField[] fields5 = {new StringField("Mary brown"), new StringField("Lake Forest"),
-                new IntegerField(42), new DoubleField(5.99),
-                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Short angry")};
+
         List<Tuple> expectedResults = new ArrayList<>();
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields1));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields2));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields3));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields4));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields5));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(1));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(2));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(3));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(4));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(5));
 
         // check the results
-        Assert.assertEquals(5, returnedResults.size());
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
         Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
     }
 
@@ -239,16 +194,13 @@ public class ComparableMatcherTest {
         ComparisonType matchingType = ComparisonType.EQUAL_TO;
 
         // Perform the query
-        List<Tuple> returnedResults = getDoubleQueryResults(attributeName, matchingType, threshold);
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, threshold);
 
-        IField[] fields1 = {new StringField("brad lie angelina"), new StringField("pitt"), new IntegerField(44),
-                new DoubleField(6.10), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-12-1972")),
-                new TextField("White Angry")};
         List<Tuple> expectedResults = new ArrayList<>();
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields1));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(2));
 
         // check the results
-        Assert.assertEquals(1, returnedResults.size());
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
         Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
     }
 
@@ -266,33 +218,18 @@ public class ComparableMatcherTest {
         ComparisonType matchingType = ComparisonType.NOT_EQUAL_TO;
 
         // Perform the query
-        List<Tuple> returnedResults = getDoubleQueryResults(attributeName, matchingType, threshold);
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, threshold);
 
-        IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
-                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
-                new TextField("Tall Angry") };
-        IField[] fields2 = { new StringField("tom hanks"), new StringField("cruise"), new IntegerField(45),
-                new DoubleField(5.95), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1971")),
-                new TextField("Short Brown") };
-        IField[] fields3 = { new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
-                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
-                new TextField("Lin Clooney is Short and lin clooney is Angry") };
-        IField[] fields4 = { new StringField("christian john wayne"), new StringField("rock bale"),
-                new IntegerField(42), new DoubleField(5.99),
-                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair") };
-        IField[] fields5 = { new StringField("Mary brown"), new StringField("Lake Forest"),
-                new IntegerField(42), new DoubleField(5.99),
-                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Short angry") };
 
         List<Tuple> expectedResults = new ArrayList<>();
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields1));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields2));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields3));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields4));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields5));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(0));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(1));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(3));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(4));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(5));
 
         // check the results
-        Assert.assertEquals(5, returnedResults.size());
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
         Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
     }
 
@@ -310,20 +247,15 @@ public class ComparableMatcherTest {
         ComparisonType matchingType = ComparisonType.EQUAL_TO;
 
         // Perform the query
-        List<Tuple> returnedResults = getIntegerQueryResults(attributeName, matchingType, threshold);
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, threshold);
 
-        IField[] fields1 = {new StringField("christian john wayne"), new StringField("rock bale"),
-                new IntegerField(42), new DoubleField(5.99),
-                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair")};
-        IField[] fields2 = {new StringField("Mary brown"), new StringField("Lake Forest"),
-                new IntegerField(42), new DoubleField(5.99),
-                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Short angry")};
         List<Tuple> expectedResults = new ArrayList<>();
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields1));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields2));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(4));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(5));
+
 
         // check the results
-        Assert.assertEquals(2, returnedResults.size());
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
         Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
     }
 
@@ -341,16 +273,13 @@ public class ComparableMatcherTest {
         ComparisonType matchingType = ComparisonType.GREATER_THAN;
 
         // Perform the query
-        List<Tuple> returnedResults = getIntegerQueryResults(attributeName, matchingType, threshold);
-
-        IField[] fields1 = {new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
-                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
-                new TextField("Tall Angry")};
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, threshold);
         List<Tuple> expectedResults = new ArrayList<>();
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields1));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(0));
+
 
         // check the results
-        Assert.assertEquals(1, returnedResults.size());
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
         Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
     }
 
@@ -368,20 +297,15 @@ public class ComparableMatcherTest {
         ComparisonType matchingType = ComparisonType.GREATER_THAN_OR_EQUAL_TO;
 
         // Perform the query
-        List<Tuple> returnedResults = getIntegerQueryResults(attributeName, matchingType, threshold);
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, threshold);
 
-        IField[] fields1 = {new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
-                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
-                new TextField("Tall Angry")};
-        IField[] fields2 = {new StringField("tom hanks"), new StringField("cruise"), new IntegerField(45),
-                new DoubleField(5.95), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1971")),
-                new TextField("Short Brown")};
         List<Tuple> expectedResults = new ArrayList<>();
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields1));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields2));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(0));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(1));
+
 
         // check the results
-        Assert.assertEquals(2, returnedResults.size());
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
         Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
     }
 
@@ -399,24 +323,16 @@ public class ComparableMatcherTest {
         ComparisonType matchingType = ComparisonType.LESS_THAN_OR_EQUAL_TO;
 
         // Perform the query
-        List<Tuple> returnedResults = getIntegerQueryResults(attributeName, matchingType, threshold);
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, threshold);
 
-        IField[] fields1 = {new StringField("george lin lin"), new StringField("lin clooney"), new IntegerField(43),
-                new DoubleField(6.06), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1973")),
-                new TextField("Lin Clooney is Short and lin clooney is Angry")};
-        IField[] fields2 = {new StringField("christian john wayne"), new StringField("rock bale"),
-                new IntegerField(42), new DoubleField(5.99),
-                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair")};
-        IField[] fields3 = {new StringField("Mary brown"), new StringField("Lake Forest"),
-                new IntegerField(42), new DoubleField(5.99),
-                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Short angry")};
         List<Tuple> expectedResults = new ArrayList<>();
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields1));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields2));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields3));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(3));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(4));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(5));
+
 
         // check the results
-        Assert.assertEquals(3, returnedResults.size());
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
         Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
     }
 
@@ -434,20 +350,14 @@ public class ComparableMatcherTest {
         ComparisonType matchingType = ComparisonType.LESS_THAN;
 
         // Perform the query
-        List<Tuple> returnedResults = getIntegerQueryResults(attributeName, matchingType, threshold);
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, threshold);
 
-        IField[] fields1 = {new StringField("christian john wayne"), new StringField("rock bale"),
-                new IntegerField(42), new DoubleField(5.99),
-                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair")};
-        IField[] fields2 = {new StringField("Mary brown"), new StringField("Lake Forest"),
-                new IntegerField(42), new DoubleField(5.99),
-                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Short angry")};
         List<Tuple> expectedResults = new ArrayList<>();
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields1));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields2));
-
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(4));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(5));
+        
         // check the results
-        Assert.assertEquals(2, returnedResults.size());
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
         Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
     }
 
@@ -465,33 +375,138 @@ public class ComparableMatcherTest {
         ComparisonType matchingType = ComparisonType.NOT_EQUAL_TO;
 
         // Perform the query
-        List<Tuple> returnedResults = getIntegerQueryResults(attributeName, matchingType, threshold);
-
-        IField[] fields1 = { new StringField("bruce"), new StringField("john Lee"), new IntegerField(46),
-                new DoubleField(5.50), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-14-1970")),
-                new TextField("Tall Angry") };
-        IField[] fields2 = { new StringField("tom hanks"), new StringField("cruise"), new IntegerField(45),
-                new DoubleField(5.95), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1971")),
-                new TextField("Short Brown") };
-        IField[] fields3 = { new StringField("brad lie angelina"), new StringField("pitt"), new IntegerField(44),
-                new DoubleField(6.10), new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-12-1972")),
-                new TextField("White Angry") };
-        IField[] fields4 = { new StringField("christian john wayne"), new StringField("rock bale"),
-                new IntegerField(42), new DoubleField(5.99),
-                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Tall Fair") };
-        IField[] fields5 = { new StringField("Mary brown"), new StringField("Lake Forest"),
-                new IntegerField(42), new DoubleField(5.99),
-                new DateField(new SimpleDateFormat("MM-dd-yyyy").parse("01-13-1974")), new TextField("Short angry") };
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, threshold);
 
         List<Tuple> expectedResults = new ArrayList<>();
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields1));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields2));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields3));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields4));
-        expectedResults.add(new Tuple(TestConstants.SCHEMA_PEOPLE, fields5));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(0));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(1));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(2));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(4));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(5));
 
         // check the results
-        Assert.assertEquals(5, returnedResults.size());
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
+        Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
+    }
+    
+    @Test
+    public void testDate1() throws Exception {
+        // Prepare the query
+        String dateCompared = "1970-01-14";
+        String attributeName = TestConstants.DATE_OF_BIRTH_ATTR.getName();
+        ComparisonType matchingType = ComparisonType.EQUAL_TO;
+        
+        // Perform the query
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, dateCompared);
+        
+        List<Tuple> expectedResults = new ArrayList<>();
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(0));
+
+        // check the results
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
+        Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
+    }
+    
+    
+    @Test
+    public void testDate2() throws Exception {
+        // Prepare the query
+        String dateCompared = "1973-01-13";
+        String attributeName = TestConstants.DATE_OF_BIRTH_ATTR.getName();
+        ComparisonType matchingType = ComparisonType.GREATER_THAN;
+        
+        // Perform the query
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, dateCompared);
+        
+        List<Tuple> expectedResults = new ArrayList<>();
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(4));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(5));
+
+        // check the results
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
+        Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
+    }
+    
+    @Test
+    public void testDate3() throws Exception {
+        // Prepare the query
+        String dateCompared = "1973-01-13";
+        String attributeName = TestConstants.DATE_OF_BIRTH_ATTR.getName();
+        ComparisonType matchingType = ComparisonType.GREATER_THAN_OR_EQUAL_TO;
+        
+        // Perform the query
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, dateCompared);
+        
+        List<Tuple> expectedResults = new ArrayList<>();
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(3));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(4));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(5));
+
+        // check the results
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
+        Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
+    }
+    
+    @Test
+    public void testDate4() throws Exception {
+        // Prepare the query
+        String dateCompared = "1973-01-13";
+        String attributeName = TestConstants.DATE_OF_BIRTH_ATTR.getName();
+        ComparisonType matchingType = ComparisonType.LESS_THAN;
+        
+        // Perform the query
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, dateCompared);
+        
+        List<Tuple> expectedResults = new ArrayList<>();
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(0));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(1));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(2));
+
+        // check the results
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
+        Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
+    }
+    
+    @Test
+    public void testDate5() throws Exception {
+        // Prepare the query
+        String dateCompared = "1973-01-13";
+        String attributeName = TestConstants.DATE_OF_BIRTH_ATTR.getName();
+        ComparisonType matchingType = ComparisonType.LESS_THAN_OR_EQUAL_TO;
+        
+        // Perform the query
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, dateCompared);
+        
+        List<Tuple> expectedResults = new ArrayList<>();
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(0));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(1));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(2));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(3));
+
+        // check the results
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
+        Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
+    }
+    
+    @Test
+    public void testDate6() throws Exception {
+        // Prepare the query
+        String dateCompared = "1973-01-13";
+        String attributeName = TestConstants.DATE_OF_BIRTH_ATTR.getName();
+        ComparisonType matchingType = ComparisonType.NOT_EQUAL_TO;
+        
+        // Perform the query
+        List<Tuple> returnedResults = getQueryResults(attributeName, matchingType, dateCompared);
+        
+        List<Tuple> expectedResults = new ArrayList<>();
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(0));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(1));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(2));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(4));
+        expectedResults.add(TestConstants.getSamplePeopleTuples().get(5));
+
+        // check the results
+        Assert.assertEquals(expectedResults.size(), returnedResults.size());
         Assert.assertTrue(TestUtils.equals(expectedResults, returnedResults));
     }
 

--- a/core/storage/src/main/java/edu/uci/ics/texera/storage/utils/StorageUtils.java
+++ b/core/storage/src/main/java/edu/uci/ics/texera/storage/utils/StorageUtils.java
@@ -8,7 +8,6 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.text.ParseException;
-import java.time.LocalDateTime;
 import java.util.Arrays;
 
 import org.apache.lucene.document.Field.Store;
@@ -17,6 +16,7 @@ import org.apache.lucene.index.IndexableField;
 
 import edu.uci.ics.texera.api.exception.StorageException;
 import edu.uci.ics.texera.api.field.DateField;
+import edu.uci.ics.texera.api.field.DateTimeField;
 import edu.uci.ics.texera.api.field.DoubleField;
 import edu.uci.ics.texera.api.field.IDField;
 import edu.uci.ics.texera.api.field.IField;
@@ -44,7 +44,10 @@ public class StorageUtils {
             field = new DoubleField(Double.parseDouble(fieldValue));
             break;
         case DATE:
-            field = new DateField(LocalDateTime.parse(fieldValue));
+            field = new DateField(fieldValue);
+            break;
+        case DATETIME:
+            field = new DateTimeField(fieldValue);
             break;
         case TEXT:
             field = new TextField(fieldValue);
@@ -70,12 +73,15 @@ public class StorageUtils {
             luceneField = new org.apache.lucene.document.IntField(attributeName, (Integer) fieldValue, Store.YES);
             break;
         case DOUBLE:
-            double value = (Double) fieldValue;
-            luceneField = new org.apache.lucene.document.DoubleField(attributeName, value, Store.YES);
+            luceneField = new org.apache.lucene.document.DoubleField(attributeName, (Double) fieldValue, Store.YES);
             break;
         case DATE:
-            String dateString = ((LocalDateTime) fieldValue).toString();
+            String dateString = fieldValue.toString();
             luceneField = new org.apache.lucene.document.StringField(attributeName, dateString, Store.YES);
+            break;
+        case DATETIME:
+            String dateTimeString = fieldValue.toString();
+            luceneField = new org.apache.lucene.document.StringField(attributeName, dateTimeString, Store.YES);
             break;
         case TEXT:
             // By default we enable positional indexing in Lucene so that we can

--- a/core/storage/src/main/java/edu/uci/ics/texera/storage/utils/StorageUtils.java
+++ b/core/storage/src/main/java/edu/uci/ics/texera/storage/utils/StorageUtils.java
@@ -8,11 +8,9 @@ import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.text.ParseException;
+import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.Date;
 
-import org.apache.lucene.document.DateTools;
-import org.apache.lucene.document.DateTools.Resolution;
 import org.apache.lucene.document.Field.Store;
 import org.apache.lucene.index.IndexOptions;
 import org.apache.lucene.index.IndexableField;
@@ -46,7 +44,7 @@ public class StorageUtils {
             field = new DoubleField(Double.parseDouble(fieldValue));
             break;
         case DATE:
-            field = new DateField(DateTools.stringToDate(fieldValue));
+            field = new DateField(LocalDateTime.parse(fieldValue));
             break;
         case TEXT:
             field = new TextField(fieldValue);
@@ -76,7 +74,7 @@ public class StorageUtils {
             luceneField = new org.apache.lucene.document.DoubleField(attributeName, value, Store.YES);
             break;
         case DATE:
-            String dateString = DateTools.dateToString((Date) fieldValue, Resolution.MILLISECOND);
+            String dateString = ((LocalDateTime) fieldValue).toString();
             luceneField = new org.apache.lucene.document.StringField(attributeName, dateString, Store.YES);
             break;
         case TEXT:


### PR DESCRIPTION
This PR modifies the current DateField because its implementation is hard to use and very prune to bugs. This PR:

- creates a new DateTimeField to represent date with time. The current DateField will be only used to represent date without time.
- changes the internal variable of the `DateField` from the old Java `Date` class to a new and better class `LocalDate` introduced in Java 8. The `DateTimeField` uses the new `LocalDateTime` class correspondingly.
- unifies the string representation of the date and date time to the standard ISO format. The date format is enforced to be `yyyy-MM-dd`, for example, `2018-01-01`. The date time format is enforced to be `yyyy-MM-dd'T'hh:mm:ss`, for example, `2018-01-01T09:01:01`. The `T` in the middle represents `Time`.
- modifies the `ComparableMatcher` to handle comparing `DateField` and `DateTimeField` correctly.
- adds test cases for `ComparableMatcher` of `DateField` and `DateTimeField`.
- changes the TwitterConverter to treat the `create_at` attribute as a `DateTimeField` rather than a `String`.
- changes the way Lucene stores the `DateField` and `DateTimeField`
