### PR TITLE
Add serialization config for Amber throwable

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberUtils.scala
@@ -35,6 +35,7 @@ object AmberUtils {
         akka.remote.artery.canonical.port = 2552
         akka.remote.artery.canonical.hostname = $localIpAddress
         akka.cluster.seed-nodes = [ "akka.tcp://Amber@$localIpAddress:2552" ]
+        akka.actor.serialization-bindings."java.lang.Throwable" = akka-misc
         """)
       .withFallback(ConfigFactory.load("clustered"))
 
@@ -52,6 +53,7 @@ object AmberUtils {
         akka.remote.netty.tcp.hostname = $localIpAddress
         akka.remote.artery.canonical.hostname = $localIpAddress
         akka.cluster.seed-nodes = [ "akka.tcp://Amber@$addr:2552" ]
+        akka.actor.serialization-bindings."java.lang.Throwable" = akka-misc
         """)
       .withFallback(ConfigFactory.load("clustered"))
     val system = ActorSystem("Amber", config)


### PR DESCRIPTION
Amber have issues when the worker throws an AmberException. We get a serialization exception instead of seeing the exception itself, which makes debugging very difficult. This PR changes the serialization config so that the exceptions can be properly serialized. 