### PR TITLE
Fix opExecConfig api by adding back worker number

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OneToOneOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OneToOneOpExecConfig.scala
@@ -15,7 +15,7 @@ import edu.uci.ics.amber.engine.operators.OpExecConfig
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 
-class OneToOneOpExecConfig(override val tag: OperatorIdentifier, val opExec: () => OperatorExecutor)
+class OneToOneOpExecConfig(override val tag: OperatorIdentifier, val opExec: Int => OperatorExecutor)
     extends OpExecConfig(tag) {
 
   override lazy val topology: Topology = {
@@ -23,7 +23,7 @@ class OneToOneOpExecConfig(override val tag: OperatorIdentifier, val opExec: () 
       Array(
         new ProcessorWorkerLayer(
           LayerTag(tag, "main"),
-          _ => opExec(),
+          opExec,
           Constants.defaultNumWorkers,
           FollowPrevious(),
           RoundRobinDeployment()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/filter/SpecializedFilterOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/filter/SpecializedFilterOpDesc.java
@@ -18,7 +18,7 @@ public class SpecializedFilterOpDesc extends FilterOpDesc {
     @Override
     public OneToOneOpExecConfig operatorExecutor() {
         return new OneToOneOpExecConfig(this.operatorIdentifier(),
-                () -> new SpecializedFilterOpExec(this));
+                worker -> new SpecializedFilterOpExec(this));
     }
 
     @Override

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/regex/RegexOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/regex/RegexOpDesc.scala
@@ -16,7 +16,7 @@ class RegexOpDesc extends FilterOpDesc {
   var regex: String = _
 
   override def operatorExecutor: OneToOneOpExecConfig = {
-    new OneToOneOpExecConfig(this.operatorIdentifier, () => new RegexOpExec(this))
+    new OneToOneOpExecConfig(this.operatorIdentifier, _ => new RegexOpExec(this))
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sentiment/SentimentAnalysisOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sentiment/SentimentAnalysisOpDesc.java
@@ -26,7 +26,7 @@ public class SentimentAnalysisOpDesc extends MapOpDesc {
         if (attribute == null) {
             throw new RuntimeException("sentiment analysis: attribute is null");
         }
-        return new OneToOneOpExecConfig(operatorIdentifier(), () -> new SentimentAnalysisOpExec(this));
+        return new OneToOneOpExecConfig(operatorIdentifier(), worker -> new SentimentAnalysisOpExec(this));
     }
 
     @Override


### PR DESCRIPTION
This PR fixes the OpExecConfig API by adding the worker number as a parameter to the lambda function. 
The original API was `() => OpExec`, the new API is `Int => OpExec`, where `Int` is the worker number. 

This change aligns the operator API with the API used by amber engine. The original API was an error to not include the worker number as a parameter.