### PR TITLE
[#603][6.1] Improve Operator Metadata Type Definition and Constants 

### DIFF
--- a/core/new-gui/package-lock.json
+++ b/core/new-gui/package-lock.json
@@ -343,6 +343,12 @@
       "integrity": "sha512-N3h+rzN518yl2xKrW0o6KKdNmWZ+OwG6SoM5TBEQFF0tTv5wXPEsoOuYQ2Kt3/89XbcSZUJLdjiT/2c3BR/ApQ==",
       "dev": true
     },
+    "@types/json-schema": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-6.0.1.tgz",
+      "integrity": "sha512-vuL/tG01yKO//gmCmnV3OZhx2hs538t+7FpQq//sUV1sF6xiKi5V8F60dvAxe/HkC4+QaMCHqrm/akqlppTAkQ==",
+      "dev": true
+    },
     "@types/lodash": {
       "version": "4.14.106",
       "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.106.tgz",

--- a/core/new-gui/package.json
+++ b/core/new-gui/package.json
@@ -46,6 +46,7 @@
     "@types/jasmine": "~2.8.3",
     "@types/jasminewd2": "~2.0.2",
     "@types/jquery": "^3.3.1",
+    "@types/json-schema": "^6.0.1",
     "@types/lodash": "^4.14.106",
     "@types/node": "~6.0.60",
     "@types/uuid": "^3.4.3",

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.spec.ts
@@ -10,13 +10,13 @@ import { StubOperatorMetadataService } from '../../../service/operator-metadata/
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { CustomNgMaterialModule } from '../../../../common/custom-ng-material.module';
-import { getMockOperatorSchemaList } from '../../../service/operator-metadata/mock-operator-metadata.data';
+import { mockOperatorSchemaList } from '../../../service/operator-metadata/mock-operator-metadata.data';
 import { By } from '@angular/platform-browser';
 import { WorkflowActionService } from '../../../service/workflow-graph/model/workflow-action.service';
 import { marbles } from 'rxjs-marbles';
 
 describe('OperatorLabelComponent', () => {
-  const mockOperatorData = getMockOperatorSchemaList()[0];
+  const mockOperatorData = mockOperatorSchemaList[0];
   let component: OperatorLabelComponent;
   let fixture: ComponentFixture<OperatorLabelComponent>;
 

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.spec.ts
@@ -13,7 +13,7 @@ import { StubOperatorMetadataService } from '../../service/operator-metadata/stu
 import { GroupInfo, OperatorSchema } from '../../types/operator-schema.interface';
 
 import {
-  getMockOperatorMetaData, getMockOperatorGroup, getMockOperatorSchemaList
+  mockOperatorMetaData, mockOperatorGroup, mockOperatorSchemaList
 } from '../../service/operator-metadata/mock-operator-metadata.data';
 
 import * as c from './operator-panel.component';
@@ -52,7 +52,7 @@ describe('OperatorPanelComponent', () => {
   });
 
   it('should sort group names correctly based on order', () => {
-    const groups = getMockOperatorGroup();
+    const groups = mockOperatorGroup;
 
     const result = c.getGroupNamesSorted(groups);
 
@@ -80,7 +80,7 @@ describe('OperatorPanelComponent', () => {
   });
 
   it('should generate a map from operator groups to a list operators correctly', () => {
-    const opMetadata = getMockOperatorMetaData();
+    const opMetadata = mockOperatorMetaData;
 
     const result = c.getOperatorGroupMap(opMetadata);
 
@@ -105,8 +105,8 @@ describe('OperatorPanelComponent', () => {
   it('should receive operator metadata from service', () => {
     // if the length of our schema list is equal to the length of mock data
     // we assume the mock data has been received
-    expect(component.operatorSchemaList.length).toEqual(getMockOperatorSchemaList().length);
-    expect(component.groupNamesOrdered.length).toEqual(getMockOperatorGroup().length);
+    expect(component.operatorSchemaList.length).toEqual(mockOperatorSchemaList.length);
+    expect(component.groupNamesOrdered.length).toEqual(mockOperatorGroup.length);
   });
 
   it('should have all group names shown in the UI side panel', () => {
@@ -116,7 +116,7 @@ describe('OperatorPanelComponent', () => {
       .map(el => el.innerText.trim());
 
     expect(groupNamesInUI).toEqual(
-      getMockOperatorGroup().map(group => group.groupName));
+      mockOperatorGroup.map(group => group.groupName));
   });
 
   it('should create child operator label component for all operators', () => {
@@ -125,7 +125,7 @@ describe('OperatorPanelComponent', () => {
       .map(debugEl => <OperatorLabelComponent>debugEl.componentInstance)
       .map(operatorLabel => operatorLabel.operator);
 
-    expect(operatorLabels.length).toEqual(getMockOperatorMetaData().operators.length);
+    expect(operatorLabels.length).toEqual(mockOperatorMetaData.operators.length);
   });
 
 });

--- a/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.spec.ts
@@ -6,7 +6,7 @@ import { WorkflowActionService } from '../workflow-graph/model/workflow-action.s
 import { WorkflowUtilService } from '../workflow-graph/util/workflow-util.service';
 import { OperatorMetadataService } from '../operator-metadata/operator-metadata.service';
 import { StubOperatorMetadataService } from '../operator-metadata/stub-operator-metadata.service';
-import { getMockOperatorMetaData } from '../operator-metadata/mock-operator-metadata.data';
+import { mockOperatorMetaData } from '../operator-metadata/mock-operator-metadata.data';
 
 import { marbles, Context } from 'rxjs-marbles';
 
@@ -38,7 +38,7 @@ describe('DragDropService', () => {
     const dragElementID = 'testing-draggable-1';
     jQuery('body').append(`<div id="${dragElementID}"></div>`);
 
-    const operatorType = getMockOperatorMetaData().operators[0].operatorType;
+    const operatorType = mockOperatorMetaData.operators[0].operatorType;
     dragDropService.registerOperatorLabelDrag(dragElementID, operatorType);
 
     expect(jQuery('#' + dragElementID).is('.ui-draggable')).toBeTruthy();
@@ -51,7 +51,7 @@ describe('DragDropService', () => {
     const dropElement = 'testing-droppable-1';
     jQuery('body').append(`<div id="${dropElement}"></div>`);
 
-    const operatorType = getMockOperatorMetaData().operators[0].operatorType;
+    const operatorType = mockOperatorMetaData.operators[0].operatorType;
     dragDropService.registerWorkflowEditorDrop(dropElement);
 
     expect(jQuery('#' + dropElement).is('.ui-droppable')).toBeTruthy();
@@ -60,7 +60,7 @@ describe('DragDropService', () => {
 
   it('should add an operator when the element is dropped', marbles((m) => {
 
-    const operatorType = getMockOperatorMetaData().operators[0].operatorType;
+    const operatorType = mockOperatorMetaData.operators[0].operatorType;
 
     const marbleString = '-a-|';
     const marbleValues = {

--- a/core/new-gui/src/app/workspace/service/operator-metadata/mock-operator-metadata.data.ts
+++ b/core/new-gui/src/app/workspace/service/operator-metadata/mock-operator-metadata.data.ts
@@ -1,101 +1,122 @@
+import { JSONSchema4 } from 'json-schema';
+import { JSONSchema6 } from 'json-schema';
 // import functions from lodash: import individual functions from lodash-es
 //  to avoid include the entire lodash library
 import cloneDeep from 'lodash-es/cloneDeep';
 import { OperatorSchema, OperatorMetadata, GroupInfo } from '../../types/operator-schema.interface';
+import { JSONSchema6TypeName, JSONSchema6Type } from 'json-schema';
 
 /**
  * Exports constants related to operator schema and operator metadata for testing purposes.
  *
  */
-
-export const getMockOperatorSchemaList: () => OperatorSchema[] =
-  () => cloneDeep([
+export const mockOperatorSchemaList: ReadonlyArray<OperatorSchema> =
+[
     {
-      'operatorType': 'ScanSource',
-      'additionalMetadata': {
-        'advancedOptions': [],
-        'operatorDescription': 'Read records from a table one by one',
-        'operatorGroupName': 'Source',
-        'numInputPorts': 0,
-        'numOutputPorts': 1,
-        'userFriendlyName': 'Source: Scan'
+      operatorType: 'ScanSource',
+      additionalMetadata: {
+        advancedOptions: [],
+        operatorDescription: 'Read records from a table one by one',
+        operatorGroupName: 'Source',
+        numInputPorts: 0,
+        numOutputPorts: 1,
+        userFriendlyName: 'Source: Scan'
       },
-      'jsonSchema': {
-        'id': 'urn:jsonschema:edu:uci:ics:texera:dataflow:source:scan:ScanSourcePredicate',
-        'properties': {
-          'tableName': {
-            'type': 'string'
+      jsonSchema: {
+        id: 'urn:jsonschema:edu:uci:ics:texera:dataflow:source:scan:ScanSourcePredicate',
+        properties: {
+          tableName: {
+            type: 'string'
           }
         },
-        'required': [
+        required: [
           'tableName'
         ],
-        'type': 'object'
+        type: 'object'
       }
     },
     {
-      'operatorType': 'NlpSentiment',
-      'additionalMetadata': {
-        'advancedOptions': [],
-        'operatorDescription': 'Sentiment analysis based on Stanford NLP package',
-        'operatorGroupName': 'Analysis',
-        'numInputPorts': 1,
-        'numOutputPorts': 1,
-        'userFriendlyName': 'Sentiment Analysis'
+      operatorType: 'NlpSentiment',
+      additionalMetadata: {
+        advancedOptions: [],
+        operatorDescription: 'Sentiment analysis based on Stanford NLP package',
+        operatorGroupName: 'Analysis',
+        numInputPorts: 1,
+        numOutputPorts: 1,
+        userFriendlyName: 'Sentiment Analysis'
       },
-      'jsonSchema': {
-        'id': 'urn:jsonschema:edu:uci:ics:texera:dataflow:nlp:sentiment:NlpSentimentPredicate',
-        'properties': {
-          'attribute': {
-            'type': 'string'
+      jsonSchema: {
+        id: 'urn:jsonschema:edu:uci:ics:texera:dataflow:nlp:sentiment:NlpSentimentPredicate',
+        properties: {
+          attribute: {
+            type: 'string'
           },
-          'resultAttribute': {
-            'type': 'string'
+          resultAttribute: {
+            type: 'string'
           }
         },
-        'required': [
+        required: [
           'attribute',
           'resultAttribute'
         ],
-        'type': 'object'
+        type: 'object'
       }
     },
     {
-      'operatorType': 'ViewResults',
-      'additionalMetadata': {
-        'advancedOptions': [],
-        'operatorDescription': 'View the results of the workflow',
-        'operatorGroupName': 'View Results',
-        'numInputPorts': 1,
-        'numOutputPorts': 0,
-        'userFriendlyName': 'View Results'
+      operatorType: 'ViewResults',
+      additionalMetadata: {
+        advancedOptions: [],
+        operatorDescription: 'View the results of the workflow',
+        operatorGroupName: 'View Results',
+        numInputPorts: 1,
+        numOutputPorts: 0,
+        userFriendlyName: 'View Results'
       },
-      'jsonSchema': {
-        'id': 'urn:jsonschema:edu:uci:ics:texera:dataflow:sink:tuple:TupleSinkPredicate',
-        'properties': {
-          'limit': {
-            'default': 10,
-            'type': 'integer'
+      jsonSchema: {
+        id: 'urn:jsonschema:edu:uci:ics:texera:dataflow:sink:tuple:TupleSinkPredicate',
+        properties: {
+          limit: {
+            default: 10,
+            type: 'integer'
           },
           'offset': {
-            'default': 0,
-            'type': 'integer'
+            default: 0,
+            type: 'integer'
           }
         },
-        'type': 'object'
+        type: 'object'
       }
     }
-  ]);
+  ];
 
-export const getMockOperatorGroup: () => GroupInfo[] =
-  () => cloneDeep([
+export const mockOperatorGroup: ReadonlyArray<GroupInfo> =
+ [
     { groupName: 'Source', groupOrder: 1 },
     { groupName: 'Analysis', groupOrder: 2 },
     { groupName: 'View Results', groupOrder: 3 },
-  ]);
+  ];
 
-export const getMockOperatorMetaData: () => OperatorMetadata =
-  () => cloneDeep({
-    operators: getMockOperatorSchemaList(),
-    groups: getMockOperatorGroup()
-  });
+export const mockOperatorMetaData: OperatorMetadata =
+{
+    operators: mockOperatorSchemaList,
+    groups: mockOperatorGroup
+  };
+
+
+export const testJsonSchema: JSONSchema4 = {
+  id: 'urn:jsonschema:edu:uci:ics:texera:dataflow:nlp:sentiment:NlpSentimentPredicate',
+  properties: {
+    attribute: {
+      type: 'string'
+    },
+    resultAttribute: {
+      type: 'string'
+    }
+  },
+  required: [
+    'attribute',
+    'resultAttribute'
+  ],
+  type: 'object'
+}
+

--- a/core/new-gui/src/app/workspace/service/operator-metadata/operator-metadata.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/operator-metadata/operator-metadata.service.spec.ts
@@ -6,7 +6,7 @@ import { OperatorMetadataService, EMPTY_OPERATOR_METADATA } from './operator-met
 import { Observable } from 'rxjs/Observable';
 
 import '../../../common/rxjs-operators';
-import { getMockOperatorMetaData } from './mock-operator-metadata.data';
+import { mockOperatorMetaData } from './mock-operator-metadata.data';
 
 
 class StubHttpClient {
@@ -14,7 +14,7 @@ class StubHttpClient {
 
   // fake an async http response with a very small delay
   public get(url: string): Observable<any> {
-    return Observable.of(getMockOperatorMetaData()).delay(1);
+    return Observable.of(mockOperatorMetaData).delay(1);
   }
 }
 

--- a/core/new-gui/src/app/workspace/service/operator-metadata/stub-operator-metadata.service.ts
+++ b/core/new-gui/src/app/workspace/service/operator-metadata/stub-operator-metadata.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 
-import { getMockOperatorMetaData } from './mock-operator-metadata.data';
+import { mockOperatorMetaData } from './mock-operator-metadata.data';
 import { OperatorMetadata } from '../../types/operator-schema.interface';
 
 import '../../../common/rxjs-operators';
@@ -12,7 +12,7 @@ import { EMPTY_OPERATOR_METADATA } from './operator-metadata.service';
 export class StubOperatorMetadataService {
 
   private operatorMetadataObservable = Observable
-    .of(getMockOperatorMetaData())
+    .of(mockOperatorMetaData)
     .shareReplay(1);
 
   constructor() { }
@@ -22,7 +22,7 @@ export class StubOperatorMetadataService {
   }
 
   public operatorTypeExists(operatorType: string): boolean {
-    const operator = getMockOperatorMetaData().operators.filter(op => op.operatorType === operatorType);
+    const operator = mockOperatorMetaData.operators.filter(op => op.operatorType === operatorType);
     if (operator.length === 0) {
       return false;
     }

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/mock-workflow-data.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/mock-workflow-data.ts
@@ -1,5 +1,5 @@
 import { Point, OperatorPredicate, OperatorLink } from './../../../types/workflow-common.interface';
-import { getMockOperatorSchemaList } from './../../operator-metadata/mock-operator-metadata.data';
+import { mockOperatorSchemaList } from './../../operator-metadata/mock-operator-metadata.data';
 
 /**
  * Provides mock data related operators and links:

--- a/core/new-gui/src/app/workspace/service/workflow-graph/util/workflow-util.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/util/workflow-util.service.spec.ts
@@ -3,7 +3,7 @@ import { OperatorMetadataService } from './../../operator-metadata/operator-meta
 import { TestBed, inject } from '@angular/core/testing';
 
 import { WorkflowUtilService } from './workflow-util.service';
-import { getMockOperatorSchemaList } from '../../operator-metadata/mock-operator-metadata.data';
+import { mockOperatorSchemaList } from '../../operator-metadata/mock-operator-metadata.data';
 
 describe('WorkflowUtilService', () => {
 
@@ -24,7 +24,7 @@ describe('WorkflowUtilService', () => {
   }));
 
   it('should be able to generate an operator predicate properly given a valid operator type', () => {
-    const operatorSchema = getMockOperatorSchemaList()[0];
+    const operatorSchema = mockOperatorSchemaList[0];
     const operatorPredicate = workflowUtilService.getNewOperatorPredicate(
       operatorSchema.operatorType
     );
@@ -61,7 +61,7 @@ describe('WorkflowUtilService', () => {
   });
 
   it('should be able to assign different operator IDs to newly generated operators', () => {
-    const operatorSchema = getMockOperatorSchemaList()[0];
+    const operatorSchema = mockOperatorSchemaList[0];
     const idSet = new Set<string>();
     const repeat = 100;
 

--- a/core/new-gui/src/app/workspace/types/operator-schema.interface.ts
+++ b/core/new-gui/src/app/workspace/types/operator-schema.interface.ts
@@ -1,3 +1,5 @@
+import { JSONSchema4, JSONSchema6 } from "json-schema";
+
 /**
  * This file contains multiple type declarations related to operator schema.
  * These type declarations should be the same with the backend API.
@@ -18,7 +20,7 @@ export interface OperatorAdditionalMetadata extends Readonly<{
 
 export interface OperatorSchema extends Readonly<{
   operatorType: string;
-  jsonSchema: Readonly<object>;
+  jsonSchema: Readonly<JSONSchema4>;
   additionalMetadata: OperatorAdditionalMetadata;
 }> { }
 


### PR DESCRIPTION
This PR:
1. improves the Operator Metadata Type Definition. Previously the type of `jsonSchema` is `object`, now we introduced the `@types/json-schema` dependency and its type is changed to `JsonSchema4`, which represents Json Schema Draft 4.
2. changes the operator metadata constants. Originally the constants are declared as `{'key':'value'}`, however, declaring the key as a string is not best practice and it should just be declared as a normal object in `{key: 'value'}` format.
3. change the constant function back to constant variable. Previously in PR #613, all the constants are changed to be a function that returns a deep copy of the constant to avoid callers modifying the object reference. However, with changes introduced in #617, all the interfaces are declared as `Readonly`, which makes the object immutable. Therefore the change is not necessary. This PR reverts those changes.