### PR TITLE
GUI fix - Fix input from jumping to the end when editing properties on property panel

### DIFF
--- a/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.ts
@@ -252,7 +252,10 @@ export class PropertyEditorComponent {
     this.workflowActionService.getTexeraGraph().getOperatorPropertyChangeStream()
       .filter(operatorChanged => operatorChanged.operator.operatorID === this.currentOperatorID)
       .subscribe(operatorChanged => {
-        this.currentOperatorInitialData = cloneDeep(operatorChanged.operator.operatorProperties);
+        if (!isEqual(this.cachedFormData, operatorChanged.operator.operatorProperties)) {
+          this.currentOperatorInitialData = cloneDeep(operatorChanged.operator.operatorProperties);
+        }
+
       });
   }
 
@@ -265,6 +268,7 @@ export class PropertyEditorComponent {
       .subscribe(formData => {
       // set the operator property to be the new form data
       if (this.currentOperatorID) {
+        this.cachedFormData = formData;
         this.workflowActionService.setOperatorProperty(this.currentOperatorID, formData);
       }
     });

--- a/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.ts
@@ -251,11 +251,9 @@ export class PropertyEditorComponent {
   private handleOperatorPropertyChange(): void {
     this.workflowActionService.getTexeraGraph().getOperatorPropertyChangeStream()
       .filter(operatorChanged => operatorChanged.operator.operatorID === this.currentOperatorID)
+      .filter(operatorChanged => !isEqual(this.cachedFormData, operatorChanged.operator.operatorProperties))
       .subscribe(operatorChanged => {
-        if (!isEqual(this.cachedFormData, operatorChanged.operator.operatorProperties)) {
-          this.currentOperatorInitialData = cloneDeep(operatorChanged.operator.operatorProperties);
-        }
-
+        this.currentOperatorInitialData = cloneDeep(operatorChanged.operator.operatorProperties);
       });
   }
 


### PR DESCRIPTION
Currently, when the user make modification on the property panel, the property panel by default will move input cursor to the end every time a user makes a change.

Here is a sample gif of the problem, where we edit the property at the middle of the data, and input jumps back to the end automatically, which will create bad user experience.

![ezgif-5-4935afd9ad71](https://user-images.githubusercontent.com/12578068/54177892-21b41300-4451-11e9-8722-f489810989a3.gif)

This PR fixes this problem by utilizing a new variable `cachedFormData`, which stores a cache of formData every time before operator property is written back to the workflow graph and triggers `getOperatorPropertyChangeStream()`. And, when `getOperatorPropertyChangeStream()` occurs, we can use this `cachedFormData` to compare with the new property change. 

When `cachedFormData` is equal to the property change, then 
`this.currentOperatorInitialData = cloneDeep(operatorChanged.operator.operatorProperties);` 
will not be called, which is the root cause of the jumping input.