### PR TITLE
Resize panels and workflow-editor

### DIFF
--- a/core/new-gui/src/app/app.module.ts
+++ b/core/new-gui/src/app/app.module.ts
@@ -83,6 +83,8 @@ import { NzCollapseModule } from 'ng-zorro-antd/collapse';
 import { NzToolTipModule } from 'ng-zorro-antd/tooltip';
 import { NzTableModule } from 'ng-zorro-antd/table';
 import { NzModalModule } from 'ng-zorro-antd/modal';
+import { NzResizableModule } from 'ng-zorro-antd/resizable';
+import { NzLayoutModule } from 'ng-zorro-antd/layout';
 
 import { UserService } from './common/service/user/user.service';
 import { NgbdModalUserLoginComponent } from './dashboard/component/top-bar/user-icon/user-login/ngbdmodal-user-login.component';
@@ -187,6 +189,8 @@ registerLocaleData(en);
     NzToolTipModule,
     NzTableModule,
     NzModalModule,
+    NzResizableModule,
+    NzLayoutModule,
     NgxAceModule,
     MatDialogModule,
   ],

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -39,7 +39,7 @@ export class ResultPanelComponent {
   private static readonly PRETTY_JSON_TEXT_LIMIT: number = 50000;
   private static readonly TABLE_COLUMN_TEXT_LIMIT: number = 1000;
 
-  @Output() public resultPanelHeightUpdate = new EventEmitter<number>();
+  @Output() public resultPanelHeightUpdate = new EventEmitter();
   public showResultPanel: boolean = false;
 
   // display error message:
@@ -85,11 +85,11 @@ export class ResultPanelComponent {
           this.workflowActionService.getJointGraphWrapper().highlightOperator(breakpointOperator);
         }
         this.resultPanelToggleService.openResultPanel();
-        this.resultPanelHeightUpdate.emit(250);
+        this.resultPanelHeightUpdate.emit();
       }
       if (event.current.state === ExecutionState.Failed) {
         this.resultPanelToggleService.openResultPanel();
-        this.resultPanelHeightUpdate.emit(250);
+        this.resultPanelHeightUpdate.emit();
       }
       if (event.current.state === ExecutionState.Completed) {
         const sinkOperators = this.workflowActionService.getTexeraGraph().getAllOperators()
@@ -98,7 +98,7 @@ export class ResultPanelComponent {
           this.workflowActionService.getJointGraphWrapper().highlightOperator(sinkOperators[0].operatorID);
         }
         this.resultPanelToggleService.openResultPanel();
-        this.resultPanelHeightUpdate.emit(250);
+        this.resultPanelHeightUpdate.emit();
       }
     });
   }

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -85,11 +85,11 @@ export class ResultPanelComponent {
           this.workflowActionService.getJointGraphWrapper().highlightOperator(breakpointOperator);
         }
         this.resultPanelToggleService.openResultPanel();
-        this.resultPanelHeightUpdate.emit(300);
+        this.resultPanelHeightUpdate.emit(250);
       }
       if (event.current.state === ExecutionState.Failed) {
         this.resultPanelToggleService.openResultPanel();
-        this.resultPanelHeightUpdate.emit(300);
+        this.resultPanelHeightUpdate.emit(250);
       }
       if (event.current.state === ExecutionState.Completed) {
         const sinkOperators = this.workflowActionService.getTexeraGraph().getAllOperators()
@@ -98,7 +98,7 @@ export class ResultPanelComponent {
           this.workflowActionService.getJointGraphWrapper().highlightOperator(sinkOperators[0].operatorID);
         }
         this.resultPanelToggleService.openResultPanel();
-        this.resultPanelHeightUpdate.emit(300);
+        this.resultPanelHeightUpdate.emit(250);
       }
     });
   }

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, EventEmitter, Input, Output } from '@angular/core';
 import { ExecuteWorkflowService } from './../../service/execute-workflow/execute-workflow.service';
 import { Observable } from 'rxjs/Observable';
 
@@ -39,6 +39,7 @@ export class ResultPanelComponent {
   private static readonly PRETTY_JSON_TEXT_LIMIT: number = 50000;
   private static readonly TABLE_COLUMN_TEXT_LIMIT: number = 1000;
 
+  @Output() public resultPanelHeightUpdate = new EventEmitter<number>();
   public showResultPanel: boolean = false;
 
   // display error message:
@@ -84,9 +85,11 @@ export class ResultPanelComponent {
           this.workflowActionService.getJointGraphWrapper().highlightOperator(breakpointOperator);
         }
         this.resultPanelToggleService.openResultPanel();
+        this.resultPanelHeightUpdate.emit(300);
       }
       if (event.current.state === ExecutionState.Failed) {
         this.resultPanelToggleService.openResultPanel();
+        this.resultPanelHeightUpdate.emit(300);
       }
       if (event.current.state === ExecutionState.Completed) {
         const sinkOperators = this.workflowActionService.getTexeraGraph().getAllOperators()
@@ -95,6 +98,7 @@ export class ResultPanelComponent {
           this.workflowActionService.getJointGraphWrapper().highlightOperator(sinkOperators[0].operatorID);
         }
         this.resultPanelToggleService.openResultPanel();
+        this.resultPanelHeightUpdate.emit(300);
       }
     });
   }

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -598,6 +598,12 @@ export class WorkflowEditorComponent implements AfterViewInit {
     this.getJointPaper().setDimensions(elementSize.width, elementSize.height);
   }
 
+  // tslint:disable-next-line:member-ordering
+  public setJointPaperDimensions2(height: number): void {
+    const elementSize = this.getWrapperElementSize();
+    this.getJointPaper().setDimensions(elementSize.width, height);
+    jQuery('#' + this.WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID).height(height);
+  }
 
   /**
    * Handles the event where the Delete button is clicked for an Operator,

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -12,6 +12,7 @@ import '../../../common/rxjs-operators';
 import * as jQuery from 'jquery';
 import * as joint from 'jointjs';
 
+import { NzResizeEvent } from 'ng-zorro-antd/resizable';
 import { ResultPanelToggleService } from '../../service/result-panel-toggle/result-panel-toggle.service';
 import { Point, OperatorPredicate, OperatorLink } from '../../types/workflow-common.interface';
 import { JointGraphWrapper } from '../../service/workflow-graph/model/joint-graph-wrapper';
@@ -591,7 +592,8 @@ export class WorkflowEditorComponent implements AfterViewInit {
   /**
    * Sets the size of the JointJS paper to be the exact size of its wrapper element.
    */
-  private setJointPaperDimensions(): void {
+  // tslint:disable-next-line:member-ordering
+  public setJointPaperDimensions(): void {
     const elementSize = this.getWrapperElementSize();
     this.getJointPaper().setDimensions(elementSize.width, elementSize.height);
   }

--- a/core/new-gui/src/app/workspace/component/workspace.component.html
+++ b/core/new-gui/src/app/workspace/component/workspace.component.html
@@ -1,12 +1,69 @@
-<div [ngClass] = "{'grid-container' : true,
-'texera-workspace' : true,
-'texera-original-workspace-grid-container' : !showResultPanel ,
-'texera-workspace-grid-container' : showResultPanel}">
-  <texera-navigation class="texera-navigation-grid-container grid-container" tourAnchor="texera-navigation-grid-container"></texera-navigation>
-  <texera-operator-panel class="texera-operator-panel-grid-container grid-container" tourAnchor="texera-operator-panel"></texera-operator-panel>
-  <texera-property-editor class="texera-property-editor-grid-container grid-container" tourAnchor="texera-property-editor-grid-container"></texera-property-editor>
-  <texera-workflow-editor class="texera-workflow-editor-grid-container grid-container" tourAnchor="texera-workflow-editor-grid-container"></texera-workflow-editor>
-  <texera-mini-map  class="texera-mini-map"></texera-mini-map>
-  <texera-result-panel-toggle class="texera-result-panel-toggle-grid-container grid-container"></texera-result-panel-toggle>
-  <texera-result-panel class="texera-result-panel-grid-container grid-container" tourAnchor="texera-result-view-grid-container"></texera-result-panel>
-</div>
+<nz-layout>
+  <nz-header>
+    <div class="container_column">
+    <div class="column1">
+    <i class="trigger" nz-icon [nzType]="isLeftCollapsed ? 'menu-unfold' : 'menu-fold'"
+    (click)="isLeftCollapsed = !isLeftCollapsed; onSideCollapse()"></i>
+    </div>
+    <div class="column2">
+    <texera-navigation></texera-navigation>
+    </div>
+    <div class="column3">
+    <i class="trigger" nz-icon [nzType]="isRightCollapsed ? 'menu-fold' : 'menu-unfold'"
+    (click)="isRightCollapsed = !isRightCollapsed; onSideCollapse()"></i>
+    </div>
+    </div>
+  </nz-header>
+  <nz-layout>
+    <nz-sider
+      nzCollapsible [nzCollapsedWidth]="0"
+      [(nzCollapsed)]="isLeftCollapsed" [nzTrigger]="null"
+      (nzCollapsedChange)="onSideCollapse()"
+      [nzWidth]="operator_panel_width"
+      nz-resizable
+      [nzMinWidth]="200" [nzMaxWidth]="300"
+      (nzResize)="onSideResize($event)">
+        <nz-resize-handle nzDirection="right">
+          <div class="sider-resize-line"></div>
+        </nz-resize-handle>
+        <texera-operator-panel class="texera-operator-panel-grid-container grid-container" tourAnchor="texera-operator-panel"></texera-operator-panel>
+    </nz-sider>
+    <nz-content>
+      <div>
+        <texera-workflow-editor class="texera-workflow-editor-grid-container grid-container"></texera-workflow-editor>
+      </div>
+      <div
+        nz-resizable
+        class="resizable-box"
+        [style.height.px]="contentHeight"
+        [nzMaxHeight]="500"
+        [nzMinHeight]="25"
+        (nzResize)="onContentResize($event)">
+        <div class="container_row">
+          <div class="layer1">
+            <nz-resize-handle nzDirection="top">
+              <div class="content-resize-line"></div>
+            </nz-resize-handle>
+            <texera-result-panel-toggle (click)="updateHeight()"></texera-result-panel-toggle>
+          </div>
+          <div class="layer2">
+            <texera-result-panel (resultPanelHeightUpdate) = "getUpdatedHeight($event)"></texera-result-panel>
+          </div>
+        </div>
+      </div>
+    </nz-content>
+    <nz-sider
+      nzCollapsible [nzCollapsedWidth]="0"
+      [(nzCollapsed)]="isRightCollapsed" [nzTrigger]="null"
+      (nzCollapsedChange)="onSideCollapse()"
+      [nzWidth]="property_panel_width"
+      nz-resizable
+      [nzMinWidth]="200" [nzMaxWidth]="300"
+      (nzResize)="onSideResize2($event)">
+      <nz-resize-handle nzDirection="left">
+        <div class="sider-resize-line"></div>
+      </nz-resize-handle>
+      <texera-property-editor></texera-property-editor>
+    </nz-sider>
+  </nz-layout>
+</nz-layout>

--- a/core/new-gui/src/app/workspace/component/workspace.component.html
+++ b/core/new-gui/src/app/workspace/component/workspace.component.html
@@ -30,7 +30,7 @@
     </nz-sider>
     <nz-content>
       <div class = "texera-workflow-container">
-        <texera-workflow-editor class="texera-workflow-editor-grid-container grid-container"></texera-workflow-editor>
+        <texera-workflow-editor [style.height.px]="workflowHeight" class="texera-workflow-editor-grid-container grid-container"></texera-workflow-editor>
         <texera-mini-map class="texera-mini-map"></texera-mini-map>
       </div>
       <div
@@ -48,7 +48,7 @@
             <texera-result-panel-toggle (click)="updateHeight()"></texera-result-panel-toggle>
           </div>
           <div class="layer2">
-            <texera-result-panel (resultPanelHeightUpdate) = "getUpdatedHeight($event)"></texera-result-panel>
+            <texera-result-panel (resultPanelHeightUpdate) = "getUpdatedHeight()"></texera-result-panel>
           </div>
         </div>
       </div>

--- a/core/new-gui/src/app/workspace/component/workspace.component.html
+++ b/core/new-gui/src/app/workspace/component/workspace.component.html
@@ -29,8 +29,9 @@
         <texera-operator-panel class="texera-operator-panel-grid-container grid-container" tourAnchor="texera-operator-panel"></texera-operator-panel>
     </nz-sider>
     <nz-content>
-      <div>
+      <div class = "texera-workflow-container">
         <texera-workflow-editor class="texera-workflow-editor-grid-container grid-container"></texera-workflow-editor>
+        <texera-mini-map class="texera-mini-map"></texera-mini-map>
       </div>
       <div
         nz-resizable

--- a/core/new-gui/src/app/workspace/component/workspace.component.html
+++ b/core/new-gui/src/app/workspace/component/workspace.component.html
@@ -1,23 +1,14 @@
 <nz-layout>
   <nz-header>
-    <div class="container_column">
-    <div class="column1">
-    <i class="trigger" nz-icon [nzType]="isLeftCollapsed ? 'menu-unfold' : 'menu-fold'"
-    (click)="isLeftCollapsed = !isLeftCollapsed; onSideCollapse()"></i>
-    </div>
-    <div class="column2">
+    <div class="header_container">
     <texera-navigation></texera-navigation>
-    </div>
-    <div class="column3">
-    <i class="trigger" nz-icon [nzType]="isRightCollapsed ? 'menu-fold' : 'menu-unfold'"
-    (click)="isRightCollapsed = !isRightCollapsed; onSideCollapse()"></i>
-    </div>
     </div>
   </nz-header>
   <nz-layout>
     <nz-sider
+      [nzTheme] = "'light'"
       nzCollapsible [nzCollapsedWidth]="0"
-      [(nzCollapsed)]="isLeftCollapsed" [nzTrigger]="null"
+      [(nzCollapsed)]="isLeftCollapsed"
       (nzCollapsedChange)="onSideCollapse()"
       [nzWidth]="operator_panel_width"
       nz-resizable
@@ -54,8 +45,10 @@
       </div>
     </nz-content>
     <nz-sider
+      [nzTheme] = "'light'"
+      [nzReverseArrow] = "true"
       nzCollapsible [nzCollapsedWidth]="0"
-      [(nzCollapsed)]="isRightCollapsed" [nzTrigger]="null"
+      [(nzCollapsed)]="isRightCollapsed"
       (nzCollapsedChange)="onSideCollapse()"
       [nzWidth]="property_panel_width"
       nz-resizable

--- a/core/new-gui/src/app/workspace/component/workspace.component.scss
+++ b/core/new-gui/src/app/workspace/component/workspace.component.scss
@@ -202,6 +202,9 @@
   overflow: auto;
 }
 
+.texera-workflow-container{
+  position: relative;
+}
 
 /**
 * this style specifies that the workflow editor in the middle
@@ -213,8 +216,9 @@
 }
 
 .texera-mini-map {
-  grid-column: 2/3;
-  grid-row: 2/4;
+  position: absolute;
+  height: 100%;
+  width: 100%;
 }
 
 /**

--- a/core/new-gui/src/app/workspace/component/workspace.component.scss
+++ b/core/new-gui/src/app/workspace/component/workspace.component.scss
@@ -36,7 +36,7 @@
     flex-direction: column;
     background: #fff;
     color: black;
-    height: calc(100vh - #{$header-height} - 1vh);
+    height: calc(99vh - #{$header-height});
   }
 
   nz-content > div {
@@ -47,9 +47,6 @@
 
   nz-content .resizable-box {
     flex: none;
-    z-index: 1;
-    overflow: scroll;
-    text-align: center;
   }
 
   nz-content,
@@ -72,9 +69,6 @@
 
   .container_row{
     display: grid;
-    grid-template-rows:
-                        $resultbar-height
-                        calc((100vh - #{$resultbar-height}));
     position: relative;
     width: 100%;
   }
@@ -82,14 +76,17 @@
   .layer1{
     position: fixed;
     width: 100%;
+    height: 25px;
     left: -0.1%;
     grid-row: 1/2;
     z-index: 1;
   }
 
   .layer2{
-    grid-row: 2/3;
+    grid-row: 1/2;
+    margin-top: 25px;
     z-index: 0;
+    overflow-y: scroll;
   }
 
   .trigger {

--- a/core/new-gui/src/app/workspace/component/workspace.component.scss
+++ b/core/new-gui/src/app/workspace/component/workspace.component.scss
@@ -219,6 +219,7 @@
   position: absolute;
   height: 100%;
   width: 100%;
+  pointer-events: none;
 }
 
 /**

--- a/core/new-gui/src/app/workspace/component/workspace.component.scss
+++ b/core/new-gui/src/app/workspace/component/workspace.component.scss
@@ -1,4 +1,4 @@
-    $header-height: 55px;
+    $header-height: 64px;
     $resultbar-height: 25px;
   nz-header {
     background: #fff;
@@ -10,6 +10,10 @@
     display: grid;
     grid-template-columns: 4% 92% 4%;
     position: relative;
+
+    &>div{
+      height: #{$header-height};
+    }
   }
   .column1{
     grid-column: 1/2;

--- a/core/new-gui/src/app/workspace/component/workspace.component.scss
+++ b/core/new-gui/src/app/workspace/component/workspace.component.scss
@@ -1,3 +1,106 @@
+    $header-height: 55px;
+    $resultbar-height: 25px;
+  nz-header {
+    background: #fff;
+    color: #fff;
+  }
+  .container_column{
+    width: 100%;
+    height: #{$header-height};
+    display: grid;
+    grid-template-columns: 4% 92% 4%;
+    position: relative;
+  }
+  .column1{
+    grid-column: 1/2;
+  }
+  .column2{
+    grid-column: 2/3;
+  }
+  .column3{
+    grid-column: 3/4;
+  }
+
+  nz-sider {
+    background: #fff;
+    color: #fff;
+    z-index: 2;
+  }
+
+  nz-sider.nz-resizable-resizing {
+    transition: none;
+  }
+
+  nz-content {
+    display: flex;
+    flex-direction: column;
+    background: #fff;
+    color: black;
+    height: calc(100vh - #{$header-height} - 1vh);
+  }
+
+  nz-content > div {
+    display: flex;
+    width: 100%;
+    flex: 1;
+  }
+
+  nz-content .resizable-box {
+    flex: none;
+    z-index: 1;
+    overflow: scroll;
+    text-align: center;
+  }
+
+  nz-content,
+  nz-header,
+  ::ng-deep nz-sider > .ant-layout-sider-children {
+    display: flex;
+  }
+
+  .sider-resize-line {
+    height: 100%;
+    width: 5px;
+    border-right: 1px solid #e8e8e8;
+  }
+
+  .content-resize-line {
+    width: 100%;
+    height: 5px;
+    border-bottom: 1px solid #e8e8e8;
+  }
+
+  .container_row{
+    display: grid;
+    grid-template-rows:
+                        $resultbar-height
+                        calc((100vh - #{$resultbar-height}));
+    position: relative;
+  }
+
+  .layer1{
+    position:fixed;
+    width: 75%;
+    grid-row: 1/2;
+    z-index: 1;
+  }
+  .layer2{
+    grid-row: 2/3;
+    z-index: 0;
+  }
+
+  .trigger {
+    color: black;
+    font-size: 18px;
+    line-height: 64px;
+    padding: 0 24px;
+    cursor: pointer;
+    transition: color 0.3s;
+  }
+
+  .trigger:hover {
+    color: #1890ff;
+  }
 /**
   * this css forces the texera user-interface
   * to cover the entire browser window

--- a/core/new-gui/src/app/workspace/component/workspace.component.scss
+++ b/core/new-gui/src/app/workspace/component/workspace.component.scss
@@ -76,14 +76,17 @@
                         $resultbar-height
                         calc((100vh - #{$resultbar-height}));
     position: relative;
+    width: 100%;
   }
 
   .layer1{
-    position:fixed;
-    width: 75%;
+    position: fixed;
+    width: 100%;
+    left: -0.1%;
     grid-row: 1/2;
     z-index: 1;
   }
+
   .layer2{
     grid-row: 2/3;
     z-index: 0;

--- a/core/new-gui/src/app/workspace/component/workspace.component.scss
+++ b/core/new-gui/src/app/workspace/component/workspace.component.scss
@@ -29,6 +29,7 @@
     background: #fff;
     color: #fff;
     z-index: 2;
+    height: 100vh;
   }
 
   nz-sider.nz-resizable-resizing {

--- a/core/new-gui/src/app/workspace/component/workspace.component.scss
+++ b/core/new-gui/src/app/workspace/component/workspace.component.scss
@@ -4,25 +4,10 @@
     background: #fff;
     color: #fff;
   }
-  .container_column{
+  .header_container{
     width: 100%;
     height: #{$header-height};
-    display: grid;
-    grid-template-columns: 4% 92% 4%;
     position: relative;
-
-    &>div{
-      height: #{$header-height};
-    }
-  }
-  .column1{
-    grid-column: 1/2;
-  }
-  .column2{
-    grid-column: 2/3;
-  }
-  .column3{
-    grid-column: 3/4;
   }
 
   nz-sider {

--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -46,13 +46,15 @@ import { WorkflowEditorComponent } from './workflow-editor/workflow-editor.compo
 export class WorkspaceComponent {
 
   public showResultPanel: boolean = false;
-  operator_panel_width = 200;
-  property_panel_width = 200;
-  contentHeight = 25;
+  operator_panel_width: number = window.innerWidth * 0.14;
+  property_panel_width: number = window.innerWidth * 0.16;
+  contentHeight: number = 25;
+  workflowHeight: number = window.innerHeight - 90;
+  header: number = 64;
   previousHeight: number = 25;
   id = -1;
-  isLeftCollapsed = false;
-  isRightCollapsed = false;
+  isLeftCollapsed: boolean = false;
+  isRightCollapsed: boolean = false;
   @ViewChild(WorkflowEditorComponent)
   workflowComponent!: WorkflowEditorComponent;
 
@@ -99,7 +101,8 @@ export class WorkspaceComponent {
       this.id = requestAnimationFrame(() => {
         this.contentHeight = height!;
         this.previousHeight = this.contentHeight;
-        this.workflowComponent.setJointPaperDimensions();
+        this.workflowHeight = window.innerHeight - this.contentHeight - this.header;
+        this.workflowComponent.setJointPaperDimensions2(this.workflowHeight);
       });
     }
 
@@ -112,16 +115,20 @@ export class WorkspaceComponent {
           this.contentHeight = this.previousHeight;
         } else {
           // default height
-          this.contentHeight = 250;
+          this.contentHeight = (window.innerHeight - this.header) * 0.35;
         }
       }
+      this.workflowHeight = window.innerHeight - this.contentHeight - this.header;
+      this.workflowComponent.setJointPaperDimensions2(this.workflowHeight);
     }
 
-    getUpdatedHeight(val: number) {
+    getUpdatedHeight() {
       if (this.previousHeight !== 25) {
         this.contentHeight = this.previousHeight;
       } else {
-        this.contentHeight = val;
+        this.contentHeight = (window.innerHeight - this.header) * 0.35;
       }
+      this.workflowHeight = window.innerHeight - this.contentHeight - this.header;
+      this.workflowComponent.setJointPaperDimensions2(this.workflowHeight);
     }
 }

--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -112,7 +112,7 @@ export class WorkspaceComponent {
           this.contentHeight = this.previousHeight;
         } else {
           // default height
-          this.contentHeight = 300;
+          this.contentHeight = 250;
         }
       }
     }

--- a/core/new-gui/src/theme.less
+++ b/core/new-gui/src/theme.less
@@ -1,4 +1,5 @@
 @import "~ng-zorro-antd/ng-zorro-antd.less";
+@import "~ng-zorro-antd/resizable/style/entry.less";
 @theme: default;
 
 // The prefix to use on all css classes from ant.


### PR DESCRIPTION
1. Enable resize of operator panel, property panel, and workflow-editor. 
Change layout from grid to flex, mainly using nz-layout.
Take reference to [NzResizableModule](https://ng.ant.design/experimental/resizable/en).
![resize](https://user-images.githubusercontent.com/24601423/99763405-a2913200-2aaf-11eb-86e3-d5ba91aa4905.gif)
![resize2](https://user-images.githubusercontent.com/24601423/99763252-3adae700-2aaf-11eb-8b1b-88297281bd3d.gif)

2. Add toggle to operator panel and property panel.
Use `nzCollapsible` feature of nz-sider component.
![toggle](https://user-images.githubusercontent.com/24601423/99763467-cb192c00-2aaf-11eb-94bf-4662c4bfd2e4.gif)
