### PR TITLE
fix the wrong websocket URL

### DIFF
--- a/core/new-gui/src/app/workspace/service/workflow-websocket/workflow-websocket.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-websocket/workflow-websocket.service.ts
@@ -39,7 +39,7 @@ export class WorkflowWebsocketService {
   }
 
   public static getWorkflowWebsocketUrl(): string {
-    const websocketUrl = new URL(WorkflowWebsocketService.TEXERA_WEBSOCKET_ENDPOINT, window.location.href);
+    const websocketUrl = new URL(WorkflowWebsocketService.TEXERA_WEBSOCKET_ENDPOINT, window.location.origin);
     // replace protocol, so that http -> ws, https -> wss
     websocketUrl.protocol = websocketUrl.protocol.replace('http', 'ws');
     return websocketUrl.toString();


### PR DESCRIPTION
Previously the WebSocket URL depends on the `window.location.href`. It is the current URL in the browser. When the workspace is requested by some other URLs, e.g., `/workflow/:id`, it is no longer relevant to use this as part of WebSocket URL.

Thus this changes  `window.location.href` to  `window.location.origin` to temporarily fix the issue. 