### PR TITLE
[#603][6.2] Add ability to highlight / unhighlight an operator

### DIFF
--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
@@ -1,3 +1,4 @@
+import { JointGraphWrapper } from './../../service/workflow-graph/model/joint-graph-wrapper';
 import { DragDropService } from './../../service/drag-drop/drag-drop.service';
 import { WorkflowUtilService } from './../../service/workflow-graph/util/workflow-util.service';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
@@ -15,10 +16,15 @@ import { WorkflowActionService } from '../../service/workflow-graph/model/workfl
 class StubWorkflowActionService {
 
   private jointGraph = new joint.dia.Graph();
+  private jointGraphWrapper = new JointGraphWrapper(this.jointGraph);
 
   public attachJointPaper(paperOptions: joint.dia.Paper.Options): joint.dia.Paper.Options {
     paperOptions.model = this.jointGraph;
     return paperOptions;
+  }
+
+  public getJointGraphWrapper(): JointGraphWrapper {
+    return this.jointGraphWrapper;
   }
 }
 

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
@@ -1,3 +1,4 @@
+import { WorkflowActionService } from './../../service/workflow-graph/model/workflow-action.service';
 import { JointGraphWrapper } from './../../service/workflow-graph/model/joint-graph-wrapper';
 import { DragDropService } from './../../service/drag-drop/drag-drop.service';
 import { WorkflowUtilService } from './../../service/workflow-graph/util/workflow-util.service';
@@ -10,7 +11,7 @@ import { StubOperatorMetadataService } from '../../service/operator-metadata/stu
 import { JointUIService } from '../../service/joint-ui/joint-ui.service';
 
 import * as joint from 'jointjs';
-import { WorkflowActionService } from '../../service/workflow-graph/model/workflow-action.service';
+import { mockScanPredicate, mockPoint } from '../../service/workflow-graph/model/mock-workflow-data';
 
 
 class StubWorkflowActionService {
@@ -29,92 +30,200 @@ class StubWorkflowActionService {
 }
 
 describe('WorkflowEditorComponent', () => {
-  let component: WorkflowEditorComponent;
-  let fixture: ComponentFixture<WorkflowEditorComponent>;
-  let jointUIService: JointUIService;
-  let jointGraph: joint.dia.Graph;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [WorkflowEditorComponent],
-      providers: [
-        JointUIService,
-        WorkflowUtilService,
-        DragDropService,
-        { provide: WorkflowActionService, useClass: StubWorkflowActionService },
-        { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
-      ]
+  /**
+   * This sub test suite test if the JointJS paper is integrated with our Angular component well.
+   * It uses a fake stub Workflow model that only provides the binding of JointJS graph.
+   * It tests if manipulating the JointJS graph is correctly shown in the UI.
+   */
+  describe('WorkflowEditorComponent JointJS Paper', () => {
+    let component: WorkflowEditorComponent;
+    let fixture: ComponentFixture<WorkflowEditorComponent>;
+    let jointUIService: JointUIService;
+    let jointGraph: joint.dia.Graph;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        declarations: [WorkflowEditorComponent],
+        providers: [
+          JointUIService,
+          WorkflowUtilService,
+          DragDropService,
+          { provide: WorkflowActionService, useClass: StubWorkflowActionService },
+          { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
+        ]
+      })
+        .compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(WorkflowEditorComponent);
+      component = fixture.componentInstance;
+      jointUIService = fixture.debugElement.injector.get(JointUIService);
+      // detect changes first to run ngAfterViewInit and bind Model
+      fixture.detectChanges();
+      jointGraph = component.getJointPaper().model;
+    });
+
+    it('should create', () => {
+      expect(component).toBeTruthy();
+    });
+
+    it('should create element in the UI after adding operator in the model', () => {
+      const operatorID = 'test_one_operator_1';
+
+      const element = new joint.shapes.basic.Rect();
+      element.set('id', operatorID);
+
+      jointGraph.addCell(element);
+
+      expect(component.getJointPaper().findViewByModel(element.id)).toBeTruthy();
+
+    });
+
+    it('should create a graph of multiple cells in the UI', () => {
+      const operator1 = 'test_multiple_1_op_1';
+      const operator2 = 'test_multiple_1_op_2';
+
+      const element1 = new joint.shapes.basic.Rect({
+        size: { width: 100, height: 50 },
+        position: { x: 100, y: 400 }
+      });
+      element1.set('id', operator1);
+
+      const element2 = new joint.shapes.basic.Rect({
+        size: { width: 100, height: 50 },
+        position: { x: 100, y: 400 }
+      });
+      element2.set('id', operator2);
+
+      const link1 = new joint.dia.Link({
+        source: { id: operator1 },
+        target: { id: operator2 }
+      });
+
+      jointGraph.addCell(element1);
+      jointGraph.addCell(element2);
+      jointGraph.addCell(link1);
+
+      // check the model is added correctly
+      expect(jointGraph.getElements().find(el => el.id === operator1)).toBeTruthy();
+      expect(jointGraph.getElements().find(el => el.id === operator2)).toBeTruthy();
+      expect(jointGraph.getLinks().find(link => link.id === link1.id)).toBeTruthy();
+
+
+      // check the view is updated correctly
+      expect(component.getJointPaper().findViewByModel(element1.id)).toBeTruthy();
+      expect(component.getJointPaper().findViewByModel(element2.id)).toBeTruthy();
+      expect(component.getJointPaper().findViewByModel(link1.id)).toBeTruthy();
+
+    });
+
+
+  });
+
+
+  /**
+   * This sub test suites test the Integration of WorkflowEditorComponent with external modules,
+   *  such as drag and drop module, and highlight operator module.
+   */
+  describe('WorkflowEditorComponent External Module Integration', () => {
+
+    let component: WorkflowEditorComponent;
+    let fixture: ComponentFixture<WorkflowEditorComponent>;
+    let workflowActionService: WorkflowActionService;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        declarations: [WorkflowEditorComponent],
+        providers: [
+          JointUIService,
+          WorkflowUtilService,
+          DragDropService,
+          WorkflowActionService,
+          { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
+        ]
+      })
+        .compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(WorkflowEditorComponent);
+      component = fixture.componentInstance;
+      workflowActionService = TestBed.get(WorkflowActionService);
+      // detect changes to run ngAfterViewInit and bind Model
+      fixture.detectChanges();
+    });
+
+    it('should register itself as a droppable element', () => {
+      const jqueryElement = jQuery(`#${component.WORKFLOW_EDITOR_JOINTJS_ID}`);
+      expect(jqueryElement.data('uiDroppable')).toBeTruthy();
+    });
+
+    it('should try to highlight the operator when user mouse clicks on an operator', () => {
+      const JointGraphWrapper = workflowActionService.getJointGraphWrapper();
+      // install a spy on the highlight operator function and pass the call through
+      const highlightOperatorFunctionSpy = spyOn(JointGraphWrapper, 'highlightOperator').and.callThrough();
+
+      workflowActionService.addOperator(mockScanPredicate, mockPoint);
+
+      // find the joint Cell View object of the operator element
+      const jointCellView = component.getJointPaper().findViewByModel(mockScanPredicate.operatorID);
+
+      // tirgger a click on the cell view using its jQuery element
+      jointCellView.$el.trigger('click');
+
+      fixture.detectChanges();
+
+      // assert the function is called once
+      expect(highlightOperatorFunctionSpy.calls.count()).toEqual(1);
+      // assert the highlighted operator is correct
+      expect(JointGraphWrapper.getCurrentHighlightedOpeartorID()).toEqual(mockScanPredicate.operatorID);
+
+    });
+
+    it('should react to operator highlight event and change the appearance of the operator to be highlighted', () => {
+      const JointGraphWrapper = workflowActionService.getJointGraphWrapper();
+      workflowActionService.addOperator(mockScanPredicate, mockPoint);
+
+      // highlight the operator
+      JointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
+
+      // find the joint Cell View object of the operator element
+      const jointCellView = component.getJointPaper().findViewByModel(mockScanPredicate.operatorID);
+
+      // find the cell's child element with the joint highlighter class name `joint-highlight-stroke`
+      const jointHighlighterElements = jointCellView.$el.children('.joint-highlight-stroke');
+
+      // the element should have the highlighter element in it
+      expect(jointHighlighterElements.length).toEqual(1);
     })
-      .compileComponents();
-  }));
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(WorkflowEditorComponent);
-    component = fixture.componentInstance;
-    jointUIService = fixture.debugElement.injector.get(JointUIService);
-    // detect changes first to run ngAfterViewInit and bind Model
-    fixture.detectChanges();
-    jointGraph = component.getJointPaper().model;
-  });
+    it('should react to operator unhighlight event and change the appearance of the operator to be unhighlighted', () => {
+      const JointGraphWrapper = workflowActionService.getJointGraphWrapper();
+      workflowActionService.addOperator(mockScanPredicate, mockPoint);
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
-  });
+      // highlight the oprator first
+      JointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
 
-  it('should create element in the UI after adding operator in the model', () => {
-    const operatorID = 'test_one_operator_1';
+      // find the joint Cell View object of the operator element
+      const jointCellView = component.getJointPaper().findViewByModel(mockScanPredicate.operatorID);
 
-    const element = new joint.shapes.basic.Rect();
-    element.set('id', operatorID);
+      // find the cell's child element with the joint highlighter class name `joint-highlight-stroke`
+      const jointHighlighterElements = jointCellView.$el.children('.joint-highlight-stroke');
 
-    jointGraph.addCell(element);
+      // the element should have the highlighter element in it right now
+      expect(jointHighlighterElements.length).toEqual(1)
 
-    expect(component.getJointPaper().findViewByModel(element.id)).toBeTruthy();
+      // then unhighlight the operator
+      JointGraphWrapper.unhighlightCurrent();
 
-  });
+      // the highlighter element should not exist
+      const jointHighlighterElementAfterUnhighlight = jointCellView.$el.children('.joint-highlight-stroke');
+      expect(jointHighlighterElementAfterUnhighlight.length).toEqual(0);
 
-  it('should create a graph of multiple cells in the UI', () => {
-    const operator1 = 'test_multiple_1_op_1';
-    const operator2 = 'test_multiple_1_op_2';
+    })
 
-    const element1 = new joint.shapes.basic.Rect({
-      size: { width: 100, height: 50 },
-      position: { x: 100, y: 400 }
-    });
-    element1.set('id', operator1);
-
-    const element2 = new joint.shapes.basic.Rect({
-      size: { width: 100, height: 50 },
-      position: { x: 100, y: 400 }
-    });
-    element2.set('id', operator2);
-
-    const link1 = new joint.dia.Link({
-      source: { id: operator1 },
-      target: { id: operator2 }
-    });
-
-    jointGraph.addCell(element1);
-    jointGraph.addCell(element2);
-    jointGraph.addCell(link1);
-
-    // check the model is added correctly
-    expect(jointGraph.getElements().find(el => el.id === operator1)).toBeTruthy();
-    expect(jointGraph.getElements().find(el => el.id === operator2)).toBeTruthy();
-    expect(jointGraph.getLinks().find(link => link.id === link1.id)).toBeTruthy();
-
-
-    // check the view is updated correctly
-    expect(component.getJointPaper().findViewByModel(element1.id)).toBeTruthy();
-    expect(component.getJointPaper().findViewByModel(element2.id)).toBeTruthy();
-    expect(component.getJointPaper().findViewByModel(link1.id)).toBeTruthy();
-
-  });
-
-  it('should register itself as a droppable element', () => {
-    const jqueryElement = jQuery(`#${component.WORKFLOW_EDITOR_JOINTJS_ID}`);
-    expect(jqueryElement.data('uiDroppable')).toBeTruthy();
-  });
-
+  })
 
 });

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
@@ -36,7 +36,7 @@ describe('WorkflowEditorComponent', () => {
    * It uses a fake stub Workflow model that only provides the binding of JointJS graph.
    * It tests if manipulating the JointJS graph is correctly shown in the UI.
    */
-  describe('WorkflowEditorComponent JointJS Paper', () => {
+  describe('JointJS Paper', () => {
     let component: WorkflowEditorComponent;
     let fixture: ComponentFixture<WorkflowEditorComponent>;
     let jointUIService: JointUIService;
@@ -78,7 +78,6 @@ describe('WorkflowEditorComponent', () => {
       jointGraph.addCell(element);
 
       expect(component.getJointPaper().findViewByModel(element.id)).toBeTruthy();
-
     });
 
     it('should create a graph of multiple cells in the UI', () => {
@@ -116,9 +115,7 @@ describe('WorkflowEditorComponent', () => {
       expect(component.getJointPaper().findViewByModel(element1.id)).toBeTruthy();
       expect(component.getJointPaper().findViewByModel(element2.id)).toBeTruthy();
       expect(component.getJointPaper().findViewByModel(link1.id)).toBeTruthy();
-
     });
-
 
   });
 
@@ -127,7 +124,7 @@ describe('WorkflowEditorComponent', () => {
    * This sub test suites test the Integration of WorkflowEditorComponent with external modules,
    *  such as drag and drop module, and highlight operator module.
    */
-  describe('WorkflowEditorComponent External Module Integration', () => {
+  describe('External Module Integration', () => {
 
     let component: WorkflowEditorComponent;
     let fixture: ComponentFixture<WorkflowEditorComponent>;
@@ -179,7 +176,6 @@ describe('WorkflowEditorComponent', () => {
       expect(highlightOperatorFunctionSpy.calls.count()).toEqual(1);
       // assert the highlighted operator is correct
       expect(JointGraphWrapper.getCurrentHighlightedOpeartorID()).toEqual(mockScanPredicate.operatorID);
-
     });
 
     it('should react to operator highlight event and change the appearance of the operator to be highlighted', () => {
@@ -221,9 +217,8 @@ describe('WorkflowEditorComponent', () => {
       // the highlighter element should not exist
       const jointHighlighterElementAfterUnhighlight = jointCellView.$el.children('.joint-highlight-stroke');
       expect(jointHighlighterElementAfterUnhighlight.length).toEqual(0);
+    });
 
-    })
-
-  })
+  });
 
 });

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -102,7 +102,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
    */
   private handleHighlightMouseInput(): void {
     // on user mouse clicks a operator cell, highlight that operator
-    Observable.fromEvent(this.getJointPaper(), 'cell:lcick')
+    Observable.fromEvent(this.getJointPaper(), 'cell:pointerclick')
       .map(value => <joint.dia.CellView>value)
       .filter(cellView => cellView.model.isElement())
       .subscribe(cellView => this.workflowActionService.getJointGraphWrapper().highlightOperator(cellView.model.id.toString()));

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -101,8 +101,8 @@ export class WorkflowEditorComponent implements AfterViewInit {
    * Handles user mouse down events to trigger logically highlight and unhighlight an operator
    */
   private handleHighlightMouseInput(): void {
-    // on user mouse pointer down a operator cell, highlight that operator
-    Observable.fromEvent(this.getJointPaper(), 'cell:pointerdown')
+    // on user mouse clicks a operator cell, highlight that operator
+    Observable.fromEvent(this.getJointPaper(), 'cell:lcick')
       .map(value => <joint.dia.CellView>value)
       .filter(cellView => cellView.model.isElement())
       .subscribe(cellView => this.workflowActionService.getJointGraphWrapper().highlightOperator(cellView.model.id.toString()));

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -101,13 +101,19 @@ export class WorkflowEditorComponent implements AfterViewInit {
    * Handles user mouse down events to trigger logically highlight and unhighlight an operator
    */
   private handleHighlightMouseInput(): void {
+    // on user mouse pointer down a operator cell, highlight that operator
     Observable.fromEvent(this.getJointPaper(), 'cell:pointerdown')
       .map(value => <joint.dia.CellView>value)
       .filter(cellView => cellView.model.isElement())
       .subscribe(cellView => this.workflowActionService.getJointGraphWrapper().highlightOperator(cellView.model.id.toString()));
 
-    Observable.fromEvent(this.getJointPaper(), 'blank:pointerdown')
-      .subscribe(value => this.workflowActionService.getJointGraphWrapper().unhighlightCurrent());
+    /**
+     * One possible way to unhighlight an operator when user clicks on the blank area,
+     *  and bind `blank:pointerdown` event to unhighlight the operator.
+     * However, in real life, randomly clicking the blank area happens a lot,
+     *  and users are forced to click the operator again to highlight it,
+     *  which would make the UI not user-friendly
+     */
   }
 
   private handleOperatorHightlightEvent(): void {

--- a/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.ts
+++ b/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.ts
@@ -75,6 +75,7 @@ export class DragDropService {
         this.currentOperatorType = DragDropService.DRAG_DROP_TEMP_OPERATOR_TYPE;
         const operator = this.workflowUtilService.getNewOperatorPredicate(value.operatorType);
         this.workflowActionService.addOperator(operator, value.offset);
+        this.workflowActionService.getJointGraphWrapper().highlightOperator(operator.operatorID);
       }
     );
   }

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.spec.ts
@@ -143,49 +143,164 @@ describe('JointGraphWrapperService', () => {
 
     }));
 
-  it('should handle the event when an operator is highlighted or unhighlighted in the JointJS paper', marbles((m) => {
+  it('should emit a highlight event correctly when an operator is highlighted', marbles((m) => {
     const workflowActionService: WorkflowActionService = TestBed.get(WorkflowActionService);
     const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
-    localJointGraphWrapper.getJointCellHighlightStream().subscribe(
-      operator => {
-        expect(operator.operatorID).toEqual(mockScanPredicate.operatorID);
-      }
-    );
-
+    // add one operator
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
+
+    // prepare marble operation for highlighting an operator
+    const highlightActionMarbleEvent = m.hot(
+      '-a-|',
+      { a: mockScanPredicate.operatorID }
+    ).share();
+
+    // highlight that operator at events
+    highlightActionMarbleEvent.subscribe(
+      value => localJointGraphWrapper.highlightOperator(value)
+    )
+
+    // prepare expected output highlight event stream
+    const expectedHighlightEventStream = m.hot('-a-', {
+      a: { operatorID: mockScanPredicate.operatorID }
+    })
+
+    // expect the output event stream is correct
+    m.expect(localJointGraphWrapper.getJointCellHighlightStream()).toBeObservable(expectedHighlightEventStream);
+
+    // expect the current highlighted operator is correct
+    highlightActionMarbleEvent.subscribe({
+      complete: () => {
+        expect(localJointGraphWrapper.getCurrentHighlightedOpeartorID()).toEqual(mockScanPredicate.operatorID);
+      }
+    });
+
+  }));
+
+  it('should emit an unhighlight event correctly when an operator is unhighlighted', marbles((m) => {
+    const workflowActionService: WorkflowActionService = TestBed.get(WorkflowActionService);
+    const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
+
+    // add one operator
+    workflowActionService.addOperator(mockScanPredicate, mockPoint);
+    // highlight the operator
     localJointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
 
-    expect(localJointGraphWrapper.getCurrentHighlightedOpeartorID()).toEqual(mockScanPredicate.operatorID);
+    // prepare marble operation for unhighlighting an operator
+    const unhighlightActionMarbleEvent = m.hot('-a-|').share();
 
+    // unhighlight that operator at events
+    unhighlightActionMarbleEvent.subscribe(
+      value => localJointGraphWrapper.unhighlightCurrent()
+    )
 
-    localJointGraphWrapper.getJointCellUnhighlightStream().subscribe(
-      operator => {
-        expect(operator.operatorID).toEqual(mockScanPredicate.operatorID);
+    // prepare expected output highlight event stream
+    const expectedUnhighlightEventStream = m.hot('-a-', {
+      a: { operatorID: mockScanPredicate.operatorID }
+    })
+
+    // expect the output event stream is correct
+    m.expect(localJointGraphWrapper.getJointCellUnhighlightStream()).toBeObservable(expectedUnhighlightEventStream);
+
+    // expect the current highlighted operator is correct
+    unhighlightActionMarbleEvent.subscribe({
+      complete: () => {
+        expect(localJointGraphWrapper.getCurrentHighlightedOpeartorID()).toBeFalsy();
       }
-    );
+    });
 
-    localJointGraphWrapper.unhighlightCurrent();
-    expect(localJointGraphWrapper.getCurrentHighlightedOpeartorID()).toBeFalsy();
   }));
 
   it('should unhighlight previous highlighted operator if a new operator is highlighted', marbles((m) => {
     const workflowActionService: WorkflowActionService = TestBed.get(WorkflowActionService);
     const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
-    localJointGraphWrapper.getJointCellUnhighlightStream().subscribe(
-      operator => {
-        expect(operator.operatorID).toEqual(mockScanPredicate.operatorID);
-      }
-    );
-
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
     workflowActionService.addOperator(mockResultPredicate, mockPoint);
 
-    localJointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
-    localJointGraphWrapper.highlightOperator(mockResultPredicate.operatorID);
+    // prepare marble operation for highlighting one operator, then highlight another
+    const highlightActionMarbleEvent = m.hot(
+      '-a-b-|',
+      { a: mockScanPredicate.operatorID, b: mockResultPredicate.operatorID }
+    ).share();
 
-    expect(localJointGraphWrapper.getCurrentHighlightedOpeartorID()).toEqual(mockResultPredicate.operatorID);
+
+    // highlight that operator at events
+    highlightActionMarbleEvent.subscribe(
+      value => localJointGraphWrapper.highlightOperator(value)
+    )
+
+    // prepare expected output highlight event stream
+    const expectedHighlightEventStream = m.hot('-a-b-', {
+      a: { operatorID: mockScanPredicate.operatorID },
+      b: { operatorID: mockResultPredicate.operatorID },
+    })
+
+    // expect the output event stream is correct
+    m.expect(localJointGraphWrapper.getJointCellHighlightStream()).toBeObservable(expectedHighlightEventStream);
+
+    // expect the current highlighted operator is correct
+    highlightActionMarbleEvent.subscribe({
+      complete: () => {
+        expect(localJointGraphWrapper.getCurrentHighlightedOpeartorID()).toEqual(mockResultPredicate.operatorID);
+      }
+    });
+
+  }));
+
+  it('should ignore the action if tring to highlight the same currently highlighted operator', marbles((m) => {
+    const workflowActionService: WorkflowActionService = TestBed.get(WorkflowActionService);
+    const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
+
+    workflowActionService.addOperator(mockScanPredicate, mockPoint);
+
+    // prepare marble operation for highlighting the same operator twice
+    const highlightActionMarbleEvent = m.hot(
+      '-a-b-|',
+      { a: mockScanPredicate.operatorID, b: mockScanPredicate.operatorID }
+    ).share();
+
+
+    // highlight that operator at events
+    highlightActionMarbleEvent.subscribe(
+      value => localJointGraphWrapper.highlightOperator(value)
+    )
+
+    // prepare expected output highlight event stream: the second highlight is ignored
+    const expectedHighlightEventStream = m.hot('-a---', {
+      a: { operatorID: mockScanPredicate.operatorID },
+    })
+
+    // expect the output event stream is correct
+    m.expect(localJointGraphWrapper.getJointCellHighlightStream()).toBeObservable(expectedHighlightEventStream);
+
+  }));
+
+  it('should unhighlight the currently highlighted operator if it is deleted', marbles((m) => {
+    const workflowActionService: WorkflowActionService = TestBed.get(WorkflowActionService);
+    const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
+
+    // add and highlight the operator
+    workflowActionService.addOperator(mockScanPredicate, mockPoint);
+    localJointGraphWrapper.highlightOperator(mockScanPredicate.operatorID)
+
+    expect(localJointGraphWrapper.getCurrentHighlightedOpeartorID()).toEqual(mockScanPredicate.operatorID);
+
+    // prepare the delete operator action marble test
+    const deleteOperatorActionMarble = m.hot('-a-').share();
+    deleteOperatorActionMarble.subscribe(
+      () => workflowActionService.deleteOperator(mockScanPredicate.operatorID)
+    );
+
+    // expect that the unhighlight event stream is triggered
+    const expectedEventStream = m.hot('-a-', { a: { operatorID: mockScanPredicate.operatorID }})
+    m.expect(localJointGraphWrapper.getJointCellUnhighlightStream()).toBeObservable(expectedEventStream);
+
+    // expect that the current highlighted operator is undefined
+    deleteOperatorActionMarble.subscribe({
+      complete: () => expect(localJointGraphWrapper.getCurrentHighlightedOpeartorID()).toBeFalsy()
+    });
 
   }));
 

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
@@ -45,6 +45,7 @@ export class JointGraphWrapper {
 
 
   constructor(private jointGraph: joint.dia.Graph) {
+    this.handleOperatorDeleteUnhighlight();
   }
 
   public getCurrentHighlightedOpeartorID(): string | undefined {
@@ -53,7 +54,7 @@ export class JointGraphWrapper {
 
   public highlightOperator(operatorID: string): void {
     // try to get the operator using operator ID
-    if (! this.jointGraph.getCell(operatorID)) {
+    if (!this.jointGraph.getCell(operatorID)) {
       throw new Error(`opeartor with ID ${operatorID} doesn't exist`);
     }
     // if there's an existing highlighted cell, unhighlight it first
@@ -140,5 +141,12 @@ export class JointGraphWrapper {
   }
 
 
+  private handleOperatorDeleteUnhighlight(): void {
+    this.getJointOperatorCellDeleteStream().subscribe(deletedOperatorCell => {
+      if (this.currentHighlightedOperator === deletedOperatorCell.id.toString()) {
+        this.unhighlightCurrent();
+      }
+    });
+  }
 
 }

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
@@ -23,8 +23,11 @@ type operatorIDType = { operatorID: string };
  */
 export class JointGraphWrapper {
 
+  // the current highlighted operator ID
   private currentHighlightedOperator: string | undefined;
+  // event stream of highlighting an operator
   private jointCellHighlightStream = new Subject<operatorIDType>();
+    // event stream of un-highlighting an operator
   private jointCellUnhighlightStream = new Subject<operatorIDType>();
 
   /**
@@ -45,26 +48,51 @@ export class JointGraphWrapper {
 
 
   constructor(private jointGraph: joint.dia.Graph) {
+    // handle if the current highlighted operator is deleted, it should be unhighlighted
     this.handleOperatorDeleteUnhighlight();
   }
 
+  /**
+   * Gets the operator ID of the current highlighted operator.
+   * Returns undefined if there is no highlighted operator.
+   */
   public getCurrentHighlightedOpeartorID(): string | undefined {
     return this.currentHighlightedOperator;
   }
 
+  /**
+   * Highlights the operator with given operatorID.
+   * Emits an event to the operator highlight stream.
+   *
+   * If the currently highlighted operator is the same, the action will be ignored.
+   *
+   * There is only one operator that could be highlighted at a time, therefore
+   *  if another operator is highlighted, it will be unhighlighted.
+   *
+   * @param operatorID
+   */
   public highlightOperator(operatorID: string): void {
     // try to get the operator using operator ID
     if (!this.jointGraph.getCell(operatorID)) {
       throw new Error(`opeartor with ID ${operatorID} doesn't exist`);
     }
-    // if there's an existing highlighted cell, unhighlight it first
-    if (this.currentHighlightedOperator && this.currentHighlightedOperator !== operatorID) {
+    // if the current highlighted operator is the same operator, don't do anything
+    if (this.currentHighlightedOperator === operatorID) {
+      return;
+    }
+    // if there is another operator currently highlighted, unhighlight it first
+    if (this.currentHighlightedOperator) {
       this.unhighlightCurrent();
     }
+    // highlight the operator and emit the event
     this.currentHighlightedOperator = operatorID;
     this.jointCellHighlightStream.next({ operatorID });
   }
 
+  /**
+   * Unhighlights the currently highlighted operator.
+   * Emits an event to the operator unhighlight stream.
+   */
   public unhighlightCurrent(): void {
     if (!this.currentHighlightedOperator) {
       return;
@@ -74,10 +102,17 @@ export class JointGraphWrapper {
     this.jointCellUnhighlightStream.next({ operatorID: unhighlightedOperatorID });
   }
 
+  /**
+   * Gets the event stream of an operator being highlighted.
+   */
   public getJointCellHighlightStream(): Observable<operatorIDType> {
     return this.jointCellHighlightStream.asObservable();
   }
 
+  /**
+   * Gets the event stream of an operator being unhighlighted.
+   * The operator could be unhighlighted because it's deleted.
+   */
   public getJointCellUnhighlightStream(): Observable<operatorIDType> {
     return this.jointCellUnhighlightStream.asObservable();
   }
@@ -141,6 +176,11 @@ export class JointGraphWrapper {
   }
 
 
+  /**
+   * Subscribes to operator cell delete event stream,
+   *  checks if the deleted operator is the currently selected operator
+   *  and unhighlight it if it is.
+   */
   private handleOperatorDeleteUnhighlight(): void {
     this.getJointOperatorCellDeleteStream().subscribe(deletedOperatorCell => {
       if (this.currentHighlightedOperator === deletedOperatorCell.id.toString()) {

--- a/core/new-gui/tslint.json
+++ b/core/new-gui/tslint.json
@@ -57,7 +57,8 @@
     "no-eval": true,
     "no-inferrable-types": [
       true,
-      "ignore-params"
+      "ignore-params",
+      "ignore-properties",
     ],
     "no-misused-new": true,
     "no-non-null-assertion": true,

--- a/core/new-gui/tslint.json
+++ b/core/new-gui/tslint.json
@@ -58,7 +58,7 @@
     "no-inferrable-types": [
       true,
       "ignore-params",
-      "ignore-properties",
+      "ignore-properties"
     ],
     "no-misused-new": true,
     "no-non-null-assertion": true,


### PR DESCRIPTION
This PR adds the ability to let users click on an operator to highlight it. The operator border will be thicker and darker to indicate that it is highlighted. In the current design, there is only one highlighted operator at any time. Clicking on another operator will cause the highlight to switch to the other operator.

This PR prepares for the operator panel PR, which relies on select (highlight) an operator to show the property editor of that operator.