### PR TITLE
Fix operator executor config after api refactor

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/mlmodel/MLModelOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/mlmodel/MLModelOpExecConfig.scala
@@ -43,4 +43,6 @@ class MLModelOpExecConfig(override val tag: OperatorIdentifier, val numWorkers: 
       topology(0).layer.filter(states(_) != WorkerState.Completed)
     )
   }
+
+  override def getInputNum(from: OperatorIdentifier): Int = 0
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpExecConfig.scala
@@ -44,4 +44,6 @@ class MysqlSourceOpExecConfig(
     breakpoint.partition(topology(0).layer.filter(states(_) != WorkerState.Completed))
   }
 
+  override def getInputNum(from: OperatorIdentifier): Int = ???
+
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/pieChart/PieChartOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/pieChart/PieChartOpExecConfig.scala
@@ -50,7 +50,8 @@ class PieChartOpExecConfig(
           partialLayer,
           finalLayer,
           Constants.defaultBatchSize,
-          x => x.asInstanceOf[Tuple].hashCode()
+          x => x.asInstanceOf[Tuple].hashCode(),
+          0
         )
       ),
       Map()
@@ -64,4 +65,6 @@ class PieChartOpExecConfig(
                                )(implicit timeout: Timeout, ec: ExecutionContext, log: LoggingAdapter): Unit = {
     breakpoint.partition(topology(0).layer.filter(states(_) != WorkerState.Completed))
   }
+
+  override def getInputNum(from: OperatorIdentifier): Int = 0
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpExecConfig.scala
@@ -49,7 +49,8 @@ class WordCloudOpExecConfig(
           partialLayer,
           finalLayer,
           Constants.defaultBatchSize,
-          x => x.asInstanceOf[Tuple].hashCode()
+          x => x.asInstanceOf[Tuple].hashCode(),
+          0
         )
       ),
       Map()
@@ -63,4 +64,6 @@ class WordCloudOpExecConfig(
                                )(implicit timeout: Timeout, ec: ExecutionContext, log: LoggingAdapter): Unit = {
     breakpoint.partition(topology(0).layer.filter(states(_) != WorkerState.Completed))
   }
+
+  override def getInputNum(from: OperatorIdentifier): Int = 0
 }


### PR DESCRIPTION
In #857, we added support of identifying input number in the engine. This PR fixes some operator executor config to follow the new API.