### PR TITLE
Use resultPanelToggleService in result-panel-component.ts and fix Pie Chart operator bug

### DIFF
--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.spec.ts
@@ -160,10 +160,8 @@ describe('ResultPanelComponent', () => {
 
     // This is a way to get the private method in Components. Since this edge case can
     //  never be reached in the public method, this architecture is required.
-
-    expect(() =>
-      (component as any).displayResultTable(mockExecutionEmptyResult.result)
-    ).toThrowError(new RegExp(`result data should not be empty`));
+    (component as any).displayResultTable(mockExecutionEmptyResult.result);
+    expect(component.showMessage).toEqual(false);
 
   });
 

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.spec.ts
@@ -156,14 +156,6 @@ describe('ResultPanelComponent', () => {
     });
   }));
 
-  it(`should throw an error when displayResultTable() is called with execution result that has 0 size`, () => {
-
-    // This is a way to get the private method in Components. Since this edge case can
-    //  never be reached in the public method, this architecture is required.
-    (component as any).displayResultTable(mockExecutionEmptyResult.result);
-    expect(component.showMessage).toEqual(false);
-
-  });
 
   it('should respond to error and print error messages', marbles((m) => {
     const endMarbleString = '-e-|';

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -124,10 +124,10 @@ export class ResultPanelComponent {
     const highlightedOperators = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs();
 
     if (highlightedOperators.length === 1) {
-      this.showResultPanel = true;
       const resultMap = this.executeWorkflowService.getResultMap();
       const result: ResultObject | undefined = resultMap.get(highlightedOperators[0]);
       if (result) {
+        this.resultPanelToggleService.openResultPanel();
         this.displayResultTable(result.table);
         if (result.chartType) {
           this.chartType = result?.chartType;
@@ -136,7 +136,7 @@ export class ResultPanelComponent {
         }
       }
     } else {
-      this.showResultPanel = false;
+      this.resultPanelToggleService.closeResultPanel();
     }
   }
 
@@ -231,9 +231,7 @@ export class ResultPanelComponent {
    * @param response
    */
   private displayResultTable(resultData: ReadonlyArray<object>) {
-     if (resultData.length < 1) {
-       throw new Error(`display result table inconsistency: result data should not be empty`);
-     }
+
      // don't display message, display result table instead
      this.showMessage = false;
 


### PR DESCRIPTION
#### Use resultPanelToggleService when a result operator is highlighted  

Use resultPanelToggleService to control the result panel to avoid consistency issues.

#### Display nothing in result panel when size of table is 0 instead of showing error message.

In some cases, there is no output in workflow. For example, use keyword search on Twitter data.  
So it is unnecessary to display error message.

![result-panel](https://user-images.githubusercontent.com/9149201/89101223-826e3200-d430-11ea-8b31-e39f76343104.gif)

#### Fix Pie Chart bug

When c3.js finds same data name in pie chart, it will display blank, so it is necessary to merge data with same name.
![20200802105656](https://user-images.githubusercontent.com/9149201/89114437-edf6e480-d4ae-11ea-8138-91c5333ae4d7.png)
