### PR TITLE
Follow up of allow null value into workflow

### DIFF
--- a/core/api/src/main/java/edu/uci/ics/texera/api/field/DateField.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/field/DateField.java
@@ -81,10 +81,7 @@ public class DateField implements IField {
 
     @Override
     public String toString() {
-        if (localDate == null) {
-            return "DateField [value= ]";
-        }
-        return "DateField [value=" + localDate.toString() + "]";
+        return "DateField [value=" + String.valueOf(localDate) + "]";
     }
 
 }

--- a/core/api/src/main/java/edu/uci/ics/texera/api/field/DateField.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/field/DateField.java
@@ -42,6 +42,9 @@ public class DateField implements IField {
 
     @JsonProperty(value = JsonConstants.FIELD_VALUE)
     public String getDateString() {
+        if (localDate == null) {
+            return "";
+        }
         return this.localDate.toString();
     }
 
@@ -78,6 +81,9 @@ public class DateField implements IField {
 
     @Override
     public String toString() {
+        if (localDate == null) {
+            return "DateField [value= ]";
+        }
         return "DateField [value=" + localDate.toString() + "]";
     }
 

--- a/core/api/src/main/java/edu/uci/ics/texera/api/field/DateTimeField.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/field/DateTimeField.java
@@ -71,10 +71,7 @@ public class DateTimeField implements IField {
 
     @Override
     public String toString() {
-        if (localDateTime == null) {
-            return "DateTimeField [value= ]";
-        }
-        return "DateTimeField [value=" + localDateTime.toString() + "]";
+        return "DateTimeField [value=" + String.valueOf(localDateTime) + "]";
     }
 
 }

--- a/core/api/src/main/java/edu/uci/ics/texera/api/field/DateTimeField.java
+++ b/core/api/src/main/java/edu/uci/ics/texera/api/field/DateTimeField.java
@@ -32,6 +32,9 @@ public class DateTimeField implements IField {
 
     @JsonProperty(value = JsonConstants.FIELD_VALUE)
     public String getDateTimeString() {
+        if (localDateTime == null) {
+            return "";
+        }
         return this.localDateTime.toString();
     }
 
@@ -68,6 +71,9 @@ public class DateTimeField implements IField {
 
     @Override
     public String toString() {
+        if (localDateTime == null) {
+            return "DateTimeField [value= ]";
+        }
         return "DateTimeField [value=" + localDateTime.toString() + "]";
     }
 


### PR DESCRIPTION
Since null value is allowed, there are bugs in DateField and DateTimeField when `toString()` is called on null object. This PR fix those bugs.