### PR TITLE
Added key bindings to copy, cut, paste, and delete operators

### DIFF
--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
@@ -277,8 +277,140 @@ describe('WorkflowEditorComponent', () => {
 
   });
 
+    it('should delete the highlighted operator when user presses the backspace key', () => {
+      const jointGraphWrapper = workflowActionService.getJointGraphWrapper();
+      const texeraGraph = workflowActionService.getTexeraGraph();
+      const deleteOperatorFunctionSpy = spyOn(workflowActionService, 'deleteOperator').and.callThrough();
 
+      workflowActionService.addOperator(mockScanPredicate, mockPoint);
+      jointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
 
+      // dispatch a keydown event on the backspace key
+      const event = new KeyboardEvent('keydown', {key: 'Backspace'});
+      document.dispatchEvent(event);
+
+      fixture.detectChanges();
+
+      // assert the function is called once
+      expect(deleteOperatorFunctionSpy.calls.count()).toEqual(1);
+      // assert the highlighted operator is deleted
+      expect(texeraGraph.getOperator(mockScanPredicate.operatorID)).toBeUndefined();
+    });
+
+    it('should delete the highlighted operator when user presses the delete key', () => {
+      const jointGraphWrapper = workflowActionService.getJointGraphWrapper();
+      const texeraGraph = workflowActionService.getTexeraGraph();
+      const deleteOperatorFunctionSpy = spyOn(workflowActionService, 'deleteOperator').and.callThrough();
+
+      workflowActionService.addOperator(mockScanPredicate, mockPoint);
+      jointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
+
+      // dispatch a keydown event on the backspace key
+      const event = new KeyboardEvent('keydown', {key: 'Delete'});
+      document.dispatchEvent(event);
+
+      fixture.detectChanges();
+
+      // assert the function is called once
+      expect(deleteOperatorFunctionSpy.calls.count()).toEqual(1);
+      // assert the highlighted operator is deleted
+      expect(texeraGraph.getOperator(mockScanPredicate.operatorID)).toBeUndefined();
+    });
+
+    it(`should create and highlight a new operator with the same metadata when user
+        copies and pastes the highlighted operator`, () => {
+      const jointGraphWrapper = workflowActionService.getJointGraphWrapper();
+      const texeraGraph = workflowActionService.getTexeraGraph();
+
+      workflowActionService.addOperator(mockScanPredicate, mockPoint);
+      jointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
+
+      // dispatch clipboard events for copy and paste
+      const copyEvent = new ClipboardEvent('copy');
+      document.dispatchEvent(copyEvent);
+      const pasteEvent = new ClipboardEvent('paste');
+      document.dispatchEvent(pasteEvent);
+
+      // the pasted operator should be highlighted
+      const pastedOperatorID = jointGraphWrapper.getCurrentHighlightedOpeartorID();
+      expect(pastedOperatorID).toBeDefined();
+
+      // get the pasted operator
+      let pastedOperator = null;
+      if (pastedOperatorID) {
+        pastedOperator = texeraGraph.getOperator(pastedOperatorID);
+      }
+      expect(pastedOperator).toBeDefined();
+
+      // two operators should have same metadata
+      expect(pastedOperatorID).not.toEqual(mockScanPredicate.operatorID);
+      if (pastedOperator) {
+        expect(pastedOperator.operatorType).toEqual(mockScanPredicate.operatorType);
+        expect(pastedOperator.operatorProperties).toEqual(mockScanPredicate.operatorProperties);
+        expect(pastedOperator.inputPorts).toEqual(mockScanPredicate.inputPorts);
+        expect(pastedOperator.outputPorts).toEqual(mockScanPredicate.outputPorts);
+        expect(pastedOperator.showAdvanced).toEqual(mockScanPredicate.showAdvanced);
+      }
+    });
+
+    it(`should delete the highlighted operator, create and highlight a new operator with the same metadata
+        when user cuts and pastes the highlighted operator`, () => {
+      const jointGraphWrapper = workflowActionService.getJointGraphWrapper();
+      const texeraGraph = workflowActionService.getTexeraGraph();
+
+      workflowActionService.addOperator(mockScanPredicate, mockPoint);
+      jointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
+
+      // dispatch clipboard events for cut and paste
+      const cutEvent = new ClipboardEvent('cut');
+      document.dispatchEvent(cutEvent);
+      const pasteEvent = new ClipboardEvent('paste');
+      document.dispatchEvent(pasteEvent);
+
+      // the copied operator should be deleted
+      expect(texeraGraph.getOperator(mockScanPredicate.operatorID)).toBeUndefined();
+
+      // the pasted operator should be highlighted
+      const pastedOperatorID = jointGraphWrapper.getCurrentHighlightedOpeartorID();
+      expect(pastedOperatorID).toBeDefined();
+
+      // get the pasted operator
+      let pastedOperator = null;
+      if (pastedOperatorID) {
+        pastedOperator = texeraGraph.getOperator(pastedOperatorID);
+      }
+      expect(pastedOperator).toBeDefined();
+
+      // two operators should have same metadata
+      expect(pastedOperatorID).not.toEqual(mockScanPredicate.operatorID);
+      if (pastedOperator) {
+        expect(pastedOperator.operatorType).toEqual(mockScanPredicate.operatorType);
+        expect(pastedOperator.operatorProperties).toEqual(mockScanPredicate.operatorProperties);
+        expect(pastedOperator.inputPorts).toEqual(mockScanPredicate.inputPorts);
+        expect(pastedOperator.outputPorts).toEqual(mockScanPredicate.outputPorts);
+        expect(pastedOperator.showAdvanced).toEqual(mockScanPredicate.showAdvanced);
+      }
+    });
+
+    it('should place the pasted operator in a non-overlapping position', () => {
+      const jointGraphWrapper = workflowActionService.getJointGraphWrapper();
+
+      workflowActionService.addOperator(mockScanPredicate, mockPoint);
+      jointGraphWrapper.highlightOperator(mockScanPredicate.operatorID);
+
+      // dispatch clipboard events for copy and paste
+      const cutEvent = new ClipboardEvent('copy');
+      document.dispatchEvent(cutEvent);
+      const pasteEvent = new ClipboardEvent('paste');
+      document.dispatchEvent(pasteEvent);
+
+      // get the pasted operator
+      const pastedOperatorID = jointGraphWrapper.getCurrentHighlightedOpeartorID();
+      if (pastedOperatorID) {
+        const pastedOperatorPosition = jointGraphWrapper.getOperatorPosition(pastedOperatorID);
+        expect(pastedOperatorPosition).not.toEqual(mockPoint);
+      }
+    });
   });
 
 

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -500,7 +500,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
    */
   private handleOperatorDelete() {
     Observable.fromEvent<KeyboardEvent>(document, 'keydown')
-      .filter(event => !(<HTMLElement> event.target).matches('input'))
+      .filter(event => (<HTMLElement> event.target).nodeName !== 'INPUT')
       .filter(event => event.key === 'Backspace' || event.key === 'Delete')
       .subscribe(() => {
         const currentOperatorID = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOpeartorID();
@@ -517,7 +517,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
    */
   private handleOperatorCopy() {
     Observable.fromEvent<ClipboardEvent>(document, 'copy')
-      .filter(event => !(<HTMLElement> event.target).matches('input'))
+      .filter(event => (<HTMLElement> event.target).nodeName !== 'INPUT')
       .subscribe(() => {
         const currentOperatorID = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOpeartorID();
         if (currentOperatorID) {
@@ -534,7 +534,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
    */
   private handleOperatorCut() {
     Observable.fromEvent<ClipboardEvent>(document, 'cut')
-      .filter(event => !(<HTMLElement> event.target).matches('input'))
+      .filter(event => (<HTMLElement> event.target).nodeName !== 'INPUT')
       .subscribe(() => {
         const currentOperatorID = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOpeartorID();
         if (currentOperatorID) {
@@ -564,7 +564,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
    */
   private handleOperatorPaste() {
     Observable.fromEvent<ClipboardEvent>(document, 'paste')
-      .filter(event => !(<HTMLElement> event.target).matches('input'))
+      .filter(event => (<HTMLElement> event.target).nodeName !== 'INPUT')
       .subscribe(() => {
         if (this.copiedOperator && this.copiedOperatorPosition) {
           const newOperator = this.copyOperator(this.copiedOperator);


### PR DESCRIPTION
**Copy**: When user triggers a DOM event related to copy (i.e. use ctrl/command + c key combination, or select the copy option from browser menu), the currently highlighted operator will be cached (in order to perform appropriate actions when the operator is pasted). If there's no highlighted operator, nothing will be done.

![copy](https://user-images.githubusercontent.com/28575315/63396022-8d909500-c37a-11e9-8e5f-8af4eea36e64.gif)

**Cut**:  This feature behaves like copy, except that it deletes the currently highlighted operator after caching it.

![cut](https://user-images.githubusercontent.com/28575315/63396215-22938e00-c37b-11e9-84da-fe1fd55abf2f.gif)

**Paste**: This feature is triggered in a similar way as copy and cut. When triggered, it creates a new operator with same metadata as the previously copied operator. There are three cases where the new operator will be pasted: 

- Normally, the new operator will be pasted to the bottom right of the copied operator or the last pasted operator.

![paste 1](https://user-images.githubusercontent.com/28575315/63395574-ff67df00-c378-11e9-9e9a-4996589ed723.gif)

- If the copied operator or any previously pasted operator is moved or deleted, the new operator will be pasted in the moved or deleted operator's position.

![paste 2](https://user-images.githubusercontent.com/28575315/63395861-fcb9b980-c379-11e9-937b-2881ae6a569b.gif)

- If the new operator's position overlaps with any existing operator, it will be pasted to the bottom right of the original position.

![paste 3](https://user-images.githubusercontent.com/28575315/63395886-1b1fb500-c37a-11e9-8043-dc269282e3ad.gif)

If there's no copied operator, nothing will be done.

**Delete**: When user presses backspace or del key on some keyboards, the currently highlighted operator will be deleted from the workflow graph. If there's no highlighted operator, nothing will be done. The gif below shows how this feature behaves.

![keyboard delete](https://user-images.githubusercontent.com/28575315/63394089-f247f180-c372-11e9-85c6-2f5f0495b1b7.gif)
