### PR TITLE
[Issue #692] Add Version Number to Texera GUI

### DIFF
--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -1,6 +1,6 @@
 <nav class="texera-navigation-body navbar navbar-expand-sm bg-dark navbar-dark justify-content-between">
   <a class="navbar-brand" href="#">
-    Texera <span class="version-number">1.0.0</span>
+    Texera <span class="version-number">0.3.0</span>
   </a>
 
 

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -1,5 +1,9 @@
 <nav class="texera-navigation-body navbar navbar-expand-sm bg-dark navbar-dark justify-content-between">
-  <a class="navbar-brand" href="#">Texera</a>
+  <a class="navbar-brand" href="#">
+    Texera <span class="version-number">1.0.0</span>
+  </a>
+
+
   <div class="button" tourAnchor= "texera-workspace-navigation-run">
     <button class="btn btn-secondary texera-workspace-tour-run" (click)="tourService.toggle()" tourAnchor="start.tour">
         <span>

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.scss
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.scss
@@ -25,6 +25,10 @@
   }
 }
 
+.version-number {
+  color: #F2F1F1;
+  font-size: 10px;
+}
 
 
 


### PR DESCRIPTION
Currently there is no version number displayed on our GUI. To prevent developers and users to use wrong GUI version, this version number allows them to double check if they are using the newest version of Texera according to the Wiki page.

With the versioning available, the users can also know which new features are introduced in each of the updates and download the most recent version based on their needs.

Here is a picture of the new versioning, which is displayed directly next to the Texera brand.

![image](https://user-images.githubusercontent.com/19577058/52154516-0294bb00-2633-11e9-95ed-aee318e9f06e.png)


This design follows the design of React-native-element library, which also display its version on the top left hand corner of its navigation bar:

![image](https://user-images.githubusercontent.com/19577058/52154552-44bdfc80-2633-11e9-8c32-53f864a9c3ef.png)


