### PR TITLE
Change default operator executor config from followPrevious to useAll

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OneToOneOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OneToOneOpExecConfig.scala
@@ -4,7 +4,7 @@ import akka.actor.ActorRef
 import akka.event.LoggingAdapter
 import akka.util.Timeout
 import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.GlobalBreakpoint
-import edu.uci.ics.amber.engine.architecture.deploysemantics.deploymentfilter.FollowPrevious
+import edu.uci.ics.amber.engine.architecture.deploysemantics.deploymentfilter.{FollowPrevious, UseAll}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.deploystrategy.RoundRobinDeployment
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{ActorLayer, ProcessorWorkerLayer}
 import edu.uci.ics.amber.engine.architecture.worker.WorkerState
@@ -25,7 +25,7 @@ class OneToOneOpExecConfig(override val tag: OperatorIdentifier, val opExec: Int
           LayerTag(tag, "main"),
           opExec,
           Constants.defaultNumWorkers,
-          FollowPrevious(),
+          UseAll(),
           RoundRobinDeployment()
         )
       ),


### PR DESCRIPTION
This PR change default operator executor config's deployment strategy from `followPrevious()` to `useAll()`.

- `followPrevious()` deployment strategy means this operator will use the same strategy as its previous operator.
- `useAll()` deployment strategy means this operator will always use all the workers on all machines

The reason for the change is the introduction of `MySQLSource` operator. `MySQLSource` operator's deployment strategy is only use one worker on one machine, because it cannot do parallel read on multiple machines. Using `followPrevious` will cause all the operators to only use one worker on one machine, which is not desirable. Using `useAll` is desriable because all operators after `MySQLSource` will still be parallel.