### PR TITLE
Add a delete all button to remove all operators on the graph

### DIFF
--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -6,7 +6,8 @@
     <i class="navbar-brand utility-button fa fa-search-minus" (click)="onClickZoomOut()" title="zoom out"></i>
     <i class="navbar-brand utility-button fa fa-search-plus" (click)="onClickZoomIn()" title="zoom in"></i>
     <i class="navbar-brand utility-button fa fa-arrows-alt" (click)="onClickRestoreZoomOffsetDefaullt()" title="reset zoom"></i>
-    <i class="navbar-brand utility-button fa fa-trash" (click)="onClickDeleteAllOperators()" title="delete all"></i>
+    <i class="navbar-brand fa fa-trash" [ngClass]="{'utility-button-disabled': !hasOperators(), 'utility-button': hasOperators()}"
+      (click)="onClickDeleteAllOperators()" title="delete all"></i>
     <!-- <i class="navbar-brand fa fa-cloud-download" [ngClass]="{'utility-button-disabled' : !executionResultID,
       'utility-button': executionResultID}" (click)="onClickDownloadExecutionResult()"
       title="download execution result"></i> -->

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -3,9 +3,10 @@
     Texera <span class="version-number">0.5.0</span>
   </a>
   <div class="collapse navbar-collapse texera-navigation-utilities">
-    <i class="navbar-brand utility-button fa fa-search-minus" (click)="onClickZoomOut()" title="zoom in"></i>
+    <i class="navbar-brand utility-button fa fa-search-minus" (click)="onClickZoomOut()" title="zoom out"></i>
     <i class="navbar-brand utility-button fa fa-search-plus" (click)="onClickZoomIn()" title="zoom in"></i>
     <i class="navbar-brand utility-button fa fa-arrows-alt" (click)="onClickRestoreZoomOffsetDefaullt()" title="reset zoom"></i>
+    <i class="navbar-brand utility-button fa fa-trash" (click)="onClickDeleteAllOperators()" title="delete all"></i>
     <!-- <i class="navbar-brand fa fa-cloud-download" [ngClass]="{'utility-button-disabled' : !executionResultID,
       'utility-button': executionResultID}" (click)="onClickDownloadExecutionResult()"
       title="download execution result"></i> -->

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.spec.ts
@@ -270,4 +270,9 @@ describe('NavigationComponent', () => {
     m.expect(restoreEndStream).toBeObservable(expectStream);
   }));
 
+  it('should delete all operators on the graph when user clicks on the delete all button', marbles((m) => {
+    m.hot('-e-').do(() => component.onClickDeleteAllOperators()).subscribe();
+    expect(workflowActionService.getTexeraGraph().getAllOperators().length).toBe(0);
+  }));
+
 });

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.spec.ts
@@ -20,6 +20,7 @@ import { mockExecutionResult } from '../../service/execute-workflow/mock-result-
 import { JointGraphWrapper } from '../../service/workflow-graph/model/joint-graph-wrapper';
 import { WorkflowUtilService } from '../../service/workflow-graph/util/workflow-util.service';
 import { environment } from '../../../../environments/environment';
+import { mockScanPredicate, mockPoint } from '../../service/workflow-graph/model/mock-workflow-data';
 
 class StubHttpClient {
 
@@ -271,7 +272,10 @@ describe('NavigationComponent', () => {
   }));
 
   it('should delete all operators on the graph when user clicks on the delete all button', marbles((m) => {
-    m.hot('-e-').do(() => component.onClickDeleteAllOperators()).subscribe();
+    m.hot('-e-').do(() => {
+      workflowActionService.addOperator(mockScanPredicate, mockPoint);
+      component.onClickDeleteAllOperators();
+    }).subscribe();
     expect(workflowActionService.getTexeraGraph().getAllOperators().length).toBe(0);
   }));
 

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -200,6 +200,15 @@ export class NavigationComponent implements OnInit {
   }
 
   /**
+   * Delete all operators on the graph
+   */
+  public onClickDeleteAllOperators(): void {
+    for (const operator of this.workflowActionService.getTexeraGraph().getAllOperators()) {
+      this.workflowActionService.deleteOperator(operator.operatorID);
+    }
+  }
+
+  /**
    * Handler for the execution result to extract successful execution ID
    */
   private handleResultData(response: ExecutionResult): void {

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -209,6 +209,13 @@ export class NavigationComponent implements OnInit {
   }
 
   /**
+   * Returns true if there's any operator on the graph; false otherwise
+   */
+  public hasOperators(): boolean {
+    return this.workflowActionService.getTexeraGraph().getAllOperators().length > 0;
+  }
+
+  /**
    * Handler for the execution result to extract successful execution ID
    */
   private handleResultData(response: ExecutionResult): void {

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -203,9 +203,9 @@ export class NavigationComponent implements OnInit {
    * Delete all operators on the graph
    */
   public onClickDeleteAllOperators(): void {
-    for (const operator of this.workflowActionService.getTexeraGraph().getAllOperators()) {
+    this.workflowActionService.getTexeraGraph().getAllOperators().forEach((operator) => {
       this.workflowActionService.deleteOperator(operator.operatorID);
-    }
+    });
   }
 
   /**


### PR DESCRIPTION
Clicking on the "delete all" button removes all operators present in the graph.

![delete all](https://user-images.githubusercontent.com/28575315/62973407-d9679b00-bdca-11e9-9fb2-9231e6cf922d.gif)
