### PR TITLE
[BUGFIX] fix generator breakpoint trigger issue

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/breakpoint/localbreakpoint/ExceptionBreakpoint.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/breakpoint/localbreakpoint/ExceptionBreakpoint.scala
@@ -8,7 +8,7 @@ class ExceptionBreakpoint()(implicit id: String, version: Long)
     //empty
   }
 
-  override def isTriggered: Boolean = triggeredTuple != null
+  override def isTriggered: Boolean = error != null
 
   override def isDirty: Boolean = isTriggered
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/common/FaultedTupleFrontend.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/common/FaultedTupleFrontend.scala
@@ -6,7 +6,12 @@ import edu.uci.ics.amber.engine.common.tuple.amber.AmberTuple
 object FaultedTupleFrontend {
   def apply(faultedTuple: FaultedTuple): FaultedTupleFrontend = {
     val tuple = faultedTuple.tuple
-    val tupleList = faultedTuple.tuple.toArray().filter(v => v != null).map(v => v.toString).toList
+    val tupleList =
+      if(tuple != null){
+        tuple.toArray().filter(v => v != null).map(v => v.toString).toList
+      }else{
+        List.empty
+      }
     FaultedTupleFrontend(tupleList, faultedTuple.id, faultedTuple.isInput)
   }
 }


### PR DESCRIPTION
There is a bug in the trigger detection of exception breakpoints. An exception breakpoint triggers if there is a faulted tuple in the breakpoint. However, a generator cannot assign the faulted tuple properly if an exception is thrown during the processing of creating a tuple. Failure of assign faulted tuple will also cause the failure of breakpoint trigger detection. Our engine will finally crash in an inconsistent state. i.e. No breakpoint triggered but the worker is in a breakpoint triggered state. 

This PR changes the trigger detection logic for exception breakpoints.