### PR TITLE
Move minimap

### DIFF
--- a/core/new-gui/.gitignore
+++ b/core/new-gui/.gitignore
@@ -24,7 +24,7 @@
 *.sublime-workspace
 
 # IDE - VSCode
-.vscode/*
+.vscode/
 !.vscode/settings.json
 !.vscode/tasks.json
 !.vscode/launch.json

--- a/core/new-gui/src/app/workspace/component/mini-map/mini-map.component.html
+++ b/core/new-gui/src/app/workspace/component/mini-map/mini-map.component.html
@@ -1,5 +1,9 @@
-<div class="texera-mini-map-body texera-mini-map-component-body" [attr.id]="MINI_MAP_JOINTJS_MAP_WRAPPER_ID">
-  <div class ="texera-workspace-mini-map-jointjs" [attr.id]="MINI_MAP_JOINTJS_MAP_ID">
+<div class="texera-mini-map-square-container">
+  <div class="texera-mini-map-body texera-mini-map-component-body" [attr.id]="MINI_MAP_JOINTJS_MAP_WRAPPER_ID">
+    <div class ="texera-workspace-mini-map-jointjs" [attr.id]="MINI_MAP_JOINTJS_MAP_ID">
+    </div>
   </div>
+  <div class="texera-mini-map-navigator" id="mini-map-navigator-id"></div>
 </div>
-<div class="texera-mini-map-navigator" id="mini-map-navigator-id"></div>
+
+

--- a/core/new-gui/src/app/workspace/component/mini-map/mini-map.component.scss
+++ b/core/new-gui/src/app/workspace/component/mini-map/mini-map.component.scss
@@ -1,10 +1,31 @@
 @import '../workspace.component.scss';
 
+.texera-mini-map-square-container {
+  position: relative; // component-body's position: absolute requires this to be the first positioned ancestor element
+  left: 75%;
+  width: 25%;
+  padding-top: 25%; // padding-top uses % of parent width (causing 1:1 aspect ratio)
+  height: 0;
+  pointer-events: none;
+
+  backdrop-filter: blur(2px);
+}
+
 .texera-mini-map-component-body {
-  min-width: 100%;
-  min-height: 100%;
-  width: 100%;
-  height: 100%;
+  position: absolute; // requires parent square-container to be positioned in order to position relative to parent
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   overflow: hidden;
-  border-top: 0.5px groove #DCDCDC;
+
+  opacity: 0.7;
+
+  box-shadow: -2px 2px 2px rgba(0,0,0,0.2);
+}
+
+.texera-mini-map-navigator {
+  border: 1px solid #797A79;
+  position: absolute;
+  z-index: 1000;
 }

--- a/core/new-gui/src/app/workspace/component/workspace.component.html
+++ b/core/new-gui/src/app/workspace/component/workspace.component.html
@@ -6,7 +6,7 @@
   <texera-operator-panel class="texera-operator-panel-grid-container grid-container" tourAnchor="texera-operator-panel"></texera-operator-panel>
   <texera-property-editor class="texera-property-editor-grid-container grid-container" tourAnchor="texera-property-editor-grid-container"></texera-property-editor>
   <texera-workflow-editor class="texera-workflow-editor-grid-container grid-container" tourAnchor="texera-workflow-editor-grid-container"></texera-workflow-editor>
-  <texera-mini-map  [ngClass]="{'texera-mini-map' : !showResultPanel,'texera-mini-map-with-result' : showResultPanel}"></texera-mini-map>
+  <texera-mini-map  class="texera-mini-map"></texera-mini-map>
   <texera-result-panel-toggle class="texera-result-panel-toggle-grid-container grid-container"></texera-result-panel-toggle>
   <texera-result-panel class="texera-result-panel-grid-container grid-container" tourAnchor="texera-result-view-grid-container"></texera-result-panel>
 </div>

--- a/core/new-gui/src/app/workspace/component/workspace.component.scss
+++ b/core/new-gui/src/app/workspace/component/workspace.component.scss
@@ -95,7 +95,7 @@
   */
 .texera-property-editor-grid-container {
   grid-column: 3/4;
-  grid-row: 2/5;
+  grid-row: 2/6;
   overflow: auto;
 }
 
@@ -110,21 +110,8 @@
 }
 
 .texera-mini-map {
-  grid-column: 3/4;
-  grid-row: 3/5;
-}
-
-.texera-mini-map-with-result {
-  grid-column: 3/4;
-  grid-row: 4/6;
-}
-
-.texera-mini-map-navigator {
-  border: 1px solid #797A79;
-  position: absolute;
-  grid-column: 3/4;
-  grid-row: 3/5;
-  z-index: 1000;
+  grid-column: 2/3;
+  grid-row: 2/4;
 }
 
 /**


### PR DESCRIPTION
Before
![image](https://user-images.githubusercontent.com/55671762/96641916-41bce100-12da-11eb-8094-61aa1ecd537a.png)
After
![image](https://user-images.githubusercontent.com/55671762/96641778-16d28d00-12da-11eb-8664-3a64b5f98bab.png)

The minimap has historically been at the bottom right corner.
Moving it to the top right brings such benefits as:

- minimap is closer to the workflow for ease-of-use
- removes hard to see border (grey on grey)