### PR TITLE
[#603][9.1] clean up unused imports and variables, fix tslint warnings

### DIFF
--- a/core/new-gui/src/app/app.component.spec.ts
+++ b/core/new-gui/src/app/app.component.spec.ts
@@ -1,6 +1,4 @@
-import { TestBed, async } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
-import { AppComponent } from './app.component';
+
 describe('AppComponent', () => {
 
 });

--- a/core/new-gui/src/app/common/custom-ng-material.module.ts
+++ b/core/new-gui/src/app/common/custom-ng-material.module.ts
@@ -1,4 +1,3 @@
-import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
 // import angular CDK modules

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.spec.ts
@@ -12,9 +12,8 @@ import { OperatorMetadataService } from '../../service/operator-metadata/operato
 import { JointUIService } from '../../service/joint-ui/joint-ui.service';
 
 import { Observable } from 'rxjs/Observable';
-import { marbles, Context } from 'rxjs-marbles';
+import { marbles } from 'rxjs-marbles';
 import { HttpClient } from '@angular/common/http';
-import { SuccessExecutionResult } from '../../types/execute-workflow.interface';
 import { mockExecutionResult } from '../../service/execute-workflow/mock-result-data';
 
 class StubHttpClient {
@@ -58,7 +57,7 @@ describe('NavigationComponent', () => {
   it('should execute the workflow when run button is clicked', marbles((m) => {
 
     const httpClient: HttpClient = TestBed.get(HttpClient);
-    const postMethodSpy = spyOn(httpClient, 'post').and.returnValue(
+    spyOn(httpClient, 'post').and.returnValue(
       Observable.of(mockExecutionResult)
     );
 
@@ -76,7 +75,7 @@ describe('NavigationComponent', () => {
   it('should show spinner when the workflow execution begins and hide spinner when execution ends', marbles((m) => {
 
     const httpClient: HttpClient = TestBed.get(HttpClient);
-    const postMethodSpy = spyOn(httpClient, 'post').and.returnValue(
+    spyOn(httpClient, 'post').and.returnValue(
       Observable.of(mockExecutionResult)
     );
 
@@ -86,10 +85,10 @@ describe('NavigationComponent', () => {
     let spinner = fixture.debugElement.query(By.css('.texera-loading-spinner'));
     expect(spinner).toBeFalsy();
 
-    m.hot('-e-').do(event => component.onClickRun()).subscribe();
+    m.hot('-e-').do(() => component.onClickRun()).subscribe();
 
     executeWorkFlowService.getExecuteStartedStream().subscribe(
-      event => {
+      () => {
         fixture.detectChanges();
         expect(component.showSpinner).toBeTruthy();
         spinner = fixture.debugElement.query(By.css('.texera-loading-spinner'));
@@ -98,7 +97,7 @@ describe('NavigationComponent', () => {
     );
 
     executeWorkFlowService.getExecuteEndedStream().subscribe(
-      event => {
+      () => {
         fixture.detectChanges();
         expect(component.showSpinner).toBeFalsy();
         spinner = fixture.debugElement.query(By.css('.texera-loading-spinner'));

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit } from '@angular/core';
 import { ExecuteWorkflowService } from './../../service/execute-workflow/execute-workflow.service';
-import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 
 /**
  * NavigationComponent is the top level navigation bar that shows

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.spec.ts
@@ -1,4 +1,3 @@
-import { Observable } from 'rxjs/Observable';
 import { WorkflowUtilService } from './../../../service/workflow-graph/util/workflow-util.service';
 import { JointUIService } from './../../../service/joint-ui/joint-ui.service';
 import { DragDropService } from './../../../service/drag-drop/drag-drop.service';
@@ -7,13 +6,11 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { OperatorLabelComponent } from './operator-label.component';
 import { OperatorMetadataService } from '../../../service/operator-metadata/operator-metadata.service';
 import { StubOperatorMetadataService } from '../../../service/operator-metadata/stub-operator-metadata.service';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 
 import { CustomNgMaterialModule } from '../../../../common/custom-ng-material.module';
 import { mockOperatorSchemaList } from '../../../service/operator-metadata/mock-operator-metadata.data';
 import { By } from '@angular/platform-browser';
 import { WorkflowActionService } from '../../../service/workflow-graph/model/workflow-action.service';
-import { marbles } from 'rxjs-marbles';
 
 describe('OperatorLabelComponent', () => {
   const mockOperatorData = mockOperatorSchemaList[0];

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.ts
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.ts
@@ -1,5 +1,5 @@
 import { DragDropService } from './../../../service/drag-drop/drag-drop.service';
-import { Component, OnInit, Input, AfterViewInit } from '@angular/core';
+import { Component, Input, AfterViewInit } from '@angular/core';
 import { v4 as uuid } from 'uuid';
 
 import { OperatorSchema } from '../../../types/operator-schema.interface';

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.spec.ts
@@ -1,6 +1,5 @@
 import { DragDropService } from './../../service/drag-drop/drag-drop.service';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import '../../../common/rxjs-operators';
 import { CustomNgMaterialModule } from '../../../common/custom-ng-material.module';

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.ts
@@ -2,7 +2,6 @@ import { Component, OnInit } from '@angular/core';
 import { OperatorMetadataService } from '../../service/operator-metadata/operator-metadata.service';
 
 import { OperatorSchema, OperatorMetadata, GroupInfo } from '../../types/operator-schema.interface';
-import { StubOperatorMetadataService } from '../../service/operator-metadata/stub-operator-metadata.service';
 
 /**
  * OperatorViewComponent is the left-side panel that shows the operators.

--- a/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.spec.ts
@@ -1,6 +1,5 @@
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { By } from '@angular/platform-browser';
-import { Observable } from 'rxjs/Observable';
 import {
   MaterialDesignFrameworkModule, JsonSchemaFormModule, JsonSchemaFormService,
   FrameworkLibraryService, WidgetLibraryService, Framework, MaterialDesignFramework
@@ -20,17 +19,14 @@ import { marbles } from 'rxjs-marbles';
 
 
 import { mockResultPredicate, mockScanPredicate, mockPoint } from '../../service/workflow-graph/model/mock-workflow-data';
-import { OperatorPredicate } from '../../types/workflow-common.interface';
-import { HotObservable } from 'rxjs/testing/HotObservable';
-import { TestScheduler } from 'rxjs/testing/TestScheduler';
 import { CustomNgMaterialModule } from '../../../common/custom-ng-material.module';
 
+/* tslint:disable:no-non-null-assertion */
 
 describe('PropertyEditorComponent', () => {
   let component: PropertyEditorComponent;
   let fixture: ComponentFixture<PropertyEditorComponent>;
   let workflowActionService: WorkflowActionService;
-  let jointUIService: JointUIService;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
@@ -62,7 +58,6 @@ describe('PropertyEditorComponent', () => {
     fixture = TestBed.createComponent(PropertyEditorComponent);
     component = fixture.componentInstance;
     workflowActionService = TestBed.get(WorkflowActionService);
-    jointUIService = TestBed.get(JointUIService);
 
     fixture.detectChanges();
   });
@@ -104,7 +99,7 @@ describe('PropertyEditorComponent', () => {
 
     // check if the form has the all the json schema property names
     Object.keys(currentSchema!.jsonSchema.properties!).forEach((propertyName) => {
-      expect((jsonSchemaFormElement.nativeElement as HTMLElement).innerHTML).toContain(propertyName)
+      expect((jsonSchemaFormElement.nativeElement as HTMLElement).innerHTML).toContain(propertyName);
     });
 
   });
@@ -117,7 +112,6 @@ describe('PropertyEditorComponent', () => {
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
     workflowActionService.addOperator(mockResultPredicate, mockPoint);
 
-    const scanOperatorSchema = component.operatorSchemaList.find(schema => schema.operatorType === mockScanPredicate.operatorType);
     const resultOperatorSchema = component.operatorSchemaList.find(schema => schema.operatorType === mockResultPredicate.operatorType);
 
     // highlight the first operator
@@ -149,7 +143,7 @@ describe('PropertyEditorComponent', () => {
 
     // check if the form has the all the json schema property names
     Object.keys(resultOperatorSchema!.jsonSchema.properties!).forEach((propertyName) => {
-      expect((jsonSchemaFormElementAfterChange.nativeElement as HTMLElement).innerHTML).toContain(propertyName)
+      expect((jsonSchemaFormElementAfterChange.nativeElement as HTMLElement).innerHTML).toContain(propertyName);
     });
 
 
@@ -161,7 +155,6 @@ describe('PropertyEditorComponent', () => {
    */
   it('should clear and hide the property editor panel correctly on unhighlighting an operator', () => {
     const predicate = mockScanPredicate;
-    const currentSchema = component.operatorSchemaList.find(schema => schema.operatorType === predicate.operatorType);
 
     component.changePropertyEditor(predicate);
 
@@ -181,7 +174,7 @@ describe('PropertyEditorComponent', () => {
 
     expect(formTitleElement).toBeFalsy();
     expect(jsonSchemaFormElement).toBeFalsy();
-  })
+  });
 
   it('should change Texera graph property when the form is edited by the user', fakeAsync(() => {
     const jointGraphWrapper = workflowActionService.getJointGraphWrapper();
@@ -193,7 +186,7 @@ describe('PropertyEditorComponent', () => {
 
     // stimulate a form change by the user
     const formChangeValue = { tableName: 'twitter_sample' };
-    component.onFormChanges(formChangeValue)
+    component.onFormChanges(formChangeValue);
 
     // maintain a counter of how many times the event is emitted
     let emitEventCounter = 0;
@@ -229,7 +222,7 @@ describe('PropertyEditorComponent', () => {
       c: { tableName: 'tab' },
       d: { tableName: 'tabl' },
       e: { tableName: 'table' },
-    }
+    };
     const formUserInputEventStream = m.hot(formUserInputMarbleString, formUserInputMarbleValue);
 
     // prepare the expected output stream after debounce time
@@ -260,7 +253,7 @@ describe('PropertyEditorComponent', () => {
     // add an operator and highligh the operator so that the
     //  variables in property editor component is set correctly
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
-    const mockOperatorProperty = { tableName: 'table' }
+    const mockOperatorProperty = { tableName: 'table' };
     // set operator property first before displaying the operator property in property panel
     workflowActionService.setOperatorProperty(mockScanPredicate.operatorID, mockOperatorProperty);
     jointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
@@ -281,6 +274,6 @@ describe('PropertyEditorComponent', () => {
     expect(emitEventCounter).toEqual(0);
 
 
-  }))
+  }));
 
 });

--- a/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.ts
@@ -2,7 +2,7 @@ import { OperatorSchema } from './../../types/operator-schema.interface';
 import { OperatorPredicate } from '../../types/workflow-common.interface';
 import { WorkflowActionService } from './../../service/workflow-graph/model/workflow-action.service';
 import { OperatorMetadataService } from './../../service/operator-metadata/operator-metadata.service';
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
 
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
@@ -45,6 +45,10 @@ import isEqual from 'lodash-es/isEqual';
 })
 export class PropertyEditorComponent {
 
+  // debounce time for form input in miliseconds
+  //  please set this to multiples of 10 to make writing tests easy
+  public static formInputDebounceTime: number = 150;
+
   // the operatorID corresponds to the property editor's current operator
   public currentOperatorID: string | undefined;
   // a *copy* of the operator property as the initial input to the json schema form
@@ -66,10 +70,6 @@ export class PropertyEditorComponent {
 
   // the current operator schema list, used to find the operator schema of current operator
   public operatorSchemaList: ReadonlyArray<OperatorSchema> = [];
-
-  // debounce time for form input in miliseconds
-  //  please set this to multiples of 10 to make writing tests easy
-  public static formInputDebounceTime: number = 150;
 
 
   constructor(
@@ -129,13 +129,13 @@ export class PropertyEditorComponent {
     }
 
     // set displayForm to false first to hide the view while constructing data
-    this.displayForm = false
+    this.displayForm = false;
 
     // set the operator data needed
     this.currentOperatorID = operator.operatorID;
     this.currentOperatorSchema = this.operatorSchemaList.find(schema => schema.operatorType === operator.operatorType);
     if (!this.currentOperatorSchema) {
-      throw new Error(`operator schema for operator type ${operator.operatorType} doesn't exist`)
+      throw new Error(`operator schema for operator type ${operator.operatorType} doesn't exist`);
     }
     /**
      * Make a deep copy of the initial property data object.
@@ -171,7 +171,7 @@ export class PropertyEditorComponent {
 
     this.workflowActionService.getJointGraphWrapper().getJointCellUnhighlightStream()
       .filter(value => value.operatorID === this.currentOperatorID)
-      .subscribe(value => this.clearPropertyEditor());
+      .subscribe(() => this.clearPropertyEditor());
   }
 
   /**
@@ -210,7 +210,7 @@ export class PropertyEditorComponent {
         // when the form is initialized, the change event is triggered for the inital data
         // however, the operator property is not changed and shouldn't emit this event
         if (isEqual(formData, operator.operatorProperties)) {
-          return false
+          return false;
         }
         return true;
       })

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.spec.ts
@@ -12,17 +12,15 @@ import { NgbModule, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { marbles } from 'rxjs-marbles';
 import { mockExecutionResult, mockResultData,
   mockExecutionErrorResult, mockExecutionEmptyResult } from '../../service/execute-workflow/mock-result-data';
-import { MatTableDataSource } from '@angular/material';
 import { By } from '@angular/platform-browser';
 import { Observable } from 'rxjs/Observable';
 import { HttpClient } from '@angular/common/http';
-import { ExecutionResult } from '../../types/execute-workflow.interface';
 
 
 class StubHttpClient {
   constructor() {}
 
-  public post<T>(): Observable<string> { return Observable.of('a'); }
+  public post(): Observable<string> { return Observable.of('a'); }
 }
 
 describe('ResultPanelComponent', () => {
@@ -120,7 +118,7 @@ describe('ResultPanelComponent', () => {
     });
   }));
 
-  it(`should throw an error when displayResultTable() is called with execution result that has 0 size`, marbles((m) => {
+  it(`should throw an error when displayResultTable() is called with execution result that has 0 size`, () => {
 
     // This is a way to get the private method in Components. Since this edge case can
     //  never be reached in the public method, this architecture is required.
@@ -129,7 +127,7 @@ describe('ResultPanelComponent', () => {
       (component as any).displayResultTable(mockExecutionEmptyResult)
     ).toThrowError( new RegExp(`result data should not be empty`));
 
-  }));
+  });
 
   it('should respond to error and print error messages', marbles((m) => {
     const endMarbleString = '-e-|';
@@ -175,7 +173,7 @@ describe('ResultPanelComponent', () => {
     });
   }));
 
-  it('should generate the result table correctly on the user interface', marbles((m) => {
+  it('should generate the result table correctly on the user interface', () => {
 
     const httpClient: HttpClient = TestBed.get(HttpClient);
     spyOn(httpClient, 'post').and.returnValue(
@@ -191,5 +189,6 @@ describe('ResultPanelComponent', () => {
 
     const resultTable = fixture.debugElement.query(By.css('.result-table'));
     expect(resultTable).toBeTruthy();
-  }));
+  });
+
 });

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
@@ -39,7 +39,6 @@ describe('WorkflowEditorComponent', () => {
   describe('JointJS Paper', () => {
     let component: WorkflowEditorComponent;
     let fixture: ComponentFixture<WorkflowEditorComponent>;
-    let jointUIService: JointUIService;
     let jointGraph: joint.dia.Graph;
 
     beforeEach(async(() => {
@@ -59,7 +58,6 @@ describe('WorkflowEditorComponent', () => {
     beforeEach(() => {
       fixture = TestBed.createComponent(WorkflowEditorComponent);
       component = fixture.componentInstance;
-      jointUIService = fixture.debugElement.injector.get(JointUIService);
       // detect changes first to run ngAfterViewInit and bind Model
       fixture.detectChanges();
       jointGraph = component.getJointPaper().model;
@@ -158,9 +156,9 @@ describe('WorkflowEditorComponent', () => {
     });
 
     it('should try to highlight the operator when user mouse clicks on an operator', () => {
-      const JointGraphWrapper = workflowActionService.getJointGraphWrapper();
+      const jointGraphWrapper = workflowActionService.getJointGraphWrapper();
       // install a spy on the highlight operator function and pass the call through
-      const highlightOperatorFunctionSpy = spyOn(JointGraphWrapper, 'highlightOperator').and.callThrough();
+      const highlightOperatorFunctionSpy = spyOn(jointGraphWrapper, 'highlightOperator').and.callThrough();
 
       workflowActionService.addOperator(mockScanPredicate, mockPoint);
 
@@ -175,15 +173,15 @@ describe('WorkflowEditorComponent', () => {
       // assert the function is called once
       expect(highlightOperatorFunctionSpy.calls.count()).toEqual(1);
       // assert the highlighted operator is correct
-      expect(JointGraphWrapper.getCurrentHighlightedOpeartorID()).toEqual(mockScanPredicate.operatorID);
+      expect(jointGraphWrapper.getCurrentHighlightedOpeartorID()).toEqual(mockScanPredicate.operatorID);
     });
 
     it('should react to operator highlight event and change the appearance of the operator to be highlighted', () => {
-      const JointGraphWrapper = workflowActionService.getJointGraphWrapper();
+      const jointGraphWrapper = workflowActionService.getJointGraphWrapper();
       workflowActionService.addOperator(mockScanPredicate, mockPoint);
 
       // highlight the operator
-      JointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
+      jointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
 
       // find the joint Cell View object of the operator element
       const jointCellView = component.getJointPaper().findViewByModel(mockScanPredicate.operatorID);
@@ -193,14 +191,14 @@ describe('WorkflowEditorComponent', () => {
 
       // the element should have the highlighter element in it
       expect(jointHighlighterElements.length).toEqual(1);
-    })
+    });
 
     it('should react to operator unhighlight event and change the appearance of the operator to be unhighlighted', () => {
-      const JointGraphWrapper = workflowActionService.getJointGraphWrapper();
+      const jointGraphWrapper = workflowActionService.getJointGraphWrapper();
       workflowActionService.addOperator(mockScanPredicate, mockPoint);
 
       // highlight the oprator first
-      JointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
+      jointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
 
       // find the joint Cell View object of the operator element
       const jointCellView = component.getJointPaper().findViewByModel(mockScanPredicate.operatorID);
@@ -209,10 +207,10 @@ describe('WorkflowEditorComponent', () => {
       const jointHighlighterElements = jointCellView.$el.children('.joint-highlight-stroke');
 
       // the element should have the highlighter element in it right now
-      expect(jointHighlighterElements.length).toEqual(1)
+      expect(jointHighlighterElements.length).toEqual(1);
 
       // then unhighlight the operator
-      JointGraphWrapper.unhighlightCurrent();
+      jointGraphWrapper.unhighlightCurrent();
 
       // the highlighter element should not exist
       const jointHighlighterElementAfterUnhighlight = jointCellView.$el.children('.joint-highlight-stroke');

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -1,16 +1,12 @@
 import { DragDropService } from './../../service/drag-drop/drag-drop.service';
 
 import { JointUIService } from './../../service/joint-ui/joint-ui.service';
-import { WorkflowUtilService } from './../../service/workflow-graph/util/workflow-util.service';
 import { WorkflowActionService } from './../../service/workflow-graph/model/workflow-action.service';
 import { Component, AfterViewInit } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import '../../../common/rxjs-operators';
 
 import * as joint from 'jointjs';
-import {
-  mockScanPredicate, mockResultPredicate, mockScanResultLink
-} from '../../service/workflow-graph/model/mock-workflow-data';
 
 /**
  * WorkflowEditorComponent is the componenet for the main workflow editor part of the UI.
@@ -42,7 +38,6 @@ export class WorkflowEditorComponent implements AfterViewInit {
   constructor(
     private workflowActionService: WorkflowActionService,
     private dragDropService: DragDropService,
-    private jointUIService: JointUIService
   ) {
   }
 

--- a/core/new-gui/src/app/workspace/component/workspace.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.spec.ts
@@ -1,6 +1,3 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
-import { WorkspaceComponent } from './workspace.component';
 
 describe('WorkspaceComponent', () => {
 

--- a/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.spec.ts
@@ -8,7 +8,7 @@ import { OperatorMetadataService } from '../operator-metadata/operator-metadata.
 import { StubOperatorMetadataService } from '../operator-metadata/stub-operator-metadata.service';
 import { mockOperatorMetaData } from '../operator-metadata/mock-operator-metadata.data';
 
-import { marbles, Context } from 'rxjs-marbles';
+import { marbles } from 'rxjs-marbles';
 
 describe('DragDropService', () => {
 
@@ -33,7 +33,7 @@ describe('DragDropService', () => {
   }));
 
 
-  it('should successfully register the element as draggable', marbles((m) => {
+  it('should successfully register the element as draggable', () => {
 
     const dragElementID = 'testing-draggable-1';
     jQuery('body').append(`<div id="${dragElementID}"></div>`);
@@ -43,20 +43,19 @@ describe('DragDropService', () => {
 
     expect(jQuery('#' + dragElementID).is('.ui-draggable')).toBeTruthy();
 
-  }));
+  });
 
 
-  it('should successfully register the element as droppable', marbles((m) => {
+  it('should successfully register the element as droppable', () => {
 
     const dropElement = 'testing-droppable-1';
     jQuery('body').append(`<div id="${dropElement}"></div>`);
 
-    const operatorType = mockOperatorMetaData.operators[0].operatorType;
     dragDropService.registerWorkflowEditorDrop(dropElement);
 
     expect(jQuery('#' + dropElement).is('.ui-droppable')).toBeTruthy();
 
-  }));
+  });
 
   it('should add an operator when the element is dropped', marbles((m) => {
 
@@ -75,7 +74,7 @@ describe('DragDropService', () => {
 
     dragDropService.handleOperatorDropEvent();
 
-    const addOperatorStream = workflowActionService.getTexeraGraph().getOperatorAddStream().map(value => 'a');
+    const addOperatorStream = workflowActionService.getTexeraGraph().getOperatorAddStream().map(() => 'a');
 
     const expectedStream = m.hot('-a-');
     m.expect(addOperatorStream).toBeObservable(expectedStream);

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
@@ -14,14 +14,14 @@ import { mockWorkflowPlan, mockLogicalPlan } from './mock-workflow-plan';
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
 import { marbles } from 'rxjs-marbles';
 import { WorkflowGraph } from '../workflow-graph/model/workflow-graph';
-import { LogicalPlan, SuccessExecutionResult } from '../../types/execute-workflow.interface';
+import { LogicalPlan } from '../../types/execute-workflow.interface';
 
 
 class StubHttpClient {
 
   constructor() {}
 
-  public post<T>(): Observable<string> { return Observable.of('a'); }
+  public post(): Observable<string> { return Observable.of('a'); }
 
 }
 
@@ -49,17 +49,17 @@ describe('ExecuteWorkflowService', () => {
     expect(injectedService).toBeTruthy();
   }));
 
-  it('should generate a logical plan request based on the workflow graph that is passed to the function', marbles((m) => {
+  it('should generate a logical plan request based on the workflow graph that is passed to the function', () => {
     const workflowGraph: WorkflowGraph = mockWorkflowPlan;
     const newLogicalPlan: LogicalPlan = ExecuteWorkflowService.getLogicalPlanRequest(workflowGraph);
     expect(newLogicalPlan).toEqual(mockLogicalPlan);
-  }));
+  });
 
   it('should notify execution start event stream when an execution begins', marbles((m) => {
     const executionStartStream = service.getExecuteStartedStream()
-      .map(value => 'a');
+      .map(() => 'a');
 
-    m.hot('-a-').do(event => service.executeWorkflow()).subscribe();
+    m.hot('-a-').do(() => service.executeWorkflow()).subscribe();
 
     const expectedStream = m.hot('-a-');
 
@@ -69,10 +69,10 @@ describe('ExecuteWorkflowService', () => {
 
   it('should notify execution end event stream when a correct result is passed from backend', marbles((m) => {
     const executionEndStream = service.getExecuteEndedStream()
-      .map(value => 'a');
+      .map(() => 'a');
 
     // execute workflow at this time
-    m.hot('-a-').do(event => service.executeWorkflow()).subscribe();
+    m.hot('-a-').do(() => service.executeWorkflow()).subscribe();
 
     const expectedStream = m.hot('-a-');
 
@@ -96,7 +96,7 @@ describe('ExecuteWorkflowService', () => {
     const mockErrorMessage = 'mock backend error message';
 
     const httpClient: HttpClient = TestBed.get(HttpClient);
-    const postMethodSpy = spyOn(httpClient, 'post').and.returnValue(
+    spyOn(httpClient, 'post').and.returnValue(
       Observable.throw({
         status: 400,
         error: {
@@ -123,7 +123,7 @@ describe('ExecuteWorkflowService', () => {
     const mockErrorMessage = 'mock server error message';
 
     const httpClient: HttpClient = TestBed.get(HttpClient);
-    const postMethodSpy = spyOn(httpClient, 'post').and.returnValue(
+    spyOn(httpClient, 'post').and.returnValue(
       Observable.throw({
         status: 500,
         error: {

--- a/core/new-gui/src/app/workspace/service/execute-workflow/mock-workflow-plan.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/mock-workflow-plan.ts
@@ -1,6 +1,6 @@
 import { WorkflowGraph } from './../workflow-graph/model/workflow-graph';
 import { mockScanPredicate, mockResultPredicate, mockScanResultLink } from './../workflow-graph/model/mock-workflow-data';
-import { LogicalPlan, LogicalLink, LogicalOperator } from '../../types/execute-workflow.interface';
+import { LogicalPlan } from '../../types/execute-workflow.interface';
 
 
 // TODO: unify the port handling interface

--- a/core/new-gui/src/app/workspace/service/joint-ui/joint-ui.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/joint-ui/joint-ui.service.spec.ts
@@ -1,5 +1,4 @@
-import { Point, OperatorPredicate } from './../../types/workflow-common.interface';
-import { mockResultPredicate, mockPoint, mockScanResultLink } from './../workflow-graph/model/mock-workflow-data';
+import { mockResultPredicate, mockPoint } from './../workflow-graph/model/mock-workflow-data';
 import { TestBed, inject } from '@angular/core/testing';
 import * as joint from 'jointjs';
 

--- a/core/new-gui/src/app/workspace/service/joint-ui/joint-ui.service.ts
+++ b/core/new-gui/src/app/workspace/service/joint-ui/joint-ui.service.ts
@@ -3,7 +3,7 @@ import { OperatorMetadataService } from '../operator-metadata/operator-metadata.
 import { OperatorSchema } from '../../types/operator-schema.interface';
 
 import * as joint from 'jointjs';
-import { Point, OperatorPredicate, OperatorLink, OperatorPort } from '../../types/workflow-common.interface';
+import { Point, OperatorPredicate, OperatorLink } from '../../types/workflow-common.interface';
 
 /**
  * Defines the SVG path for the delete button

--- a/core/new-gui/src/app/workspace/service/operator-metadata/mock-operator-metadata.data.ts
+++ b/core/new-gui/src/app/workspace/service/operator-metadata/mock-operator-metadata.data.ts
@@ -1,10 +1,5 @@
 import { JSONSchema4 } from 'json-schema';
-import { JSONSchema6 } from 'json-schema';
-// import functions from lodash: import individual functions from lodash-es
-//  to avoid include the entire lodash library
-import cloneDeep from 'lodash-es/cloneDeep';
 import { OperatorSchema, OperatorMetadata, GroupInfo } from '../../types/operator-schema.interface';
-import { JSONSchema6TypeName, JSONSchema6Type } from 'json-schema';
 
 /**
  * Exports constants related to operator schema and operator metadata for testing purposes.

--- a/core/new-gui/src/app/workspace/service/operator-metadata/operator-metadata.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/operator-metadata/operator-metadata.service.spec.ts
@@ -21,7 +21,6 @@ class StubHttpClient {
 describe('OperatorMetadataService', () => {
 
   let service: OperatorMetadataService;
-  let stubHttp: StubHttpClient;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -30,7 +29,6 @@ describe('OperatorMetadataService', () => {
         { provide: HttpClient, useClass: StubHttpClient }
       ]
     });
-    stubHttp = TestBed.get(HttpClient);
   });
 
   beforeEach(inject([OperatorMetadataService, HttpClient], (ser: OperatorMetadataService) => {
@@ -55,7 +53,7 @@ describe('OperatorMetadataService', () => {
 
   it('should check if operatorType exists correctly', () => {
     service.getOperatorMetadata().last().subscribe(
-      value => {
+      () => {
         expect(service.operatorTypeExists('ScanSource')).toBeTruthy();
         expect(service.operatorTypeExists('InvalidOperatorType')).toBeFalsy();
       }

--- a/core/new-gui/src/app/workspace/service/operator-metadata/operator-metadata.service.ts
+++ b/core/new-gui/src/app/workspace/service/operator-metadata/operator-metadata.service.ts
@@ -1,8 +1,6 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
-import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import '../../../common/rxjs-operators';
 
 import { AppSettings } from '../../../common/app-setting';

--- a/core/new-gui/src/app/workspace/service/operator-metadata/stub-operator-metadata.service.ts
+++ b/core/new-gui/src/app/workspace/service/operator-metadata/stub-operator-metadata.service.ts
@@ -1,12 +1,10 @@
 import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
-import { Subject } from 'rxjs/Subject';
 
 import { mockOperatorMetaData } from './mock-operator-metadata.data';
 import { OperatorMetadata } from '../../types/operator-schema.interface';
 
 import '../../../common/rxjs-operators';
-import { EMPTY_OPERATOR_METADATA } from './operator-metadata.service';
 
 @Injectable()
 export class StubOperatorMetadataService {

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.spec.ts
@@ -2,9 +2,8 @@ import { WorkflowActionService } from './workflow-action.service';
 import { OperatorMetadataService } from '../../operator-metadata/operator-metadata.service';
 import { JointUIService } from '../../joint-ui/joint-ui.service';
 import { JointGraphWrapper } from './joint-graph-wrapper';
-import { TestBed, inject } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { marbles } from 'rxjs-marbles';
-import { isEqual } from 'lodash';
 
 import {
   mockScanPredicate, mockResultPredicate, mockScanResultLink,
@@ -39,9 +38,9 @@ describe('JointGraphWrapperService', () => {
 
     jointGraph.addCell(jointUIService.getJointOperatorElement(mockScanPredicate, mockPoint));
 
-    m.hot('-e-').do(v => jointGraph.getCell(mockScanPredicate.operatorID).remove()).subscribe();
+    m.hot('-e-').do(() => jointGraph.getCell(mockScanPredicate.operatorID).remove()).subscribe();
 
-    const jointOperatorDeleteStream = jointGraphWrapper.getJointOperatorCellDeleteStream().map(value => 'e');
+    const jointOperatorDeleteStream = jointGraphWrapper.getJointOperatorCellDeleteStream().map(() => 'e');
     const expectedStream = m.hot('-e-');
 
     m.expect(jointOperatorDeleteStream).toBeObservable(expectedStream);
@@ -56,9 +55,9 @@ describe('JointGraphWrapperService', () => {
 
     const mockScanResultLinkCell = JointUIService.getJointLinkCell(mockScanResultLink);
 
-    m.hot('-e-').do(event => jointGraph.addCell(mockScanResultLinkCell)).subscribe();
+    m.hot('-e-').do(() => jointGraph.addCell(mockScanResultLinkCell)).subscribe();
 
-    const jointLinkAddStream = jointGraphWrapper.getJointLinkCellAddStream().map(value => 'e');
+    const jointLinkAddStream = jointGraphWrapper.getJointLinkCellAddStream().map(() => 'e');
     const expectedStream = m.hot('-e-');
 
     m.expect(jointLinkAddStream).toBeObservable(expectedStream);
@@ -74,9 +73,9 @@ describe('JointGraphWrapperService', () => {
     const mockScanResultLinkCell = JointUIService.getJointLinkCell(mockScanResultLink);
     jointGraph.addCell(mockScanResultLinkCell);
 
-    m.hot('---e-').do(event => jointGraph.getCell(mockScanResultLink.linkID).remove()).subscribe();
+    m.hot('---e-').do(() => jointGraph.getCell(mockScanResultLink.linkID).remove()).subscribe();
 
-    const jointLinkDeleteStream = jointGraphWrapper.getJointLinkCellDeleteStream().map(value => 'e');
+    const jointLinkDeleteStream = jointGraphWrapper.getJointLinkCellDeleteStream().map(() => 'e');
     const expectedStream = m.hot('---e-');
 
     m.expect(jointLinkDeleteStream).toBeObservable(expectedStream);
@@ -100,10 +99,10 @@ describe('JointGraphWrapperService', () => {
       const mockScanResultLinkCell = JointUIService.getJointLinkCell(mockScanResultLink);
       jointGraph.addCell(mockScanResultLinkCell);
 
-      m.hot('-e-').do(event => jointGraph.getCell(mockScanPredicate.operatorID).remove()).subscribe();
+      m.hot('-e-').do(() => jointGraph.getCell(mockScanPredicate.operatorID).remove()).subscribe();
 
-      const jointOperatorDeleteStream = jointGraphWrapper.getJointOperatorCellDeleteStream().map(value => 'e');
-      const jointLinkDeleteStream = jointGraphWrapper.getJointLinkCellDeleteStream().map(value => 'e');
+      const jointOperatorDeleteStream = jointGraphWrapper.getJointOperatorCellDeleteStream().map(() => 'e');
+      const jointLinkDeleteStream = jointGraphWrapper.getJointLinkCellDeleteStream().map(() => 'e');
 
       const expectedStream = '-e-';
 
@@ -130,10 +129,10 @@ describe('JointGraphWrapperService', () => {
       jointGraph.addCell(mockScanSentimentLinkCell);
       jointGraph.addCell(mockSentimentResultLinkCell);
 
-      m.hot('-e--').do(event => jointGraph.getCell(mockSentimentPredicate.operatorID).remove()).subscribe();
+      m.hot('-e--').do(() => jointGraph.getCell(mockSentimentPredicate.operatorID).remove()).subscribe();
 
-      const jointOperatorDeleteStream = jointGraphWrapper.getJointOperatorCellDeleteStream().map(value => 'e');
-      const jointLinkDeleteStream = jointGraphWrapper.getJointLinkCellDeleteStream().map(value => 'e');
+      const jointOperatorDeleteStream = jointGraphWrapper.getJointOperatorCellDeleteStream().map(() => 'e');
+      const jointLinkDeleteStream = jointGraphWrapper.getJointLinkCellDeleteStream().map(() => 'e');
 
       const expectedStream = '-e--';
       const expectedMultiStream = '-(ee)--';
@@ -159,12 +158,12 @@ describe('JointGraphWrapperService', () => {
     // highlight that operator at events
     highlightActionMarbleEvent.subscribe(
       value => localJointGraphWrapper.highlightOperator(value)
-    )
+    );
 
     // prepare expected output highlight event stream
     const expectedHighlightEventStream = m.hot('-a-', {
       a: { operatorID: mockScanPredicate.operatorID }
-    })
+    });
 
     // expect the output event stream is correct
     m.expect(localJointGraphWrapper.getJointCellHighlightStream()).toBeObservable(expectedHighlightEventStream);
@@ -192,13 +191,13 @@ describe('JointGraphWrapperService', () => {
 
     // unhighlight that operator at events
     unhighlightActionMarbleEvent.subscribe(
-      value => localJointGraphWrapper.unhighlightCurrent()
-    )
+      () => localJointGraphWrapper.unhighlightCurrent()
+    );
 
     // prepare expected output highlight event stream
     const expectedUnhighlightEventStream = m.hot('-a-', {
       a: { operatorID: mockScanPredicate.operatorID }
-    })
+    });
 
     // expect the output event stream is correct
     m.expect(localJointGraphWrapper.getJointCellUnhighlightStream()).toBeObservable(expectedUnhighlightEventStream);
@@ -229,13 +228,13 @@ describe('JointGraphWrapperService', () => {
     // highlight that operator at events
     highlightActionMarbleEvent.subscribe(
       value => localJointGraphWrapper.highlightOperator(value)
-    )
+    );
 
     // prepare expected output highlight event stream
     const expectedHighlightEventStream = m.hot('-a-b-', {
       a: { operatorID: mockScanPredicate.operatorID },
       b: { operatorID: mockResultPredicate.operatorID },
-    })
+    });
 
     // expect the output event stream is correct
     m.expect(localJointGraphWrapper.getJointCellHighlightStream()).toBeObservable(expectedHighlightEventStream);
@@ -265,12 +264,12 @@ describe('JointGraphWrapperService', () => {
     // highlight that operator at events
     highlightActionMarbleEvent.subscribe(
       value => localJointGraphWrapper.highlightOperator(value)
-    )
+    );
 
     // prepare expected output highlight event stream: the second highlight is ignored
     const expectedHighlightEventStream = m.hot('-a---', {
       a: { operatorID: mockScanPredicate.operatorID },
-    })
+    });
 
     // expect the output event stream is correct
     m.expect(localJointGraphWrapper.getJointCellHighlightStream()).toBeObservable(expectedHighlightEventStream);
@@ -283,7 +282,7 @@ describe('JointGraphWrapperService', () => {
 
     // add and highlight the operator
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
-    localJointGraphWrapper.highlightOperator(mockScanPredicate.operatorID)
+    localJointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
 
     expect(localJointGraphWrapper.getCurrentHighlightedOpeartorID()).toEqual(mockScanPredicate.operatorID);
 
@@ -294,7 +293,7 @@ describe('JointGraphWrapperService', () => {
     );
 
     // expect that the unhighlight event stream is triggered
-    const expectedEventStream = m.hot('-a-', { a: { operatorID: mockScanPredicate.operatorID }})
+    const expectedEventStream = m.hot('-a-', { a: { operatorID: mockScanPredicate.operatorID }});
     m.expect(localJointGraphWrapper.getJointCellUnhighlightStream()).toBeObservable(expectedEventStream);
 
     // expect that the current highlighted operator is undefined

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/mock-workflow-data.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/mock-workflow-data.ts
@@ -1,5 +1,4 @@
 import { Point, OperatorPredicate, OperatorLink } from './../../../types/workflow-common.interface';
-import { mockOperatorSchemaList } from './../../operator-metadata/mock-operator-metadata.data';
 
 /**
  * Provides mock data related operators and links:

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/sync-texera-model.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/sync-texera-model.spec.ts
@@ -1,14 +1,13 @@
 import { SyncTexeraModel } from './sync-texera-model';
 import { JointGraphWrapper } from './joint-graph-wrapper';
 import { WorkflowGraph } from './workflow-graph';
-import { Point, OperatorPredicate, OperatorLink } from './../../../types/workflow-common.interface';
+import { OperatorLink } from './../../../types/workflow-common.interface';
 import {
   mockScanPredicate, mockResultPredicate, mockSentimentPredicate,
-  mockScanResultLink, mockScanSentimentLink, mockSentimentResultLink, mockPoint
+  mockScanResultLink, mockScanSentimentLink, mockSentimentResultLink
 } from './mock-workflow-data';
-import { Observable } from 'rxjs/Observable';
-import { TestBed, inject } from '@angular/core/testing';
-import { marbles, Context } from 'rxjs-marbles';
+import { TestBed } from '@angular/core/testing';
+import { marbles } from 'rxjs-marbles';
 
 import '../../../../common/rxjs-operators';
 
@@ -19,13 +18,6 @@ describe('SyncTexeraModel', () => {
 
   let texeraGraph: WorkflowGraph;
   let jointGraphWrapper: JointGraphWrapper;
-
-  function getAddOperatorValue(operator: OperatorPredicate) {
-    return {
-      operator: operator,
-      point: mockPoint
-    };
-  }
 
   /**
    * Returns a mock JointJS operator Element object (joint.dia.Element)
@@ -134,7 +126,7 @@ describe('SyncTexeraModel', () => {
     );
 
     // construct the texera sync model with spied dependencies
-    const texeraSyncModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
+    const syncTexeraModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
 
     // assert workflow graph
     jointGraphWrapper.getJointOperatorCellDeleteStream().subscribe({
@@ -175,7 +167,7 @@ describe('SyncTexeraModel', () => {
     );
 
     // construct the texera sync model with spied dependencies
-    const texeraSyncModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
+    const syncTexeraModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
 
     jointGraphWrapper.getJointOperatorCellDeleteStream().subscribe({
       complete: () => {
@@ -224,7 +216,7 @@ describe('SyncTexeraModel', () => {
     // construct the texera sync model with spied dependencies
 
     // TODO: expect error to be thrown
-    // const texeraSyncModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
+    // const syncTexeraModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
 
 
     // this should throw an error when the model is constructed and the
@@ -259,7 +251,7 @@ describe('SyncTexeraModel', () => {
     );
 
     // construct the texera sync model with spied dependencies
-    const texeraSyncModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
+    const syncTexeraModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
 
     jointGraphWrapper.getJointLinkCellAddStream().subscribe({
       complete: () => {
@@ -307,7 +299,7 @@ describe('SyncTexeraModel', () => {
     );
 
     // construct the texera sync model with spied dependencies
-    const texeraSyncModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
+    const syncTexeraModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
 
     jointGraphWrapper.getJointLinkCellDeleteStream().subscribe({
       complete: () => {
@@ -348,7 +340,7 @@ describe('SyncTexeraModel', () => {
     );
 
     // construct the texera sync model with spied dependencies
-    const texeraSyncModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
+    const syncTexeraModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
 
     jointGraphWrapper.getJointLinkCellDeleteStream().subscribe({
       complete: () => {
@@ -402,7 +394,7 @@ describe('SyncTexeraModel', () => {
     );
 
     // construct the texera sync model with spied dependencies
-    const texeraSyncModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
+    const syncTexeraModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
 
     jointGraphWrapper.getJointLinkCellAddStream().subscribe({
       complete: () => {
@@ -446,7 +438,7 @@ describe('SyncTexeraModel', () => {
     );
 
     // construct the texera sync model with spied dependencies
-    const texeraSyncModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
+    const syncTexeraModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
 
     jointGraphWrapper.getJointLinkCellChangeStream().subscribe({
       complete: () => {
@@ -508,7 +500,7 @@ describe('SyncTexeraModel', () => {
     );
 
     // construct the texera sync model with spied dependencies
-    const texeraSyncModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
+    const syncTexeraModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
 
     jointGraphWrapper.getJointLinkCellChangeStream()
       .subscribe({
@@ -575,7 +567,7 @@ describe('SyncTexeraModel', () => {
     );
 
     // construct the texera sync model with spied dependencies
-    const texeraSyncModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
+    const syncTexeraModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
 
     jointGraphWrapper.getJointLinkCellChangeStream().subscribe({
       complete: () => {
@@ -651,7 +643,7 @@ describe('SyncTexeraModel', () => {
       );
 
       // construct texera model
-      const texeraSyncModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
+      const syncTexeraModel = new SyncTexeraModel(texeraGraph, jointGraphWrapper);
       jointGraphWrapper.getJointOperatorCellDeleteStream().subscribe({
         complete: () => {
           expect(texeraGraph.hasOperator(mockSentimentPredicate.operatorID)).toBeFalsy();

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.spec.ts
@@ -1,7 +1,6 @@
 import { StubOperatorMetadataService } from './../../operator-metadata/stub-operator-metadata.service';
 import { OperatorMetadataService } from './../../operator-metadata/operator-metadata.service';
 import { JointUIService } from './../../joint-ui/joint-ui.service';
-import { JointGraphWrapper } from './joint-graph-wrapper';
 import { WorkflowGraph } from './workflow-graph';
 import {
   mockScanPredicate, mockResultPredicate, mockSentimentPredicate, mockScanResultLink,
@@ -11,13 +10,11 @@ import {
 import { TestBed, inject } from '@angular/core/testing';
 
 import { WorkflowActionService } from './workflow-action.service';
-import { marbles } from 'rxjs-marbles';
 import { OperatorPredicate } from '../../../types/workflow-common.interface';
 
 describe('WorkflowActionService', () => {
 
   let service: WorkflowActionService;
-  let jointUIService: JointUIService;
   let texeraGraph: WorkflowGraph;
   let jointGraph: joint.dia.Graph;
 
@@ -30,7 +27,6 @@ describe('WorkflowActionService', () => {
       ]
     });
     service = TestBed.get(WorkflowActionService);
-    jointUIService = TestBed.get(JointUIService);
     texeraGraph = (service as any).texeraGraph;
     jointGraph = (service as any).jointGraph;
   });

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
@@ -1,5 +1,4 @@
 import { OperatorMetadataService } from './../../operator-metadata/operator-metadata.service';
-import { OperatorMetadata } from './../../../types/operator-schema.interface';
 import { SyncTexeraModel } from './sync-texera-model';
 import { JointGraphWrapper } from './joint-graph-wrapper';
 import { JointUIService } from './../../joint-ui/joint-ui.service';

--- a/core/new-gui/src/app/workspace/types/operator-schema.interface.ts
+++ b/core/new-gui/src/app/workspace/types/operator-schema.interface.ts
@@ -1,4 +1,4 @@
-import { JSONSchema4, JSONSchema6 } from "json-schema";
+import { JSONSchema4 } from 'json-schema';
 
 /**
  * This file contains multiple type declarations related to operator schema.


### PR DESCRIPTION
This PR is a cleanup PR to remove unused imports and local variables. Some files also has tslint warnings in them, this PR also fix those warnings (such as missing semicolon, etc..). This PR doesn't touch any logic of the code, so it can be merged straightly.