### PR TITLE
GUI fix - Fix the starting position for draggable operator element

### DIFF
--- a/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.ts
+++ b/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.ts
@@ -127,7 +127,12 @@ export class DragDropService {
       helper: () => this.createFlyingOperatorElement(operatorType),
       // declare event as type any because the jQueryUI type declaration is wrong
       // it should be of type JQuery.Event, which is incompatible with the the declared type Event
-      start: (event: any, ui) => this.handleOperatorStartDrag(event, ui)
+      start: (event: any, ui) => this.handleOperatorStartDrag(event, ui),
+      // The draggable element will be created with the mouse starting point at the center
+      cursorAt : {
+        left: JointUIService.DEFAULT_OPERATOR_WIDTH / 2,
+        top: JointUIService.DEFAULT_OPERATOR_HEIGHT / 2
+      }
     });
   }
 


### PR DESCRIPTION
After the new PR #679 is merged, there is a minor problem when dragging operator element to the workspace-component.

If the user drags the right hand corner of any operator in the operator panel, the draggable element will always display on the left instead of moving directly with user's mouse.

This PR fixes the problem by introducing a new parameter in JQuery.Draggable, cursorAt, which sets the offset of the dragging helper relative to the mouse cursor. In this PR, this cursorAt is set to operator width / 2 and operator height / 2 to display the helper at the `center` of the draggable element.
