### PR TITLE
Fix schema propagation not propagating schema for sink operators

### DIFF
--- a/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/plangen/LogicalPlan.java
+++ b/core/dataflow/src/main/java/edu/uci/ics/texera/dataflow/plangen/LogicalPlan.java
@@ -180,10 +180,6 @@ public class LogicalPlan {
             }
 
             for (String destination: adjacencyList.get(origin)) {
-                if(operatorObjectMap.get(destination) instanceof ISink) {
-                    continue;
-                }
-
                 if (inputSchemas.containsKey(destination)) {
                     inputSchemas.get(destination).add(currentOutputSchema.get());
                 } else {


### PR DESCRIPTION
This PR fixes a bug where schema proapgation incorrectly ignore sink operator when propagating its input schema. Sink operators should also have their input schema for autocomplete.