### PR TITLE
fix bug in the NLP-sentiment operator

### DIFF
--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/nlp/sentiment/NlpSentimentOperator.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/nlp/sentiment/NlpSentimentOperator.java
@@ -117,6 +117,7 @@ public class NlpSentimentOperator implements IOperator {
             String sentenceText = sentence.toString();
             if (sentenceText.length() > longestSentenceLength) {
                 mainSentiment = sentiment;
+                longestSentenceLength=sentenceText.length();
             }
         }
         return normalizeSentimentScore(mainSentiment);

--- a/core/dataflow/src/test/java/edu/uci/ics/texera/dataflow/nlp/sentiment/NlpSentimentTest.java
+++ b/core/dataflow/src/test/java/edu/uci/ics/texera/dataflow/nlp/sentiment/NlpSentimentTest.java
@@ -12,7 +12,7 @@ import edu.uci.ics.texera.dataflow.sink.tuple.TupleSink;
 import edu.uci.ics.texera.dataflow.source.tuple.TupleSourceOperator;
 
 public class NlpSentimentTest {
-    
+
     /*
      * Test sentiment with a positive sentence, result should be 3 (positive)
      */
@@ -23,18 +23,18 @@ public class NlpSentimentTest {
         NlpSentimentOperator sentiment = new NlpSentimentOperator(
                 new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
         TupleSink tupleSink = new TupleSink();
-        
+
         sentiment.setInputOperator(tupleSource);
         tupleSink.setInputOperator(sentiment);
-        
+
         tupleSink.open();
         List<Tuple> results = tupleSink.collectAllTuples();
         tupleSink.close();
-        
+
         Tuple tuple = results.get(0);
         Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.POSITIVE);
     }
-    
+
     /*
      * Test sentiment with a neutral sentence, result should be 2 (neutral)
      */
@@ -45,18 +45,18 @@ public class NlpSentimentTest {
         NlpSentimentOperator sentiment = new NlpSentimentOperator(
                 new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
         TupleSink tupleSink = new TupleSink();
-        
+
         sentiment.setInputOperator(tupleSource);
         tupleSink.setInputOperator(sentiment);
-        
+
         tupleSink.open();
         List<Tuple> results = tupleSink.collectAllTuples();
         tupleSink.close();
-        
+
         Tuple tuple = results.get(0);
-        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.NEUTRAL);     
+        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.NEUTRAL);
     }
-    
+
     /*
      * Test sentiment with a negative sentence, result should be 1 (negative)
      */
@@ -67,37 +67,40 @@ public class NlpSentimentTest {
         NlpSentimentOperator sentiment = new NlpSentimentOperator(
                 new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
         TupleSink tupleSink = new TupleSink();
-        
+
         sentiment.setInputOperator(tupleSource);
         tupleSink.setInputOperator(sentiment);
-        
+
         tupleSink.open();
         List<Tuple> results = tupleSink.collectAllTuples();
         tupleSink.close();
-        
+
         Tuple tuple = results.get(0);
-        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.NEGATIVE);        
-    }  
+        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.NEGATIVE);
+    }
+
     /*
-     * Test sentiment with multiple sentences in a tweet, 
-     * the sentiment result should equal to the sentiment of the longest sentence.
-     * For this input "Blabla. Bugs are always annoying. But programming is so super awesome. Blabla.", the result should be 3 (positive)
+     * Test sentiment with multiple sentences in a tweet, the sentiment result
+     * should equal to the sentiment of the longest sentence. For this input
+     * "Blabla. Bugs are always annoying. But programming is so super awesome. Blabla."
+     * , the result should be 3 (positive)
      */
     @Test
-    public void test4() throws TexeraException{
-    	TupleSourceOperator tupleSource = new TupleSourceOperator(
-                Arrays.asList(NlpSentimentTestConstants.MULTIPLE_SENTENCES_TUPLE), NlpSentimentTestConstants.SENTIMENT_SCHEMA);
-    	NlpSentimentOperator sentiment = new NlpSentimentOperator(
+    public void test4() throws TexeraException {
+        TupleSourceOperator tupleSource = new TupleSourceOperator(
+                Arrays.asList(NlpSentimentTestConstants.MULTIPLE_SENTENCES_TUPLE),
+                NlpSentimentTestConstants.SENTIMENT_SCHEMA);
+        NlpSentimentOperator sentiment = new NlpSentimentOperator(
                 new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
-    	TupleSink tupleSink = new TupleSink();
-    	
-    	sentiment.setInputOperator(tupleSource);
+        TupleSink tupleSink = new TupleSink();
+
+        sentiment.setInputOperator(tupleSource);
         tupleSink.setInputOperator(sentiment);
-        
+
         tupleSink.open();
         List<Tuple> results = tupleSink.collectAllTuples();
         tupleSink.close();
-        
+
         Tuple tuple = results.get(0);
         Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.POSITIVE);
     }

--- a/core/dataflow/src/test/java/edu/uci/ics/texera/dataflow/nlp/sentiment/NlpSentimentTest.java
+++ b/core/dataflow/src/test/java/edu/uci/ics/texera/dataflow/nlp/sentiment/NlpSentimentTest.java
@@ -16,15 +16,82 @@ public class NlpSentimentTest {
     /*
      * Test sentiment with a positive sentence, result should be 3 (positive)
      */
+//    @Test
+//    public void test1() throws TexeraException {
+//        TupleSourceOperator tupleSource = new TupleSourceOperator(
+//                Arrays.asList(NlpSentimentTestConstants.POSITIVE_TUPLE), NlpSentimentTestConstants.SENTIMENT_SCHEMA);
+//        NlpSentimentOperator sentiment = new NlpSentimentOperator(
+//                new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
+//        TupleSink tupleSink = new TupleSink();
+//        
+//        sentiment.setInputOperator(tupleSource);
+//        tupleSink.setInputOperator(sentiment);
+//        
+//        tupleSink.open();
+//        List<Tuple> results = tupleSink.collectAllTuples();
+//        tupleSink.close();
+//        
+//        Tuple tuple = results.get(0);
+//        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.POSITIVE);
+//    }
+//    
+//    /*
+//     * Test sentiment with a neutral sentence, result should be 2 (neutral)
+//     */
+//    @Test
+//    public void test2() throws TexeraException {
+//        TupleSourceOperator tupleSource = new TupleSourceOperator(
+//                Arrays.asList(NlpSentimentTestConstants.NEUTRAL_TUPLE), NlpSentimentTestConstants.SENTIMENT_SCHEMA);
+//        NlpSentimentOperator sentiment = new NlpSentimentOperator(
+//                new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
+//        TupleSink tupleSink = new TupleSink();
+//        
+//        sentiment.setInputOperator(tupleSource);
+//        tupleSink.setInputOperator(sentiment);
+//        
+//        tupleSink.open();
+//        List<Tuple> results = tupleSink.collectAllTuples();
+//        tupleSink.close();
+//        
+//        Tuple tuple = results.get(0);
+//        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.NEUTRAL);     
+//    }
+//    
+//    /*
+//     * Test sentiment with a negative sentence, result should be 1 (negative)
+//     */
+//    @Test
+//    public void test3() throws TexeraException {
+//        TupleSourceOperator tupleSource = new TupleSourceOperator(
+//                Arrays.asList(NlpSentimentTestConstants.NEGATIVE_TUPLE), NlpSentimentTestConstants.SENTIMENT_SCHEMA);
+//        NlpSentimentOperator sentiment = new NlpSentimentOperator(
+//                new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
+//        TupleSink tupleSink = new TupleSink();
+//        
+//        sentiment.setInputOperator(tupleSource);
+//        tupleSink.setInputOperator(sentiment);
+//        
+//        tupleSink.open();
+//        List<Tuple> results = tupleSink.collectAllTuples();
+//        tupleSink.close();
+//        
+//        Tuple tuple = results.get(0);
+//        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.NEGATIVE);        
+//    }  
+    /*
+     * Test sentiment with multiple sentences in a tweet, 
+     * the sentiment result should equal to the sentiment of the longest sentence.
+     * For this input "Blabla. Bugs are always annoying. But programming is so super awesome. Blabla.", the result should be 3 (positive)
+     */
     @Test
-    public void test1() throws TexeraException {
-        TupleSourceOperator tupleSource = new TupleSourceOperator(
-                Arrays.asList(NlpSentimentTestConstants.POSITIVE_TUPLE), NlpSentimentTestConstants.SENTIMENT_SCHEMA);
-        NlpSentimentOperator sentiment = new NlpSentimentOperator(
+    public void test4() throws TexeraException{
+    	TupleSourceOperator tupleSource = new TupleSourceOperator(
+                Arrays.asList(NlpSentimentTestConstants.MULTIPLE_SENTENCES_TUPLE), NlpSentimentTestConstants.SENTIMENT_SCHEMA);
+    	NlpSentimentOperator sentiment = new NlpSentimentOperator(
                 new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
-        TupleSink tupleSink = new TupleSink();
-        
-        sentiment.setInputOperator(tupleSource);
+    	TupleSink tupleSink = new TupleSink();
+    	
+    	sentiment.setInputOperator(tupleSource);
         tupleSink.setInputOperator(sentiment);
         
         tupleSink.open();
@@ -34,49 +101,4 @@ public class NlpSentimentTest {
         Tuple tuple = results.get(0);
         Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.POSITIVE);
     }
-    
-    /*
-     * Test sentiment with a neutral sentence, result should be 2 (neutral)
-     */
-    @Test
-    public void test2() throws TexeraException {
-        TupleSourceOperator tupleSource = new TupleSourceOperator(
-                Arrays.asList(NlpSentimentTestConstants.NEUTRAL_TUPLE), NlpSentimentTestConstants.SENTIMENT_SCHEMA);
-        NlpSentimentOperator sentiment = new NlpSentimentOperator(
-                new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
-        TupleSink tupleSink = new TupleSink();
-        
-        sentiment.setInputOperator(tupleSource);
-        tupleSink.setInputOperator(sentiment);
-        
-        tupleSink.open();
-        List<Tuple> results = tupleSink.collectAllTuples();
-        tupleSink.close();
-        
-        Tuple tuple = results.get(0);
-        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.NEUTRAL);     
-    }
-    
-    /*
-     * Test sentiment with a negative sentence, result should be 1 (negative)
-     */
-    @Test
-    public void test3() throws TexeraException {
-        TupleSourceOperator tupleSource = new TupleSourceOperator(
-                Arrays.asList(NlpSentimentTestConstants.NEGATIVE_TUPLE), NlpSentimentTestConstants.SENTIMENT_SCHEMA);
-        NlpSentimentOperator sentiment = new NlpSentimentOperator(
-                new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
-        TupleSink tupleSink = new TupleSink();
-        
-        sentiment.setInputOperator(tupleSource);
-        tupleSink.setInputOperator(sentiment);
-        
-        tupleSink.open();
-        List<Tuple> results = tupleSink.collectAllTuples();
-        tupleSink.close();
-        
-        Tuple tuple = results.get(0);
-        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.NEGATIVE);        
-    }  
-
 }

--- a/core/dataflow/src/test/java/edu/uci/ics/texera/dataflow/nlp/sentiment/NlpSentimentTest.java
+++ b/core/dataflow/src/test/java/edu/uci/ics/texera/dataflow/nlp/sentiment/NlpSentimentTest.java
@@ -16,68 +16,68 @@ public class NlpSentimentTest {
     /*
      * Test sentiment with a positive sentence, result should be 3 (positive)
      */
-//    @Test
-//    public void test1() throws TexeraException {
-//        TupleSourceOperator tupleSource = new TupleSourceOperator(
-//                Arrays.asList(NlpSentimentTestConstants.POSITIVE_TUPLE), NlpSentimentTestConstants.SENTIMENT_SCHEMA);
-//        NlpSentimentOperator sentiment = new NlpSentimentOperator(
-//                new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
-//        TupleSink tupleSink = new TupleSink();
-//        
-//        sentiment.setInputOperator(tupleSource);
-//        tupleSink.setInputOperator(sentiment);
-//        
-//        tupleSink.open();
-//        List<Tuple> results = tupleSink.collectAllTuples();
-//        tupleSink.close();
-//        
-//        Tuple tuple = results.get(0);
-//        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.POSITIVE);
-//    }
-//    
-//    /*
-//     * Test sentiment with a neutral sentence, result should be 2 (neutral)
-//     */
-//    @Test
-//    public void test2() throws TexeraException {
-//        TupleSourceOperator tupleSource = new TupleSourceOperator(
-//                Arrays.asList(NlpSentimentTestConstants.NEUTRAL_TUPLE), NlpSentimentTestConstants.SENTIMENT_SCHEMA);
-//        NlpSentimentOperator sentiment = new NlpSentimentOperator(
-//                new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
-//        TupleSink tupleSink = new TupleSink();
-//        
-//        sentiment.setInputOperator(tupleSource);
-//        tupleSink.setInputOperator(sentiment);
-//        
-//        tupleSink.open();
-//        List<Tuple> results = tupleSink.collectAllTuples();
-//        tupleSink.close();
-//        
-//        Tuple tuple = results.get(0);
-//        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.NEUTRAL);     
-//    }
-//    
-//    /*
-//     * Test sentiment with a negative sentence, result should be 1 (negative)
-//     */
-//    @Test
-//    public void test3() throws TexeraException {
-//        TupleSourceOperator tupleSource = new TupleSourceOperator(
-//                Arrays.asList(NlpSentimentTestConstants.NEGATIVE_TUPLE), NlpSentimentTestConstants.SENTIMENT_SCHEMA);
-//        NlpSentimentOperator sentiment = new NlpSentimentOperator(
-//                new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
-//        TupleSink tupleSink = new TupleSink();
-//        
-//        sentiment.setInputOperator(tupleSource);
-//        tupleSink.setInputOperator(sentiment);
-//        
-//        tupleSink.open();
-//        List<Tuple> results = tupleSink.collectAllTuples();
-//        tupleSink.close();
-//        
-//        Tuple tuple = results.get(0);
-//        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.NEGATIVE);        
-//    }  
+    @Test
+    public void test1() throws TexeraException {
+        TupleSourceOperator tupleSource = new TupleSourceOperator(
+                Arrays.asList(NlpSentimentTestConstants.POSITIVE_TUPLE), NlpSentimentTestConstants.SENTIMENT_SCHEMA);
+        NlpSentimentOperator sentiment = new NlpSentimentOperator(
+                new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
+        TupleSink tupleSink = new TupleSink();
+        
+        sentiment.setInputOperator(tupleSource);
+        tupleSink.setInputOperator(sentiment);
+        
+        tupleSink.open();
+        List<Tuple> results = tupleSink.collectAllTuples();
+        tupleSink.close();
+        
+        Tuple tuple = results.get(0);
+        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.POSITIVE);
+    }
+    
+    /*
+     * Test sentiment with a neutral sentence, result should be 2 (neutral)
+     */
+    @Test
+    public void test2() throws TexeraException {
+        TupleSourceOperator tupleSource = new TupleSourceOperator(
+                Arrays.asList(NlpSentimentTestConstants.NEUTRAL_TUPLE), NlpSentimentTestConstants.SENTIMENT_SCHEMA);
+        NlpSentimentOperator sentiment = new NlpSentimentOperator(
+                new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
+        TupleSink tupleSink = new TupleSink();
+        
+        sentiment.setInputOperator(tupleSource);
+        tupleSink.setInputOperator(sentiment);
+        
+        tupleSink.open();
+        List<Tuple> results = tupleSink.collectAllTuples();
+        tupleSink.close();
+        
+        Tuple tuple = results.get(0);
+        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.NEUTRAL);     
+    }
+    
+    /*
+     * Test sentiment with a negative sentence, result should be 1 (negative)
+     */
+    @Test
+    public void test3() throws TexeraException {
+        TupleSourceOperator tupleSource = new TupleSourceOperator(
+                Arrays.asList(NlpSentimentTestConstants.NEGATIVE_TUPLE), NlpSentimentTestConstants.SENTIMENT_SCHEMA);
+        NlpSentimentOperator sentiment = new NlpSentimentOperator(
+                new NlpSentimentPredicate(NlpSentimentTestConstants.TEXT, "sentiment"));
+        TupleSink tupleSink = new TupleSink();
+        
+        sentiment.setInputOperator(tupleSource);
+        tupleSink.setInputOperator(sentiment);
+        
+        tupleSink.open();
+        List<Tuple> results = tupleSink.collectAllTuples();
+        tupleSink.close();
+        
+        Tuple tuple = results.get(0);
+        Assert.assertEquals(tuple.getField("sentiment").getValue(), SentimentConstants.NEGATIVE);        
+    }  
     /*
      * Test sentiment with multiple sentences in a tweet, 
      * the sentiment result should equal to the sentiment of the longest sentence.

--- a/core/dataflow/src/test/java/edu/uci/ics/texera/dataflow/nlp/sentiment/NlpSentimentTestConstants.java
+++ b/core/dataflow/src/test/java/edu/uci/ics/texera/dataflow/nlp/sentiment/NlpSentimentTestConstants.java
@@ -23,4 +23,6 @@ public class NlpSentimentTestConstants {
     public static Tuple NEGATIVE_TUPLE = new Tuple(SENTIMENT_SCHEMA,
             new TextField("Bugs are always annoying."));
     
+    public static Tuple MULTIPLE_SENTENCES_TUPLE=new Tuple(SENTIMENT_SCHEMA,new TextField("Blabla. Bugs are always annoying. But programming is so super awesome. Blabla."));
+    
 }


### PR DESCRIPTION
The bug is that if the input contains multiple sentences, previous code always get the sentiment for the last sentence. 

If the input contains multiple sentences, there are two possible solutions for the sentiment of the input. (i) One is that we can use the sentiment of the longest sentence as the sentiment of the input. (ii) Another one is that we can use the average sentiments for all sentences in the input as sentiment of the input. For this implementation, we use the first solution.

For example, the input is "_Blabla. Bugs are always annoying. But programming is so super awesome. Blabla._". It contains four sentences. The sentiment for the first sentence "_Blabla._" is neutral. The sentiment for the second sentence "_Bugs are always annoying._" is negative. The sentiment for the third sentence "_But programming is so super awesome._"is positive. And the sentiment for the last sentence "_Blabla._" is neutral.

The previous code get the last sentiment for this input. It's neutral. The first solution get the longest sentence's sentiment. It's positive. The second solution get the average sentiment. It's neutral. In fact, the first solution is meaningful.

Finally, we use the first solution for this implementation.