### PR TITLE
Introducing Privileges to Pause Feature 

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Generator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Generator.scala
@@ -3,6 +3,7 @@ package edu.uci.ics.amber.engine.architecture.worker
 import akka.actor.{ActorLogging, Props, Stash}
 import edu.uci.ics.amber.engine.architecture.breakpoint.FaultedTuple
 import edu.uci.ics.amber.engine.architecture.worker.neo.PauseManager
+import edu.uci.ics.amber.engine.architecture.worker.neo.PauseManager.PauseLevel
 import edu.uci.ics.amber.engine.common.ambermessage.ControlMessage._
 import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage._
 import edu.uci.ics.amber.engine.common.ambertag.{LayerTag, WorkerTag}
@@ -44,7 +45,7 @@ class Generator(var operator: IOperatorExecutor, val tag: WorkerTag)
 
   override def onResuming(): Unit = {
     super.onResuming()
-    pauseManager.resume()
+    pauseManager.resume(PauseLevel.User)
   }
 
   override def onCompleted(): Unit = {
@@ -91,7 +92,7 @@ class Generator(var operator: IOperatorExecutor, val tag: WorkerTag)
 
   override def onPausing(): Unit = {
     super.onPausing()
-    pauseManager.pause()
+    pauseManager.pause(PauseLevel.User)
     // if dp thread is blocking on waiting for input tuples:
     if (workerInternalQueue.blockingDeque.isEmpty && tupleInput.isCurrentBatchExhausted) {
       // insert dummy batch to unblock dp thread

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
@@ -4,6 +4,7 @@ import akka.actor.Props
 import edu.uci.ics.amber.engine.architecture.breakpoint.FaultedTuple
 import edu.uci.ics.amber.engine.architecture.receivesemantics.FIFOAccessPort
 import edu.uci.ics.amber.engine.architecture.worker.neo.PauseManager
+import edu.uci.ics.amber.engine.architecture.worker.neo.PauseManager.PauseLevel
 import edu.uci.ics.amber.engine.common.amberexception.AmberException
 import edu.uci.ics.amber.engine.common.ambermessage.ControlMessage.{QueryState, _}
 import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage._
@@ -55,7 +56,7 @@ class Processor(var operator: IOperatorExecutor, val tag: WorkerTag) extends Wor
 
   override def onResuming(): Unit = {
     super.onResuming()
-    pauseManager.resume()
+    pauseManager.resume(PauseLevel.User)
   }
 
   override def onSkipTuple(faultedTuple: FaultedTuple): Unit = {
@@ -167,7 +168,7 @@ class Processor(var operator: IOperatorExecutor, val tag: WorkerTag) extends Wor
 
   override def onPausing(): Unit = {
     super.onPausing()
-    pauseManager.pause()
+    pauseManager.pause(PauseLevel.User)
     // if dp thread is blocking on waiting for input tuples:
     if (workerInternalQueue.blockingDeque.isEmpty && tupleInput.isCurrentBatchExhausted) {
       // insert dummy batch to unblock dp thread

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/DataProcessor.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.Executors
 import akka.actor.ActorRef
 import edu.uci.ics.amber.engine.architecture.breakpoint.localbreakpoint.ExceptionBreakpoint
 import edu.uci.ics.amber.engine.architecture.worker.BreakpointSupport
+import edu.uci.ics.amber.engine.architecture.worker.neo.PauseManager.PauseLevel
 import edu.uci.ics.amber.engine.common.amberexception.BreakpointException
 import edu.uci.ics.amber.engine.common.ambermessage.ControlMessage.LocalBreakpointTriggered
 import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.ExecutionCompleted
@@ -86,7 +87,7 @@ class DataProcessor( // dependencies:
         tupleOutput.transferTuple(outputTuple, outputTupleCount)
       } catch {
         case bp: BreakpointException =>
-          pauseManager.pause()
+          pauseManager.pause(PauseLevel.System)
           self ! LocalBreakpointTriggered // TODO: apply FIFO & exactly-once protocol here
         case e: Exception =>
           handleOperatorException(e, isInput = false)
@@ -139,7 +140,7 @@ class DataProcessor( // dependencies:
   }
 
   private[this] def handleOperatorException(e: Exception, isInput: Boolean): Unit = {
-    pauseManager.pause()
+    pauseManager.pause(PauseLevel.System)
     assignExceptionBreakpoint(currentInputTuple.left.getOrElse(null), e, isInput)
     self ! LocalBreakpointTriggered // TODO: apply FIFO & exactly-once protocol here
   }


### PR DESCRIPTION
In current Amber, a pause can be initiated from either User or the Engine itself. This will lead to the competition of the pause. From the user's perspective, he/she doesn't want the workflow to be automatically resumed by the engine itself. The engine also doesn't want users to block internal actions.
Thus, we need to solve 2 issues:
1. Prevent the engine to resume the workflow when the user wants it to be paused.
2. For internal actions, "pause" them if the user pauses the workflow until the user resumes.

This PR only proposes one possible way to solve the 1st issue, which is the pause privileges. There are many other solutions such as buffering other pause requests until the current pause resolves.

By introducing pause privileges, we can make sure:
1. No pause/resume request will be blocked. Every pause/resume request succeeds or fails immediately.
2. Pauses with a higher privilege overrides pauses with lower privileges. So user's pause can override the engine's pause.
3. Every pause request will pause the engine regardless of its privilege.
4. Every resume request is not guaranteed to resume the workflow. Resume requests will have no effect if the resume privilege < current pause privilege. (This can be dangerous)

**Discussions are needed for this PR. I don't want to merge this PR too early**