### PR TITLE
Fix drop-down problem when not disabling

### DIFF
--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -11,9 +11,11 @@
       title="download execution result"></i> -->
 
       <div ngbDropdown class="d-inline-block">
-        <i class="navbar-brand fa fa-cloud-download"  [ngClass]="{'utility-button-disabled' : !executionResultID,
-        'utility-button': executionResultID}" id="downloadExcelOptions" ngbDropdownToggle
-          title="download execution result"></i>
+        <button class="drop-down-button" ngbDropdownToggle [disabled]="!executionResultID">
+          <i class="navbar-brand fa fa-cloud-download drop-down-icon"  [ngClass]="{'utility-button-disabled' : !executionResultID,
+          'utility-button': executionResultID}" id="downloadExcelOptions"
+            title="download execution result"></i>
+        </button>
         <div class="drop-down-menu" ngbDropdownMenu aria-labelledby="downloadExcelOptions">
           <button class="drop-down-item" ngbDropdownItem (click)="onClickDownloadExecutionResult('json')">Json File (*.json)</button>
           <button class="drop-down-item" ngbDropdownItem (click)="onClickDownloadExecutionResult('csv')"> CSV File (*.csv)</button>

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.scss
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.scss
@@ -85,3 +85,13 @@
   background-color: #C6C6C6;
   cursor: pointer;
 }
+
+.drop-down-button{
+  padding: 0px;
+  border: 0px;
+  background-color: transparent;
+}
+
+.drop-down-icon{
+  margin-right: 0px;
+}


### PR DESCRIPTION
Previously when there is no result in the result panel, even though the download execution result button looks disabled on the UI, we can still open the drop-down menu. 

This PR disable the drop-down when there is no execution result.