### PR TITLE
Added chrome debug config and removed stub operator metadata call

### DIFF
--- a/core/new-gui/.vscode/extensions.json
+++ b/core/new-gui/.vscode/extensions.json
@@ -11,6 +11,7 @@
     "formulahendry.auto-close-tag", // auto close tag
     "HookyQR.beautify", // beautify code
     "codezombiech.gitignore", // gitignore
+    "msjsdiag.debugger-for-chrome", // debugger for chrome
 
 	]
 }

--- a/core/new-gui/.vscode/launch.json
+++ b/core/new-gui/.vscode/launch.json
@@ -1,0 +1,25 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "chrome",
+      "request": "launch",
+      "name": "Launch Chrome",
+      "url": "http://localhost:4200",
+      "webRoot": "${workspaceFolder}",
+      "sourceMaps": true
+    },
+    {
+      "name": "Attach Chrome",
+      "type": "chrome",
+      "request": "attach",
+      "url": "http://localhost:4200",
+      "port": 9222,
+      "webRoot": "${workspaceFolder}",
+      "sourceMaps": true
+    }
+  ]
+}

--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -14,10 +14,9 @@ import { StubOperatorMetadataService } from '../service/operator-metadata/stub-o
   templateUrl: './workspace.component.html',
   styleUrls: ['./workspace.component.scss'],
   providers: [
-    // StubOperatorMetadataService can be used for debugging without start the backend server
-    { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
-    // OperatorMetadataService,
-
+    // uncomment this line for manual testing without opening backend server
+    // { provide: OperatorMetadataService, useClass: StubOperatorMetadataService }
+    OperatorMetadataService,
     JointUIService,
     WorkflowActionService,
     WorkflowUtilService,


### PR DESCRIPTION
This PR :-
1. adds a config file (launch.json) to allow debugging of Angular inside VS code. We just have to install chrome debug plugin to use this.

2. Removes a previous bug of calling `stub operator metadata service` in workspace component

