### PR TITLE
[BUGFIX] fix an issue of sink operator linking

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/linksemantics/OperatorLink.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/linksemantics/OperatorLink.scala
@@ -7,7 +7,7 @@ import edu.uci.ics.amber.engine.common.ambermessage.PrincipalMessage.{GetInputLa
 import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.UpdateOutputLinking
 import edu.uci.ics.amber.engine.common.ambertag.LinkTag
 import edu.uci.ics.amber.engine.common.{AdvancedMessageSending, Constants, ITupleSinkOperatorExecutor}
-import edu.uci.ics.amber.engine.operators.OpExecConfig
+import edu.uci.ics.amber.engine.operators.{OpExecConfig, SinkOpExecConfig}
 import akka.actor.ActorRef
 import akka.event.LoggingAdapter
 import akka.pattern.ask
@@ -35,7 +35,7 @@ class OperatorLink(val from: (OpExecConfig, ActorRef), val to: (OpExecConfig, Ac
           to._1.getShuffleHashFunction(sender.tag)
         )
       } else if (
-        to._1.isInstanceOf[ITupleSinkOperatorExecutor]
+        to._1.isInstanceOf[SinkOpExecConfig]
       ) {
         linkStrategy = new AllToOne(sender, receiver, Constants.defaultBatchSize)
       } else if (sender.layer.length == receiver.layer.length) {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/operators/SinkOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/operators/SinkOpExecConfig.scala
@@ -1,0 +1,5 @@
+package edu.uci.ics.amber.engine.operators
+
+import edu.uci.ics.amber.engine.common.ambertag.OperatorIdentifier
+
+abstract class SinkOpExecConfig(tag: OperatorIdentifier) extends OpExecConfig(tag)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpExecConfig.scala
@@ -9,12 +9,12 @@ import edu.uci.ics.amber.engine.architecture.deploysemantics.deploystrategy.Rand
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{ActorLayer, ProcessorWorkerLayer}
 import edu.uci.ics.amber.engine.architecture.worker.WorkerState
 import edu.uci.ics.amber.engine.common.ambertag.{LayerTag, OperatorIdentifier}
-import edu.uci.ics.amber.engine.operators.OpExecConfig
+import edu.uci.ics.amber.engine.operators.SinkOpExecConfig
 
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 
-class SimpleSinkOpExecConfig(tag: OperatorIdentifier) extends OpExecConfig(tag) {
+class SimpleSinkOpExecConfig(tag: OperatorIdentifier) extends SinkOpExecConfig(tag) {
   override lazy val topology = new Topology(
     Array(
       new ProcessorWorkerLayer(


### PR DESCRIPTION
In the current engine, the operator link class cannot identify the sink operator and create proper links for it because an `isInstanceOf` check is incorrect. I created another class on top of `OpExecConfig` which is called `SinkOpExecConfig`. All sink operator configs should be inherited from `SinkOpExecConfig` so that the engine can create proper links for them.