### PR TITLE
[#603][9.2] Initial refinement to CSS styles

### DIFF
--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -1,10 +1,10 @@
-<nav class="texera-workspace-navigation-body texera-workflow-component-body
-  navbar navbar-expand-lg navbar-dark bg-dark texera-navigation-body justify-content-between">
-  <a class="navbar-brand">Texera</a>
-  <button class="texera-workspace-navigation-run btn btn-secondary" (click)="onClickRun()">
-    <mat-spinner class="texera-loading-spinner" *ngIf="showSpinner" [diameter]="30"></mat-spinner>
-    <span *ngIf="! showSpinner">
-      <i id="texera-run-icon" class="fa fa-play-circle-o" aria-hidden="true"></i>&nbsp; Run
-    </span>
+<nav class="texera-workspace-navigation-body navbar navbar-expand-sm bg-dark navbar-dark justify-content-between">
+  <a class="navbar-brand" href="#">Texera</a>
+  <button mat-raised-button color="accent" class="texera-workspace-navigation-run-button" (click)="onClickRun()">
+    <mat-spinner class="texera-workspace-navigation-loading-spinner" *ngIf="showSpinner" [diameter]="30"></mat-spinner>
+    <div *ngIf="!showSpinner" class="texera-workspace-navigation-run-text">
+      <i id="texera-run-icon" class="fa fa-play" aria-hidden="true"></i>
+      Run
+    </div>
   </button>
 </nav>

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.scss
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.scss
@@ -1,18 +1,20 @@
 @import '../workspace.component.scss';
-
 .texera-workspace-navigation-body {
-    border: 2px solid;
+  height: 100%;
+  padding-left: 24px;
+  padding-right: 24px;
 }
 
-
-.texera-workspace-navigation-run {
-  border-radius: 3px;
-}
-
-.texera-workspace-navigation-run:hover {
-  background-color: #81C784;
-}
-
-.texera-loading-spinner {
-  color: #85e085;
+.texera-workspace-navigation-run-button {
+  margin-right: 3%;
+  .mat-raised-button {
+    height: 30px;
+  }
+  .texera-workspace-navigation-run-text {
+    font-size: 1rem;
+  }
+  .fa {
+    font-size: 1rem;
+    padding-right: 6px;
+  }
 }

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.scss
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.scss
@@ -1,6 +1,8 @@
 .texera-operator-label-body {
-    padding: 10px 8px;
-    margin-bottom: 6px;
+    padding-left: 14px;
+    padding-top: 10px;
+    padding-bottom: 10px;
+    margin-bottom: 10px;
 
     &:hover {
         background-color: #f4f5f6;

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.html
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.html
@@ -1,6 +1,6 @@
-<div class="texera-workspace-operator-panel-body texera-workflow-component-body">
+<div class="texera-workspace-operator-panel-body">
   <mat-accordion multi="false">
-    <mat-expansion-panel class="mat-elevation-z0 texera-operator-group-panel" *ngFor="let groupName of groupNamesOrdered">
+    <mat-expansion-panel class="mat-elevation-z3 texera-operator-group-panel" *ngFor="let groupName of groupNamesOrdered">
       <mat-expansion-panel-header class="texera-operator-group-name">
         {{groupName}}
       </mat-expansion-panel-header>

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.scss
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.scss
@@ -1,5 +1,1 @@
 @import '../workspace.component.scss';
-
-.texera-workspace-operator-panel-body {
-    padding: 5px;
-}

--- a/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.scss
+++ b/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.scss
@@ -1,5 +1,6 @@
 @import '../workspace.component.scss';
 
 .texera-workspace-property-editor-body {
-  padding: 12px;
+  padding: 16px;
+  padding-right: 24px;
 }

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.scss
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.scss
@@ -1,9 +1,5 @@
 @import '../workspace.component.scss';
 
-.texera-workspace-result-panel-body {
-    border: 2px solid;
-}
-
 .mat-table {
 
   .mat-header-row {

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.scss
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.scss
@@ -1,23 +1,22 @@
 @import '../workspace.component.scss';
 .texera-workspace-workflow-editor-body {
-  border: 2px solid;
   overflow: hidden;
 }
 
-/**
-* Component styles normally apply only to the HTML in the component's own template.
-* Using ::ng-deep would force a style down through
-* the child component tree into all the child component views
-**/
-
+.texera-workspace-workflow-jointjs {
+  background-color: #f2f2f2;
+}
 
 /**
-* The styles defined here under ::ng-deep is used to override
-* the default style of the operators defined by the JointJS.
-* !important forces the browser to make the style defined here
-* higher prioritized.
-**/
-
+  * Component styles normally apply only to the HTML in the component's own template.
+  * Using ::ng-deep would force a style down through
+  * the child component tree into all the child component views
+  *
+  * The styles defined here under ::ng-deep is used to override
+  * the default style of the operators defined by the JointJS.
+  * !important forces the browser to make the style defined here
+  * higher prioritized.
+  **/
 ::ng-deep .texera-workspace-workflow-editor-body .marker-arrowhead {
   fill: #919191 !important;
 }

--- a/core/new-gui/src/app/workspace/component/workspace.component.scss
+++ b/core/new-gui/src/app/workspace/component/workspace.component.scss
@@ -1,7 +1,7 @@
 /**
-* this css forces the texera user-interface
-* to cover the entire browser window
-**/
+  * this css forces the texera user-interface
+  * to cover the entire browser window
+  **/
 .grid-container {
   min-width: 100%;
   width: 100%;
@@ -10,9 +10,9 @@
 }
 
 /**
-* this style is used by all the sub-components
-* to utilize the entire area specified to them by the css grids
-**/
+  * this style is used by all the sub-components
+  * to utilize the entire area specified to them by the css grids
+  **/
 .texera-workflow-component-body {
   min-width: 100%;
   width: 100%;
@@ -21,26 +21,26 @@
 }
 
 /**
-* this css is used for creating a 3x3 grid area for the 5
-* sub-components. The percentages define the size of each
-* column and row. $header-height is the default height
-* set for the navigation bar. The function calc() calculates
-* the row percentage used for workflow-editor and result-panel. We
-* need to use calc() because when we are using auto or percentage, the
-* size will be based on the child component. Using auto and percentage
-* with a fixed px (header-height) will crash.
-**/
+  * this css is used for creating a 3x3 grid area for the 5
+  * sub-components. The percentages define the size of each
+  * column and row. $header-height is the default height
+  * set for the navigation bar. The function calc() calculates
+  * the row percentage used for workflow-editor and result-panel. We
+  * need to use calc() because when we are using auto or percentage, the
+  * size will be based on the child component. Using auto and percentage
+  * with a fixed px (header-height) will crash.
+  */
 $header-height: 56px;
 .texera-workspace-grid-container {
   display: grid;
   grid-template-columns: 14% 70% 16%;
-  grid-template-rows : $header-height calc((100% - #{$header-height}) * 0.75) calc((100% - #{$header-height}) * 0.25)
+  grid-template-rows: $header-height calc((100% - #{$header-height}) * 0.75) calc((100% - #{$header-height}) * 0.25)
 }
 
 /**
-* this style specifies that the navigation component will
-* use all three columns and the first row.
-**/
+  * this style specifies that the navigation component will
+  * use all three columns and the first row.
+  */
 .texera-navigation-grid-container {
   grid-column-start: 1;
   grid-column-end: 4;
@@ -49,11 +49,12 @@ $header-height: 56px;
 }
 
 /**
-* this style specifies that the operator bar on the left will
-* occupy the first column count from the left and use second and third rows.
-* Overflow auto creates a scrollbar when the content exceeds the size
-* of the grid
-**/
+  * this style specifies that the operator bar on the left will
+  * occupy the first column count from the left and use second and third rows.
+  * Overflow auto creates a scrollbar when the content exceeds the size
+  * of the grid
+  */
+
 .texera-operator-panel-grid-container {
   grid-column-start: 1;
   grid-column-end: 2;
@@ -63,11 +64,11 @@ $header-height: 56px;
 }
 
 /**
-* this style specifies that the property editor for the operators
-* on the right will occupy the 3rd (last) columm and use second and third
-* rows. Overflow auto creates a scrollbar when the content exceeds the size
-* of the grid
-**/
+  * this style specifies that the property editor for the operators
+  * on the right will occupy the 3rd (last) columm and use second and third
+  * rows. Overflow auto creates a scrollbar when the content exceeds the size
+  * of the grid
+  */
 .texera-property-editor-grid-container {
   grid-column-start: 3;
   grid-column-end: 4;
@@ -80,6 +81,7 @@ $header-height: 56px;
 * this style specifies that the workflow editor in the middle
 * will occupy the 2nd (middle) columm and use the second row (middle)
 **/
+
 .texera-workflow-editor-grid-container {
   grid-column-start: 2;
   grid-column-end: 3;
@@ -88,10 +90,10 @@ $header-height: 56px;
 }
 
 /**
-* this style specifies that the result panel in the middle
-* will occupy the 2nd (middle) columm and use the last row (middle). It will
-* be right under the workflow-editor
-**/
+  * this style specifies that the result panel in the middle
+  * will occupy the 2nd (middle) columm and use the last row (middle). It will
+  * be right under the workflow-editor
+  */
 .texera-result-panel-grid-container {
   grid-column-start: 2;
   grid-column-end: 3;


### PR DESCRIPTION
This PR adds some initial CSS styles to make the new GUI more usable. In the future, the new GUI CSS will be further refined. The current GUI looks like this:

<img width="1680" alt="screen shot 2018-07-05 at 2 15 38 pm" src="https://user-images.githubusercontent.com/12578068/42305547-ff4afaac-805d-11e8-9a1a-d790f9ea1168.png">
