### PR TITLE
Change scripts to start new amber engine

### DIFF
--- a/core/amber/src/main/scala/Engine/Common/AmberUtils.scala
+++ b/core/amber/src/main/scala/Engine/Common/AmberUtils.scala
@@ -1,5 +1,12 @@
 package Engine.Common
 
+import java.io.{BufferedReader, InputStreamReader}
+import java.net.URL
+
+import Clustering.ClusterListener
+import akka.actor.{ActorSystem, Props}
+import com.typesafe.config.ConfigFactory
+
 object AmberUtils {
 
   def reverseMultimap[T1, T2](map: Map[T1, Set[T2]]): Map[T2, Set[T1]] =
@@ -8,4 +15,48 @@ object AmberUtils {
       .groupBy(_._1)
       .mapValues(_.map(_._2).toSet)
 
+
+  def startActorMaster(localhost: Boolean): ActorSystem = {
+    var localIpAddress = "localhost"
+    if (!localhost) {
+      try {
+        val query = new URL("http://checkip.amazonaws.com")
+        val in = new BufferedReader(new InputStreamReader(query.openStream()))
+        localIpAddress = in.readLine()
+      } catch {
+        case e: Exception => throw e
+      }
+    }
+
+    val config = ConfigFactory
+      .parseString(s"""
+        akka.remote.netty.tcp.hostname = $localIpAddress
+        akka.remote.netty.tcp.port = 2552
+        akka.remote.artery.canonical.port = 2552
+        akka.remote.artery.canonical.hostname = $localIpAddress
+        akka.cluster.seed-nodes = [ "akka.tcp://Amber@$localIpAddress:2552" ]
+        """)
+      .withFallback(ConfigFactory.load("clustered"))
+
+    val system = ActorSystem("Amber", config)
+    val info = system.actorOf(Props[ClusterListener], "cluster-info")
+
+    system
+  }
+
+  def startActorWorker(mainNodeAddress: Option[String]): ActorSystem = {
+    val addr = mainNodeAddress.getOrElse("localhost")
+    val localIpAddress = "localhost"
+    val config = ConfigFactory
+      .parseString(s"""
+        akka.remote.netty.tcp.hostname = $localIpAddress
+        akka.remote.artery.canonical.hostname = $localIpAddress
+        akka.cluster.seed-nodes = [ "akka.tcp://Amber@$addr:2552" ]
+        """)
+      .withFallback(ConfigFactory.load("clustered"))
+    val system = ActorSystem("Amber", config)
+    val info = system.actorOf(Props[ClusterListener], "cluster-info")
+    Constants.masterNodeAddr = addr
+    system
+  }
 }

--- a/core/amber/src/main/scala/web/TexeraRunWorker.scala
+++ b/core/amber/src/main/scala/web/TexeraRunWorker.scala
@@ -1,0 +1,13 @@
+package web
+
+import Engine.Common.AmberUtils
+import texera.common.TexeraUtils
+
+object TexeraRunWorker {
+
+  def main(args: Array[String]): Unit = {
+    // start actor system worker node
+    AmberUtils.startActorWorker(Option.empty)
+  }
+
+}

--- a/core/amber/src/main/scala/web/TexeraWebApplication.scala
+++ b/core/amber/src/main/scala/web/TexeraWebApplication.scala
@@ -1,5 +1,6 @@
 package web
 
+import Engine.Common.AmberUtils
 import akka.actor.ActorSystem
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.github.dirkraft.dropwizard.fileassets.FileAssetsBundle
@@ -15,7 +16,7 @@ object TexeraWebApplication {
 
   def main(args: Array[String]): Unit = {
     // start actor system master node
-    actorSystem = WebUtils.startActorMaster(true)
+    actorSystem = AmberUtils.startActorMaster(true)
 
     // start web server
     val server = "server"
@@ -29,8 +30,7 @@ class TexeraWebApplication extends io.dropwizard.Application[TexeraWebConfigurat
 
   override def initialize(bootstrap: Bootstrap[TexeraWebConfiguration]): Unit = {
     // serve static frontend GUI files
-    val frontendPath = TexeraUtils.amberHomePath.resolve("../new-gui/dist").toString
-    bootstrap.addBundle(new FileAssetsBundle(frontendPath, "/", "index.html"))
+    bootstrap.addBundle(new FileAssetsBundle("../new-gui/dist", "/", "index.html"))
     // add websocket bundle
     bootstrap.addBundle(new WebsocketBundle(classOf[WorkflowWebsocketResource]))
     // register scala module to dropwizard default object mapper

--- a/core/amber/src/main/scala/web/WebUtils.scala
+++ b/core/amber/src/main/scala/web/WebUtils.scala
@@ -10,7 +10,7 @@ import com.typesafe.config.ConfigFactory
 object WebUtils {
 
   def startActorMaster(localhost: Boolean): ActorSystem = {
-    var localIpAddress = InetAddress.getLocalHost.getHostAddress
+    var localIpAddress = "localhost"
     if (!localhost) {
       try {
         val query = new URL("http://checkip.amazonaws.com")

--- a/core/sample_data/tweet_1K.tbl
+++ b/core/sample_data/tweet_1K.tbl
@@ -1,0 +1,1000 @@
+2020-08-01T00:00:00.000Z|1289350127463718912|Went to Apple to get a new phone today, when I got there they said I’d have to come back since their connection to… https://t.co/9gXSpwhEp5|-1|-1|0|0|en|False
+2020-08-01T00:00:00.000Z|1289350128214581248|@EmilyCWaldon 1. Easily Pujols 500 HR 2. Angels walk off Red Sox in 19 innings3. Angels walk off Rodney|1289342719459045381|489733778|0|0|en|False
+2020-08-01T00:00:00.000Z|1289350128474550274|Please, basketball gods let @sabrina_i20 be ok. 🙏🏼|-1|-1|0|0|en|False
+2020-08-01T00:00:00.000Z|1289350128554434565|So wait, bubble=sports, no bubble, no season? Its almost like science is real!|-1|-1|0|0|en|False
+2020-08-01T00:00:00.000Z|1289350128793341952|Don’t ever allow someone to push you out of the Democratic Party. Continue to show up. They cannot stop you. Sure,… https://t.co/XQyTiql7xL|-1|-1|0|0|en|False
+2020-08-01T00:00:00.000Z|1289350129237897217|Hmmm... need 1 person on this Cali trip.|-1|-1|0|0|en|False
+2020-08-01T00:00:00.000Z|1289350130223575040|Jobs really be paying like this for a college degree. Fucking ridiculous|-1|-1|0|0|en|False
+2020-08-01T00:00:00.000Z|1289350130689138688|@tedcruz This populist bullshit is so infuriating to read. There was a time when being a R meant something. What a disaster.|1289338151488520192|23022687|0|0|en|False
+2020-08-01T00:00:00.000Z|1289350130949189632|I need him https://t.co/FwKhZQJ5yb|-1|-1|0|0|en|False
+2020-08-01T00:00:00.000Z|1289350131200868353|@Bryanmelo15 I miss you|1289350021771493376|96766924|0|0|en|False
+2020-08-01T00:00:01.000Z|1289350131792244736|my bun heavy on my head😂|-1|-1|0|0|en|False
+2020-08-01T00:00:01.000Z|1289350132119425026|@notswedish1 No, I'm sure she is. This is all really bad theatre & tiresome.|1289334582446133249|826299629721395200|0|0|en|False
+2020-08-01T00:00:01.000Z|1289350132194873347|@re_tweetem Y’all Truly Have The Sickest Sense Of Humors Everr😭😭😭😭😭|1289347268747776000|280874468|0|0|en|False
+2020-08-01T00:00:01.000Z|1289350132287209472|I’ve been taking baths instead of showers so that I can drink beer while I bathe and I realized that I don’t even r… https://t.co/rhIOuV5RT7|-1|-1|0|0|en|False
+2020-08-01T00:00:01.000Z|1289350132299730944|ニューヨーク/New YorkNew York/United States at 7 evening|-1|-1|0|0|ja|False
+2020-08-01T00:00:01.000Z|1289350133587431424|@chaoticitgirl Me reading your tweets https://t.co/fytlIt8561|1289322625148186624|101408023|0|0|en|False
+2020-08-01T00:00:01.000Z|1289350133646340097|Whos gonna save you now -Rina|-1|-1|0|0|en|False
+2020-08-01T00:00:01.000Z|1289350134828904448|Wind 3.3 mph SSW. Barometer 29.83 in, Falling slowly. Temperature 96.3 °F. Rain today 0.00in. Humidity 15%|-1|-1|0|0|en|False
+2020-08-01T00:00:01.000Z|1289350134875086850|Very mild summer in Seattle this year. 91 earlier in the week. 81 today. No 100 degree weather to claim this season. No smoke either.|-1|-1|0|0|en|False
+2020-08-01T00:00:01.000Z|1289350135110086656|@joshwurster_ Right? Hey you think Sunday is a go for the beach I was thinking morning to early afternoon? I really… https://t.co/CAVDG65IxQ|1289349703713214464|106846158|0|0|en|False
+2020-08-01T00:00:01.000Z|1289350135168688128|kool kool|-1|-1|0|0|et|False
+2020-08-01T00:00:01.000Z|1289350135437316096|@mrttech24 Lmfao lmfao|1289344029339971586|1969581793|0|0|en|False
+2020-08-01T00:00:01.000Z|1289350135537795075|@TimeLordAli https://t.co/Ox73l1qSmS|1289216280504016896|1081378641991348230|0|0|und|False
+2020-08-01T00:00:01.000Z|1289350135554682881|@willslastname Dm me luv😘😘|1289350047184719873|1244462706318589953|0|0|en|False
+2020-08-01T00:00:01.000Z|1289350135621681154|@TheSWPrincess @SallyDeal4 @TheRickyDavila Me too.|1289319064674869248|815708250217840640|0|0|en|False
+2020-08-01T00:00:02.000Z|1289350136368254979|whoa where am i|-1|-1|0|0|en|False
+2020-08-01T00:00:02.000Z|1289350137437814784|Lol. https://t.co/yobHs8677r|-1|-1|0|0|und|False
+2020-08-01T00:00:02.000Z|1289350137764954112|@justin__jayne https://t.co/l9QtmQLXOe|1289348033126129664|1075414255766265857|0|0|und|False
+2020-08-01T00:00:02.000Z|1289350138935169024|@drwest1111 Haha true. I laughed at that one myself.hE wAs a fIrSt rOuNdEr|1289349855798648835|186479289|0|0|en|False
+2020-08-01T00:00:02.000Z|1289350139576905730|86.9F (Feels: 93.0F) - Humidity: 78% - Wind: 6.7mph W - Gust: 6.3mph - Pressure: 30.085in #weather https://t.co/75yzNJjEvP|-1|-1|0|0|en|False
+2020-08-01T00:00:02.000Z|1289350139673317376|♫Gasoline by @halsey, from #SoundHound with LiveLyrics® https://t.co/Rv31JKMmNb|-1|-1|0|0|en|False
+2020-08-01T00:00:02.000Z|1289350139753070592|The little boy rapping Jays verse on Mood 4 Eva. https://t.co/w6NFtczzaU|-1|-1|0|0|en|False
+2020-08-01T00:00:03.000Z|1289350140197777410|Early workout then the beach , picnic ?|-1|-1|0|0|en|False
+2020-08-01T00:00:03.000Z|1289350140503789569|@DaveFalch @NHL Please go away forever|1289344708506841088|1032096434294800385|0|0|en|False
+2020-08-01T00:00:03.000Z|1289350141304922118|Welcome to Sage Magic Academy we’re all magic school is anything could happen it’s the premiere of the… https://t.co/Zjh5thT89E|-1|-1|0|0|en|False
+2020-08-01T00:00:03.000Z|1289350141581897729|#ShowUrRight ☑️🟠 https://t.co/WrlVID72RK|-1|-1|0|0|und|False
+2020-08-01T00:00:03.000Z|1289350141703368705|21 LOL|-1|-1|0|0|und|False
+2020-08-01T00:00:03.000Z|1289350141934219267|@Alyssa_Milano Ummm...No.You will hear the word your looking at🙄|1289281118923968512|26642006|0|0|en|False
+2020-08-01T00:00:03.000Z|1289350141988806656|@WendysUSA @DoorDash are y’all serious bro waiting for more than two hours for some dam nuggets|-1|730947343877586947|0|0|en|False
+2020-08-01T00:00:03.000Z|1289350142244589570|Welcome Troy Westover back to the Desert Wind Harley-Davidson family with his new 2020 Softail Standard!… https://t.co/DJOTpKzkBM|-1|-1|0|0|en|False
+2020-08-01T00:00:03.000Z|1289350142441619457|Is Giannis held so high just because he’s willing to shoot? His offensive toolbox is very limited and that jumper i… https://t.co/9zzvjgLpUM|-1|-1|0|0|en|False
+2020-08-01T00:00:03.000Z|1289350143318192128|@ashley_dabneyy Thanks 😊❤️|1289340835968909316|546142090|0|0|en|False
+2020-08-01T00:00:03.000Z|1289350143418851328|Green af 😭😂|-1|-1|0|0|en|False
+2020-08-01T00:00:03.000Z|1289350143716626433|Time is money|-1|-1|0|0|en|False
+2020-08-01T00:00:03.000Z|1289350144106758145|@AokiTheNinja Wooow...heard you lol.|1289346002017632256|29840044|0|0|en|False
+2020-08-01T00:00:04.000Z|1289350144362602497|@johnticious how could u not stan 😌😏 https://t.co/VHSIRh5v5Q|1289348746036183041|432902234|0|0|en|False
+2020-08-01T00:00:04.000Z|1289350144366743554|@Acidsmooth @TheWallMan4000 @hippie_science @JuicySARSBurger @BretWeinstein You can’t volunteer if you’re selling y… https://t.co/yocgAeVLwV|1289349916951580673|17417076|0|0|en|False
+2020-08-01T00:00:04.000Z|1289350144404729856|swear & never will|-1|-1|0|0|en|False
+2020-08-01T00:00:04.000Z|1289350144668835840|no se si tengo sueño or Covid is taking over my body :/|-1|-1|0|0|en|False
+2020-08-01T00:00:04.000Z|1289350145159475201|@AlainnaFaith Do woman get butterflies for men anymore or for the money ??|1289340719082041344|318005134|0|0|en|False
+2020-08-01T00:00:04.000Z|1289350145264386048|I cancel my plans today fuck that 😂😂 except when my sister has her prego I never cancel on her 🥰❤️|-1|-1|0|0|en|False
+2020-08-01T00:00:04.000Z|1289350145310695425|#DemocratsHateAmerica|-1|-1|0|0|und|False
+2020-08-01T00:00:04.000Z|1289350146648494080|Fulci Friday? Might do a double feature. Just put on THE BEYOND, which I haven't seen since... high school? nothing… https://t.co/s3RwyfsoCA|-1|-1|0|0|en|False
+2020-08-01T00:00:04.000Z|1289350147311169536|It's 5 o'clock in Vallejo.|-1|-1|0|0|en|False
+2020-08-01T00:00:05.000Z|1289350148531712000|Do you even know me, @Twitter? https://t.co/bIFAC3QYQg|-1|-1|0|0|en|False
+2020-08-01T00:00:05.000Z|1289350148984901632|Hey there are like 20 real people here|-1|-1|0|0|en|False
+2020-08-01T00:00:05.000Z|1289350149282512897|Coach- something or someone that carries a valued person from where they are to where they want to be.|-1|-1|0|0|en|False
+2020-08-01T00:00:05.000Z|1289350149588709377|Get your #Fastball #Sliders 🍔 @curveballmobile 5p-9p Grab-n-Go Food Trucks. See 📷 menu, review, chat with… https://t.co/Zmp8EZMMaQ|-1|-1|0|0|en|False
+2020-08-01T00:00:05.000Z|1289350150024867840|I would like to take this time and shoutout @hulu for putting NYPD Blue (with remastered quality) in their line up. 👌🏽|-1|-1|0|0|en|False
+2020-08-01T00:00:05.000Z|1289350150196826113|@rebekahallen rip|1289315507611418625|266152432|0|0|und|False
+2020-08-01T00:00:05.000Z|1289350150209409024|What do you think are the worst examples of technology in fiction? https://t.co/gaPrjAJWda #gqotd2020|-1|-1|0|0|en|False
+2020-08-01T00:00:05.000Z|1289350150565933057|@Marlins_Man I see you! Go Royals!|-1|903407550|0|0|en|False
+2020-08-01T00:00:05.000Z|1289350151266398209|One good thing about becoming a dad is that you’ll look weight because you don’t have time to eat|-1|-1|0|0|en|False
+2020-08-01T00:00:05.000Z|1289350151404810240|I wanna go on a date🥺|-1|-1|0|0|en|False
+2020-08-01T00:00:05.000Z|1289350152021348352|@EventXtinction @AoDBabyFace @lnbshr no ofc not haha we on the same page here <3|1289349859879919616|1186502789561798657|0|0|en|False
+2020-08-01T00:00:06.000Z|1289350152843476992|@TonyJohnstone56 @eamonlynch No question Europe killed it when it came to nicknames 😂😂😂|1289348075899691010|764289907|0|0|en|False
+2020-08-01T00:00:06.000Z|1289350152847679491|@akhena26 Spine is a chain of joints, self adjusting can cause hypermobility. When increase movement happens in cer… https://t.co/VZOzIi9H5v|1289349358303850497|22573114|0|0|en|False
+2020-08-01T00:00:06.000Z|1289350152864456704|that shit makes me mad|-1|-1|0|0|en|False
+2020-08-01T00:00:06.000Z|1289350153803927552|@KingzNA Aw, you ready to hit the stage I call purgutory...you stuck there until 21. Btw H.B incase I’m ghosting h… https://t.co/jUEMONvNrV|1288277843345014785|982126712128356354|0|0|en|False
+2020-08-01T00:00:06.000Z|1289350154827440128|@bradfo @OMFonWEEI @MarcFucarile I’m looking forward to reading this in the Globe tomorrow.|1289339667897352193|21762851|0|0|en|False
+2020-08-01T00:00:06.000Z|1289350154965798914|🥺🥺🥺|-1|-1|0|0|und|False
+2020-08-01T00:00:06.000Z|1289350155070652417|Get your #PorkShoulder Bowl @uppercuttruck 5p-9p @SPARKsocialSF. See 📷 menu, review, chat with #foodtruck #foodie… https://t.co/zE904ymrVX|-1|-1|0|0|en|False
+2020-08-01T00:00:06.000Z|1289350155095781376|Not quite... #preraspberrypie @ Brewer, Maine https://t.co/y2ppigOKfv|-1|-1|0|0|en|False
+2020-08-01T00:00:06.000Z|1289350155179716608|11 easy miles in the afternoon humidity, sleep is still a challenge need to figure it out... 15 days till… https://t.co/7uoRYX5nk6|-1|-1|0|0|en|False
+2020-08-01T00:00:06.000Z|1289350155464871937|@PurdyRock82 Check out our latest pod featuring guest Walt Williams. Tune in here https://t.co/qt3GtfY2lc|-1|1924710210|0|0|en|False
+2020-08-01T00:00:06.000Z|1289350155578281985|@EyeOnPuertoRico It's a reasonable argument but more likely they block grant Fed funds to states.|1289341002491105280|2350504609|0|0|en|False
+2020-08-01T00:00:06.000Z|1289350155632668674|I wish I could go back in time to rewatch Naruto Shippuden https://t.co/YS8IwESEZ6|-1|-1|0|0|en|False
+2020-08-01T00:00:06.000Z|1289350155871727616|Wind 0.0 mph -. Barometer 29.858 in, Steady. Temperature 73.5 °F. Rain today 0.00in. Humidity 73%|-1|-1|0|0|en|False
+2020-08-01T00:00:06.000Z|1289350156052127744|@SFBART So happy to hear this success story. So many similar stories end in tragedy. Thank you for your compassion… https://t.co/bNhB7JOpHC|1288993302222524416|15640533|0|0|en|False
+2020-08-01T00:00:06.000Z|1289350156417196033|@radgurll @UCLA @UCLAchancellor DO BETTER NOW @UCLA @UCLAchancellor|1289342577997537280|60696790|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350156807073792|Teach me the wayyyy 😂|-1|-1|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350156886802433|@LorenzoHarper_ Ice cold 😂|1289346879013007361|750562769318076416|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350157159415809|I wish @DonnyThompsonBB could go on #bb22 @JulieChen : hello Donny Donny: ...Hey there*strokes beard*|-1|-1|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350157335633921|@CandaceFerraro Thank you. Glad you agree.|1289325626676019200|346621409|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350157616549889|@AndrewHarts How about NY sports in general?|1289349789813891072|46173183|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350157956349952|just casually driving around Destin & saw Gus Malzahn literally behind us. No joke. Missed opportunity to say war eagle 👀|-1|-1|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350158178635777|Buckees really be 100+ miles from eachother smh.|-1|-1|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350158384340992|i’m in love with my future @ Rhode Island https://t.co/Dx57T3CI73|-1|-1|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350158723846145|https://t.co/d8YXtpyirk|-1|-1|0|0|und|False
+2020-08-01T00:00:07.000Z|1289350158732337153|@SteveHammon @RainBirdGolf @tcgandcc The world needs more of this!|1289331171885584385|522748457|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350158883463169|Wind 0.0 mph N. Barometer 29.779 in, Rising slowly. Temperature 79.6 °F. Rain today 0.00in. Humidity 63%|-1|-1|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350158895812609|@chichi_naomi Lol nah that’s OD.|1289338913299914752|38745358|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350159747358722|Don Julio and red bull my favorite mixture 🧏🏽‍♀️😅|-1|-1|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350159764086784|Here’s a playlist for you… Slapz by Kgizzlehttps://t.co/TRXxWryT08|-1|-1|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350159927619584|😂😭|-1|-1|0|0|und|False
+2020-08-01T00:00:07.000Z|1289350160082825217|@4Mischief @Bkfor45 @militarysweep2 @jimscileppi @EtymologyTweet @OMARRSHABAZZ @MarilynLavala @pj_hurt @garway95… https://t.co/fbBk9EsSlS|1289343992207826944|450235955|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350160128962560|Friendly crowd and conversations at Lucky Oyster tonight! https://t.co/wwDMOjdp2E|-1|-1|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350160183513088|@JahHills They had some good-looking chickens.|1289349915940806657|29092660|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350160355532800|Im hurt I was at a funeral and couldn’t make it to the store to get the Dreamer sneakers 🥺 @JColeNC @KingOfQueenz,… https://t.co/b8K8vgO498|-1|-1|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350160498094080|Damn Posted withregram • sportscenter Giannis’ reach is unreal. 😦 @ Miami, Florida https://t.co/qVRVo76ZVH|-1|-1|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350160514871297|Beyoncé is King|-1|-1|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350160712003584|Check out the red hot deals at your At Home Store in Greece! https://t.co/GxfEku6OIO|-1|-1|0|0|en|False
+2020-08-01T00:00:07.000Z|1289350160732971008|@TravisMayfield Wow! Will have to check that out. Does it work on necks?|1288596836614168576|23519114|0|0|en|False
+2020-08-01T00:00:08.000Z|1289350161240477696|@Bud_Doggin @LaylaAlisha11 WTF https://t.co/hqOp3Srwlb|1289342220517036032|753774780759826433|0|0|und|False
+2020-08-01T00:00:08.000Z|1289350161299206144|Amen!|-1|-1|0|0|en|False
+2020-08-01T00:00:08.000Z|1289350161366302720|19:55 Temp. 79.5°F, Hum. 71%, Dewp. 67.3°F, Bar. 29.75 inHg, Rain Today 0 inch, Wind 90° 0.6 kn|-1|-1|0|0|en|False
+2020-08-01T00:00:08.000Z|1289350161488060416|@juhnayjuhnay Come to a party tonight 🖤|1289349876405293056|713565563650314240|0|0|en|False
+2020-08-01T00:00:08.000Z|1289350161773330433|@CourtneyFly2 Lmao that face|1289346556651433984|1134245895732641792|0|0|en|False
+2020-08-01T00:00:08.000Z|1289350162393886720|✊🏿🔥🔥🔥🔥|-1|-1|0|0|und|False
+2020-08-01T00:00:08.000Z|1289350163757060096|Yall Sleeeeeeeeeeeeppppppppp 😴😴😴😴😴😴😴😴😴😴😴😴😴 https://t.co/kKD3anxkrC|-1|-1|0|0|en|False
+2020-08-01T00:00:08.000Z|1289350164147208192|Stay tuned to FOX Sports Sun & FOX Sports Go as the @RaysBaseball take on Baltimore!Rain delay is coming to an en… https://t.co/8qCFZfyPPI|-1|-1|0|0|en|False
+2020-08-01T00:00:08.000Z|1289350164369424385|What if its JUST HELIUM LIKE THE HINDENBURG? WE NEVER USED TO ALLOW THEM TO USE FORKS OR SILVER UTENSILS! THEY WHER… https://t.co/7ddNwTWFA3|-1|-1|0|0|en|False
+2020-08-01T00:00:08.000Z|1289350164507836417|Bravo 👏👏👏|-1|-1|0|0|pt|False
+2020-08-01T00:00:08.000Z|1289350164973412353|@babilicious1 @Wolfiesmom She's not saying he's fat or ugly. She's saying he doesn't apply his make up properly.|1289348664041799680|69983028|0|0|en|False
+2020-08-01T00:00:09.000Z|1289350165355040770|Roof top for sure .!|-1|-1|0|0|en|False
+2020-08-01T00:00:09.000Z|1289350166168743936|All My Life by Foo Fighters. https://t.co/Z8kHaVM9ec|-1|-1|0|0|en|False
+2020-08-01T00:00:09.000Z|1289350166948978689|Happy Birthday @HanksBasketball🌟|-1|-1|0|0|en|False
+2020-08-01T00:00:09.000Z|1289350167980720128|Disgusting! Yet if that was Trump.......the reign of horror that would come from the left?|-1|-1|0|0|en|False
+2020-08-01T00:00:09.000Z|1289350168517570561|@TheHomieKi It was goood And so we’re the plantains , I’m def gonna give them another try 🧐|1289335574239813632|155213693|0|0|en|False
+2020-08-01T00:00:09.000Z|1289350168559509504|I can't wait for school to start|-1|-1|0|0|en|False
+2020-08-01T00:00:09.000Z|1289350168933011457|?|1289349633295056896|324022184|0|0|und|False
+2020-08-01T00:00:10.000Z|1289350169582907392|If that's rolling an ankle I never wanna do that|-1|-1|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350169582960640|I love it. You are beautiful. Always listen to mommy.|-1|-1|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350169671004160|Monty Python & the Holy Grail|-1|-1|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350170405044224|@Mike_MacAdam Ah man.|1289330402520260609|277690349|0|0|in|False
+2020-08-01T00:00:10.000Z|1289350170623213573|I love the people in the Valley, but I’m lowkey tired of the same faces and individuals. I wanna meet new people, g… https://t.co/Cs8xSEHrxh|-1|-1|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350170652549121|Well goodbye Veep chances|-1|-1|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350171097088000|19:48 Temp. 86.5°F, Hum. 83%, Dewp. 79.5°F, Bar. 29.82 inHg, Rain Today 0 inch, Wind 348° 0.3 m/s #WUTV #knchamps26 #WECTwx|-1|-1|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350171197726720|The Simple Life #campinglife 🏕 @ Olympic National Park https://t.co/nRcxqrRXlh|-1|-1|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350171411677184|@ItsShake4ndbake Go Bucks!|1289349686927585280|770869718303596544|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350171663331328|@ConanCreative POG, cooking stream when?|1289347501707812864|2400271005|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350171923374081|@Chicago1Ray @shannoneffects1 The crypt keepers yikes! https://t.co/ptKnS2hlHd|1283911971809746944|817158775610179584|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350171952726017|@GailSlaydon3 @JohnGish1 😈 Devil is Right🍊, and let's not forget about a Vampire turtle 🐢🦇, what a Hell of a Government!😳|1289348141792104449|1246916816229859331|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350172112121856|#Legendofthebluesea is proof that LMH acting is meh esp compared to JiHyun 😂😂|-1|-1|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350172300832768|@savannahlwarner 😂😂 it definitely is!! Thank you!!|1289349467464847360|1154785603805827074|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350172393185281|18:50 Temp. 88.9°F, Hum. 61%, Dewp. 71.8°F, Bar. 29.98 inHg, Rain Today 0.2598 inch, Wind 315° 2.1 kn|-1|-1|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350173018087426|I know 🎵 https://t.co/2TBU5tXOCS|-1|-1|0|0|en|False
+2020-08-01T00:00:10.000Z|1289350173110366208|This is well worth your time and consideration ...A statement that needs to be read and a sermon that needs to be… https://t.co/4KwrS1A7DS|-1|-1|0|0|en|False
+2020-08-01T00:00:11.000Z|1289350174238801922|@passportjay Go away bro|1289350140210188288|16854100|0|0|en|False
+2020-08-01T00:00:11.000Z|1289350175228481537|@LizWFab Hematopathology and transfusion medicine. Obviously. https://t.co/kC7TC8dnUQ|1289259770939990018|797263599794343936|0|0|en|False
+2020-08-01T00:00:11.000Z|1289350175341678599|@mmunzenrider Mall|1289299717592096768|117531622|0|0|en|False
+2020-08-01T00:00:11.000Z|1289350175551393792|👀 he has been all over me these past few days , I love it 😌|-1|-1|0|0|en|False
+2020-08-01T00:00:11.000Z|1289350175631106048|@seanhannity Boycott NBA games|1289238229439246336|41634520|0|0|en|False
+2020-08-01T00:00:11.000Z|1289350175656296449|7/31/2020 they confirmed that they’re bringing back, Courtney Cox, but where’s Neve Campbell? #Scream5... https://t.co/CUArOGNtXE|-1|-1|0|0|en|False
+2020-08-01T00:00:11.000Z|1289350175719190528|What I love about summer. Fab flowers! (@ Menomonee Falls in WI) https://t.co/cLSVRHzLud https://t.co/AXnrzYg5rf|-1|-1|0|0|en|False
+2020-08-01T00:00:11.000Z|1289350175786328065|@justmiche74 @ArtfulDetective Good job. Stay strong!👍🙊|1289229499096129538|14945471|0|0|en|False
+2020-08-01T00:00:11.000Z|1289350175824023553|Reposted from @1AlBillz_ My verse from #NothingNewtoMe #PIW @wpBlakout Visuals @shells456 #456 ..#Wynnefield… https://t.co/dhqmYyqrqI|-1|-1|0|0|en|False
+2020-08-01T00:00:11.000Z|1289350175916355584|These are cute AF|-1|-1|0|0|en|False
+2020-08-01T00:00:11.000Z|1289350175954149376|@AMBERALEERRRT @NikTrynaBeat_ 😭😭😭😭😭😂😂😂😂|1289349877692895232|887982889467510784|0|0|und|False
+2020-08-01T00:00:11.000Z|1289350176147214338|https://t.co/TF7kLeQwVg|-1|-1|0|0|und|False
+2020-08-01T00:00:11.000Z|1289350176931340288|THE BEST DOING IT HONESTLY 🔥🔥🔥I’ve spent over $500 in the past month! That’s how good it is...|-1|-1|0|0|en|False
+2020-08-01T00:00:11.000Z|1289350177057193984|Idk how but this racist asl😭😭😭|-1|-1|0|0|en|False
+2020-08-01T00:00:11.000Z|1289350177338269698|@xanxjety @highimallyy Oki|1289350126943657984|3294531588|0|0|und|False
+2020-08-01T00:00:11.000Z|1289350177569026048|@mschlapp Good one!👍😂|1289151725149052929|138809881|0|0|en|False
+2020-08-01T00:00:12.000Z|1289350177807929346|Tonight’s Specials: https://t.co/WWeV49Lq6j|-1|-1|0|0|en|False
+2020-08-01T00:00:12.000Z|1289350178030272513|WOAH I LUV & MISS VINE SO MUCH:)* VINE - NODRUGS4TYRICK INYOUNGFAMOUSTYRICKWETRUST BOW DOWN WORSHIP & SERVE TYRICK… https://t.co/uTE5jzvpO0|-1|-1|0|0|en|False
+2020-08-01T00:00:12.000Z|1289350178139303938|UNREAL|-1|-1|0|0|en|False
+2020-08-01T00:00:12.000Z|1289350178252627968|@brchapman65 @suthrngurl @joshgad Obama did not let 150,000 Americans die by mismanagement of a pandemic. And oh ye… https://t.co/4OxECKQHBi|1289282087573311488|718581452837953540|0|0|en|False
+2020-08-01T00:00:12.000Z|1289350178705518592|Loading 📽....Miss yal ariyannn_ cattssidy ***#capturedbygwin #PHOTOGRAPHY #sonyalpha7iii #LONGBEACH… https://t.co/nxiaHhetvh|-1|-1|0|0|en|False
+2020-08-01T00:00:12.000Z|1289350181104713728|@AmberMBerumen I also like going in to 2x with a tap to avoid as much of the black circle as possible but it does m… https://t.co/Kxlebk0bM4|1289349813339742208|24487765|0|0|en|False
+2020-08-01T00:00:12.000Z|1289350181649969152|ALL RISE|-1|-1|0|0|en|False
+2020-08-01T00:00:12.000Z|1289350181775790081|Ft. Krispy Krunchy Chicken lol|-1|-1|0|0|ht|False
+2020-08-01T00:00:13.000Z|1289350182186782725|I SAID WHAT I SAID|-1|-1|0|0|en|False
+2020-08-01T00:00:13.000Z|1289350182191001601|#AmericaFirst in number of #coronavirus and deaths in the World. No other nation come close! @GOP @realDonaldTrump… https://t.co/09LyzL45X4|-1|-1|0|0|en|False
+2020-08-01T00:00:13.000Z|1289350182228725762|JUDDGEEEEEEE|-1|-1|0|0|en|False
+2020-08-01T00:00:13.000Z|1289350182266535936|noooo, don’t do it|-1|-1|0|0|en|False
+2020-08-01T00:00:13.000Z|1289350182509764608|@1PunchKC said he needs his pp sucked so ladies tap in|-1|4317196454|0|0|en|False
+2020-08-01T00:00:13.000Z|1289350182824374277|@morris_mayson @tara_parkey https://t.co/4v15STMbDV|1289320832079032320|466997096|0|0|und|False
+2020-08-01T00:00:13.000Z|1289350183155728384|@barstooltravis It’s the second best of the series.|1289349595298897920|789118234683437056|0|0|en|False
+2020-08-01T00:00:13.000Z|1289350183545782272|I wasnt lookin at u bich Plz chill|-1|-1|0|0|en|False
+2020-08-01T00:00:13.000Z|1289350183898120194|Ain’t no skips on Steel Human I’m sorry🔥🤧|-1|-1|0|0|en|False
+2020-08-01T00:00:13.000Z|1289350184028131328|Hmmm. Did dana carvey just say, satan?!Nope. L’il green sausages.|-1|-1|0|0|en|False
+2020-08-01T00:00:13.000Z|1289350184124559361|The Machine is automatic another hit!|-1|-1|0|0|en|False
+2020-08-01T00:00:13.000Z|1289350184145567744|First photo of earth taken in 1946... 🤨🤔 @ Diamond Head - Kapahulu - St. Louis, Honolulu, Hawaii https://t.co/fFlXdeWTEd|-1|-1|0|0|et|False
+2020-08-01T00:00:13.000Z|1289350184149962753|@ellierosetx The David Dunlap Observatory in both Hannibal and Umbrella Academy https://t.co/cC4aKK4pmU|1289349794247450624|37266742|0|0|tl|False
+2020-08-01T00:00:13.000Z|1289350184384700417|@chy_dtm 😘😘|1289338713588109313|1143584421808869377|0|0|und|False
+2020-08-01T00:00:13.000Z|1289350185819103233|@KylerWortman @steak_umm I think it means Steak-Umm goes great with sports. Steak-Umm bless?|1289280154707976192|705756168061370369|0|0|en|False
+2020-08-01T00:00:14.000Z|1289350186456686595|@MEGATOPH 100% gonna do this 🤤|1289349331892363264|25800403|0|0|en|False
+2020-08-01T00:00:14.000Z|1289350186465218567|MIRROR Harry Vox 2010 Rockefeller “Scenarios for Future Tech ” And Dead ... https://t.co/rVTFQSdhDQ via @YouTube|-1|-1|0|0|en|False
+2020-08-01T00:00:14.000Z|1289350186758627329|Aaron Judge has the best arm in baseball You’re welcome to lie in the comments 👨‍⚖️|-1|-1|0|0|en|False
+2020-08-01T00:00:14.000Z|1289350187970895874|Stable calls at the Sam Adams. Holy shit it’s good to be back.|-1|-1|0|0|en|False
+2020-08-01T00:00:14.000Z|1289350188079800321|nothing but lies.. after lies|-1|-1|0|0|en|False
+2020-08-01T00:00:14.000Z|1289350188318916609|Want to work at CVSCareers? We're hiring in Charlotte, NC! Click for details: https://t.co/4c0xozVH6c #HealthyCareer #CVSJob|-1|-1|0|0|en|False
+2020-08-01T00:00:14.000Z|1289350188411154433|@USERMAYNE @DIXON_Magic @CharlesMBlow You don’t have to live in a Ohio! But I get what you are saying|1289241309379735552|964280022872838144|0|0|en|False
+2020-08-01T00:00:14.000Z|1289350188784443393|LMAO STOP IS THIS REAL|-1|-1|0|0|en|False
+2020-08-01T00:00:14.000Z|1289350189216456704|I'm so sick of all the negativity from Joe man. Every day it's just negative negative negative...|-1|-1|0|0|en|False
+2020-08-01T00:00:14.000Z|1289350189254287360|@MilkboneIsNoFox Someone's asked me to to this so comment for a thing  first impression: WOOF your nickname in… https://t.co/mKuP7pGifp|1289321743430033408|1268052371235500034|0|0|en|False
+2020-08-01T00:00:14.000Z|1289350189472350208|@HSWT2020 @KHOU You like that? I’m all about facts!! Lmao|1289340542451580929|1142891088367292416|0|0|en|False
+2020-08-01T00:00:14.000Z|1289350189573013504|@yungbeastgamer Rip 😂|1289333558306156546|949120480815988737|0|0|und|False
+2020-08-01T00:00:14.000Z|1289350190294392832|Anyways no wonder your wife is so angry all time. You tweet at people for days about shit they TRULY don’t care abo… https://t.co/ln5d7RDIOd|-1|-1|0|0|en|False
+2020-08-01T00:00:15.000Z|1289350190348922880|Very tough day today. We buried my little sisters ashes with my grandma next to my uncle Johnny. My gramma always h… https://t.co/3kgaF5XEGB|-1|-1|0|0|en|False
+2020-08-01T00:00:15.000Z|1289350192387379201|i get to see my sisters tomorrow 😁|-1|-1|0|0|en|False
+2020-08-01T00:00:15.000Z|1289350193406545923|Just posted a video @ Cheyenne Mountain Zoo https://t.co/rlABqOFNMc|-1|-1|0|0|en|False
+2020-08-01T00:00:15.000Z|1289350193410748416|@TIME They are afraid of “going postal in reverse”.|1288667326636871680|14293310|0|0|en|False
+2020-08-01T00:00:15.000Z|1289350193410748418|@pablothehaitian @shroomymello Nope, we don’t listen n we proud idc 🤨|1289348970217578499|4922581889|0|0|en|False
+2020-08-01T00:00:15.000Z|1289350193557786625|@Pally__Ray @OnlyFuturistic crazy shit|1289291785533964289|3378168339|0|0|en|False
+2020-08-01T00:00:15.000Z|1289350193599483904|1. HOUR. #MFFL #BigNewsSoon👀|-1|-1|0|0|en|False
+2020-08-01T00:00:15.000Z|1289350193775808512|mane whatttt|-1|-1|0|0|en|False
+2020-08-01T00:00:15.000Z|1289350193792524288|@highme 🤔🤔🤔🤔|1289344588428111872|14885869|0|0|und|False
+2020-08-01T00:00:15.000Z|1289350194044133376|That’s a pretty pile of kitties! 😸|-1|-1|0|0|en|False
+2020-08-01T00:00:16.000Z|1289350194652274688|fred_derd masked up with the #RichOvernight tee 🔥😷 @ Atlantis Mariscos & Sushi https://t.co/PCkVaKESCj|-1|-1|0|0|en|False
+2020-08-01T00:00:16.000Z|1289350194773909504|@stella_immanue @JOHNTPOTTS1 @POTUS Don't worry Stella God is on your side|1289225134272897025|1288076529134698497|0|0|en|False
+2020-08-01T00:00:16.000Z|1289350196271489026|y’all f*gs with the colored lights really piss me off. it looks tacky and tasteless honestly|-1|-1|0|0|en|False
+2020-08-01T00:00:16.000Z|1289350196338417664|Noodle pulls are just... necessary https://t.co/tg9z8jg4lh|-1|-1|0|0|en|False
+2020-08-01T00:00:16.000Z|1289350196447465472|house music + homework= productivity|-1|-1|0|0|en|False
+2020-08-01T00:00:16.000Z|1289350196757819392|Umm. We don't want to see black people be killed. That's kinda the opposite of that.|-1|-1|0|0|en|False
+2020-08-01T00:00:16.000Z|1289350197617688576|@alec_bell_7 Wouldn’t have gotten there without you big dog|1289325983900643328|1422038970|0|0|en|False
+2020-08-01T00:00:16.000Z|1289350198443962369|@alara__yasemin That dude is a cuck. No question. 😂😂😂|1289235281606881283|1186419485814771714|0|0|en|False
+2020-08-01T00:00:16.000Z|1289350198666252290|i don’t believe in second chances that’s the type of shit that makes you soft .|-1|-1|0|0|en|False
+2020-08-01T00:00:17.000Z|1289350198796226560|Baseball players are funny jackasses|-1|-1|0|0|en|False
+2020-08-01T00:00:17.000Z|1289350198955659264|I have so much time for activities.|-1|-1|0|0|en|False
+2020-08-01T00:00:17.000Z|1289350198989185024|Mood|-1|-1|0|0|en|False
+2020-08-01T00:00:17.000Z|1289350200562089984|$bklynprince @irasmith93|-1|-1|0|0|tl|False
+2020-08-01T00:00:17.000Z|1289350200637550593|for the broke losers 🤣 $5 each cashapp: $britneyforevenmo: @britneyforehttps://t.co/GgSvDHZDEe#Findom #Beta… https://t.co/colFvSVeKb|-1|-1|0|0|en|False
+2020-08-01T00:00:17.000Z|1289350200683687937|@shannon0318 💯💯💯💯🔥🔥🔥|1289172624791150594|26555320|0|0|und|False
+2020-08-01T00:00:17.000Z|1289350201858076672|@fardlord who is she...|1289049302237622275|935881291567980544|0|0|en|False
+2020-08-01T00:00:17.000Z|1289350201921085441|@DatelineNBC If it’s new!|1289350128227278850|11856932|0|0|en|False
+2020-08-01T00:00:17.000Z|1289350202105593856|It is now putting down significant rain on the west slopes if the Organs@NWSElPaso @NMClimate|-1|-1|0|0|en|False
+2020-08-01T00:00:17.000Z|1289350202269167616|It’s really no good places to eat|-1|-1|0|0|en|False
+2020-08-01T00:00:18.000Z|1289350203187896320|@bpolitics https://t.co/brlM06DyLV|1288601261030375427|564111558|0|0|und|False
+2020-08-01T00:00:18.000Z|1289350203204440064|This is the last day to buy this|-1|-1|0|0|en|False
+2020-08-01T00:00:18.000Z|1289350203204501504|Miguel Cabrera has got to never want to see Luis Castillo ever again|-1|-1|0|0|en|False
+2020-08-01T00:00:18.000Z|1289350203300933632|@realDonaldTrump Look at that @GovInslee is throwing out the first. Your right you didn't get invited because nobod… https://t.co/nT9dXi5Sje|-1|25073877|0|0|en|False
+2020-08-01T00:00:18.000Z|1289350203951087617|Tell 'em Steven!|-1|-1|0|0|en|False
+2020-08-01T00:00:18.000Z|1289350204857053186|sometimes people get tired of being the bigger person|-1|-1|0|0|en|False
+2020-08-01T00:00:18.000Z|1289350205805010945|Just a bunch of guys being dudes. Local streamers trying to make it. Gaming clans matter. DOG# matters.Pull up… https://t.co/LCDgq6uHfs|-1|-1|0|0|en|False
+2020-08-01T00:00:18.000Z|1289350206085971969|It’s me, I’m the one that doesn’t give a fuck|-1|-1|0|0|en|False
+2020-08-01T00:00:18.000Z|1289350206203494401|@liberalinohio @PugloverDeb @JoeBiden Uhhhh. No. What was done to HRC is now being done to KH.|1289349989886550016|157136170|0|0|en|False
+2020-08-01T00:00:19.000Z|1289350207314960384|I tried deep fried oreos for the first time today... I CAN DIE HAPPY NOW|-1|-1|0|0|en|False
+2020-08-01T00:00:19.000Z|1289350207478484992|I can’t wait to shop at Ross again.|-1|-1|0|0|en|False
+2020-08-01T00:00:19.000Z|1289350207570759680|@Teesa_Michele I’m a Coloradoan... we vote for mail@l for everything !|1289309473807298562|492202782|0|0|en|False
+2020-08-01T00:00:19.000Z|1289350207994462209|i hate u ❤️|-1|-1|0|0|en|False
+2020-08-01T00:00:19.000Z|1289350208288161793|Road Work - FAIRFIELD #RT15 South at Exit 44 (RTE 58) at 7/31/2020 7:59:50 PM #cttraffic|-1|-1|0|0|en|False
+2020-08-01T00:00:19.000Z|1289350208401235969|Road Work - FAIRFIELD #RT15 South at Exit 44 (RTE 58) at 7/31/2020 7:59:50 PM #cttraffic|-1|-1|0|0|en|False
+2020-08-01T00:00:19.000Z|1289350208464314368|#powerful #queen peeeige @ Historic Bayside Baywood Park, Miami https://t.co/B4DxzHDg6Z|-1|-1|0|0|und|False
+2020-08-01T00:00:19.000Z|1289350208569180160|Twitter se está volviendo el lugar de las ofensas, de los ataques, de las criticas porque no piensas como yo...De… https://t.co/6TQFd1M3Sl|-1|-1|0|0|es|False
+2020-08-01T00:00:19.000Z|1289350208908742657|This Girl BD Lookin Scrumptious Asf .. She Already Think We Fckin Around .. Sooo Why Tf Not 🥴😌|-1|-1|0|0|en|False
+2020-08-01T00:00:19.000Z|1289350209051308032|i’m in P A I N|-1|-1|0|0|en|False
+2020-08-01T00:00:19.000Z|1289350209063940096|Different|-1|-1|0|0|en|False
+2020-08-01T00:00:19.000Z|1289350209227485184|Had a great time participating on the GSMP webinar panel for Business Resources this week. I really enjoyed hearing… https://t.co/qqZG1v0f4C|-1|-1|0|0|en|False
+2020-08-01T00:00:19.000Z|1289350210380902400|Tatum gone have to step it up|-1|-1|0|0|en|False
+2020-08-01T00:00:19.000Z|1289350210804572160|@RepDanCrenshaw @SteveScalise Bravo 👏👏👏|1289347845938483200|1080894931311431682|0|0|pt|False
+2020-08-01T00:00:19.000Z|1289350210850676737|@Cle_Eric_23 Keeeeep|1289322124465721344|447698260|0|0|und|False
+2020-08-01T00:00:20.000Z|1289350211748298753|So fun!!! @lollapalooza perryfarrellofficial @ettylaufarrell taylorhawkinsofficial kindheavenorchestra… https://t.co/E01SJJlP4R|-1|-1|0|0|en|False
+2020-08-01T00:00:20.000Z|1289350211844759552|@avazura https://t.co/XIZUUnOtfZ|1289003934930042880|2595089707|0|0|und|False
+2020-08-01T00:00:20.000Z|1289350213316964352|@HockeyFanGirl12 @SenSasse @marcorubio @SenatorCollins @lisamurkowski @SenCoryGardner @SenMikeLee @MiaBLove… https://t.co/8jLRRNDdM3|1289342237386702853|2540607781|0|0|en|False
+2020-08-01T00:00:20.000Z|1289350213572804608|@GOPLeader Stop lyinghttps://t.co/4k02WGQ7l3|1289219724992110593|19739126|0|0|en|False
+2020-08-01T00:00:20.000Z|1289350215216975873|chevy fresco and i are not dating we are entangled|-1|-1|0|0|en|False
+2020-08-01T00:00:21.000Z|1289350215523155968|@Elkeid28 If you’re not doing Cactuar then don’t come|1289349940297076736|753774272649232384|0|0|en|False
+2020-08-01T00:00:21.000Z|1289350215636418560|@robtraylorswift @BernieSanders Ok so that’s insanity, but the rich getting tax breaks (for example Kanye’s yeezy B… https://t.co/c8CylbpkPH|1289341326643720194|58562436|0|0|en|False
+2020-08-01T00:00:21.000Z|1289350215774822400|I bought an extra bottle of sake because it was cucumber flavored and I was craving fresh cucumbers and fruits afte… https://t.co/lmmqNIoxa9|-1|-1|0|0|en|False
+2020-08-01T00:00:21.000Z|1289350216798347266|Walked to @ChickfilA with the family today to pick up lunch curbside for a picnic at @AvalonInsider and they brough… https://t.co/cg1bpY41TQ|-1|-1|0|0|en|False
+2020-08-01T00:00:21.000Z|1289350217205035008|This is why I don’t grocery shopping when I’m hungry. I’d be buying the whole store.|1289350215774822400|758384342|0|0|en|False
+2020-08-01T00:00:21.000Z|1289350217288962051|You then hurt me 3 times now I need me time. https://t.co/piwRbZCqpu|-1|-1|0|0|en|False
+2020-08-01T00:00:21.000Z|1289350218052333568|@17Counting Check out our latest pod featuring guest Walt Williams. Tune in here https://t.co/qt3GtfY2lc|-1|1094648850260914176|0|0|en|False
+2020-08-01T00:00:21.000Z|1289350219264479232|ALLLLL RISSSSEEEEE|-1|-1|0|0|en|False
+2020-08-01T00:00:22.000Z|1289350219977564162|No what I miss is seeing people stand up and not do sh@t when over 32-days ago we saw Russia bounty and like normal… https://t.co/mXaaPi62tC|-1|-1|0|0|en|False
+2020-08-01T00:00:22.000Z|1289350220279578624|Whoever holding them back need to chilllll|-1|-1|0|0|en|False
+2020-08-01T00:00:22.000Z|1289350220610863105|Joe Biden for President and Kamala Harris for Vice-president 2020|-1|-1|0|0|en|False
+2020-08-01T00:00:22.000Z|1289350220677963776|Smh i don’t understand why people are like this just stay tf home!!!|-1|-1|0|0|en|False
+2020-08-01T00:00:22.000Z|1289350221558722560|When the problem is with Russia we get a hmm or oh or well we have some bad people here! NOW I AM SICK OF SEEING HI… https://t.co/1frOwY4p8V|1289350219977564162|704520881423253505|0|0|en|False
+2020-08-01T00:00:22.000Z|1289350222095609858|@Mike_Hall11 @minakimes Like me, she has 100 jobs, but I’d love to have her on if she’s interested and ESPN allows… https://t.co/Zt4W52wkE4|1289349540227813376|211747133|0|0|en|False
+2020-08-01T00:00:22.000Z|1289350222502535168|Thanks buddy‼️‼️ you’re up next @NDFootball TAKE NOTICE!!!|-1|-1|0|0|en|False
+2020-08-01T00:00:22.000Z|1289350222624305156|North Korea and they said they were done testing and the nuclear threat was gone well since that comment we have ha… https://t.co/py4TVIboIp|1289350221558722560|704520881423253505|0|0|en|False
+2020-08-01T00:00:22.000Z|1289350222959669249|@TurnerEdwin @wgriffin28 @jwlpc @NASCARonNBC @bakerracingpix @toomuchcountry @TimLeeming83 @RMinENC 😀|1289349591087775745|1897520299|0|0|und|False
+2020-08-01T00:00:22.000Z|1289350223119056896|@SDHighwayPatrol I think the sunglasses make you look like @karaswisher And that’s definitely a complement!|1289315606898937856|479851680|0|0|en|False
+2020-08-01T00:00:22.000Z|1289350223362510848|FIRST OF ALL BIIIIIIIIITTTTCHHHH @dbleudazzled SNAPPED on these ALFITS in Find Your Way Back #BlackIsKing|-1|-1|0|0|en|False
+2020-08-01T00:00:22.000Z|1289350223559405568|With that!|1289350222624305156|704520881423253505|0|0|en|False
+2020-08-01T00:00:23.000Z|1289350224649940992|@smaisley @oncorage @Colorado @coffee_n_mtns @universaIphotos @JustTraveI 🥰♥️|1289349982571520002|803081568822521856|0|0|und|False
+2020-08-01T00:00:23.000Z|1289350225232977920|@glisson_meg well hi😩🥰|1289335452139319296|2322887558|0|0|en|False
+2020-08-01T00:00:23.000Z|1289350225392410624|The man does it all!! #allrise|-1|-1|0|0|en|False
+2020-08-01T00:00:23.000Z|1289350225484603392|@panelstopixels https://t.co/7DHWkzoRmg|1289346313348235264|912741930009755650|0|0|und|False
+2020-08-01T00:00:23.000Z|1289350225501462529|Oh UT, how I love thee, but LOL if you think this is going to work. 😂|-1|-1|0|0|en|False
+2020-08-01T00:00:23.000Z|1289350225551937536|@canelaverdemiel https://t.co/Tt6raXfQyI|1289348948553916416|4095047482|0|0|und|False
+2020-08-01T00:00:23.000Z|1289350225648160768|@Obeykira_1228 @7ftvonn @PineappleRingz @valor_iam @_Mugwe @ellorelloo @millysvantage This exchange really was it t… https://t.co/S0bV8NwNcy|1289294763556888579|3437499287|0|0|en|False
+2020-08-01T00:00:23.000Z|1289350225727860736|@KevinShockey @kmunro1 I’m on a strict 2-beers-per-inning diet and I have to ‘double’ if we go into extras. 2020 mlb rules are wild right|1289349869316972550|19280389|0|0|en|False
+2020-08-01T00:00:23.000Z|1289350225904074755|This whole “What meme are you” trend is giving me serious “I can’t get my name on a mug or keychain” childhood vacay flashbacks. 😐|-1|-1|0|0|en|False
+2020-08-01T00:00:23.000Z|1289350226537414656|@fIatbedroses @DAYGLOWVlBES ur my indie wife|1289349985285242880|725142007128150016|0|0|en|False
+2020-08-01T00:00:23.000Z|1289350226587705345|Reimburse me for my bikini boys😈 https://t.co/v1fLGy07jc|-1|-1|0|0|en|False
+2020-08-01T00:00:23.000Z|1289350226894032898|This weather is just 😍😍😍|-1|-1|0|0|en|False
+2020-08-01T00:00:23.000Z|1289350227011358723|@super70ssports1 You’re back!|1289349373747294210|1288587913798852608|0|0|en|False
+2020-08-01T00:00:23.000Z|1289350227804090369|prophecy is cyclical so what you gonna do|-1|-1|0|0|en|False
+2020-08-01T00:00:24.000Z|1289350228156600324|@mmpadellan Maybe the FAN won't Fail US 🤞🤞🤞#TrumpVirus #FanSavesUS https://t.co/YR9PUqQv7x|1289339160902295552|1640929196|0|0|en|False
+2020-08-01T00:00:24.000Z|1289350228282400770|We are no longer Slaves in America. Now treat us as such. #blacklivesmatter✊🏽✊🏾✊🏿 @ Louisville, Kentucky https://t.co/YzUN1zru62|-1|-1|0|0|en|False
+2020-08-01T00:00:24.000Z|1289350228785561600|https://t.co/35MGAAkUvD|-1|-1|0|0|und|False
+2020-08-01T00:00:24.000Z|1289350228936544257|@TheAtlantic that’s the kind of day where you can’t open your mouth WITHOUT A COVID-19 DROPLET FALLING IN. https://t.co/9h52Vgdoxy|-1|35773039|0|0|en|False
+2020-08-01T00:00:24.000Z|1289350229028818945|Test shoot last weekend with the talented @blac__art ✨ https://t.co/sf5hE3P0z9|-1|-1|0|0|en|False
+2020-08-01T00:00:24.000Z|1289350229200789504|Nip slip https://t.co/4u2Z1VJyaG|-1|-1|0|0|en|False
+2020-08-01T00:00:24.000Z|1289350229397889024|Say Me https://t.co/jX7BRyjsFM|-1|-1|0|0|en|False
+2020-08-01T00:00:24.000Z|1289350229469233152|Bucks -4.5Giants +105Yankees -167|1289051383786766336|196289996|0|0|en|False
+2020-08-01T00:00:24.000Z|1289350230131896321|It’s hard finding a dope ass loctician out here.. sheeshAll of the good ones are out of state|-1|-1|0|0|en|False
+2020-08-01T00:00:24.000Z|1289350230421303296|@hifipeeellaaah 🤯😍|1289168318541119490|959218472|0|0|und|False
+2020-08-01T00:00:24.000Z|1289350230576517120|@runningfromdc @personfromnope @TheJimmyRiviera @h00dieharden @krishansonRCF @DipoWRLD you’re so stupid|1289343093376860160|1082850367572852737|0|0|en|False
+2020-08-01T00:00:24.000Z|1289350231386214400|@NormaOr59133189 @astros 😂|1289350025013731329|1246461394050076672|0|0|und|False
+2020-08-01T00:00:25.000Z|1289350233856475136|I miss the days when I would go in the lockeroom in middle school / high school & it will just smell like axe body… https://t.co/3CAjflHgUt|-1|-1|0|0|en|False
+2020-08-01T00:00:25.000Z|1289350234309562369|Start emailing all your friends and relatives that Trump moved their elections to Nov 10th!|-1|-1|0|0|en|False
+2020-08-01T00:00:25.000Z|1289350234355761154|https://t.co/p8ijA5qFSj|-1|-1|0|0|und|False
+2020-08-01T00:00:25.000Z|1289350236133945345|@SceneableG Yes but Biden literally voted for DOMA|1289346853356498944|1259913615252938752|0|0|en|False
+2020-08-01T00:00:25.000Z|1289350236368850944|“To every little girl who dreams big: Yes, you can be anything you want—even president.” -@HillaryClinton @ewarren… https://t.co/JWKXDm9J6K|-1|-1|0|0|en|False
+2020-08-01T00:00:25.000Z|1289350236452696067|LAFC needs to do the lord’s work and win this game.|-1|-1|0|0|en|False
+2020-08-01T00:00:26.000Z|1289350236557598721|@jpierni Takanis|1289343915691143168|827265998|0|0|in|False
+2020-08-01T00:00:26.000Z|1289350237086035968|@BLKMDL3 🤮|1289329761945153537|988975103785365504|0|0|und|False
+2020-08-01T00:00:26.000Z|1289350237090455552|@ oomf|-1|-1|0|0|tl|False
+2020-08-01T00:00:26.000Z|1289350237157568513|I'd really rather be bored then have toxic ppl around me|-1|-1|0|0|en|False
+2020-08-01T00:00:26.000Z|1289350237211959296|What a load of baloney|-1|-1|0|0|en|False
+2020-08-01T00:00:26.000Z|1289350237862031360|@davidhogg111 No way! GOP is done. He screwed this state bad enough.|1289348712922193921|1915033663|0|0|en|False
+2020-08-01T00:00:26.000Z|1289350238549864448|@SteveScalise @realDonaldTrump He actuallythought he could just pretend it didn't exist. So he did a partial ban.… https://t.co/ERI9D2LoRV|1289208463659278336|1209417007|0|0|en|False
+2020-08-01T00:00:26.000Z|1289350238856187904|Its 7 & It feels like it’s noon|-1|-1|0|0|en|False
+2020-08-01T00:00:26.000Z|1289350239434964992|@Reuters Is Trump going to get him off|1289347611779108864|1652541|0|0|en|False
+2020-08-01T00:00:26.000Z|1289350239879495683|I be drunk with no boo to call😩|-1|-1|0|0|en|False
+2020-08-01T00:00:26.000Z|1289350240642859008|👇🥇|-1|-1|0|0|und|False
+2020-08-01T00:00:27.000Z|1289350240806375424|https://t.co/aU9PvGWcI4|-1|-1|0|0|und|False
+2020-08-01T00:00:27.000Z|1289350240818978817|At a corner restaurant having some dinner outside and everyone is talking about their pending move out of NYC or th… https://t.co/C1mJS56eSR|-1|-1|0|0|en|False
+2020-08-01T00:00:27.000Z|1289350240974385152|Take VR to the NEXT LEVEL! YawVR (Setup, Review & Gameplay) https://t.co/d8hnvozMA6|-1|-1|0|0|en|False
+2020-08-01T00:00:27.000Z|1289350241695625216|@millyfromoz Sophie figured out the window thing herself. Now if we can get some decent sun!! You are lucky to have… https://t.co/PtPQAOYsL7|1289150754125561856|948310858156818433|0|0|en|False
+2020-08-01T00:00:27.000Z|1289350241800482816|El Grupo de Cardiología de #OrlandoHealth Heart Institute les ofrece a los residentes de Osceola y comunidades veci… https://t.co/yfi9LtaINf|-1|-1|0|0|es|False
+2020-08-01T00:00:27.000Z|1289350241846616064|@DeniseLHeureux1 @TheOnion @ChrisCuomo https://t.co/m0UcbD50iY|1289346563702022144|563446951|0|0|und|False
+2020-08-01T00:00:27.000Z|1289350242031112192|whew|-1|-1|0|0|en|False
+2020-08-01T00:00:27.000Z|1289350242035351552|@tjdelsanto https://t.co/SeYIMMmncd|-1|36184638|0|0|und|False
+2020-08-01T00:00:27.000Z|1289350242274430976|ALL RISE #NYYforNY|-1|-1|0|0|en|False
+2020-08-01T00:00:27.000Z|1289350243482509314|Sisters vibes ❤️🔥‼️#vibing❤️🔥#sistersbond‼️ https://t.co/HiMvP3CLG4|-1|-1|0|0|en|False
+2020-08-01T00:00:27.000Z|1289350243717386241|Wow! I won the week per the great Al Franken!|-1|-1|0|0|en|False
+2020-08-01T00:00:27.000Z|1289350243889213441|Did y’all vote for @machinegunkelly today on the VMA nominations? Get fucking to it|-1|-1|0|0|en|False
+2020-08-01T00:00:27.000Z|1289350244233166848|Dying of laughter at this thread. @RaysBaseball Being amazingly savage 🤣|-1|-1|0|0|en|False
+2020-08-01T00:00:27.000Z|1289350244392607744|This Needs to Be SHARED !!!https://t.co/HWxF57AlC7|-1|-1|0|0|en|False
+2020-08-01T00:00:27.000Z|1289350244577075200|Fregin auto correct..... https://t.co/SM2Hs68sNM|1289349718301016066|96113627|0|0|es|False
+2020-08-01T00:00:28.000Z|1289350246280003585|This is as the 4th of July project. Old one was wired to an old ivy root in the ground. Used epoxy vs. concrete to… https://t.co/6QgPy5mevj|-1|-1|0|0|en|False
+2020-08-01T00:00:28.000Z|1289350246703616003|In the span of like 36 hours, my wedding was postponed because Americans suck at doing things right, my dad was dia… https://t.co/9O3zlYJ6gm|-1|-1|0|0|en|False
+2020-08-01T00:00:28.000Z|1289350247144071170|Aaron Judge is locked in|-1|-1|0|0|en|False
+2020-08-01T00:00:28.000Z|1289350247756394496|Trump is a dangerous man. He isn’t wearing a mask nor are the people around him. He doesn’t care about their lives… https://t.co/x5lplSoJ9M|-1|-1|0|0|en|False
+2020-08-01T00:00:28.000Z|1289350247982837760|@TimWeisberg something that you want will arrive at the station as a gift for all you have done during the pandemic… https://t.co/mOHeK05iRu|-1|27516458|0|0|en|False
+2020-08-01T00:00:28.000Z|1289350248205152256|@tamaleimpala I live in so-called low income housing which for me is half of my income but I’m sure I am making mor… https://t.co/2gyWxF8UhV|1288937502754177027|979768008|0|0|en|False
+2020-08-01T00:00:28.000Z|1289350248502931456|Yes! Total cringeworthy scene! Ugh! #SaveSandition #Sanditon|-1|-1|0|0|en|False
+2020-08-01T00:00:28.000Z|1289350248523919360|i slang in my white tee|-1|-1|0|0|en|False
+2020-08-01T00:00:28.000Z|1289350248708497408|MC Dersher|-1|-1|0|0|en|False
+2020-08-01T00:00:28.000Z|1289350248830103553|@politicalpanini It’s fun!|1289312931742703616|194347409|0|0|en|False
+2020-08-01T00:00:29.000Z|1289350249169920001|@JigglyDad @ShutupToshi9227 @AliLuckey11 @trainer_remamco @gingerlykimber1 I can try to park near a starbucks.. (for the internet) haha|1289348668080836608|1227781580615278592|0|0|en|False
+2020-08-01T00:00:29.000Z|1289350249513771008|@teslaquadcities @dogsoftesla @AustinTeslaClub @Tesla @jamesbuchanan27 https://t.co/SjPE1yBEiX|1289349895191556096|1113245983390011393|0|0|und|False
+2020-08-01T00:00:29.000Z|1289350250084225024|This the fastest fuel city has ever been with my food.|-1|-1|0|0|en|False
+2020-08-01T00:00:29.000Z|1289350250453282816|Adorbs!|-1|-1|0|0|pt|False
+2020-08-01T00:00:29.000Z|1289350250616913920|@FiercegoddessB https://t.co/hYguJYOFbt|1289349449265762305|731541536832245760|0|0|und|False
+2020-08-01T00:00:29.000Z|1289350250621095938|this hit home|-1|-1|0|0|en|False
+2020-08-01T00:00:29.000Z|1289350251678019586|#BlackIsKing is visually stunning!Congrats @Beyonce and Disney+|-1|-1|0|0|en|False
+2020-08-01T00:00:29.000Z|1289350252202323968|Subscribe to our YouTube channelhttps://t.co/jhDiCTyXl5|-1|-1|0|0|en|False
+2020-08-01T00:00:29.000Z|1289350252332331008|Nooooo|-1|-1|0|0|und|False
+2020-08-01T00:00:29.000Z|1289350252705677312|@eastonbec_12 Potential use the hawks as a get away if the crocodiles get overrun, I like your strategy|1289349274187321344|719715157962846210|0|0|en|False
+2020-08-01T00:00:29.000Z|1289350252898656256|Oakland needs a Chic-Fil-a, a Dutch bros and a Canes im tored of all the good things being far|-1|-1|0|0|en|False
+2020-08-01T00:00:30.000Z|1289350253439787009|@yourhoodrat What’s your sun sign?|1289346708351025152|1157158698579423232|0|0|en|False
+2020-08-01T00:00:30.000Z|1289350254811205633|@lapetiteemily @bennyjohnson @replouiegohmert Exactly. He could have just as easily said he's injecting bleach into… https://t.co/XIqdgYbCxK|1289327230141845512|1024441561969451008|0|0|en|False
+2020-08-01T00:00:30.000Z|1289350255905914880|@Hard_Ona_Hoe111 @Auto_Porn https://t.co/7OP3ee8p3Y|1289345788158517248|587144616|0|0|und|False
+2020-08-01T00:00:30.000Z|1289350255918477312|@Turtle_andretti I’m joking I’m joking please lmao|1289350131490476032|248580741|0|0|en|False
+2020-08-01T00:00:30.000Z|1289350256069472256|@djbolkas @dattanhoang @J8Aleks @heraldsunsport An embarrassing number of white men commit more rape and sexual ass… https://t.co/LxMR9Gm6v4|1289348913325981696|1341552949|0|0|en|False
+2020-08-01T00:00:30.000Z|1289350256669257728|Attempted to take pics outside and that was a hard nooo 🙅🏻‍♀️ i get cranky in this heat|-1|-1|0|0|en|False
+2020-08-01T00:00:31.000Z|1289350257818533889|Parents! The application deadline for the Pandemic Electronic Benefit (P-EBT), a one time payment for each child wh… https://t.co/9iMc8WUFvB|-1|-1|0|0|en|False
+2020-08-01T00:00:31.000Z|1289350258858721280|With them pretty ass legs 🥴|-1|-1|0|0|en|False
+2020-08-01T00:00:31.000Z|1289350258896453632|Starting at 10 am tomorrow the first to call me will get to RENT this beauty (the Canon R5 w/lens). Let the fun beg… https://t.co/pYzlYixfub|-1|-1|0|0|en|False
+2020-08-01T00:00:31.000Z|1289350259190177793|@KoppMia Ask your fuckin neighbor she was sitting there laughing her ass off.|1289349622800908288|708583613789392896|0|0|en|False
+2020-08-01T00:00:31.000Z|1289350259659833347|@texasgolf6971 Little scamp.|1289344758549295104|728212838750167040|0|0|en|False
+2020-08-01T00:00:31.000Z|1289350260007956480|@TDA3397 @Clong03 Jetty is a scrub Met fan. Always hating.|1289348247706714113|2805919844|0|0|en|False
+2020-08-01T00:00:31.000Z|1289350260175691776|OH, HELL YEAH!!!|-1|-1|0|0|en|False
+2020-08-01T00:00:31.000Z|1289350260448403456|love my second home ❤️☀️ https://t.co/WJr14Dxmxk|-1|-1|0|0|en|False
+2020-08-01T00:00:31.000Z|1289350260469325826|Over the fence. Still counts. Let’s goooooo|-1|-1|0|0|en|False
+2020-08-01T00:00:31.000Z|1289350260905525249|@Buffalojilll I’m about to put the Franks Wing Sauce and get down to business https://t.co/zKkwqmKvdS|1289240489661669377|947847565474779136|0|0|en|False
+2020-08-01T00:00:31.000Z|1289350261413011456|@ThatHoustonKid WHAT?!|1289341064273305602|190114686|0|0|en|False
+2020-08-01T00:00:32.000Z|1289350261945688064|@HeyyDalis|-1|343138287|0|0|und|False
+2020-08-01T00:00:32.000Z|1289350262188994561|MadDog2020|-1|-1|0|0|cy|False
+2020-08-01T00:00:32.000Z|1289350262679670792|‼️‼️‼️|-1|-1|0|0|und|False
+2020-08-01T00:00:32.000Z|1289350262696685576|Stimulus checks debate now focuses on size, eligibility https://t.co/IXQFFuc7sc|-1|-1|0|0|en|False
+2020-08-01T00:00:32.000Z|1289350262843305984|I've been so annoyed forgot today is payday, let me go blow some money and make myself feel better.|-1|-1|0|0|en|False
+2020-08-01T00:00:32.000Z|1289350264688844803|Black and White challange accepted.#strongwomen @ Kinnelon, New Jersey https://t.co/4dn506D3Yi|-1|-1|0|0|en|False
+2020-08-01T00:00:32.000Z|1289350265229815808|@katmomma21 Good luck|1289284405551235073|380007463|0|0|en|False
+2020-08-01T00:00:32.000Z|1289350265296916481|@JacobDWelch They wouldn’t card the beer guy|1289345707112042496|2302184504|0|0|en|False
+2020-08-01T00:00:32.000Z|1289350265347309568|sick of talking head democrats and republicans consistently pitting americans against each other. break the cycle and think for yourself|-1|-1|0|0|en|False
+2020-08-01T00:00:32.000Z|1289350265460723714|@keegandubs_ @ItsShake4ndbake He hit him on the arm it was a foul|1289349932705411072|1244725299973144576|0|0|en|False
+2020-08-01T00:00:32.000Z|1289350265800286208|@scade43 Yeah,fucking good.!!|1289341066156466176|2169081853|0|0|en|False
+2020-08-01T00:00:33.000Z|1289350266060288000|@coachnoonan Not sure the rule on this honestly. We have played with only one before do to malfunctions but think d… https://t.co/6smP56gVLO|1289216914175082496|28396660|0|0|en|False
+2020-08-01T00:00:33.000Z|1289350266446200832|📍 https://t.co/HgWuMpFjkj|-1|-1|0|0|und|False
+2020-08-01T00:00:33.000Z|1289350267016581120|@Predatedtunaa @ladderofjacob23 @TheRealMaradkel @WhitlockJason No because no one knew exactly what it was all abou… https://t.co/CnUkeQoREN|1289346293588848642|1237940950816694272|0|0|en|False
+2020-08-01T00:00:33.000Z|1289350267138273280|@HilltopTough_HC Check out our latest pod featuring guest Walt Williams. Tune in here https://t.co/qt3GtfY2lc|-1|1059990855149408256|0|0|en|False
+2020-08-01T00:00:33.000Z|1289350267180220417|Dr. Pimple Popper is my SHIT. https://t.co/RHiR9tJloN|-1|-1|0|0|en|False
+2020-08-01T00:00:33.000Z|1289350267738238976|@Gretche03376852 @NicfromO ❤️|1289349935448686592|1205117429883555842|0|0|und|False
+2020-08-01T00:00:33.000Z|1289350268660793345|That’s awesome!!!|-1|-1|0|0|en|False
+2020-08-01T00:00:33.000Z|1289350268878860288|ofotw👀|-1|-1|0|0|pl|False
+2020-08-01T00:00:33.000Z|1289350268908441601|@deathordesire @realkasherquon @TRichOfficial 🥵|1288662580295274496|1222247672012247041|0|0|und|False
+2020-08-01T00:00:33.000Z|1289350269294260229|All Rise 👨🏽‍⚖️ 2-1 Yankees! #NYYForNY|-1|-1|0|0|en|False
+2020-08-01T00:00:33.000Z|1289350269428355073|Judge!!! 2 run blast and yanks lead 2-1 !!|-1|-1|0|0|en|False
+2020-08-01T00:00:33.000Z|1289350269843566593|@RamonaKimona What if I drink three in the lot after the game|1289347492132331520|77026798|0|0|en|False
+2020-08-01T00:00:34.000Z|1289350270535659520|@patribotics @BarbaraB9999 @RepKarenBass F her then|1289323303442747393|842398676714676228|0|0|en|False
+2020-08-01T00:00:34.000Z|1289350270988640256|Nothing like frozen butter beer on a hot Florida day!! But the brain freeze was not fun! 😫 🍺 #harrypotter… https://t.co/4aXsaeRKsr|-1|-1|0|0|en|False
+2020-08-01T00:00:34.000Z|1289350271697444864|@CoastalFootball @missyellenberge So proud of Luke. Great student athlete|1289211424816824321|256174987|0|0|en|False
+2020-08-01T00:00:34.000Z|1289350271739367424|In your cityyyy https://t.co/4J2ljIUoQO|-1|-1|0|0|en|False
+2020-08-01T00:00:34.000Z|1289350271915757568|elisa really called her hornYI- 💀|-1|-1|0|0|en|False
+2020-08-01T00:00:34.000Z|1289350272418852864|@DrewChamplin @CecilHurt @AlabamaMBB Lol I left that part out|1289348758275203072|16258706|0|0|en|False
+2020-08-01T00:00:34.000Z|1289350272834314242|Today we discharged home our first patient from our covid unit. The family thanked us with @deliastamales and… https://t.co/kjupdUzmjP|-1|-1|0|0|en|False
+2020-08-01T00:00:34.000Z|1289350273312395266|@KeysRealTalk @DanAndShay You’re slaaaaacking! But it just dropped yesterday so I’ll give you a pass this time|1289317189749637120|1176328431916736513|0|0|en|False
+2020-08-01T00:00:34.000Z|1289350273660416002|@AwengChuol You’re truly divine ❤️|1289286001899184129|867328402331582466|0|0|en|False
+2020-08-01T00:00:34.000Z|1289350273870123008|@Thrpdo24 @CThorpe3 It's definitely an American film.|1289348470709526528|700365018|0|0|en|False
+2020-08-01T00:00:34.000Z|1289350274113445889|Wearing a face mask after smacking some garlic noodles <|-1|-1|0|0|en|False
+2020-08-01T00:00:35.000Z|1289350274239275008|@kbeezytoyou You about to get some kinky twist|1289326032416251905|1287775947614236678|0|0|en|False
+2020-08-01T00:00:35.000Z|1289350274281140225|الحمدالله على اجواء فلوريدا|-1|-1|0|0|ar|False
+2020-08-01T00:00:35.000Z|1289350274763481089|Also, man this sucks. Hope she ok|-1|-1|0|0|en|False
+2020-08-01T00:00:35.000Z|1289350274964848642|@MoreOfMie I wanna sign up 🙈|1289342916914118658|1266674356580577280|0|0|en|False
+2020-08-01T00:00:35.000Z|1289350275623346181|@iamwandasykes So true|1289224795364536320|262799542|0|0|en|False
+2020-08-01T00:00:35.000Z|1289350275984105473|Vibe unmatched 🖤 https://t.co/AKDZD8USyg|-1|-1|0|0|en|False
+2020-08-01T00:00:35.000Z|1289350276374081536|we taking shots fuck it|-1|-1|0|0|en|False
+2020-08-01T00:00:35.000Z|1289350276441411585|@TruGiffers Tko|1289349744410497025|1286714483621212162|0|0|und|False
+2020-08-01T00:00:35.000Z|1289350276500070402|@natea4real91 Lol why|1289014519923118080|27981325|0|0|en|False
+2020-08-01T00:00:35.000Z|1289350277649186817|I’m pretty sure @GetSpectrum @Ask_Spectrum is throttling my internet. It’s ridiculous when I have to use @TMobile h… https://t.co/3mgHbZtQR0|-1|-1|0|0|en|False
+2020-08-01T00:00:36.000Z|1289350278752481280|This is great|-1|-1|0|0|en|False
+2020-08-01T00:00:36.000Z|1289350278844575745|#DemocratsHateAmerica|-1|-1|0|0|und|False
+2020-08-01T00:00:36.000Z|1289350279251423236|ALLL RISE BABYYYYY|-1|-1|0|0|en|False
+2020-08-01T00:00:36.000Z|1289350279561789440|TANTRUM #LISTEN #EDM #ElectronicMusic #Techno #HouseMusic #DJ #MusicFestival #Rave #RaveDance#Shuffle #DeepHouse… https://t.co/NZFgOmETkx|-1|-1|0|0|en|False
+2020-08-01T00:00:36.000Z|1289350279616270336|So I’ve been doing yoga on and off for years, mostly since high school. But sadly I still need guidance from videos… https://t.co/vrFLk55CWl|-1|-1|0|0|en|False
+2020-08-01T00:00:36.000Z|1289350279708602368|At 6:00 PM CDT, 2 WSW OLD Shawneetown [Gallatin Co, IL] PUBLIC reports FLASH FLOOD. FLOODED ROADS REPORTED SOUTHEAS… https://t.co/LbDIFyvL2F|-1|-1|0|0|en|False
+2020-08-01T00:00:36.000Z|1289350279742107648|At 6:00 PM CDT, 2 WSW OLD Shawneetown [Gallatin Co, IL] PUBLIC reports FLASH FLOOD. FLOODED ROADS REPORTED SOUTHEAS… https://t.co/mDYG9IRcLC|-1|-1|0|0|en|False
+2020-08-01T00:00:36.000Z|1289350280216227841|🍪 😋 🍪😋 https://t.co/IEvQ55qKNi|-1|-1|0|0|und|False
+2020-08-01T00:00:36.000Z|1289350280312532995|My goal was to sell 5 notebooks today and I sold 17. God is good.|-1|-1|0|0|en|False
+2020-08-01T00:00:36.000Z|1289350280908136448|@Mountaingal456 @MarciaNicklas ALL RISE !!!! Maybe 🥂🍾|1289349762236338176|1017435527098888192|0|0|en|False
+2020-08-01T00:00:36.000Z|1289350281315180547|Could Cranford baseball beat the 2019 Baltimore Orioles?|-1|-1|0|0|en|False
+2020-08-01T00:00:36.000Z|1289350281658904578|@svensundgaard Awwww 🥰|1289312755489570817|32332771|0|0|und|False
+2020-08-01T00:00:36.000Z|1289350281713668097|@laurdizzl https://t.co/PYgtlhJ8rL|1289348105499009024|123029978|0|0|und|False
+2020-08-01T00:00:36.000Z|1289350281826693120|Watch @memsql co-CEO @Big_Data_Raj discuss how #RealTime #data is the key for orgs to make quick, informed decision… https://t.co/P0MfVFSXnS|-1|-1|0|0|en|False
+2020-08-01T00:00:36.000Z|1289350282598653953|for the millionth time, it’s “would have” NOT “would of” y’all mfs killing me|-1|-1|0|0|en|False
+2020-08-01T00:00:37.000Z|1289350282690740224|Washington trip - North Cascades NP Diablo Lake Trail with Jordan, Matt, and Kaiya! Look at that turquoise 😍 @ No… https://t.co/Ts2xi5Mz61|-1|-1|0|0|en|False
+2020-08-01T00:00:37.000Z|1289350283118522368|There is something about the ref for this #DCFC game that I really like. Can't quite put my finger on it. @rodgrn, any ideas?|-1|-1|0|0|en|False
+2020-08-01T00:00:37.000Z|1289350283311513601|It means ANYBODY can get it! #stayready #winninginparadise|-1|-1|0|0|en|False
+2020-08-01T00:00:37.000Z|1289350283512778754|@Tiemposalvaje Bah.|1289186119905505285|1083789225965879296|0|0|und|False
+2020-08-01T00:00:37.000Z|1289350284116783104|@RichardManso3 It might be related to that. Would make sense.|1289346795554738176|1088183660950384640|0|0|en|False
+2020-08-01T00:00:37.000Z|1289350284322328578|@Mickeyhomerun @ZackCz @ProjectLincoln @realDonaldTrump Thanks for the nightmares jfk|1289345740280459264|1121162100393381888|0|0|en|False
+2020-08-01T00:00:37.000Z|1289350284825829378|I have realized that my writing is often written like pieces of a puzzle connecting to things that will need to be… https://t.co/b8qSVzzHy0|-1|-1|0|0|en|False
+2020-08-01T00:00:37.000Z|1289350284838178822|@kennylbelvin My husbands cheating on me at a genealogy conference is top ten best excuses|1289331503151816704|1080180230491439106|0|0|en|False
+2020-08-01T00:00:37.000Z|1289350284863344640|🥺|-1|-1|0|0|und|False
+2020-08-01T00:00:37.000Z|1289350285186359297|@ImjustSayingJC Revolutionary|1289335153110679556|27689872|0|0|en|False
+2020-08-01T00:00:37.000Z|1289350285366824961|"""Congruent with one's values."" I like that Bob/inner peace & happiness is also enlivened & expanded-when we continu… https://t.co/xKaqz1R9cg"|-1|-1|0|0|en|False
+2020-08-01T00:00:37.000Z|1289350285379289089|@HelenRoda2 Feliz tarde Helen|1289340901509042176|881564753453359104|0|0|tr|False
+2020-08-01T00:00:37.000Z|1289350285379346432|😂😂😂😂👌🏾|-1|-1|0|0|und|False
+2020-08-01T00:00:37.000Z|1289350285832228864|In a revelation to myself. I am learning so much. My writing stamina ain’t shit these days but I hope what is produced is quality.|1289350284825829378|37566612|0|0|en|False
+2020-08-01T00:00:38.000Z|1289350286947938304|#99 in full DICK UM DOWN MODE💪💪|-1|-1|0|0|en|False
+2020-08-01T00:00:38.000Z|1289350287182856194|Get fucked n https://t.co/q7FpCxZZzg|-1|-1|0|0|en|False
+2020-08-01T00:00:38.000Z|1289350287409348608|Adios Joe...|-1|-1|0|0|pt|False
+2020-08-01T00:00:38.000Z|1289350287686213632|@_faithebey @fusion_kb|1289349180549238784|1637229474|0|0|und|False
+2020-08-01T00:00:38.000Z|1289350288411774976|rip dodi💞|-1|-1|0|0|ht|False
+2020-08-01T00:00:38.000Z|1289350288474701824|@sheseezstarz @Jaxcarly0612 No not at this point - no rehabs if he’s got choices. I’ve heard that people w hip repl… https://t.co/BOntpSCX6u|1289349178464886785|3240037009|0|0|en|False
+2020-08-01T00:00:38.000Z|1289350288881717249|I miss the New Orleans I grew up in|-1|-1|0|0|en|False
+2020-08-01T00:00:38.000Z|1289350289087008769|@cammorrison2 @LevarStoney Vote @aerodgers she is FOR THE PEOPLE|1289343761693044736|580132539|0|0|en|False
+2020-08-01T00:00:38.000Z|1289350289120571392|My pleasure! Thank you for always being the awesome person that you are. Your positivity is infectious|-1|-1|0|0|en|False
+2020-08-01T00:00:38.000Z|1289350289183535105|marilyn monroe + animal print = EVACUATE|-1|-1|0|0|ro|False
+2020-08-01T00:00:38.000Z|1289350289263296519|@DereckCoatney @xenophon112 I wish you luck... but you must not be up on that position... yet at least|1289350119582662656|3266165605|0|0|en|False
+2020-08-01T00:00:38.000Z|1289350289279967232|Damn I’m getting accused of being homophobic cause I said “ no “ under a post 😐 I didn’t even know that post was ab… https://t.co/KzbO4HAJJb|-1|-1|0|0|en|False
+2020-08-01T00:00:38.000Z|1289350289347112960|@porter690314 @RKJ65 @realDonaldTrump The reason the crowd is so small is there wasn’t any broken glass for the cro… https://t.co/7gdyIhNSwO|1289343474920169473|64085145|0|0|en|False
+2020-08-01T00:00:38.000Z|1289350289774936072|@HotlineJosh @jaketapper Get ready to have the last 4 years jammed up your Republican asses|1289322522517807104|21612122|0|0|en|False
+2020-08-01T00:00:38.000Z|1289350289804283904|@dan_wickes It’s like if @OANN and @TheSun had a baby|1289317793549041665|442247542|0|0|en|False
+2020-08-01T00:00:38.000Z|1289350290336931841|Y’all sleep on @NikoG4|-1|-1|0|0|en|False
+2020-08-01T00:00:38.000Z|1289350290416611328|pistol poppin poppy street|-1|-1|0|0|en|False
+2020-08-01T00:00:38.000Z|1289350290420822019|@tonyrowley Eww|1289346618970370048|37161314|0|0|und|False
+2020-08-01T00:00:39.000Z|1289350291230470145|Why not both ?🥺😍|-1|-1|0|0|en|False
+2020-08-01T00:00:39.000Z|1289350291624665089|@servivigiledeus @biden_brigade When was Trump vindicated? He has fifty pending cases including the treasure of a c… https://t.co/YpLDc8E9ck|1289233481306841089|44554315|0|0|en|False
+2020-08-01T00:00:39.000Z|1289350291658117120|@joeltovar56 do u have the brown cmiac vinyl?? I’ve been trying to find it online but I can’t find it anywhere|1289317494214148096|126850802|0|0|en|False
+2020-08-01T00:00:39.000Z|1289350291926577153|This 👇|-1|-1|0|0|en|False
+2020-08-01T00:00:39.000Z|1289350292090179584|This caption feels racist|-1|-1|0|0|en|False
+2020-08-01T00:00:39.000Z|1289350292790587393|The #ImpotusAmericanus is known to enflame its throat sack when it feels threatened.|-1|-1|0|0|en|False
+2020-08-01T00:00:39.000Z|1289350293876953090|@Kehlani is everything https://t.co/lMeg9tL9rW|-1|776860630934360064|0|0|en|False
+2020-08-01T00:00:39.000Z|1289350294267076609|2-0 ALL RISE!!!!!! JBJ WHO!?!?!|-1|-1|0|0|en|False
+2020-08-01T00:00:39.000Z|1289350294954840065|Don’t let one rotten fruit mess of the whole basket .|-1|-1|0|0|en|False
+2020-08-01T00:00:40.000Z|1289350296498364417|Drinking a Neon Daydream by @deschutesbeer @ Porchadise Lost — https://t.co/g1XufYwJj5|-1|-1|0|0|en|False
+2020-08-01T00:00:40.000Z|1289350296812974081|Hi. I work in a factory in Maine that sews around 6k masks per day and we screen print around 2k per day. She would… https://t.co/ff3SFVAlWE|-1|-1|0|0|en|False
+2020-08-01T00:00:40.000Z|1289350297056235523|This is not a joke at all. I almost broke my neck looking at this that shit hurt|-1|-1|0|0|en|False
+2020-08-01T00:00:40.000Z|1289350297412722688|@AARYNINGRAM https://t.co/cIy0YGrFiG|1289298837732032512|1236089798382759937|0|0|und|False
+2020-08-01T00:00:40.000Z|1289350297572147202|She want that lovely dovey kiss kiss 🤣🤣|-1|-1|0|0|en|False
+2020-08-01T00:00:40.000Z|1289350297782018048|@SenTedCruz @marcorubio @SenThomTillis @SenatorLoeffler You do realize Epoch Times is run by a cult, right?Not int… https://t.co/XBSzUliJr8|1288895172898586625|1074480192|0|0|en|False
+2020-08-01T00:00:40.000Z|1289350298561998848|@Jason Risk and Return.|1289347827533926400|3840|0|0|en|False
+2020-08-01T00:00:40.000Z|1289350298675195905|@DNy1818 @marc99316464 @Sethrogen You sound increasingly desperate- understandable given people like your fellow Pr… https://t.co/LSp6ffYdMI|1289349121988386816|1171474695981600768|0|0|en|False
+2020-08-01T00:00:40.000Z|1289350299161751552|@JMizgata I’ve been really fascinated by how many layers there are to Jon Hamm’s performance? He slips between char… https://t.co/QRQieAFA98|1289349768678797313|41170121|0|0|en|False
+2020-08-01T00:00:41.000Z|1289350300164186114|@whisperish17 @khazaei_parviz چندسوال برای تعقل و نقدبرای پیشگیری از توهین به افرادی با نظرات متفاوت:🍁آیاجنابعالی… https://t.co/VS7vq5TDWX|1288885185857982464|1175973298565337093|0|0|fa|False
+2020-08-01T00:00:41.000Z|1289350300227125253|@Breeyeezy UGH. I love it. You need to watch To all the boys I’ve ever loved!|1289350180035112960|444309763|0|0|en|False
+2020-08-01T00:00:41.000Z|1289350302324256769|Neva slackin wit the mackin|-1|-1|0|0|en|False
+2020-08-01T00:00:41.000Z|1289350302626451457|Happy Birthday to one fabulous guy! @seanlhoey Keep celebrating 🥳 🥰👠 https://t.co/MrAo1UL2Xm|-1|-1|0|0|en|False
+2020-08-01T00:00:41.000Z|1289350302802444288|This mask trend is really irritating. I hate the world|-1|-1|0|0|en|False
+2020-08-01T00:00:41.000Z|1289350302970257408|@AnnaJKlassen Truth https://t.co/57eWdQC7kc|1289268704673280000|205782791|0|0|en|False
+2020-08-01T00:00:41.000Z|1289350303448350720|Bill Clinton will die in prison. Calling it now.|-1|-1|0|0|en|False
+2020-08-01T00:00:41.000Z|1289350303456739331|17:00 113F(Hi114/Lo82) Feels like 111F Wind WNW 5->6mph (Lt Brz) Hum 11% Baro 29.78(-) Solar 443 UV 0.6 ET 0.262 Cl… https://t.co/RWNUZdXi0W|-1|-1|0|0|en|False
+2020-08-01T00:00:42.000Z|1289350303813263361|@Jhol_92 https://t.co/3TP0ilavUD|1289347821615816704|414952046|0|0|und|False
+2020-08-01T00:00:42.000Z|1289350303838384129|Just posted a photo @ Cheyenne Mountain Zoo https://t.co/6CT7FqvAzc|-1|-1|0|0|en|False
+2020-08-01T00:00:42.000Z|1289350303914102785|23 anos com meu carro quitado, 3 línguas, trabalhando até tarde da noite, não peço minha mãe $1, e eu que sou a sem… https://t.co/3Z7YmQrK2q|-1|-1|0|0|pt|False
+2020-08-01T00:00:42.000Z|1289350303960068096|@JaeCity_1 Amazing, definitely check it out|1289347391133450241|1133703875989516289|0|0|en|False
+2020-08-01T00:00:42.000Z|1289350304119447552|Shit don’t feel good when it’s you I won’t cap|-1|-1|0|0|en|False
+2020-08-01T00:00:42.000Z|1289350304249634816|s/o @TheBrasilianKid one time for one time! if you wanna make some money, hit his line!!|-1|-1|0|0|en|False
+2020-08-01T00:00:42.000Z|1289350305138659329|@bella_jonny_des Thx sweetieI need to hear that|1289349103692857344|228510306|0|0|en|False
+2020-08-01T00:00:42.000Z|1289350305277030400|TIME TO MOVE!  Kill It With Fire  Let's Play https://t.co/OaRDKupQEa via @YouTube|-1|-1|0|0|en|False
+2020-08-01T00:00:42.000Z|1289350305553899521|Great to see Billy Butler doing the National Anthem https://t.co/2QSlOvO6pP|-1|-1|0|0|en|False
+2020-08-01T00:00:42.000Z|1289350306430627840|JUDGE AGAIN! Turn that shit up!!|-1|-1|0|0|en|False
+2020-08-01T00:00:42.000Z|1289350307256836102|I had to do an intake form today to do a telehealth appointment with my therapist. The paperwork was excruciating|-1|-1|0|0|en|False
+2020-08-01T00:00:42.000Z|1289350307302891520|He’s a coward!!!|-1|-1|0|0|en|False
+2020-08-01T00:00:42.000Z|1289350307579719680|Your true colorsTrue colors are beautifulLike a rainbow 🏳️‍🌈😙🎶#AlwaysProud❤️🧡💛💚💙💜 https://t.co/RYIUWmUDiF|-1|-1|0|0|en|False
+2020-08-01T00:00:43.000Z|1289350307961479171|Smokin’ hot tongs in every scene https://t.co/6Z5DyqvJhs|-1|-1|0|0|en|False
+2020-08-01T00:00:43.000Z|1289350308200460288|Dersh is going to jail!|-1|-1|0|0|en|False
+2020-08-01T00:00:43.000Z|1289350308284362754|2-1 Yanks via a two run shot by Judge! All Rise! #NYYforNY|-1|-1|0|0|en|False
+2020-08-01T00:00:43.000Z|1289350309488156673|Okay now this is some diabolical beyond evil shit. Fucking asshole.|-1|-1|0|0|en|False
+2020-08-01T00:00:43.000Z|1289350309630947335|@LilWhoUBankWit We got a few jits round here gotta have some 😭🔥|1289349157845573633|2295222253|0|0|en|False
+2020-08-01T00:00:43.000Z|1289350309668478977|@DrizzyKev @tbuhrman1 bruh hahahahaaaa|1289015663579869185|1230476998423851008|0|0|tl|False
+2020-08-01T00:00:43.000Z|1289350310297657345|Correction: Aaron judge is a MF GOD ALL RISE RN|-1|-1|0|0|en|False
+2020-08-01T00:00:43.000Z|1289350310758998016|Varalakshmi Vratham Pooja was celebrated today July 31 Friday at my daughter’s place in Chicago Mother and daught… https://t.co/0rOV9b2zPT|-1|-1|0|0|en|False
+2020-08-01T00:00:44.000Z|1289350313510490113|20 minutes is how long it takes for an ice cream to melt anyways|-1|-1|0|0|en|False
+2020-08-01T00:00:44.000Z|1289350313644658688|Prob Odell and Landry but ima rock with My boys Djax and Alshon when healthy could be nasty|-1|-1|0|0|en|False
+2020-08-01T00:00:44.000Z|1289350313778884613|KELAN PA KAMI MGKACAR ULIT IM SO FCKN BORED|-1|-1|0|0|in|False
+2020-08-01T00:00:44.000Z|1289350313971834880|@Jay100__ Say less 😂 https://t.co/nqhvLsdgWS|1289349829231968256|154209380|0|0|en|False
+2020-08-01T00:00:44.000Z|1289350314680676354|@vvsko9|-1|1286159029413142529|0|0|und|False
+2020-08-01T00:00:44.000Z|1289350314726797314|@CoachDouglas21 https://t.co/6dlXj3PEj8|1289349867425296384|26926933|0|0|und|False
+2020-08-01T00:00:44.000Z|1289350315100127232|https://t.co/uKkbpFFhIi|1289219054108958722|895355525071867904|0|0|und|False
+2020-08-01T00:00:44.000Z|1289350315121225730|@megslngr $javierl 👁👄👁|-1|70178276|0|0|es|False
+2020-08-01T00:00:44.000Z|1289350315137855491|Paging @GovTimWalz another mom’s comment “I am interested to see how this Hybrid is suppose to work w students tha… https://t.co/ffqytxIfnB|-1|-1|0|0|en|False
+2020-08-01T00:00:44.000Z|1289350315297271809|If I play a draw two, draw you're fucking two.|-1|-1|0|0|en|False
+2020-08-01T00:00:44.000Z|1289350316031262722|Sorry to be annoying, but 1 hour warning! Just got another donation right now, so I know there are more of you out… https://t.co/7vReH7jQeL|-1|-1|0|0|en|False
+2020-08-01T00:00:45.000Z|1289350316723494912|@MyDogJosie HELL YES!!!!|1289277430918795264|822570417428828160|0|0|en|False
+2020-08-01T00:00:45.000Z|1289350316954066944|#MLB #AllRise Aaron Judge 2 Run HR. #Yankees 2-1 Bot 3rd 0 Out https://t.co/kFkgWqjbWf|-1|-1|0|0|en|False
+2020-08-01T00:00:45.000Z|1289350317709041664|I was too busy trying better US and forgot I had to better MY DAMN SELF first🤦🏾‍♂️|-1|-1|0|0|en|False
+2020-08-01T00:00:45.000Z|1289350318250065920|https://t.co/8CWYI9vjsL|-1|-1|0|0|und|False
+2020-08-01T00:00:45.000Z|1289350318493319170|Who told Ed Rendell that anyone gives a shit what he thinks?|-1|-1|0|0|en|False
+2020-08-01T00:00:45.000Z|1289350318753320960|My ride or die 😂😂😂🤷🏻‍♀️ @ChickenNuggs94 https://t.co/tBghrZMBfR|-1|-1|0|0|en|False
+2020-08-01T00:00:45.000Z|1289350318875013120|Idk if I posted this here before but one time I made a white woman apologize to me for being white|-1|-1|0|0|en|False
+2020-08-01T00:00:45.000Z|1289350318992457728|https://t.co/rQXermVuyd|-1|-1|0|0|und|False
+2020-08-01T00:00:45.000Z|1289350319126614018|2 RUN FUCKING BOMB!!!! Judge!!!|-1|-1|0|0|en|False
+2020-08-01T00:00:45.000Z|1289350319239917570|Bruh I’m debating if I should drove 5+ hrs to this spot tomorrow morning|-1|-1|0|0|en|False
+2020-08-01T00:00:45.000Z|1289350319248248832|Nothing to see here. Everyone move along, quickly now !|-1|-1|0|0|en|False
+2020-08-01T00:00:45.000Z|1289350319516737536|Damn|-1|-1|0|0|en|False
+2020-08-01T00:00:45.000Z|1289350319541903360|Anyways after seeing 2 owls last night i had a weird ass mix of dreams hahaha|-1|-1|0|0|en|False
+2020-08-01T00:00:45.000Z|1289350319898419201|Girls are temporary, music is forever https://t.co/KQUyn7iLTZ|-1|-1|0|0|en|False
+2020-08-01T00:00:45.000Z|1289350320238272513|@RosiemHD @HD_Freddy6529 @wendyrussell44 @jreed4401 https://t.co/m1ndRFBu92|1289245782076305408|4559568991|0|0|und|False
+2020-08-01T00:00:46.000Z|1289350320540196865|@lijaylen4 The corona bro 💀|1289347674991235072|1242793899237801984|0|0|en|False
+2020-08-01T00:00:46.000Z|1289350320556924929|This is the most wholesome shit I’ve seen all day 🥺|-1|-1|0|0|en|False
+2020-08-01T00:00:46.000Z|1289350320586280960|LMFAOOO sis deadass kicked me out too|-1|-1|0|0|en|False
+2020-08-01T00:00:46.000Z|1289350320888279043|I oscillate between grumbling about ERG work and feeling on-the-verge-of-happy-crying when ERG work creates this ty… https://t.co/wOIWUFU57k|-1|-1|0|0|en|False
+2020-08-01T00:00:46.000Z|1289350321462898688|Cake, cake, cake, cake, cake....|-1|-1|0|0|en|False
+2020-08-01T00:00:46.000Z|1289350322683432960|@lorigraceaz Beautiful shots!|1289335246836494337|134375125|0|0|en|False
+2020-08-01T00:00:46.000Z|1289350322935087104|@DJLeMahieu I think you’re my favorite Yankee???|-1|57551273|0|0|en|False
+2020-08-01T00:00:46.000Z|1289350323572600832|Went for a great spot to bluff. It didn't work. but still have 24k. blinds going to 200/400/40 #wsop @ Henderson,… https://t.co/V9BhtlJ1HN|-1|-1|0|0|en|False
+2020-08-01T00:00:47.000Z|1289350326340870145|near bsgstblender: c47e9023-e32c-45e7-8ca9-64eb72120698|-1|-1|0|0|it|False
+2020-08-01T00:00:47.000Z|1289350326609424386|He’s getting hot !!!|-1|-1|0|0|en|False
+2020-08-01T00:00:47.000Z|1289350326772850688|Hot board game restocks and new releases just in! #ettingames #wingspan #camelup #undauntednormandy… https://t.co/KH205UpK1T|-1|-1|0|0|en|False
+2020-08-01T00:00:47.000Z|1289350326978359297|My kick step is kinda insane coach|-1|-1|0|0|en|False
+2020-08-01T00:00:47.000Z|1289350327045459969|🌊 https://t.co/e3akZiVxjw|-1|-1|0|0|und|False
+2020-08-01T00:00:47.000Z|1289350327162908672|#ALLRISE|-1|-1|0|0|und|False
+2020-08-01T00:00:47.000Z|1289350327544631296|Excited to be a part of this chapter and this FAMILY! #TrustTheClimb|-1|-1|0|0|en|False
+2020-08-01T00:00:47.000Z|1289350328039673857|@chrissyteigen Check out @TheBillyMartin 💯💯💯|1289243908967264258|39364684|0|0|en|False
+2020-08-01T00:00:47.000Z|1289350328576430081|Walks into VP pundit twitter https://t.co/OxJk1wE2bk|-1|-1|0|0|en|False
+2020-08-01T00:00:48.000Z|1289350328760983553|@nancyloppez Pues si, yo solo leí como 4 de sus respuestas y fue suficiente!|1289349302624559105|294262541|0|0|es|False
+2020-08-01T00:00:48.000Z|1289350328937111553|@freakyTAI Lol. Give me a check and let me hit that mobile deposit. Stay in the house until it clears and then I’m OUTTA THERE. Lol.|1289347898803654656|21280882|0|0|en|False
+2020-08-01T00:00:48.000Z|1289350329683701760|New video posted on my YouTube (Thick Hilary Duff) link in bio! What theme should I do next on my decorative pine t… https://t.co/aEJuSq21ha|-1|-1|0|0|en|False
+2020-08-01T00:00:48.000Z|1289350329725784064|@CHP_Slic 😂😂😂😂😂😂|1289341323057610753|43642638|0|0|und|False
+2020-08-01T00:00:48.000Z|1289350330577072128|@seananmcguire I freaking ADORE your gown! It’s GORGEOUS and you look AMAZING|1289303490750115841|20492950|0|0|en|False
+2020-08-01T00:00:48.000Z|1289350330652614656|Just cause you got it don’t mean you gone pop it. 🙏🏾|-1|-1|0|0|en|False
+2020-08-01T00:00:48.000Z|1289350331013332992|Juan Gabriel ✨✨✨|-1|-1|0|0|es|False
+2020-08-01T00:00:48.000Z|1289350331038494720|My name is Justine Amanda Mulatto. I put that shit on everything.|-1|-1|0|0|en|False
+2020-08-01T00:00:48.000Z|1289350331218812928|The kid who was bullied in grade school & high school has a platform handed to him so HE can be the bully now. Ther… https://t.co/Tmw1UxR4YO|-1|-1|0|0|en|False
+2020-08-01T00:00:48.000Z|1289350331248214016|@CorriAnne80 Sending you lots of love. I’m sorry you’re having a rough time. Give yourself lots of grace right now.|1289192479309221888|221245374|0|0|en|False
+2020-08-01T00:00:48.000Z|1289350331558576128|@Ordinary1World I am.|1289219996816531456|260947492|0|0|und|False
+2020-08-01T00:00:48.000Z|1289350332082843648|A pre-game like no other. God bless baseball. #AlwaysRoyal https://t.co/YBIMMSQ32m|-1|-1|0|0|en|False
+2020-08-01T00:00:48.000Z|1289350332259033088|@myounger03 I thought it was him!!!|1289331946221449217|121301847|0|0|en|False
+2020-08-01T00:00:48.000Z|1289350332800282624|#AllRise #MVP|-1|-1|0|0|und|False
+2020-08-01T00:00:49.000Z|1289350333282443264|Mad at the world cuz you hidin yo affection|-1|-1|0|0|en|False
+2020-08-01T00:00:49.000Z|1289350333466959873|@MilkboneIsNoFox 👀👀👀👀|1289322690155696128|1268052371235500034|0|0|und|False
+2020-08-01T00:00:49.000Z|1289350333563645953|@AMagicWriter Hello, Meghan!|1289335435790110720|2228511739|0|0|hu|False
+2020-08-01T00:00:49.000Z|1289350333634928642|@CRlSSFILMS A$$holes|1289304878628577280|1256415233033240576|0|0|en|False
+2020-08-01T00:00:49.000Z|1289350334104526849|@kirstin you should go live on insta i miss hearing your voice! ill even go live with you|-1|33315233|0|0|en|False
+2020-08-01T00:00:49.000Z|1289350334171590657|@YESNetwork @Toyota Some hot dogs and @Yankees baseball on the patio on a beautiful Florida summer night… https://t.co/FPuPFnL5I2|1289343001957810176|18766687|0|0|en|False
+2020-08-01T00:00:49.000Z|1289350335182512128|See I have to study 🌚|-1|-1|0|0|en|False
+2020-08-01T00:00:49.000Z|1289350335782256640|Did JBJ just get his foot stuck in the padding on the right field wall trying to rob Judge’s HR? Yo @J_OCallaghan93 come get yer boy.|-1|-1|0|0|en|False
+2020-08-01T00:00:49.000Z|1289350336004493316|So pretty 🎉|-1|-1|0|0|en|False
+2020-08-01T00:00:49.000Z|1289350336159682560|The @MLB will do anything to protect their beloved Yankees. That’s why they haven’t opened the letter.… https://t.co/dASHkjAGyF|-1|-1|0|0|en|False
+2020-08-01T00:00:49.000Z|1289350336696573952|bitches get brave when you ain’t around. i’ll knock a nigga out w/o hesitation. #facts|-1|-1|0|0|en|False
+2020-08-01T00:00:50.000Z|1289350337275367424|@g00dneighbour @chrislhayes https://t.co/IRD4VdnGWn|1289210317210345472|3281496966|0|0|und|False
+2020-08-01T00:00:50.000Z|1289350337527074816|Got my Tat and took that shit like a G 😤😂💪🏾|-1|-1|0|0|en|False
+2020-08-01T00:00:50.000Z|1289350337589960704|🤔|-1|-1|0|0|und|False
+2020-08-01T00:00:50.000Z|1289350337850089472|@chesleydohl But no glove no love ❤️ 🤣🤣🤣|1289324295999479808|35829818|0|0|en|False
+2020-08-01T00:00:50.000Z|1289350338189770754|@desertdaddyLV I've heard it helps.|1289350041652457472|1147612182227509248|0|0|en|False
+2020-08-01T00:00:50.000Z|1289350338193981440|🤗|-1|-1|0|0|und|False
+2020-08-01T00:00:50.000Z|1289350338755964929|Since no one is living in the guest house my mom moved our 18 yr old cat in and he's a whole new cat! He usually hi… https://t.co/ttifxAkQbZ|-1|-1|0|0|en|False
+2020-08-01T00:00:50.000Z|1289350338781249536|middle school me says buy my art|1289350207994462209|131362060|0|0|en|False
+2020-08-01T00:00:50.000Z|1289350338814803969|ALL RISE MOTHER FUCKERS!!!!!!!!! https://t.co/pa4nKfS6m0|-1|-1|0|0|en|False
+2020-08-01T00:00:50.000Z|1289350339703930880|#RogerStone #MichaelFlynn|-1|-1|0|0|und|False
+2020-08-01T00:00:50.000Z|1289350339821363200|@kevinleeme really enjoy your threads. Thanks for sharing!|-1|18030023|0|0|en|False
+2020-08-01T00:00:50.000Z|1289350340337336323|@thereidout so proud of you, congrats @JoyAnnReid 🙌🏾🙇🏽‍♀️👸🏾Please stop #craziestdamnthing and more of… https://t.co/zelJwbzcpK|-1|205864193|0|0|en|False
+2020-08-01T00:00:50.000Z|1289350340672798720|Noooo sh*t, really...|-1|-1|0|0|en|False
+2020-08-01T00:00:51.000Z|1289350341515862022|@lloochy People die everyday regardless|1289349592903897089|1025610419245699077|0|0|en|False
+2020-08-01T00:00:51.000Z|1289350341549424640|So rice with seaweed? 🥴|-1|-1|0|0|en|False
+2020-08-01T00:00:51.000Z|1289350342056894464|@VincentCrypt46 Like|1289202885671100416|1093774442264707072|0|0|en|False
+2020-08-01T00:00:51.000Z|1289350342056927232|@Acidsmooth @TheWallMan4000 @hippie_science @JuicySARSBurger @BretWeinstein Here we go. “People can only innovate i… https://t.co/CeXuNt7IWK|1289349786802372609|17417076|0|0|en|False
+2020-08-01T00:00:51.000Z|1289350342556057601|@AmalShal27 @edusapiranga @sachiko32111969 @DCordell2016 @FritzWilhelm6 @Z42Be @Rose96698479 @MistressTepco… https://t.co/n52Uj7HCJ7|1289349168423526401|403008358|0|0|en|False
+2020-08-01T00:00:51.000Z|1289350342635855877|Work kicked my ass! Time for a chela 🍺|-1|-1|0|0|en|False
+2020-08-01T00:00:51.000Z|1289350342757425152|@kiagoodall @PocketEmptyDave @rodwave @dalvin1415 Biiiiiitch? You dead ass have the nerve to talk abortion lmfao https://t.co/TGHxst4uo9|1289346851678781441|810975086576603136|0|0|en|False
+2020-08-01T00:00:51.000Z|1289350343071903744|Omg these brows and lash extensions and face card wow. 😍|-1|-1|0|0|en|False
+2020-08-01T00:00:51.000Z|1289350345290743808|Initiative turns me on 🥴|-1|-1|0|0|en|False
+2020-08-01T00:00:51.000Z|1289350345475395586|One thing I keep in constant rotation (ordering) for my baby at school is Dr Bonner’s soap. Don’t want him to ever… https://t.co/AuP1DFlBPB|-1|-1|0|0|en|False
+2020-08-01T00:00:52.000Z|1289350345596874753|.....|-1|-1|0|0|und|False
+2020-08-01T00:00:52.000Z|1289350345739526144|@Breaking911 Awwww, just let him go in downtown Boston. But only if he will wear a shirt that states he’s the Bost… https://t.co/gHHUa30z6J|1289290483944972291|375721095|0|0|en|False
+2020-08-01T00:00:52.000Z|1289350345924075520|Just looked down and someone was asking for food...was so startled I couldn't get the shot in focus. 😂 https://t.co/8RL1ms3yMS|-1|-1|0|0|en|False
+2020-08-01T00:00:52.000Z|1289350346104430594|@AngrierWHStaff My entire office gathered around with appropriate social distance to watch him three times|1289315683755384832|848148994102611969|0|0|en|False
+2020-08-01T00:00:52.000Z|1289350346498691072|@KingzNA No dyes, close enough to good to me.|1287468641802387464|982126712128356354|0|0|en|False
+2020-08-01T00:00:52.000Z|1289350346532196352|My 80’s uniform 🤪...https://t.co/jNrIHwmoBs...#DMITRY #trilogy #album #photooftheday #train… https://t.co/YGf5wIbBjs|-1|-1|0|0|en|False
+2020-08-01T00:00:52.000Z|1289350346939101185|https://t.co/B1pvWxZpv5|-1|-1|0|0|und|False
+2020-08-01T00:00:52.000Z|1289350347182415872|Bihh be a cool 6 wanting Whole 10 privileges. 😂|-1|-1|0|0|en|False
+2020-08-01T00:00:52.000Z|1289350347375276033|❤️ @cristinafoxtv|-1|-1|0|0|und|False
+2020-08-01T00:00:52.000Z|1289350347501129728|@wduffield5 @abc13houston Tell that cock sucker Mitch McConnell die!|1289332892397531136|921392462572158977|0|0|en|False
+2020-08-01T00:00:52.000Z|1289350347945730049|@hudin Southern Oregon, yes. Pretty unusual for this region, as this grower has had his foot on the gas regarding i… https://t.co/esKyAFFqOn|1289111571361398786|14118523|0|0|en|False
+2020-08-01T00:00:52.000Z|1289350348096733187|@NicfromO @chelseahandler https://t.co/PIpOFIUEdu|1289347378005196800|1105280236562731008|0|0|und|False
+2020-08-01T00:00:52.000Z|1289350348692262912|HEARING A LOUD BANGING AT THE DOOR#20106230|-1|-1|0|0|en|False
+2020-08-01T00:00:52.000Z|1289350349359202305|I’ll cut you off then get mad when you leave 🎶|-1|-1|0|0|en|False
+2020-08-01T00:00:52.000Z|1289350349539561473|I think it’s another sad movie night|-1|-1|0|0|en|False
+2020-08-01T00:00:53.000Z|1289350350168825858|I want this for my future son and husband 💕💕💕|-1|-1|0|0|en|False
+2020-08-01T00:00:53.000Z|1289350351968034816|🌟⚖️⚖️🌟|-1|-1|0|0|und|False
+2020-08-01T00:00:53.000Z|1289350352706269184|@doodlybish THANK YOU🥺🥺🥺|1289347318542548993|1619814708|0|0|en|False
+2020-08-01T00:00:53.000Z|1289350353058541570|@joof_13 @EliAki2 @andrxwitch @deadenisee @slitmyclitt And bothered enough https://t.co/lqFiiIqJZE|1289345545752809473|1146806451538673664|0|0|en|False
+2020-08-01T00:00:53.000Z|1289350353243144192|@thejonesmi Can’t go wrong with a classic!|1289294233761796097|2602411428|0|0|en|False
+2020-08-01T00:00:53.000Z|1289350353713090560|August 2️⃣1️⃣th doesn’t have to be explained... You know who’s on the ⏰ ! #AHSBBN🏴 #UnleashHavoc✴️ https://t.co/58uFKduRWU|-1|-1|0|0|en|False
+2020-08-01T00:00:54.000Z|1289350354056802304|if i leave the game would my xbox love me|-1|-1|0|0|en|False
+2020-08-01T00:00:54.000Z|1289350354455285760|king of New York... melo... @carmeloanthony|-1|-1|0|0|en|False
+2020-08-01T00:00:54.000Z|1289350354623016961|Ha|-1|-1|0|0|und|False
+2020-08-01T00:00:54.000Z|1289350354883063809|Dr Pepper Snapple Group https://t.co/fSLuB01b4g via @YouTube Suprised these guys haven’t created YouTube content in… https://t.co/XSVndaWihS|-1|-1|0|0|en|False
+2020-08-01T00:00:54.000Z|1289350355189301248|Had to delete Facebook for a while 🤦🏽‍♀️|-1|-1|0|0|en|False
+2020-08-01T00:00:54.000Z|1289350355277553664|Beers ✅Head ready to head bang ✅Voice ready to sing ✅All that’s left is @UnderoathBand https://t.co/ImyJcAWsWX|-1|-1|0|0|en|False
+2020-08-01T00:00:54.000Z|1289350355315077120|@BlaineScully1 @WorldRugby Their ability to keep the ball alive is the most impressive thing for me. Love watching their skill.|1289279821315321858|389887281|0|0|en|False
+2020-08-01T00:00:54.000Z|1289350355331846147|@TheTrueAmerica5 I can’t wait to celebrate @JoeBiden as our legitimate POTUS.#StrongerTogether #Resist… https://t.co/CcdPeTiSAX|1289280693172711425|1023045913994919936|0|0|en|False
+2020-08-01T00:00:54.000Z|1289350356971880448|So I watched the first Muppets Now. A bit uneven. Concept could work though. I wish they’d remember that Miss Piggy… https://t.co/iDUGezHqHl|-1|-1|0|0|en|False
+2020-08-01T00:00:54.000Z|1289350357143810049|@Jim_Jordan You’re so embarrassing. You consistently behave like a child for the world to see. I’m shocked by your lack of self awareness.|1289215154899435522|18166778|0|0|en|False
+2020-08-01T00:00:54.000Z|1289350357525475329|Before and after @RealPaigeWWE https://t.co/AJVMXeNGBs|-1|-1|0|0|en|False
+2020-08-01T00:00:54.000Z|1289350357710249984|Up to 632k followers in 10 days on 251 tweets. The market reallllllly wanted some @accidental_left|1285677045767385091|6651022|0|0|en|False
+2020-08-01T00:00:54.000Z|1289350358020452353|@king_jackson43 @jackiesimoneee Latte’s are predominately milk........|1289348239351623680|839508110423252992|0|0|en|False
+2020-08-01T00:00:55.000Z|1289350358326636545|@sara__pequeno wait i think they already did that a year ago! or are they moving even closer??|1289347612601012224|778696609328537603|0|0|en|False
+2020-08-01T00:00:55.000Z|1289350358456627201|@mariakat1407 Same|1289350209051308032|1678948598|0|0|en|False
+2020-08-01T00:00:55.000Z|1289350358477803520|@_griffindrew @souIserum absolutely love the colors and style|1288841524776706053|834473983|0|0|en|False
+2020-08-01T00:00:55.000Z|1289350358532345856|@DYTHoopInsider That’s your opinion. I don’t write anything negative about kids. I point out the positives and let… https://t.co/jrkBqhvBOY|1289349694653702144|1252994393377845249|0|0|en|False
+2020-08-01T00:00:55.000Z|1289350358729449473|the way I’ve been working on this damn code for HOURS and my professor fixed it in just MINUTES|-1|-1|0|0|en|False
+2020-08-01T00:00:55.000Z|1289350359245156352|My whole team fire 🔥|-1|-1|0|0|en|False
+2020-08-01T00:00:55.000Z|1289350359320678400|Crushing balls like we crushed @RiggsBarstool in the pond hockey tourney... https://t.co/YpeJoyvmY2|-1|-1|0|0|en|False
+2020-08-01T00:00:55.000Z|1289350359962365954|@MOchoa_EHS De nada! Tu solita! Ayuda mucho ese tutorial, te quedó muy tú 😍|1289350178323853312|862392856534814720|0|0|es|False
+2020-08-01T00:00:55.000Z|1289350361631936513|OUT HERE. https://t.co/i3qJq5Ee5B|1289349581570895873|58871968|0|0|en|False
+2020-08-01T00:00:55.000Z|1289350361644294146|Prospect open 👀|-1|-1|0|0|en|False
+2020-08-01T00:00:55.000Z|1289350361719791617|just really nothing much to look at out here, you know? ☺️ https://t.co/yjZYsOs4HR|-1|-1|0|0|en|False
+2020-08-01T00:00:55.000Z|1289350362172801024|"If jobs with titles like ""Transportation Manager"" sound appealing to you, follow us to hear about these types of op… https://t.co/M2DrNOx0x1"|-1|-1|0|0|en|False
+2020-08-01T00:00:55.000Z|1289350362265038849|@dogsoftesla @phibetakitten @WholeMarsBlog @AustinTeslaClub @Tesla @jamesbuchanan27 https://t.co/26q1hdyfTf|1289348809722433537|1048345748079751168|0|0|und|False
+2020-08-01T00:00:56.000Z|1289350362462183428|My mom keeps saying that Corona is just like the flu..... please help me https://t.co/fR1kIIYNu7|-1|-1|0|0|en|False
+2020-08-01T00:00:56.000Z|1289350362659540992|@watchboysvlog @Bhacon01 I'm most certainly not a Kool-aid drinker 😎...i just don't think there is any equivalency… https://t.co/uyfN6CHu0w|1289348390602473472|2922307191|0|0|en|False
+2020-08-01T00:00:56.000Z|1289350362701467648|Yesterday felt like Friday and today feels like Thursday. 🤷🏻‍♂️ https://t.co/Bp4zuSkrqM|-1|-1|0|0|en|False
+2020-08-01T00:00:56.000Z|1289350363120906241|This is confirmed that I should get my boobs done|-1|-1|0|0|en|False
+2020-08-01T00:00:56.000Z|1289350363179491328|AARON JUDGE. #AllRise|-1|-1|0|0|en|False
+2020-08-01T00:00:56.000Z|1289350363666173952|Yes it does! 🤩|-1|-1|0|0|en|False
+2020-08-01T00:00:56.000Z|1289350364056043521|@CPat11 Haha. Like.|1289350248519946241|205124104|0|0|en|False
+2020-08-01T00:00:56.000Z|1289350364198666240|@tomkazansky12 You must really be BMOC in “fighter town.” Safely behind the tough guy aviators. What a little girl. Apologies to girls. LOL|1289344996567420929|1285440177704325120|0|0|en|False
+2020-08-01T00:00:56.000Z|1289350364613902336|Open the door... for an adventure. https://t.co/O2FlvdbgC3|-1|-1|0|0|en|False
+2020-08-01T00:00:56.000Z|1289350364785807361|@TexasTribune @K8brannen It's the great revealed.#COVID19|1289347117115269120|44513878|0|0|en|False
+2020-08-01T00:00:56.000Z|1289350364924264448|❤️#colorstreet https://t.co/632Z49aZRL|-1|-1|0|0|und|False
+2020-08-01T00:00:56.000Z|1289350365394026497|@AnitaMalik @RepDavid @AnitaMalik called it.|1289343310360793088|5019861|0|0|en|False
+2020-08-01T00:00:56.000Z|1289350366170030086|@Ezekiel2020plu1 That’s right. BOOM|1289339992410472450|1286826892096659458|0|0|en|False
+2020-08-01T00:00:56.000Z|1289350366291562496|@FILGuadalajara Tinisísima, fotógrafa, revolucionaria|1289339399956832257|15635191|0|0|es|False
+2020-08-01T00:00:57.000Z|1289350367809953793|@GjordyC congratulations|1289158890777489411|429067687|0|0|en|False
+2020-08-01T00:00:57.000Z|1289350367897989120|I do this quite often|-1|-1|0|0|en|False
+2020-08-01T00:00:57.000Z|1289350368141377536|@hecallsmePP At this point it looks like the only way he's going to learn is through consequences. He talked a good… https://t.co/JJy4zlV6ml|1289328896584933383|2980620744|0|0|en|False
+2020-08-01T00:00:57.000Z|1289350368518795264|All Rise!!!! AARON JUDGE goes deep!! 2-1 Yankees!! #NYYFORNY #LETSGOYANKEES|-1|-1|0|0|en|False
+2020-08-01T00:00:57.000Z|1289350369563172864|@BushJustinD @OleMissFB You'd be alot cooler if you weren't an over paid E-3/PFC but we can't all be that cool can… https://t.co/AzdgiCitYv|1289349180708724737|220880544|0|0|en|False
+2020-08-01T00:00:57.000Z|1289350369563222016|@karinjohnson @WLWT I kinda laugh when republicans say what their republican governor is doing is “politically moti… https://t.co/j876PnAuSS|1289187500238557184|19977599|0|0|en|False
+2020-08-01T00:00:57.000Z|1289350369663827968|@myafropuff If anyone sees this keep scrolling I’m trying to change still hurt tho😶|1289349407729528833|637110430|0|0|en|False
+2020-08-01T00:00:57.000Z|1289350369684856832|@keroriel (o^^o)|1289345174762483712|2465489935|0|0|und|False
+2020-08-01T00:00:57.000Z|1289350370284560384|Here we go! #SmackDown|-1|-1|0|0|en|False
+2020-08-01T00:00:58.000Z|1289350371643539457|You tryna learn some street knowledge? I’m a mentor|-1|-1|0|0|en|False
+2020-08-01T00:00:58.000Z|1289350371723243520|found a video of McLovin pouting bc i was leaving and now i’m crying https://t.co/1nEtWIVZyR|-1|-1|0|0|en|False
+2020-08-01T00:00:58.000Z|1289350372012593154|I will give you the questions on Sunday afternoon so those who go to church will have a chance to play.|-1|-1|0|0|en|False
+2020-08-01T00:00:58.000Z|1289350373208014849|WE ARE OPEN AND COVID-19 COMPLIANT!On Sundays at 11:00 AMCome worship with us! https://t.co/DtbFtBCBm0|-1|-1|0|0|en|False
+2020-08-01T00:00:58.000Z|1289350373279281152|All by yourself 💪🏻😒|-1|-1|0|0|en|False
+2020-08-01T00:00:58.000Z|1289350373300252672|Do straight men not know what a big dick is? Do not tell me your dick is big then send a piece of fleshy asparagus… https://t.co/MAiwn4bDL0|-1|-1|0|0|en|False
+2020-08-01T00:00:58.000Z|1289350373560352770|ALLLLLLL RISE MOTHERFUCKERS AARON JUDGE IS HOT AF!!!!! 2 RUN DONG TO RIGHT AND THE YANKEES GRAB THE LEAD!!!!!|-1|-1|0|0|en|False
+2020-08-01T00:00:58.000Z|1289350373958750210|@slewfan @USA4LIFE2 @CrownSlew @redpillednow123 @brendas1961i @May461014344 @classytexasgirl @deplorable_rube… https://t.co/6hgGIsuq1d|1289262565889957890|122462526|0|0|en|False
+2020-08-01T00:00:58.000Z|1289350374243971073|Please tell me y’all see @BlooperBraves opening a box of coal 😭😭😭|-1|-1|0|0|en|False
+2020-08-01T00:00:58.000Z|1289350374655057923|@Christianher55 MAGAt|-1|2850074315|0|0|en|False
+2020-08-01T00:00:59.000Z|1289350375028355072|@GivethNoFxcketh Beautiful|1289343749298913281|145415898|0|0|en|False
+2020-08-01T00:00:59.000Z|1289350375145762816|How does Clark Kent fit the cape under his suit? 🤔 https://t.co/IpJyKYBfCm|-1|-1|0|0|en|False
+2020-08-01T00:00:59.000Z|1289350375217098752|Family can be just as toxic as friends. 💁🏽‍♀️|-1|-1|0|0|en|False
+2020-08-01T00:00:59.000Z|1289350375254835200|LMFAOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOOO|-1|-1|0|0|en|False
+2020-08-01T00:00:59.000Z|1289350376378871809|@Emckinnie14 Don’t worry I cried locking up the door😢|1289348251573825536|389213041|0|0|en|False
+2020-08-01T00:00:59.000Z|1289350377280884737|Get fucked. https://t.co/xGrRCYAoUE|-1|-1|0|0|en|False
+2020-08-01T00:00:59.000Z|1289350377326784513|@alefecarv @MAD0NNAARMY1 Oh, okay. And how many Oscars has Britney won?|1289315760980946945|1127946668597489664|0|0|en|False
+2020-08-01T00:00:59.000Z|1289350377544929287|Are you dumb or stupid the wheels on the rolls is Chromazz headshot domazz|-1|-1|0|0|en|False
+2020-08-01T00:00:59.000Z|1289350377825906689|I saw something about “crushing fatigue” and “Lena Dunham” and thought, “Yes, exactly!” But it was just more of t… https://t.co/XSORMXKkR9|-1|-1|0|0|en|False
+2020-08-01T00:00:59.000Z|1289350378589323266|❤️|-1|-1|0|0|und|False
+2020-08-01T00:00:59.000Z|1289350378698338305|@BlackWomenLead_ They have to be #TheHelp or #Handmaids 🤬|1289283548508114944|80679812|0|0|en|False
+2020-08-01T00:01:00.000Z|1289350379877076992|@hawklyf49 @LorenCollins @atrupar All true. Which is why the Advance Team should have planned differently. We’ve be… https://t.co/W0myFD75L1|1289326492619603972|785563624265945088|0|0|en|False
+2020-08-01T00:01:00.000Z|1289350380279574529|@WorkoutKing1976 Bada&$ ♥️💪🏻♥️|1289278608058404864|4299434495|0|0|eu|False
+2020-08-01T00:01:00.000Z|1289350380661477376|@PeterMallouk And a good portion of my consumer spending.|1289199196684214272|712853262450429952|0|0|en|False
+2020-08-01T00:01:00.000Z|1289350380950818816|I love this place. https://t.co/4crx5x5QhB|-1|-1|0|0|en|False
+2020-08-01T00:01:00.000Z|1289350381361704961|Rekt’d|-1|-1|0|0|lv|False
+2020-08-01T00:01:00.000Z|1289350382024421377|Candace Owens - Liberty University Convocation https://t.co/adhTbZK7O7 via @YouTubeShe’s my best friend now❤️… https://t.co/Cu93vll7AT|-1|-1|0|0|en|False
+2020-08-01T00:01:00.000Z|1289350382171254785|@DarbyT_IC Glad you Tweeted this! @mixon_tracey read it this summer and really liked it! She has referenced it in a… https://t.co/yMEZYk1sC8|1289347923076145152|794873750|0|0|en|False
+2020-08-01T00:01:00.000Z|1289350382456418305|@bighairbigtotal Yes, and it means the world. 🥰|1289349595277844480|1183433162032062469|0|0|en|False
+2020-08-01T00:01:00.000Z|1289350382661931010|plus his bday during that month 😩|-1|-1|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350383488253952|😂😂bro what|-1|-1|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350383840591873|@tom_tuna @mooncult @usebigears @ReeseW Honestly I hadn’t seen all the old and truly crazy shit up thread. Your new… https://t.co/F6KeD7PQWo|1289348194476765185|24807470|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350383991570433|@briweeby Garlic parmesan on the outside.|1289329159769006080|902921765856432128|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350384025133056|Look who came to day hi! @ Lake Parsippany, New Jersey https://t.co/X6uSG08F5v|-1|-1|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350384025137154|https://t.co/CVZmLQnlPA subscribe to see me naked and my ass shake|-1|-1|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350384062930945|Judge barely touched that ball|-1|-1|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350384641691650|https://t.co/CS47NT08YN|-1|-1|0|0|und|False
+2020-08-01T00:01:01.000Z|1289350384696270850|Telling people older than you “whatchu know about this??” When they put on a song from before you were born that they were alive for >>>>>>|-1|-1|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350384809639943|Ahhh....the old days!!! KHYI Texas Music Revolution up in Plano, Tx today with walt_wilkins @ Southfork Ranch https://t.co/PJfo8S8t52|-1|-1|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350385501638656|@TheHulk_36 He needs to be lead off or where he was.|1289344482442244096|2240122202|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350386017431552|@brookmiller_ When did you say that|1289350311673335810|2258446314|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350386071945217|@CoachCFrye and @OfficialBraylon killing it in this @McDonalds @Browns commercial!! #ImLovinIt|-1|925721622501347328|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350386361409537|Damn I couldn’t even spell google right|1289349557717934082|1056372859579305985|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350386650759168|fruitful and multipy|-1|-1|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350386776563712|@Scattyfi @HKrassenstein @realDonaldTrump I am rude. I don’t watch CNN. However, “politely” lying still makes you… https://t.co/9MeuqOU1Wp|1289328680762609664|20339671|0|0|en|False
+2020-08-01T00:01:01.000Z|1289350387376373761|@StephanRBarnard Hard to pick one. They are all good on their own way.|1289348496240201728|467705283|0|0|en|False
+2020-08-01T00:01:02.000Z|1289350387493777409|Get a bang for your buck! Enroll as a VIP and get a 15% discount on all the best products. Plus a free item and fre… https://t.co/G5N2rlrEYR|-1|-1|0|0|en|False
+2020-08-01T00:01:02.000Z|1289350387518980096|@Al_Carey1 ALL RISE|1289348197890977793|2382404392|0|0|en|False
+2020-08-01T00:01:02.000Z|1289350387628089345|@Vyvian07 @vnshmax Omg! That schedule is insane.|1289349856360685568|216087215|0|0|en|False
+2020-08-01T00:01:02.000Z|1289350387690954752|@EmilyCWaldon Trevor Hoffman becoming the all time saves leader.|1289342719459045381|489733778|0|0|en|False
+2020-08-01T00:01:02.000Z|1289350388064215040|Thank you Dr @PaulConn You’ve impacted our children’s lives forever!|-1|-1|0|0|en|False
+2020-08-01T00:01:02.000Z|1289350388286492672|@gtconway3d @MiaFarrow Now up to 1500 deaths per day is a World Trade Center every 2 days.|1289341368783876096|471677441|0|0|en|False
+2020-08-01T00:01:02.000Z|1289350388714557440|LETS GO JUDGE!!|-1|-1|0|0|en|False
+2020-08-01T00:01:02.000Z|1289350388852781056|All I ever wanted to be was rich, I came in wit shit and I can’t leave wit shit|-1|-1|0|0|en|False
+2020-08-01T00:01:02.000Z|1289350389062463494|#SmackDown|-1|-1|0|0|und|False
+2020-08-01T00:01:02.000Z|1289350389158957056|@sheaDUCK Mine takes 37 years to do anything all the time. It’s infuriating|1289333118134939648|82404415|0|0|en|False
+2020-08-01T00:01:02.000Z|1289350389981093888|@Hdouble0s Nope lol|1289291930497462272|1171006786691903488|0|0|en|False
+2020-08-01T00:01:02.000Z|1289350390144622593|@LorenzoButlerPR Damndemic https://t.co/rv4Qj3d6dg|1289347392194711553|94138345|0|0|ht|False
+2020-08-01T00:01:02.000Z|1289350390429831169|Our philosophy, core purpose, vision, and values are the driving force behind DEA. Within this framework, we make a… https://t.co/7mCDEYDO9j|-1|-1|0|0|en|False
+2020-08-01T00:01:02.000Z|1289350390463397888|watching ted talks|-1|-1|0|0|en|False
+2020-08-01T00:01:03.000Z|1289350392116019200|we have the worst luck :(|-1|-1|0|0|en|False
+2020-08-01T00:01:03.000Z|1289350392191397888|Alhambra CA Fri Jul 31st PM Forecast: TONIGHT Clear Lo 70 SATURDAY Sunny Hi 101|-1|-1|0|0|en|False
+2020-08-01T00:01:03.000Z|1289350392657014786|Trynna match up who trynna smoke? Need new smoking buddies|-1|-1|0|0|en|False
+2020-08-01T00:01:03.000Z|1289350392770252800|@MOLMFpod @NekoGhostJump Thanks!|1289332866447314945|4717152026|0|0|en|False
+2020-08-01T00:01:03.000Z|1289350393256914945|I wonder who the first douchebag to name their dog buddy was? “Hey cmon buddy” “oh wow that’s a good name for a dog”|-1|-1|0|0|en|False
+2020-08-01T00:01:03.000Z|1289350393688756224|"My Derm Recruiter is looking for teammates like you. See our latest #Dermatology job openings, including ""Port Rich… https://t.co/FxQHYzQina"|-1|-1|0|0|en|False
+2020-08-01T00:01:03.000Z|1289350394284367872|WAIT WHAT NO|-1|-1|0|0|en|False
+2020-08-01T00:01:03.000Z|1289350394871607298|My life a movie but ion rewind it|-1|-1|0|0|en|False
+2020-08-01T00:01:03.000Z|1289350394947047424|That's just bad baserunning|-1|-1|0|0|en|False
+2020-08-01T00:01:03.000Z|1289350395211341824|@francesca_taryn Whenever you come back from Bermuda Bbyyy|1289349327140327431|533678095|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350395962068992|@EandJPapi You can't be that surprised 🤫|1289349218788769792|1723991910|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350396406710273|@cmsilvajr @Ryan_King_Now https://t.co/9KzjdsGv2D|1289349113121656832|26446817|0|0|und|False
+2020-08-01T00:01:04.000Z|1289350396419293184|Tequila>anything else|-1|-1|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350396863852544|And so are we!|-1|-1|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350397325463562|baby luv me lights out 🥺|-1|-1|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350398126497798|Steph is here after hours competing in a Stern Pinball arranged Teenage Mutant Ninja Turtles pinball Zoom tournam… https://t.co/zaKN6AeZPP|-1|-1|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350398575140865|Alisal CA Fri Jul 31st PM Forecast: TONIGHT Partly Cloudy Lo 55 SATURDAY Partly Cloudy Hi 76|-1|-1|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350398612996097|@_savannanoel What thing|1289347387807264768|3903259634|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350398680039424|I’m too lit rn & I shouldn’t have my phone 😂💀|-1|-1|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350398759690241|At 4:35 PM EDT, 1 NNW Grandview [Rhea Co, TN] PUBLIC reports TSTM WND DMG. ONE TREE DOWN WITH POWER LINES IN THE FA… https://t.co/mpgm7DwYXY|-1|-1|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350398780743682|At 4:35 PM EDT, 1 NNW Grandview [Rhea Co, TN] PUBLIC reports TSTM WND DMG. ONE TREE DOWN WITH POWER LINES IN THE FA… https://t.co/e1tesiPAw6|-1|-1|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350399212699651|@glitteroutboy @BayouBun Facts|1289294129806024704|1250460728043220995|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350399237844994|S https://t.co/6JTAeZODHA|-1|-1|0|0|und|False
+2020-08-01T00:01:04.000Z|1289350399388876800|Just arrived in Boston, MA! Checked into our Airbnb and ready for the last leg of our adventure for the next 5 days… https://t.co/PHCdvqrZwk|-1|-1|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350399812567040|@emgarcia1266 Damn dude, that’s romantic. It looks like I’ll have to step my game up with @Chi_JBean . 😇|1289244790471548928|3551842033|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350399833460737|I thought thar was an easy flyout.. love Judge’s oppo power!|-1|-1|0|0|en|False
+2020-08-01T00:01:04.000Z|1289350400030543872|@pieper34 Having to sleep in the car lmfaoooo 🤦🏽‍♂️😂😂|1289348682437935105|767124032|0|0|en|False
+2020-08-01T00:01:05.000Z|1289350400219332609|@doomedparade @goc1978 @perroju666 @SabreHess @LFCMFighter @UniqueHiFi @docvader2 @Kingoboy666 @Sym246… https://t.co/vO19Ab65RH|1289348146359803904|2880120915|0|0|und|False
+2020-08-01T00:01:05.000Z|1289350400286498816|Vegas, baby!@Cosmopolitan_LV  Las Vegas  July 2020 https://t.co/EuvIjUcaES|-1|-1|0|0|en|False
+2020-08-01T00:01:05.000Z|1289350400944902145|Friday ride 🚴🏽💨💨 21 miles @ Bronx, New York https://t.co/sc41Iz7itI|-1|-1|0|0|en|False
+2020-08-01T00:01:05.000Z|1289350401020424193|ALLLLRISSSEEEEE #Yankees https://t.co/dDe1aF1NWZ|-1|-1|0|0|en|False
+2020-08-01T00:01:05.000Z|1289350401389506561|Praying I get that push behind me even when I’m unsure where to start god I trust you WE GOT THIS!! Gotta give him… https://t.co/nZyNArA19j|-1|-1|0|0|en|False
+2020-08-01T00:01:05.000Z|1289350401985150976|yeaaaa b💯|-1|-1|0|0|en|False
+2020-08-01T00:01:05.000Z|1289350402089967618|How are they not earning AT LEAST minimum wage cause Ik I can’t do that job|-1|-1|0|0|en|False
+2020-08-01T00:01:05.000Z|1289350402261921793|@micheleceee Target!!|1289332435738476545|1159163131509256197|0|0|en|False
+2020-08-01T00:01:05.000Z|1289350402329079808|PSA https://t.co/f4woITXJdX|-1|-1|0|0|und|False
+2020-08-01T00:01:05.000Z|1289350402383609858|Somebody tell @EEzyLiving @TommyGemini relax|1289350399237844994|23022232|0|0|en|False
+2020-08-01T00:01:06.000Z|1289350404426342405|@savagelee54 😭😭😭😭😭 my g no I graduated and grown ass man in engineering come now...|1289350199039520768|61629027|0|0|en|False
+2020-08-01T00:01:06.000Z|1289350404619120642|Here we gooo!!! https://t.co/R0CEJB7xuK|-1|-1|0|0|en|False
+2020-08-01T00:01:06.000Z|1289350404665270272|✨CALIFORNIA GRILL’S GOUDA MAC & CHEESE✨On today’s Food Friday, I make a dish from my favorite restaurant in the w… https://t.co/0IbdZbJlBY|-1|-1|0|0|en|False
+2020-08-01T00:01:06.000Z|1289350404879167488|@cptnwillie @Msmariablack @BrentTerhune @Gavarnos Best one I’ve read of it’s ilk! He tricks people every time.|1289333243439849472|1010643484867350533|0|0|en|False
+2020-08-01T00:01:06.000Z|1289350405474799616|@swaycii @Lmoneyyy_ https://t.co/3oTmFvnKZL|1289349695811141634|2251119295|0|0|und|False
+2020-08-01T00:01:06.000Z|1289350406733144064|Can you recommend anyone for this job? CROSSMARK Walmart Retail Merchandiser Part Time - Reader Link -… https://t.co/x3IYoMXKU9|-1|-1|0|0|en|False
+2020-08-01T00:01:06.000Z|1289350407412572161|@lowcountrycalm @RepCunningham You fall for bs conspiracy theories...who's the useful idiot. Google mirror.|1289345831989121025|2616136729|0|0|en|False
+2020-08-01T00:01:06.000Z|1289350407492272128|It’s not Opening Day until Aaron Judge goes opposite field. It’s 2-1 Yankees.|-1|-1|0|0|en|False
+2020-08-01T00:01:06.000Z|1289350407773286400|@_guapele hit me|-1|1234616232671793152|0|0|en|False
+2020-08-01T00:01:06.000Z|1289350408289185792|@M_DaffaRI Possibly, but i want both of them to succeed just like you. I honestly prefer Rodrygo, though|1288939374629908480|580940518|0|0|en|False
+2020-08-01T00:01:07.000Z|1289350408691802112|@mmmmela icon!!!|1289346438392995840|22870659|0|0|es|False
+2020-08-01T00:01:07.000Z|1289350408758915072|Antioch CA Fri Jul 31st PM Forecast: TONIGHT Mostly Clear Lo 59 SATURDAY Sunny Hi 90|-1|-1|0|0|en|False
+2020-08-01T00:01:07.000Z|1289350408851222529|weird how a show from 2010 has an outbreak from the flu and to prevent their town from getting it, the town quarant… https://t.co/mbs064gS0b|-1|-1|0|0|en|False
+2020-08-01T00:01:07.000Z|1289350408880582657|Get it Shawty by Lloyd will always be a banger|-1|-1|0|0|en|False
+2020-08-01T00:01:07.000Z|1289350409107075072|@mfrisbee527 😂😂😂😂|1289310610753110016|2904305501|0|0|und|False
+2020-08-01T00:01:07.000Z|1289350409497317377|"""I keep company with principled people BUT tolerate the religious ones with the HOPE that they may become principle… https://t.co/UF7ZJS6YBz"|-1|-1|0|0|en|False
+2020-08-01T00:01:07.000Z|1289350409715212291|@lando_1_ ✊🏾❤️|1289332966678765570|484413119|0|0|und|False
+2020-08-01T00:01:07.000Z|1289350410860281857|Have you checked out the new tune yet? Have a listen here:https://t.co/w3yBQu4HMq https://t.co/XGgt5kH4kL|-1|-1|0|0|en|False
+2020-08-01T00:01:07.000Z|1289350411162279936|FaceTime me in|-1|-1|0|0|en|False
+2020-08-01T00:01:07.000Z|1289350411653062656|Yes I think that funny too David coble sister and think my Job fun @ Huntsville, Alabama https://t.co/rImyQq1dV5|-1|-1|0|0|en|False
+2020-08-01T00:01:07.000Z|1289350411795566593|Worse than getting played|-1|-1|0|0|en|False
+2020-08-01T00:01:07.000Z|1289350411833360384|I know 🎵 https://t.co/QeyEzSqdnw|-1|-1|0|0|en|False
+2020-08-01T00:01:07.000Z|1289350411946618880|Commercial in a sack  McDonald’s https://t.co/kDoNtNDOlh via @YouTube|-1|-1|0|0|en|False
+2020-08-01T00:01:07.000Z|1289350412198383618|Redemption on the river felt oh so good. @nuthreadz #nuthreadz #nuthreadzfishingteam @ Stoddard, Wisconsin https://t.co/BPpErLIRQz|-1|-1|0|0|en|False
+2020-08-01T00:01:07.000Z|1289350412265390080|Always had mad love for Oakland. I remember growing up listening to e-40 in Detroit|-1|-1|0|0|en|False
+2020-08-01T00:01:07.000Z|1289350412395405313|Holy shit... tomorrow’s my last day in Cali 😅🥺|-1|-1|0|0|en|False
+2020-08-01T00:01:08.000Z|1289350413024518144|Larry David has starred in all my nightmares this month|-1|-1|0|0|en|False
+2020-08-01T00:01:08.000Z|1289350413498511360|https://t.co/RBDR2ekH9p|-1|-1|0|0|und|False
+2020-08-01T00:01:08.000Z|1289350413930487808|Dear America, Get Well Soon!|-1|-1|0|0|en|False
+2020-08-01T00:01:08.000Z|1289350414152818689|Not eem 20|-1|-1|0|0|en|False
+2020-08-01T00:01:08.000Z|1289350414433845248|@JoeyMulinaro 🤢|1289208427164491776|233777204|0|0|und|False
+2020-08-01T00:01:08.000Z|1289350414463143936|Aight....this is 🔥🔥🔥|-1|-1|0|0|en|False
+2020-08-01T00:01:08.000Z|1289350414777724928|Arleta CA Fri Jul 31st PM Forecast: TONIGHT Clear Lo 70 SATURDAY Sunny Hi 103|-1|-1|0|0|en|False
+2020-08-01T00:01:08.000Z|1289350414790307840|I have the worst headaches|-1|-1|0|0|en|False
+2020-08-01T00:01:08.000Z|1289350415486607360|@GenieReal I guess it would depend on how much life ins. your husband has out in you!|1288907482237108224|1272657522709626885|0|0|en|False
+2020-08-01T00:01:08.000Z|1289350415507697664|https://t.co/dGh3AdVyBT|1289218031214710789|895355525071867904|0|0|und|False
+2020-08-01T00:01:08.000Z|1289350415813771266|@TravisMayfield Madonna bleach blond in the 90's|1288452257587924992|23519114|0|0|en|False
+2020-08-01T00:01:08.000Z|1289350415843078144|@thebadbroadcast I could see you on skates more than a board ✨ https://t.co/nZnaBFMdqL|1289336115363606528|1286345899459846144|0|0|en|False
+2020-08-01T00:01:08.000Z|1289350416015056896|@bagman928 Play will improve over the next few weeks|1289342057056632832|1687073264|0|0|en|False
+2020-08-01T00:01:08.000Z|1289350416346411008|I’m obsessed with BCALLA boa bags|-1|-1|0|0|en|False
+2020-08-01T00:01:08.000Z|1289350416799596547|I’ve never once struck my wife, you foolish piece of shit.|-1|-1|0|0|en|False
+2020-08-01T00:01:09.000Z|1289350416862531588|Hog Wild 1996. https://t.co/B5FzlLwIkp|-1|-1|0|0|nl|False
+2020-08-01T00:01:09.000Z|1289350416916873216|"En mi país de origen, VENEZUELA, en los años 80tas se desarrolló un fenómeno llamado ""Las MINITECAS"" (Discoteca Móv… https://t.co/7910R8CBMf"|-1|-1|0|0|es|False
+2020-08-01T00:01:09.000Z|1289350417147727872|Argue with parrots.https://t.co/wEuwOI7pkP|-1|-1|0|0|en|False
+2020-08-01T00:01:09.000Z|1289350417189462016|I was going to do overtime but fuck that I already got extra hours on my shit|-1|-1|0|0|en|False
+2020-08-01T00:01:09.000Z|1289350417269178369|Uuuugggghhhhh|-1|-1|0|0|und|False
+2020-08-01T00:01:09.000Z|1289350417386811397|@SeminoleDaDon You start with community outreach, such as what the football team did. You adopt a school, a youth p… https://t.co/gkUebReFIb|1289349067940794371|2250918423|0|0|en|False
+2020-08-01T00:01:09.000Z|1289350419425013760|@CityOfChampion2 So far so good!!?? We watching the same game?? Lol https://t.co/VAaQgVH4IW|1289350097247989762|601291199|0|0|en|False
+2020-08-01T00:01:09.000Z|1289350419492216833|pou’d off a 4 of this Mgpski|-1|-1|0|0|en|False
+2020-08-01T00:01:09.000Z|1289350419630587906|Lane Pryce referring to Mountain Dew with religious reverence|-1|-1|0|0|en|False
+2020-08-01T00:01:09.000Z|1289350419668508678|@Daaance_Ki 😛😛|1289349041214685184|25032528|0|0|und|False
+2020-08-01T00:01:09.000Z|1289350420087939073|@Will386_ https://t.co/IrOvHje624|1289350285031141376|45933458|0|0|und|False
+2020-08-01T00:01:09.000Z|1289350420268163073|Every day is a good hair day!!❤️💯🙌🏻. #balayagetechniques #nikkolemichaels #springhillfl #hernandocounty @… https://t.co/vraTjikffK|-1|-1|0|0|en|False
+2020-08-01T00:01:09.000Z|1289350420339589120|@michele_oneL83 Thank you Michele! 🙏🏽❤️|1289347438696783874|528576648|0|0|en|False
+2020-08-01T00:01:09.000Z|1289350420419108864|The @PulitzerPrizes would disagree.|-1|-1|0|0|en|False
+2020-08-01T00:01:09.000Z|1289350420649906176|@ChiBDM he hasn’t been cancelled yet for impregnating and then marrying a 16-year old while already being married t… https://t.co/w31gs2vKiW|1289348496147898370|53315324|0|0|en|False
+2020-08-01T00:01:10.000Z|1289350421211836416|Judge takes that inside slider to Right Center... amazing to me.|-1|-1|0|0|en|False
+2020-08-01T00:01:10.000Z|1289350421216075778|all rise|-1|-1|0|0|en|False
+2020-08-01T00:01:10.000Z|1289350421593468928|Crusher for #Liberty top pick Sabrina Ionescu. She had 33 points in her 2nd career WNBA game.|-1|-1|0|0|en|False
+2020-08-01T00:01:10.000Z|1289350421874524163|“Ain’t nothing been giving easy to me... ain’t nothing been giving easy to this town.” Real shit. Keep grinding Grizz. #GrzNxtGen|-1|-1|0|0|en|False
+2020-08-01T00:01:10.000Z|1289350422453342213|As far as YALL know I get my nail supplies from amazon 🤣 I got my secret lil websites I can’t give away|-1|-1|0|0|en|False
+2020-08-01T00:01:10.000Z|1289350422772305921|I cannot believe Beyoncé made #BlackIsKing and actually gave it to us. Especially after how evil the Black communit… https://t.co/4CJZXyXDq8|-1|-1|0|0|en|False
+2020-08-01T00:01:10.000Z|1289350423250259970|Judge clutch 💣💣 back to back nights fucking monster|-1|-1|0|0|en|False
+2020-08-01T00:01:10.000Z|1289350423556456448|@bigjimwebb @PeaceNo12524189 @kanyewest 😂🤣😂😂🤣🤣I took one glimpse on your page and saw 5 racist remarks in 1 sec 🤣🤣🤣|1289323201676185602|980812861|0|0|en|False
+2020-08-01T00:01:10.000Z|1289350423732604929|WTF.|-1|-1|0|0|und|False
+2020-08-01T00:01:10.000Z|1289350424097509376|I am truly never happier than when I can spend the day by the ocean. https://t.co/TVdOFc9oYZ|-1|-1|0|0|en|False
+2020-08-01T00:01:10.000Z|1289350424194174976|Five years ago today, Mexican journalist Rubén Espinosa (31) and activist Nadia Vera (32) were murdered. Rubén and… https://t.co/6QdqBFPNUG|-1|-1|0|0|en|False
+2020-08-01T00:01:10.000Z|1289350424370192384|@rellRomaNce Yoooo. What I missed?|1289342560792539137|101636425|0|0|en|False
+2020-08-01T00:01:10.000Z|1289350424659521536|@FOXSportsSD @SycuanCasino #imwithsweeney|1289345109557796864|510674085|0|0|und|False
+2020-08-01T00:01:10.000Z|1289350424869273601|@TheACap It’s soooo ugly 😭|1289331072979726336|476186682|0|0|en|False
+2020-08-01T00:01:10.000Z|1289350425070583808|Show the “crowd”. Seems like his followers are seeing him for the con that he is. (Turns out twitter morons and bot… https://t.co/LOq1stWYPn|-1|-1|0|0|en|False
+2020-08-01T00:01:11.000Z|1289350425968168960|@BuzzFeedNews #EllenDeGeneres https://t.co/T3OatjXHX1|1289207576685576194|1020058453|0|0|und|False
+2020-08-01T00:01:11.000Z|1289350426224033792|@kylegriffin1 Yay!! Stay strong Justice Ginsburg!!!|1289304841773146112|32871086|0|0|en|False
+2020-08-01T00:01:11.000Z|1289350427071242240|@HSF1017 Wow this is crazy. Unfollowing now|1289345662111199232|1230667117852151809|0|0|en|False
+2020-08-01T00:01:11.000Z|1289350427478069249|Check out The Friday Finale Summer Edition v2.https://t.co/BCUKVxP1zU|-1|-1|0|0|en|False
+2020-08-01T00:01:11.000Z|1289350427868184576|We are live STEAM Symposium Summer 2920 https://t.co/QdBfI1fnDw #TRIOworks @CCAS_NEIU @NEIU|-1|-1|0|0|en|False
+2020-08-01T00:01:11.000Z|1289350428023386112|@Eldinlewds Awesome, I’m glad to be in your circle|1289334382956695552|786232332072079361|0|0|en|False
+2020-08-01T00:01:11.000Z|1289350428065329153|JUMP YOUR MOTHER FUCKING ASS ALL YOU WANT YOU AINT GETTING THAT BALL|-1|-1|0|0|en|False
+2020-08-01T00:01:11.000Z|1289350428157648896|Link to join!See you in 30 min... Friday, July 31 at 5:30PM PST/8:00PM ESTWorld Premiere of Comedy Parlour Live… https://t.co/1INgDeQ5UX|-1|-1|0|0|en|False
+2020-08-01T00:01:11.000Z|1289350428535078912|I need to lock a seamstress in my basement like how grimes had azelia locked up makin music .....|-1|-1|0|0|en|False
+2020-08-01T00:01:12.000Z|1289350430296641536|@amyywins 🥴🥴🥴|1289297997465968641|1054368529389182978|0|0|und|False
+2020-08-01T00:01:12.000Z|1289350430502215681|tofu friday|-1|-1|0|0|en|False
+2020-08-01T00:01:12.000Z|1289350430661709825|Focus workforce computer call saying their hiring https://t.co/BPMXaYh4Ub|-1|-1|0|0|en|False
+2020-08-01T00:01:12.000Z|1289350431332737024|Kelly Services is looking for teammates like you. See our latest Biotech/Clinical/R&D/Science job openings, includi… https://t.co/9lqbfKdy08|-1|-1|0|0|en|False
+2020-08-01T00:01:12.000Z|1289350431341076480|@EmilyCWaldon Mr November game 2001|1289342719459045381|489733778|0|0|en|False
+2020-08-01T00:01:12.000Z|1289350431622062080|The student progress form asks for a list of recognitions, honors and awards from the last year. I wanted to write.… https://t.co/gxyFdbaOrP|-1|-1|0|0|en|False
+2020-08-01T00:01:12.000Z|1289350432200957952|@LexxxAnastasia Somebody on my Twitter smh|1289350018860814336|1279423746378551300|0|0|en|False
+2020-08-01T00:01:12.000Z|1289350432851197952|Bunky tryn sleep in singing Rest In Peace Slim Dunkin! 🙅🏽‍♂️🧢|-1|-1|0|0|en|False
+2020-08-01T00:01:12.000Z|1289350432901406720|@DLShower1x @spif1x to be fair spif called me a monkey and he said i should kms|1289341148268380160|1244161708605800448|0|0|en|False
+2020-08-01T00:01:12.000Z|1289350433178173442|😂😂|-1|-1|0|0|und|False
+2020-08-01T00:01:12.000Z|1289350433471782912|The external world only fixes external issues.|-1|-1|0|0|en|False
+2020-08-01T00:01:12.000Z|1289350433484320768|@sillyauntie I haven’t watched ONE millisecond of it I’ve been living it since 2018|1289350258598674432|15842984|0|0|en|False
+2020-08-01T00:01:12.000Z|1289350433585205250|@rn_murse @jakery Hey! I enjoy funny accounts regardless of gender/sexual orientation/race/etc! I don’t really read… https://t.co/7sF0Tqyxaj|1289348417768939521|1258740035731566593|0|0|en|False
+2020-08-01T00:01:13.000Z|1289350434834898944|Grow your career in Ballwin, MO! Learn more about our latest Restaurant Manager - Manchester, MO - HL position:… https://t.co/iTkxPOB4Zq|-1|-1|0|0|en|False
+2020-08-01T00:01:13.000Z|1289350435069779968|Maybe Trump’s adverse position to the United States Postal Service directly relates to his position on mail in vote… https://t.co/Xdz9cEBbTU|-1|-1|0|0|en|False
+2020-08-01T00:01:13.000Z|1289350435363368961|@KingMarison 😂 I'm not a Golden Girl Yet..Hell I'm Young 😜 😂|1289218947007434753|41482930|0|0|en|False
+2020-08-01T00:01:13.000Z|1289350435871088644|Man that song was one of my favorites even though my friends gave me shit. Prob why I love Friday|-1|-1|0|0|en|False
+2020-08-01T00:01:13.000Z|1289350435887702018|Here’s my new stock of Monsta and Anarchy. Almost all if it is NIW or minty. If you have a question/ questions abou… https://t.co/psvH0QSWNr|-1|-1|0|0|en|False
+2020-08-01T00:01:13.000Z|1289350436441317378|@lgarf3 @NESN Did you have the Fios? That’s what we had in town.|1289348604214140930|821070911348572160|0|0|en|False
+2020-08-01T00:01:13.000Z|1289350437083045888|@thexybeatht 😜|1289228574491254785|1056627030836490240|0|0|und|False
+2020-08-01T00:01:13.000Z|1289350437145997312|Readings 🤓 https://t.co/TBZXQrrmqe|-1|-1|0|0|en|False
+2020-08-01T00:01:13.000Z|1289350437531869184|@coachnoonan Trained yes of course. Shot clock was run by a college student at our games. Not a hard job relative to scorekeeping table IMO.|1289216913281896451|28396660|0|0|en|False
+2020-08-01T00:01:13.000Z|1289350437611528193|@kanyewest Thank you Kenya for speaking the truth!|1289199762315517952|169686021|0|0|en|False
+2020-08-01T00:01:14.000Z|1289350437955465216|@LostNTheAbyss Sweet and sour lol🤣 https://t.co/XVy8ZfKLmo|1289345128570556416|1116156023574802432|0|0|en|False
+2020-08-01T00:01:14.000Z|1289350438538469377|@gtarias @nacion ayyyy....|1289349240058023941|198052004|0|0|und|False
+2020-08-01T00:01:14.000Z|1289350438790168577|@SBTribune https://t.co/brlM06lXnl|1288451120617205760|20528760|0|0|und|False
+2020-08-01T00:01:14.000Z|1289350438857236486|Matt Adams out here reminding everyone that @GaryClarkJr is a national treasure|-1|-1|0|0|en|False
+2020-08-01T00:01:14.000Z|1289350440065196032|#AllRise @Yankees|-1|-1|0|0|und|False
+2020-08-01T00:01:14.000Z|1289350440744701952|It’s really true that black men glorify the idea of finding “light skinned” counter part. And I hate that shit, cuz… https://t.co/l2KqBSwfpt|-1|-1|0|0|en|False
+2020-08-01T00:01:14.000Z|1289350440820150272|@renato_mariotti What an awful person he is.|1289194855223234560|759481842814726144|0|0|en|False
+2020-08-01T00:01:14.000Z|1289350441373859842|@Scone_Mason @varindersingh24 👋 Friend of Bill?|1289324697646063618|17852307|0|0|en|False
+2020-08-01T00:01:14.000Z|1289350441764085761|#SomethingINeverTrust Lending Members Of The Family Money! https://t.co/o49EbUU6wv|-1|-1|0|0|en|False
+2020-08-01T00:01:15.000Z|1289350442216910848|Chicken and rice! https://t.co/jSSnEwjad0|-1|-1|0|0|en|False
+2020-08-01T00:01:15.000Z|1289350442535866369|@GmaJV40 @realDonaldTrump He said same thing last time and won and left side been making shit up this whole time on… https://t.co/x1VzmRScnO|1288876306562781184|2890110154|0|0|en|False
+2020-08-01T00:01:15.000Z|1289350443181588482|I’ve been watching like an hour of Raw and just straight up skipping Smackdown for the past month and I’ve been way happier lately. Weird.|-1|-1|0|0|en|False
+2020-08-01T00:01:15.000Z|1289350443341029377|@RamTommyInLA I guess it's better these situations arrive now than in season. Need to have a bubble|1289303090785447936|263874274|0|0|en|False
+2020-08-01T00:01:15.000Z|1289350443441647618|@jackandyxxx @DominikRider @adamrussoxxx Hot,love your guys cocks,so hard and ready to cum|1289350187979173890|796822278625492992|0|0|en|False
+2020-08-01T00:01:15.000Z|1289350444544741377|@mmeyerdc @tribelaw @CitizenWonk @SpeakerPelosi Hmmm...why is there no House? B/C they're elected but haven't been… https://t.co/GPHYMzhPiq|1289254552286441473|59246236|0|0|en|False
+2020-08-01T00:01:15.000Z|1289350444771184647|@Mrsbananapuddin I thought you were cool 😔|1289350343290052613|755099940385239040|0|0|en|False
+2020-08-01T00:01:15.000Z|1289350444775612417|PRESIDENT @SpeakerPelosi 💙 Hmmm 🤔 @JoyAnnReid @tribelaw #ReidOut #PresidentPelosi 🙌🏽 #FAFO|-1|-1|0|0|en|False
+2020-08-01T00:01:16.000Z|1289350446520262657|Hey Twin. @ Las Vegas Nevada https://t.co/pjGW1TO6wz|-1|-1|0|0|es|False
+2020-08-01T00:01:16.000Z|1289350447489142789|@Gtwan1 Bitch I’m leaning grab the wheel, this high fashion🥱|1289350000162398208|282844448|0|0|en|False
+2020-08-01T00:01:16.000Z|1289350448055345152|Tone deaf...|-1|-1|0|0|en|False
+2020-08-01T00:01:16.000Z|1289350448109953024|I'm at Yellow Brick Road Preschool in Anaheim, CA https://t.co/kcUqgp5su0|-1|-1|0|0|en|False
+2020-08-01T00:01:16.000Z|1289350448357560322|@WorldWideWiggz Pure energy 😂😂|1289349787045621762|32759357|0|0|en|False
+2020-08-01T00:01:16.000Z|1289350448617381888|@StormyJ_ take ur time g|1289054497868664832|4770534313|0|0|en|False
+2020-08-01T00:01:16.000Z|1289350448902574084|Eid Mubarak to any of my Muslim friends.|-1|-1|0|0|en|False
+2020-08-01T00:01:16.000Z|1289350449187913729|😌😌|-1|-1|0|0|und|False
+2020-08-01T00:01:16.000Z|1289350449825366016|#AllRise https://t.co/3wfnzdpBlU|-1|-1|0|0|und|False
+2020-08-01T00:01:16.000Z|1289350450064420864|Weekly underappreciated movie: #MilesAhead#FilmTwitter https://t.co/mVm78T83ne|-1|-1|0|0|en|False
+2020-08-01T00:01:16.000Z|1289350450202910721|@Bweeb_UwU These things called terpenes that determine a strains taste and flavor profile amongst other thingsHad… https://t.co/2LVyYpjBnI|1289350039882481665|1083258341235834881|0|0|en|False
+2020-08-01T00:01:17.000Z|1289350450618089472|@linzlovesyou @PDXAccessible Oh yeah he’s from Redding/Bethel Church|1289350063894872064|26982451|0|0|en|False
+2020-08-01T00:01:17.000Z|1289350450676785152|Again https://t.co/VfZVeOoML3|-1|-1|0|0|en|False
+2020-08-01T00:01:17.000Z|1289350450890731520|@kylakardashian1 Right that’s what I’m thinking too cuz I can give it to her when she get older|1289349777696493569|952781878637006848|0|0|en|False
+2020-08-01T00:01:17.000Z|1289350451599511553|N948CP, a Cessna 182-T, (callsign CAP448) is circling over Sylmar, Los Angeles at 5925 feet, speed 135 MPH, squawki… https://t.co/vJy4rWSbAw|-1|-1|0|0|en|False
+2020-08-01T00:01:17.000Z|1289350451880632320|@fritziannette It can all be so simple|1289348707364691968|1169460760759504896|0|0|en|False
+2020-08-01T00:01:17.000Z|1289350451989606400|Watching the second season of @UmbrellaAcad on @netflix and so far it’s amazing!!!!💗💗💗|-1|-1|0|0|en|False
+2020-08-01T00:01:17.000Z|1289350452610396160|@realDonaldTrump You are a #LIAR #SIMP and an #Idiot|1289284178127646720|25073877|0|0|en|False
+2020-08-01T00:01:17.000Z|1289350453340155904|@ralph6esposito @RealOmarNavarro My personal favorite.|1289281531408654337|970341848479862786|0|0|en|False
+2020-08-01T00:01:17.000Z|1289350453411459072|Another great game from Jalen Gilmore of North Point Youth our of Florida. The class of 2022 guard pumped in a hard… https://t.co/qtzHh46mDf|-1|-1|0|0|en|False
+2020-08-01T00:01:17.000Z|1289350453596000256|@lotsofuss @PuestoLoco @JoeBiden AFAICT (30 seconds w Google), she dared to say Scientology's “creed is a universal… https://t.co/T3dF28JYrk|1289333914670993410|181140029|0|0|en|False
+2020-08-01T00:01:17.000Z|1289350454334423042|@gueroaustin You don’t have FSSW?|1289350221604876289|715957273|0|0|en|False
+2020-08-01T00:01:18.000Z|1289350455231823872|Surprised Pillar after years in the AL East would venture so far off first with Judge coming in on the ball #Yankees|-1|-1|0|0|en|False
+2020-08-01T00:01:18.000Z|1289350455282348033|Live a little. Reserve yours today.-#Ford #FordBronco #BuiltFordTough #Bronco #CavenderFord #MakeConfidenceHappen… https://t.co/dGlXjoTx7F|-1|-1|0|0|en|False
+2020-08-01T00:01:18.000Z|1289350455311519744|first league match tonight 🎾🎾🎾|-1|-1|0|0|en|False
+2020-08-01T00:01:18.000Z|1289350455319912453|@NadaAJones No shit!!!|1289266691935895553|808275049195048960|0|0|en|False
+2020-08-01T00:01:18.000Z|1289350456653701120|“Orange is always next to green” 💚🧡|-1|-1|0|0|en|False
+2020-08-01T00:01:18.000Z|1289350457165377536|@lycheemoji 🙈💜💙|1289350304597762048|1002688496811827200|0|0|und|False
+2020-08-01T00:01:18.000Z|1289350457513529346|Damn I miss all my homie on the boat 😞😞|-1|-1|0|0|en|False
+2020-08-01T00:01:19.000Z|1289350459665211393|So that’s insanity, but the rich getting tax breaks (for ex. Kanye’s yeezy Business getting millions in relief aid… https://t.co/3R6wskPdWL|-1|-1|0|0|en|False
+2020-08-01T00:01:19.000Z|1289350459866537984|It’s gone 2-1 judge..streak continues|-1|-1|0|0|en|False
+2020-08-01T00:01:19.000Z|1289350459908481024|https://t.co/dQereGjOvk|-1|-1|0|0|und|False
+2020-08-01T00:01:19.000Z|1289350460801859585|@myleencdg SAME!!|1289332213679448065|120976873|0|0|en|False
+2020-08-01T00:01:19.000Z|1289350461988827138|Gotta hope the two get along @greggutfeld|-1|-1|0|0|en|False
+2020-08-01T00:01:19.000Z|1289350462467002369|FUCK THATS COOL 😍😍😍|-1|-1|0|0|en|False
+2020-08-01T00:01:20.000Z|1289350463016407041|I really miss enjoying a Friday afternoon with co-workers at the office. But I have rediscovered how much fun it is… https://t.co/2VlR2WDWNo|-1|-1|0|0|en|False
+2020-08-01T00:01:20.000Z|1289350463763042304|@replouiegohmert Liar. You're taking no such thing.|1289299030325866497|22055226|0|0|en|False
+2020-08-01T00:01:20.000Z|1289350463964364802|@AMysticMuse https://t.co/xUaavNhdgR|1289349090820517888|1002434346|0|0|und|False
+2020-08-01T00:01:20.000Z|1289350463977074688|Listening to storm ASMR during an actual storm >>>>|-1|-1|0|0|en|False
+2020-08-01T00:01:20.000Z|1289350464509706241|@officiallykeith Bolis|1289327958767919106|804971957708066816|0|0|pt|False
+2020-08-01T00:01:20.000Z|1289350464782434305|y’all|-1|-1|0|0|en|False
+2020-08-01T00:01:20.000Z|1289350465407213568|My parents are transphobes and I walk around all day like this! #sorrynotsorry #transwoman #transisbeautiful… https://t.co/L1U4CLKRrb|-1|-1|0|0|en|False
+2020-08-01T00:01:20.000Z|1289350465512079360|I KNOW ONE MA’FCKING THING: Let @TheRealDougie_ bail on me tonight; we gonna have a problem! #BLACKISKING|-1|-1|0|0|en|False
+2020-08-01T00:01:20.000Z|1289350465562394624|Kinda want to be a line cook at a pasta place in Brooklyn. Wouldn’t hate it.|-1|-1|0|0|en|False
+2020-08-01T00:01:20.000Z|1289350466036355072|Thinking about getting into indoor biking|-1|-1|0|0|en|False
+2020-08-01T00:01:20.000Z|1289350466178965504|@Rockies In honor of #Rockies #OpeningDay, I would like to apologize for/bring awareness to a press box chair my bu… https://t.co/V8tafS5zhG|1289305836247031808|159143990|0|0|en|False
+2020-08-01T00:01:20.000Z|1289350467034652673|Eid Mubarak to everyone celebrating! https://t.co/ENQ4blw5mN|-1|-1|0|0|en|False
+2020-08-01T00:01:21.000Z|1289350467336560640|@NiTeNull You’re hiding a huge cookie! Lol https://t.co/WtpHTVsP28|1289349388897095682|2241276212|0|0|en|False
+2020-08-01T00:01:21.000Z|1289350467969929216|#Houston #WeAintGotNoProblemsProblems #HOO!!! https://t.co/hXs3BbxCFI|-1|-1|0|0|und|False
+2020-08-01T00:01:21.000Z|1289350468158631936|@BeatinTheBookie 1.Over2.houston +13. Harden 37 points|1289349216418988033|2807680549|0|0|en|False
+2020-08-01T00:01:21.000Z|1289350469328891904|#BradPitt still the most powerful man in America that's the Good News|1289349793005748226|898786896|0|0|en|False
+2020-08-01T00:01:21.000Z|1289350469547175936|Had my first post COVID-19 patient today. 3 weeks on a ventilator. We’re rebuilding from scratch. I can assure you. This is no hoax.|-1|-1|0|0|en|False
+2020-08-01T00:01:21.000Z|1289350469769338884|This song made me so rude ....get out my face get out my face 😭🤣 ...jah mom said take the trash out ..yah trick ya… https://t.co/wWZEbR4KZd|-1|-1|0|0|en|False
+2020-08-01T00:01:21.000Z|1289350469953839104|@moeill I am relaxing, that’s the issue. 😅🤣😂|1289350273756827648|983597622|0|0|en|False
+2020-08-01T00:01:21.000Z|1289350470977220608|Exactly!|-1|-1|0|0|en|False
+2020-08-01T00:01:21.000Z|1289350471077912576|@andyhuber15 @davidhogg111 @NRA And his beard is all your brain can focus on?! Sad.|1289310468394201088|1119961731751718912|0|0|en|False
+2020-08-01T00:01:22.000Z|1289350471560204289|0001ZN668PD LOS ANGELES POLICE DEPT AIR SUPPORT DIVISIONSquawk: 1200N34.0646 W118.2716Altitude: 850ftCourse: 2… https://t.co/qqjL1GWsel|-1|-1|0|0|en|False
+2020-08-01T00:01:22.000Z|1289350472675889153|@JonahDispatch Harold and Maude|1289346848545599489|71627462|0|0|en|False
+2020-08-01T00:01:22.000Z|1289350473686736896|@KING5Seattle the west Seattle bridge pillars look strong. Extend them up and swing cables to support the middle span. Like the golden gate.|-1|19430999|0|0|en|False
+2020-08-01T00:01:22.000Z|1289350473837940737|Slaughter and south park meadows area is my least favorite place to be like WHY do so many people live here|-1|-1|0|0|en|False
+2020-08-01T00:01:22.000Z|1289350474215251969|@msharresse_ Yaaaay, i try to make the at home experience the best i can! ✨❤️|1289319192773050369|1193950766|0|0|en|False
+2020-08-01T00:01:22.000Z|1289350474315988992|i going to join forex once i have enough free time|-1|-1|0|0|en|False
+2020-08-01T00:01:22.000Z|1289350474508963840|Wow|-1|-1|0|0|und|False
+2020-08-01T00:01:22.000Z|1289350474563375105|Just posted a photo @ Newark Moonlight Cinema https://t.co/SEZq2urolc|-1|-1|0|0|en|False
+2020-08-01T00:01:22.000Z|1289350475226128386|Ima play my part till the end.|-1|-1|0|0|en|False
+2020-08-01T00:01:23.000Z|1289350476434030592|@TrillBroDude I had this idea a few years ago. To tweet “x team will win the Super Bowl” for every team during the… https://t.co/zElqqyJ5di|1289350010778378240|1240727220534030338|0|0|en|False
+2020-08-01T00:01:23.000Z|1289350476538863617|Soo tmobile bought sprint? AND NOW I GET TMOBILE TUESDAYS my service is still shit but I’ll take what I can get|-1|-1|0|0|en|False
+2020-08-01T00:01:23.000Z|1289350476660498432|@theshrk22 That, right there, is the key.|1289340488621985793|287868732|0|0|en|False
+2020-08-01T00:01:23.000Z|1289350476895412224|@King_Eog1984 Says who ? I been posting his music.|1289350332783493120|439833566|0|0|en|False
+2020-08-01T00:01:23.000Z|1289350477017231360|@__soulsista Yessssss like literally a dream|1289343278815383553|3291799273|0|0|en|False
+2020-08-01T00:01:23.000Z|1289350477214183425|@tweet_der @LisaMarieBoothe Oh really!! Damned if you do and damned if you don't. There has NEVER been anyone in… https://t.co/6s8P6BcVj6|1288921756644909057|51113625|0|0|en|False
+2020-08-01T00:01:23.000Z|1289350477348352002|this is the funniest shit I ever seen|-1|-1|0|0|en|False
+2020-08-01T00:01:23.000Z|1289350478212415488|I guess this idiot has a stake in tRumps failure drug|-1|-1|0|0|en|False
+2020-08-01T00:01:23.000Z|1289350478224998400|https://t.co/I9tXQqZGK2|-1|-1|0|0|und|False
+2020-08-01T00:01:23.000Z|1289350479651119104|This all seems true to me! https://t.co/lCctQKbcfR|-1|-1|0|0|en|False
+2020-08-01T00:01:24.000Z|1289350479823040512|@myinfoingridz1 @eileendiana @veritasrepublic @Shelley2021|-1|4889384753|0|0|und|False
+2020-08-01T00:01:24.000Z|1289350481601388544|Taco stop on the bike @ Dogleg Brewing Company https://t.co/RQX9PmXfnh|-1|-1|0|0|en|False
+2020-08-01T00:01:24.000Z|1289350481706246144|@lovingsimulacra Yes. Super goals mega fem sexy. :)|1289349269531500544|243431924|0|0|en|False
+2020-08-01T00:01:24.000Z|1289350482130014213|So Proud!!⚡️ Our team officially closed 21 Transactions in the month of July! ⁣⁣⁣⁣At just a year and a half in to… https://t.co/KsFd8q9rXg|-1|-1|0|0|en|False
+2020-08-01T00:01:24.000Z|1289350482150871040|@_MelissaEgan @KOLDNews I hope not !|1289347670528548864|211016708|0|0|en|False
+2020-08-01T00:01:24.000Z|1289350483073630208|#EidMubarak to our Muslim community members celebrating the festival of sacrifice, #EidAlAdha! https://t.co/bOpQaHb9jR|-1|-1|0|0|en|False
+2020-08-01T00:01:24.000Z|1289350483769925632|https://t.co/DnQQF2s1Qw|-1|-1|0|0|und|False
+2020-08-01T00:01:25.000Z|1289350484109582336|a dime fr 💫 https://t.co/KdRmW0ol7x|-1|-1|0|0|fr|False
+2020-08-01T00:01:25.000Z|1289350484906536960|@bayne_wendy @HattieHarte @ElsieMcarthur @BrokenTwigs2020 @missemilyl1 @RRTwriting @RjSorrento @AddyBrossWrites… https://t.co/Lqs1fIOpen|1289349516173488130|1255892670129602561|0|0|en|False
+2020-08-01T00:01:25.000Z|1289350485166759936|Tonight’s @orioles first pitch brought to you by #EmersonBrooks on masnorioles ⚾ bringing the heat 🔥 @ Oriole Park… https://t.co/WK4Eu77Cvd|-1|-1|0|0|en|False
+2020-08-01T00:01:25.000Z|1289350485200130050|@Royal_Matter You gotta be louder!! Lol|1289295550152495104|528227100|0|0|en|False
+2020-08-01T00:01:25.000Z|1289350485288222720|@BleacherReport https://t.co/59QhIyxwxW|1289349566370742273|890891|0|0|und|False
+2020-08-01T00:01:25.000Z|1289350486399660032|@JJMaples55_MST https://t.co/JL4QS4FiEY|1289348376232779777|345158690|0|0|und|False
+2020-08-01T00:01:25.000Z|1289350486487961605|@NoahCRothman They’re all still scared to death of a mean tweet. They’re like dogs that have been beaten too much.|1289339190375616513|168531961|0|0|en|False
+2020-08-01T00:01:25.000Z|1289350486508703745|@MarySueSays You’d prefer LAFC win?|1289350134745030656|48390222|0|0|en|False
+2020-08-01T00:01:25.000Z|1289350486802354177|@ProjectLincoln @DesignationSix https://t.co/0bp3bmWdCA|1289252608880697344|1205226529455632385|0|0|und|False
+2020-08-01T00:01:25.000Z|1289350487129460737|@Ofacewrestling https://t.co/t8grYzwZAD|1289349040841175040|1138517810592845825|0|0|und|False
+2020-08-01T00:01:25.000Z|1289350487485984768|@AnxietySong Who does this?|1289349591041634304|1124195581256241152|0|0|en|False
+2020-08-01T00:01:25.000Z|1289350487737688064|ALLL RISEEE HERE COMES THE JUDGE https://t.co/VWUJFjjaK0|-1|-1|0|0|en|False
+2020-08-01T00:01:26.000Z|1289350488912207872|WOW|-1|-1|0|0|und|False
+2020-08-01T00:01:26.000Z|1289350489000128514|Rod Wave never seen a good day in his life???|-1|-1|0|0|en|False
+2020-08-01T00:01:26.000Z|1289350489977442304|You are a disgrace to our Country attacking the American people. The people you suppose to support and defend. You… https://t.co/sMOEgkWu4K|-1|-1|0|0|en|False
+2020-08-01T00:01:26.000Z|1289350490099027971|So, the stimulus checks printed out already but they still deciding on the unemployment 🥴|-1|-1|0|0|en|False
+2020-08-01T00:01:26.000Z|1289350490212446208|@tedlieu @realDonaldTrump @GOP @realDonaldTrump stop lying|1289288839979102208|21059255|0|0|en|False
+2020-08-01T00:01:26.000Z|1289350490736570368|@realDonaldTrump No ne wearing masks as usual|1289312630608465920|25073877|0|0|en|False
+2020-08-01T00:01:26.000Z|1289350491458002944|Like fuck it , it’s busssin, one of my oops my cousin 🤣|-1|-1|0|0|en|False
+2020-08-01T00:01:26.000Z|1289350491575431169|Sometimes you need a burger. Hooohmygosh hit the spot 👌 ....#impossibleburger #veggieburger #vegan… https://t.co/8U2sgiuEfv|-1|-1|0|0|en|False
+2020-08-01T00:01:27.000Z|1289350492565323776|Y’all 🥴🥴|-1|-1|0|0|en|False
+2020-08-01T00:01:27.000Z|1289350492628242432|@RedBIGDick_ Delicious|1289349359969042432|1214000149103464448|0|0|en|False
+2020-08-01T00:01:27.000Z|1289350492766629888|@sarahcpr Must not have caught any fish. Will sleaze for food.|1289232345971662848|14642495|0|0|en|False
+2020-08-01T00:01:27.000Z|1289350493303496712|Shoulda been had sports back|-1|-1|0|0|en|False
+2020-08-01T00:01:27.000Z|1289350493601333248|This ⬇️|-1|-1|0|0|en|False
+2020-08-01T00:01:27.000Z|1289350494343712769|@TheNYYBabe2 That Red Sox lead was short lived|1289348045440610305|1037801906473717762|0|0|en|False
+2020-08-01T00:01:27.000Z|1289350494968672256|I need to start putting money away for the upgrade on the Charger I want a widebody scat or go full Hellcat|-1|-1|0|0|en|False
+2020-08-01T00:01:27.000Z|1289350495136444416|@MrErikJackson The girl laughs as she asks if he’s okay.. so I wouldn’t feel too bad about cackling over it.|1289321299303469056|2585973360|0|0|en|False
+2020-08-01T00:01:28.000Z|1289350497187504128|Thanks to the team for carrying me back down. https://t.co/CU6Y0OoIjv|-1|-1|0|0|en|False
+2020-08-01T00:01:28.000Z|1289350498168930304|My dawg 🖤🦍⚔️|-1|-1|0|0|en|False
+2020-08-01T00:01:28.000Z|1289350498269532163|@ThePragmatist5 @SarahLarchmont @TxsleuthUSA @TexHellCat @JaybeeStewee @cachobweeney @Gerhard_kreuz @MarilynCapps… https://t.co/nh2XhzCnPA|1289343381231947776|1109895148677132288|0|0|und|False
+2020-08-01T00:01:28.000Z|1289350498387021825|@shrekthepunk @ziggystardad @EMMYreincarnate @waywardmegan15 @PhilDiagnosis @42Gnome @TrumpSugar @misshellca… https://t.co/T27c9iGmhJ|1289350236201037824|3733796722|0|0|und|False
+2020-08-01T00:01:28.000Z|1289350498714136576|Apparently this is not an issue I’m supposed to set down. Wholesale order to Cayman Islands 🌴just popped up ... app… https://t.co/291bkXK3kJ|-1|-1|0|0|en|False
+2020-08-01T00:01:28.000Z|1289350498865340416|Yall be fuckin with the workers i be fuckin with the plug|-1|-1|0|0|en|False
+2020-08-01T00:01:28.000Z|1289350500584808448|@SLEDGE_Report Ftw 🤏🏻 https://t.co/pwmtCvZfl1|1289345377972490240|397727231|0|0|und|False
+2020-08-01T00:01:29.000Z|1289350500740030464|@SenatorDurbin #ImmigrantsDieWhenDurbinLies #UnblockS386 #S386IsEquality #S386IsGoodForAmerica|-1|247334603|0|0|und|False
+2020-08-01T00:01:29.000Z|1289350501759217666|@BallParkBrand just donated $1 on my behalf to help out-of-work baseball stadium vendors. Join in to help us #FrankitForward this summer.|-1|463255392|0|0|en|False
+2020-08-01T00:01:29.000Z|1289350501763395585|🥳|-1|-1|0|0|und|False

--- a/core/scripts/build.sh
+++ b/core/scripts/build.sh
@@ -1,2 +1,4 @@
-mvn clean install -DskipTests
+cd amber
+sbt compile
+cd ..
 ./scripts/gui.sh

--- a/core/scripts/old_engine/build.sh
+++ b/core/scripts/old_engine/build.sh
@@ -1,0 +1,2 @@
+mvn clean install -DskipTests
+./scripts/gui.sh

--- a/core/scripts/old_engine/gui.sh
+++ b/core/scripts/old_engine/gui.sh
@@ -1,3 +1,3 @@
 cd new-gui
 npm install
-npm run build
+ng build --prod

--- a/core/scripts/old_engine/server.sh
+++ b/core/scripts/old_engine/server.sh
@@ -1,0 +1,1 @@
+java -jar web/target/web-0.1.0.jar server conf/web-config.yml 

--- a/core/scripts/package-lock.json
+++ b/core/scripts/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}

--- a/core/scripts/server.sh
+++ b/core/scripts/server.sh
@@ -1,1 +1,2 @@
-java -jar web/target/web-0.1.0.jar server conf/web-config.yml 
+cd amber
+sbt "runMain web.TexeraWebApplication" --no-colors

--- a/core/scripts/worker.sh
+++ b/core/scripts/worker.sh
@@ -1,0 +1,2 @@
+cd amber
+sbt "runMain web.TexeraRunWorker" --no-colors


### PR DESCRIPTION
This PR 
- changes the default startup scripts to use the new amber engine
- changes the Amber engine to use localhost by default, so that normal development on a single machine is easier
- adds a new class to directly start up the worker process, so developers don't need to manually specify it
- adds a sample twitter file that can be used by the amber engine