### PR TITLE
[#603][3.1] Make Jointjs Paper responsive and disallow links from in port of operators 

### DIFF
--- a/core/new-gui/src/app/common/rxjs-operators.ts
+++ b/core/new-gui/src/app/common/rxjs-operators.ts
@@ -17,10 +17,12 @@ import 'rxjs/add/operator/switchMap';
 import 'rxjs/add/operator/mergeMap';
 import 'rxjs/add/operator/filter';
 import 'rxjs/add/operator/debounceTime';
+import 'rxjs/add/operator/auditTime';
 import 'rxjs/add/operator/distinctUntilChanged';
 import 'rxjs/add/operator/startWith';
 import 'rxjs/add/operator/shareReplay';
 import 'rxjs/add/operator/first';
 import 'rxjs/add/operator/last';
 import 'rxjs/add/operator/delay';
+import 'rxjs/add/observable/fromEvent';
 

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -1,6 +1,7 @@
 import { Component, AfterViewInit, HostListener } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import '../../../common/rxjs-operators';
+import 'rxjs/add/observable/fromEvent';
 
 import * as joint from 'jointjs';
 import { JointUIService } from '../../service/joint-ui/joint-ui.service';
@@ -43,10 +44,13 @@ export class WorkflowEditorComponent implements AfterViewInit {
 
     this.createJointjsPaper();
 
+    Observable.fromEvent(window, 'resize').subscribe(
+      resizeEvent => {this.paper.setDimensions(this.getWrapperElementSize().width, this.getWrapperElementSize().height); }
+    );
+
     // add a 500ms delay for joint-ui.service to fetch the operator metaData
     // this code is temporary and will be deleted in future PRs when drag
     // and drop is implemented
-
     Observable.of([]).delay(500).subscribe(
       emptyData => {
         // add some dummy operators and links to show that JointJS works
@@ -123,11 +127,6 @@ export class WorkflowEditorComponent implements AfterViewInit {
       width: $('#' + this.WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID).width(),
       height: $('#' + this.WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID).height()
     };
-  }
-
-  @HostListener('window:resize', ['$event'])
-  onResize(event) {
-    this.paper.setDimensions(this.getWrapperElementSize().width, this.getWrapperElementSize().height);
   }
 }
 

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -1,4 +1,4 @@
-import { Component, AfterViewInit } from '@angular/core';
+import { Component, AfterViewInit, HostListener } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import '../../../common/rxjs-operators';
 
@@ -100,6 +100,8 @@ export class WorkflowEditorComponent implements AfterViewInit {
       linkPinning: false,
       // provide a validation to determine if two ports could be connected (only output connect to input is allowed)
       validateConnection: validateOperatorConnection,
+      // provide a validation to determine if the port where link starts from is an out port
+      validateMagnet: validateOperatorMagnet,
       // disable jointjs default action of adding vertexes to the link
       interactive: { vertexAdd: false },
       // set a default link element used by jointjs when user creates a link on UI
@@ -123,6 +125,10 @@ export class WorkflowEditorComponent implements AfterViewInit {
     };
   }
 
+  @HostListener('window:resize', ['$event'])
+  onResize(event) {
+    this.paper.setDimensions(this.getWrapperElementSize().width, this.getWrapperElementSize().height);
+  }
 }
 
 /**
@@ -145,6 +151,19 @@ function validateOperatorConnection(sourceView: joint.dia.CellView, sourceMagnet
   if (targetMagnet && targetMagnet.getAttribute('port-group') === 'out') { return false; }
 
   return sourceView.id !== targetView.id;
+}
+
+/**
+* This function is provided to JointJS to disallow links starting from an in port.
+*
+* https://resources.jointjs.com/docs/jointjs/v2.0/joint.html#dia.Paper.prototype.options.validateMagnet
+*
+* @param cellView
+* @param magnet
+*/
+function validateOperatorMagnet(cellView: joint.dia.CellView, magnet: SVGElement): boolean {
+  if (magnet && magnet.getAttribute('port-group') === 'in') {return false; }
+  if (magnet && magnet.getAttribute('port-group') === 'out') {return true; }
 }
 
 

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -1,4 +1,4 @@
-import { Component, AfterViewInit, HostListener } from '@angular/core';
+import { Component, AfterViewInit} from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import '../../../common/rxjs-operators';
 import 'rxjs/add/observable/fromEvent';

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -1,7 +1,6 @@
-import { Component, AfterViewInit} from '@angular/core';
+import { Component, AfterViewInit } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import '../../../common/rxjs-operators';
-import 'rxjs/add/observable/fromEvent';
 
 import * as joint from 'jointjs';
 import { JointUIService } from '../../service/joint-ui/joint-ui.service';
@@ -44,7 +43,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
 
     this.createJointjsPaper();
 
-    Observable.fromEvent(window, 'resize').subscribe(
+    Observable.fromEvent(window, 'resize').auditTime(1000).subscribe(
       resizeEvent => {this.paper.setDimensions(this.getWrapperElementSize().width, this.getWrapperElementSize().height); }
     );
 


### PR DESCRIPTION
This PR implements two UI functionalities:-

1. It makes the jointjs paper responsive i.e. when we resize the screen, the paper also gets resized.
2. It restricts users to make any links starting from the in ports of the operators.

New Frontend PR status:
[1]: PR #604 creates the app using Angular CLI, which sets up the project with basic templates. The basic components are created.
[2]: PR #605 adds the left side operator panel, which shows the operators and the groups. It adds OperatorMetadataService, which fetches metadata from the backend.
[3]: PR #606 integrates JointJS to the app. JointJS is used to display the operators and the links. This PR integrates JointJS in the View level.
[4]: PR #609  makes some changes to make jointjs paper responsive and restricts creation of links from in ports of operators. It can be viewed as a small extension of PR #606 .