### PR TITLE
Fix Autocomplete Frontend not handling error returned from backend properly

### DIFF
--- a/core/new-gui/package-lock.json
+++ b/core/new-gui/package-lock.json
@@ -9228,6 +9228,14 @@
       "resolved": "https://registry.npmjs.org/ngx-json-viewer/-/ngx-json-viewer-2.4.0.tgz",
       "integrity": "sha512-26QmLp+0ds90aFug3KbSIwqtmQgCcJYFNNNcmcZHgPRj75nhKzbo4ceKxkhWmY5auKZClVO0HTZSs5bBhgb1Bw=="
     },
+    "ngx-logger": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/ngx-logger/-/ngx-logger-3.3.12.tgz",
+      "integrity": "sha512-qO5+WUcCFGM5E+m/SEhz3FrL9UR3l2Q3ZgrlvBsCn+ihyn4G8rhFrUMsidTMSvTJq9NLF6UOqnWh4BOmXHF33Q==",
+      "requires": {
+        "tslib": "1.9.0"
+      }
+    },
     "ngx-popper": {
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/ngx-popper/-/ngx-popper-2.8.2.tgz",

--- a/core/new-gui/package.json
+++ b/core/new-gui/package.json
@@ -40,6 +40,7 @@
     "lodash-es": "^4.17.10",
     "ngx-bootstrap": "^3.0.1",
     "ngx-json-viewer": "^2.4.0",
+    "ngx-logger": "^3.3.12",
     "ngx-popper": "^2.7.1",
     "ngx-tour-core": "^3.0.0",
     "ngx-tour-ng-bootstrap": "^3.0.0",

--- a/core/new-gui/src/app/app.module.ts
+++ b/core/new-gui/src/app/app.module.ts
@@ -1,15 +1,15 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 import { HttpClientModule } from '@angular/common/http';
-
 import { AppRoutingModule } from './app-routing.module';
+import { environment } from './../environments/environment';
 
 import { CustomNgMaterialModule } from './common/custom-ng-material.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { RouterModule } from '@angular/router';
 import { TourNgBootstrapModule } from 'ngx-tour-ng-bootstrap';
-
+import { LoggerModule, NgxLoggerLevel } from 'ngx-logger';
 
 import { MaterialDesignFrameworkModule } from 'angular6-json-schema-form';
 import { NgxJsonViewerModule } from 'ngx-json-viewer';
@@ -50,7 +50,7 @@ import { ResultPanelToggleComponent } from './workspace/component/result-panel-t
     NgbModule.forRoot(),
     RouterModule.forRoot([]),
     TourNgBootstrapModule.forRoot(),
-
+    LoggerModule.forRoot({level: environment.production ? NgxLoggerLevel.ERROR : NgxLoggerLevel.DEBUG, serverLogLevel: NgxLoggerLevel.OFF}),
     MaterialDesignFrameworkModule
 
   ],


### PR DESCRIPTION
This PR fixes an issue that the frontend stop listens to events related to Autocomplete and SchemaPropagation after the server returns an error in a request.

The reason is that an RxJS Stream is stopped after an uncaught error from an event. To recover the stream from an error, we must catch the error and recover the stream. 