### PR TITLE
[BUGFIX] fix incorrect pause logic in worker

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Generator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Generator.scala
@@ -95,7 +95,7 @@ class Generator(var operator: IOperatorExecutor, val tag: WorkerTag)
     // if dp thread is blocking on waiting for input tuples:
     if (workerInternalQueue.blockingDeque.isEmpty && tupleInput.isCurrentBatchExhausted) {
       // insert dummy batch to unblock dp thread
-      workerInternalQueue.addBatch(null)
+      workerInternalQueue.addDummyBatch()
     }
     pauseManager.waitForDPThread()
     onPaused()
@@ -110,7 +110,7 @@ class Generator(var operator: IOperatorExecutor, val tag: WorkerTag)
 
   override def onStart(): Unit = {
     super.onStart()
-    workerInternalQueue.addBatch((LayerTag("", "", ""), null))
+    workerInternalQueue.addEndBatch(LayerTag("", "", ""))
     context.become(running)
     unstashAll()
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Generator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Generator.scala
@@ -95,7 +95,7 @@ class Generator(var operator: IOperatorExecutor, val tag: WorkerTag)
     // if dp thread is blocking on waiting for input tuples:
     if (workerInternalQueue.blockingDeque.isEmpty && tupleInput.isCurrentBatchExhausted) {
       // insert dummy batch to unblock dp thread
-      workerInternalQueue.addDummyBatch()
+      workerInternalQueue.addDummyInput()
     }
     pauseManager.waitForDPThread()
     onPaused()
@@ -110,7 +110,7 @@ class Generator(var operator: IOperatorExecutor, val tag: WorkerTag)
 
   override def onStart(): Unit = {
     super.onStart()
-    workerInternalQueue.addEndBatch(LayerTag("", "", ""))
+    workerInternalQueue.addEndMarker(LayerTag("", "", ""))
     context.become(running)
     unstashAll()
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
@@ -143,7 +143,7 @@ class Processor(var operator: IOperatorExecutor, val tag: WorkerTag) extends Wor
   def onSaveEndSending(seq: Long): Unit = {
     if (input.registerEnd(sender, seq)) {
       val currentEdge: LayerTag = input.actorToEdge(sender)
-      workerInternalQueue.addEndBatch(currentEdge)
+      workerInternalQueue.addEndMarker(currentEdge)
     }
   }
 
@@ -175,7 +175,7 @@ class Processor(var operator: IOperatorExecutor, val tag: WorkerTag) extends Wor
     // if dp thread is blocking on waiting for input tuples:
     if (workerInternalQueue.blockingDeque.isEmpty && tupleInput.isCurrentBatchExhausted) {
       // insert dummy batch to unblock dp thread
-      workerInternalQueue.addDummyBatch()
+      workerInternalQueue.addDummyInput()
     }
     pauseManager.waitForDPThread()
     onPaused()

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
@@ -133,7 +133,7 @@ class Processor(var operator: IOperatorExecutor, val tag: WorkerTag) extends Wor
     val currentEdge = input.actorToEdge(sender)
 
     while (messagingManager.hasNextDataBatch()) {
-      workerInternalQueue.addDataBatch(currentEdge, messagingManager.getNextDataBatch())
+      workerInternalQueue.addDataPayload(currentEdge, messagingManager.getNextDataBatch())
     }
   }
 
@@ -153,7 +153,7 @@ class Processor(var operator: IOperatorExecutor, val tag: WorkerTag) extends Wor
     val currentEdge = input.actorToEdge(sender)
 
     while (messagingManager.hasNextDataBatch()) {
-      workerInternalQueue.addDataBatch(currentEdge, messagingManager.getNextDataBatch())
+      workerInternalQueue.addDataPayload(currentEdge, messagingManager.getNextDataBatch())
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
@@ -135,7 +135,7 @@ class Processor(var operator: IOperatorExecutor, val tag: WorkerTag) extends Wor
       case Some(batches) =>
         val currentEdge = input.actorToEdge(sender)
         for (i <- batches)
-          workerInternalQueue.addBatch((currentEdge, i))
+          workerInternalQueue.addDataBatch((currentEdge, i))
       case None =>
     }
   }
@@ -143,7 +143,7 @@ class Processor(var operator: IOperatorExecutor, val tag: WorkerTag) extends Wor
   def onSaveEndSending(seq: Long): Unit = {
     if (input.registerEnd(sender, seq)) {
       val currentEdge: LayerTag = input.actorToEdge(sender)
-      workerInternalQueue.addBatch((currentEdge, null))
+      workerInternalQueue.addEndBatch(currentEdge)
     }
   }
 
@@ -156,7 +156,7 @@ class Processor(var operator: IOperatorExecutor, val tag: WorkerTag) extends Wor
       case Some(batches) =>
         val currentEdge = input.actorToEdge(sender)
         for (i <- batches)
-          workerInternalQueue.addBatch((currentEdge, i))
+          workerInternalQueue.addDataBatch((currentEdge, i))
       case None =>
     }
   }
@@ -175,7 +175,7 @@ class Processor(var operator: IOperatorExecutor, val tag: WorkerTag) extends Wor
     // if dp thread is blocking on waiting for input tuples:
     if (workerInternalQueue.blockingDeque.isEmpty && tupleInput.isCurrentBatchExhausted) {
       // insert dummy batch to unblock dp thread
-      workerInternalQueue.addBatch(null)
+      workerInternalQueue.addDummyBatch()
     }
     pauseManager.waitForDPThread()
     onPaused()

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/BatchToTupleConverter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/BatchToTupleConverter.scala
@@ -1,13 +1,20 @@
 package edu.uci.ics.amber.engine.architecture.worker.neo
 
+import edu.uci.ics.amber.engine.architecture.worker.neo.WorkerInternalQueue.{
+  DataEvent,
+  DataPayload,
+  DummyPayload,
+  EndPayload
+}
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 
 class BatchToTupleConverter(internalQueue: WorkerInternalQueue) {
 
   // save current batch related information
-  private var currentBatch: (Int, Array[ITuple]) = _
-  private var currentTupleIndex = 0
+  private var currentBatch: DataEvent = _
+  private var currentInput = 0
+  private var exhaustedFlag = true
 
   // indicate if all upstreams exhausted
   private var allExhausted = false
@@ -18,34 +25,33 @@ class BatchToTupleConverter(internalQueue: WorkerInternalQueue) {
     * @return tuple
     */
   def getNextInputTuple: Either[ITuple, InputExhausted] = {
-    // increment cursor
-    currentTupleIndex += 1
     // if batch is unavailable, take one from batchInput and reset cursor
     if (isCurrentBatchExhausted) {
       currentBatch = internalQueue.blockingDeque.take()
-      currentTupleIndex = 0
     }
     // if the batch is dummy batch inserted by worker, return null to unblock dp thread
-    if (currentBatch == null) {
-      return null
-    }
-    // if current batch is a data batch, return tuple
-    if (currentBatch._2 != null) {
-      Left(currentBatch._2(currentTupleIndex))
-    } else {
-      // current batch is an End of Data sign.
-      inputExhaustedCount += 1
-      // check if End of Data sign from every upstream has been received
-      allExhausted = internalQueue.inputMap.size == inputExhaustedCount
-      // return InputExhausted
-      Right(InputExhausted())
+    currentBatch match {
+      case DataPayload(input, tuples) =>
+        // if current batch is a data batch, return tuple
+        currentInput = input
+        // empty iterators will be filtered in WorkerInternalQueue so we can safely call next()
+        Left(tuples.next())
+      case EndPayload(input) =>
+        // current batch is an End of Data sign.
+        inputExhaustedCount += 1
+        // check if End of Data sign from every upstream has been received
+        allExhausted = internalQueue.inputMap.size == inputExhaustedCount
+        currentInput = input
+        Right(InputExhausted())
+      case DummyPayload() =>
+        null
     }
   }
 
-  def getCurrentInput: Int = currentTupleIndex
+  def getCurrentInput: Int = currentInput
 
   def isAllUpstreamsExhausted: Boolean = allExhausted
 
   def isCurrentBatchExhausted: Boolean =
-    currentBatch == null || currentTupleIndex >= currentBatch._2.length
+    currentBatch == null || currentBatch.isExhausted
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/BatchToTupleConverter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/BatchToTupleConverter.scala
@@ -29,7 +29,6 @@ class BatchToTupleConverter(internalQueue: WorkerInternalQueue) {
     if (isCurrentBatchExhausted) {
       currentBatch = internalQueue.blockingDeque.take()
     }
-    // if the batch is dummy batch inserted by worker, return null to unblock dp thread
     currentBatch match {
       case DataPayload(input, tuples) =>
         // if current batch is a data batch, return tuple
@@ -44,6 +43,7 @@ class BatchToTupleConverter(internalQueue: WorkerInternalQueue) {
         currentInput = input
         Right(InputExhausted())
       case DummyPayload() =>
+        // if the batch is dummy batch inserted by worker, return null to unblock dp thread
         null
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/BatchToTupleConverter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/BatchToTupleConverter.scala
@@ -1,10 +1,10 @@
 package edu.uci.ics.amber.engine.architecture.worker.neo
 
 import edu.uci.ics.amber.engine.architecture.worker.neo.WorkerInternalQueue.{
-  DataBatch,
   DataPayload,
-  DummyPayload,
-  EndPayload
+  DummyInput,
+  EndMarker,
+  InternalQueueElement
 }
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.tuple.ITuple
@@ -12,9 +12,9 @@ import edu.uci.ics.amber.engine.common.tuple.ITuple
 class BatchToTupleConverter(internalQueue: WorkerInternalQueue) {
 
   // save current batch related information
-  private var currentBatch: DataBatch = _
+  private var currentBatch: InternalQueueElement = _
+  // what input is the tuple coming from
   private var currentInput = 0
-  private var exhaustedFlag = true
 
   // indicate if all upstreams exhausted
   private var allExhausted = false
@@ -35,14 +35,14 @@ class BatchToTupleConverter(internalQueue: WorkerInternalQueue) {
         currentInput = input
         // empty iterators will be filtered in WorkerInternalQueue so we can safely call next()
         Left(tuples.next())
-      case EndPayload(input) =>
+      case EndMarker(input) =>
         // current batch is an End of Data sign.
         inputExhaustedCount += 1
         // check if End of Data sign from every upstream has been received
         allExhausted = internalQueue.inputMap.size == inputExhaustedCount
         currentInput = input
         Right(InputExhausted())
-      case DummyPayload() =>
+      case DummyInput() =>
         // if the batch is dummy batch inserted by worker, return null to unblock dp thread
         null
     }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/BatchToTupleConverter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/BatchToTupleConverter.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.amber.engine.architecture.worker.neo
 
 import edu.uci.ics.amber.engine.architecture.worker.neo.WorkerInternalQueue.{
-  DataEvent,
+  DataBatch,
   DataPayload,
   DummyPayload,
   EndPayload
@@ -12,7 +12,7 @@ import edu.uci.ics.amber.engine.common.tuple.ITuple
 class BatchToTupleConverter(internalQueue: WorkerInternalQueue) {
 
   // save current batch related information
-  private var currentBatch: DataEvent = _
+  private var currentBatch: DataBatch = _
   private var currentInput = 0
   private var exhaustedFlag = true
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/PauseManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/PauseManager.scala
@@ -15,6 +15,7 @@ class PauseManager {
   // current pause privilege level
   private val pausePrivilegeLevel = new AtomicInteger(PauseManager.NoPause)
   // yielded control of the dp thread
+  // volatile is necessary otherwise main thread cannot notice the change
   @volatile
   private var currentFuture: CompletableFuture[Void] = _
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/PauseManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/PauseManager.scala
@@ -15,6 +15,7 @@ class PauseManager {
   // current pause privilege level
   private val pausePrivilegeLevel = new AtomicInteger(PauseManager.NoPause)
   // yielded control of the dp thread
+  @volatile
   private var currentFuture: CompletableFuture[Void] = _
 
   /** pause functionality

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/PauseManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/PauseManager.scala
@@ -15,7 +15,8 @@ class PauseManager {
   // current pause privilege level
   private val pausePrivilegeLevel = new AtomicInteger(PauseManager.NoPause)
   // yielded control of the dp thread
-  // volatile is necessary otherwise main thread cannot notice the change
+  // volatile is necessary otherwise main thread cannot notice the change.
+  // volatile means read/writes are through memory rather than CPU cache
   @volatile
   private var currentFuture: CompletableFuture[Void] = _
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/WorkerInternalQueue.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/WorkerInternalQueue.scala
@@ -18,7 +18,12 @@ object WorkerInternalQueue {
     // indicate if the batch is exhausted so dp thread can fetch the next batch
     def isExhausted: Boolean
   }
-  // data batch with the input as a number and an iterator of tuples (guaranteed to be non-empty)
+
+  /**
+    * Data Payload is 'input identifier + data batch'
+    * @param input
+    * @param tuples
+    */
   case class DataPayload(input: Int, tuples: Iterator[ITuple]) extends InternalQueueElement {
     // when the iterator has no next, it's exhausted.
     // Note: since the iterator is guaranteed to be non-empty,
@@ -29,6 +34,12 @@ object WorkerInternalQueue {
     // this will only be used once so it's always exhausted
     override def isExhausted: Boolean = true
   }
+
+  /**
+    * Used to unblock the dp thread when pause arrives but
+    * dp thread is blocked waiting for the next element in the
+    * worker-internal-queue
+    */
   case class DummyInput() extends InternalQueueElement {
     // this will only be used once so it's always exhausted
     override def isExhausted: Boolean = true
@@ -48,7 +59,7 @@ class WorkerInternalQueue {
   /** take one FIFO batch from worker actor then put into the queue.
     * @param batch
     */
-  def addDataBatch(batch: (LayerTag, Array[ITuple])): Unit = {
+  def addDataPayload(batch: (LayerTag, Array[ITuple])): Unit = {
     if (batch == null || batch._2.isEmpty) {
       // also filter out the batch with no tuple here
       return

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/WorkerInternalQueue.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/WorkerInternalQueue.scala
@@ -2,16 +2,37 @@ package edu.uci.ics.amber.engine.architecture.worker.neo
 
 import java.util.concurrent.LinkedBlockingDeque
 
+import edu.uci.ics.amber.engine.architecture.worker.neo.WorkerInternalQueue.{
+  DataEvent,
+  DataPayload,
+  DummyPayload,
+  EndPayload
+}
 import edu.uci.ics.amber.engine.common.ambertag.LayerTag
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 
 import scala.collection.mutable
 
+object WorkerInternalQueue {
+  trait DataEvent {
+    def isExhausted: Boolean
+  }
+  case class DataPayload(input: Int, tuples: Iterator[ITuple]) extends DataEvent {
+    override def isExhausted: Boolean = !tuples.hasNext
+  }
+  case class EndPayload(input: Int) extends DataEvent {
+    override def isExhausted: Boolean = true
+  }
+  case class DummyPayload() extends DataEvent {
+    override def isExhausted: Boolean = true
+  }
+}
+
 class WorkerInternalQueue {
   // blocking deque for batches:
   // main thread put batches into this queue
   // tuple input (dp thread) take batches from this queue
-  var blockingDeque = new LinkedBlockingDeque[(Int, Array[ITuple])]
+  var blockingDeque = new LinkedBlockingDeque[DataEvent]
 
   // map from layerTag to input number
   // TODO: we also need to refactor all identifiers
@@ -20,7 +41,21 @@ class WorkerInternalQueue {
   /** take one FIFO batch from worker actor then put into the queue.
     * @param batch
     */
-  def addBatch(batch: (LayerTag, Array[ITuple])): Unit = {
-    blockingDeque.add((inputMap(batch._1), batch._2))
+  def addDataBatch(batch: (LayerTag, Array[ITuple])): Unit = {
+    if (batch == null || batch._2.isEmpty) {
+      return
+    }
+    blockingDeque.add(DataPayload(inputMap(batch._1), batch._2.iterator))
+  }
+
+  def addEndBatch(layer: LayerTag): Unit = {
+    if (layer == null) {
+      return
+    }
+    blockingDeque.add(EndPayload(inputMap(layer)))
+  }
+
+  def addDummyBatch(): Unit = {
+    blockingDeque.add(DummyPayload())
   }
 }


### PR DESCRIPTION
This PR:

1. fix the issue that the workflow cannot be paused during the execution. It was caused by the `null` usage and also missing `volatile` keyword on `currentFuture`.
2. reduce the ambiguous `null` usages in the internal queue by identifying 3 types of batches: 1)data batch 2) end-identifier batch 3) dummy batch.