### PR TITLE
Putting the message sending part in MessagingManager

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/DataTransferPolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/DataTransferPolicy.scala
@@ -12,15 +12,18 @@ import scala.concurrent.ExecutionContext
 abstract class DataTransferPolicy(var batchSize: Int) extends Serializable {
   var tag: LinkTag = _
 
-  def addToBatch(tuple: ITuple)(implicit sender: ActorRef = Actor.noSender): Option[]
+  /**
+    * Keeps on adding tuples to the batch. When the batch_size is reached, the batch is returned along with the receiver
+    * to send the batch to.
+    * @param tuple
+    * @param sender
+    * @return
+    */
+  def addToBatch(tuple: ITuple)(implicit sender: ActorRef = Actor.noSender): Option[(ActorRef,Array[ITuple])]
 
-  def noMore()(implicit sender: ActorRef = Actor.noSender): Unit
+  def noMore()(implicit sender: ActorRef = Actor.noSender): Array[(ActorRef,Array[ITuple])]
 
-  def pause(): Unit
-
-  def resume()(implicit sender: ActorRef): Unit
-
-  def initialize(linkTag: LinkTag, next: Array[BaseRoutee])(implicit
+  def initialize(linkTag: LinkTag, receivers: Array[ActorRef])(implicit
       ac: ActorContext,
       sender: ActorRef,
       timeout: Timeout,
@@ -28,10 +31,8 @@ abstract class DataTransferPolicy(var batchSize: Int) extends Serializable {
       log: LoggingAdapter
   ): Unit = {
     this.tag = linkTag
-    next.foreach(x => log.info("link: {}", x))
+    // receivers.foreach(x => log.info("link: {}", x))
   }
-
-  def dispose(): Unit
 
   def reset(): Unit
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/DataTransferPolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/DataTransferPolicy.scala
@@ -12,7 +12,7 @@ import scala.concurrent.ExecutionContext
 abstract class DataTransferPolicy(var batchSize: Int) extends Serializable {
   var tag: LinkTag = _
 
-  def accept(tuple: ITuple)(implicit sender: ActorRef = Actor.noSender): Unit
+  def addToBatch(tuple: ITuple)(implicit sender: ActorRef = Actor.noSender): Option[]
 
   def noMore()(implicit sender: ActorRef = Actor.noSender): Unit
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/DataTransferPolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/DataTransferPolicy.scala
@@ -1,6 +1,5 @@
 package edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy
 
-import edu.uci.ics.amber.engine.architecture.sendsemantics.routees.BaseRoutee
 import edu.uci.ics.amber.engine.common.ambertag.LinkTag
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import akka.actor.{Actor, ActorContext, ActorRef}
@@ -31,7 +30,7 @@ abstract class DataTransferPolicy(var batchSize: Int) extends Serializable {
       log: LoggingAdapter
   ): Unit = {
     this.tag = linkTag
-    // receivers.foreach(x => log.info("link: {}", x))
+    receivers.foreach(x => log.info("link: {}", x))
   }
 
   def reset(): Unit

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/HashBasedShufflePolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/HashBasedShufflePolicy.scala
@@ -8,84 +8,71 @@ import akka.actor.{Actor, ActorContext, ActorRef}
 import akka.event.LoggingAdapter
 import akka.util.Timeout
 
+import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionContext
 
 class HashBasedShufflePolicy(batchSize: Int, val hashFunc: ITuple => Int)
     extends DataTransferPolicy(batchSize) {
-  var routees: Array[BaseRoutee] = _
-  var sequenceNum: Array[Long] = _
+  // var routees: Array[BaseRoutee] = _
+  // var sequenceNum: Array[Long] = _
   var batches: Array[Array[ITuple]] = _
+  var receivers: Array[ActorRef] = _
   var currentSizes: Array[Int] = _
 
-  override def noMore()(implicit sender: ActorRef): Unit = {
-    for (k <- routees.indices) {
+  override def noMore()(implicit sender: ActorRef): Array[(ActorRef,Array[ITuple])] = {
+    var receiversAndBatches = new ArrayBuffer[(ActorRef,Array[ITuple])]
+    for (k <- receivers.indices) {
       if (currentSizes(k) > 0) {
-        routees(k).schedule(DataMessage(sequenceNum(k), batches(k).slice(0, currentSizes(k))))
-        sequenceNum(k) += 1
+        //routees(k).schedule(DataMessage(sequenceNum(k), batches(k).slice(0, currentSizes(k))))
+        //sequenceNum(k) += 1
+        receiversAndBatches.append((receivers(k), batches(k).slice(0, currentSizes(k))))
       }
     }
-    var i = 0
-    while (i < routees.length) {
-      routees(i).schedule(EndSending(sequenceNum(i)))
-      i += 1
-    }
+    receiversAndBatches.toArray
   }
 
-  override def pause(): Unit = {
-    for (i <- routees) {
-      i.pause()
-    }
-  }
-
-  override def resume()(implicit sender: ActorRef): Unit = {
-    for (i <- routees) {
-      i.resume()
-    }
-  }
-
-  override def accept(tuple: ITuple)(implicit sender: ActorRef): Unit = {
-    val numBuckets = routees.length
+  override def addToBatch(tuple: ITuple)(implicit sender: ActorRef): Option[(ActorRef,Array[ITuple])] = {
+    val numBuckets = receivers.length
     val index = (hashFunc(tuple) % numBuckets + numBuckets) % numBuckets
     batches(index)(currentSizes(index)) = tuple
     currentSizes(index) += 1
     if (currentSizes(index) == batchSize) {
       currentSizes(index) = 0
-      routees(index).schedule(DataMessage(sequenceNum(index), batches(index)))
-      sequenceNum(index) += 1
+      // routees(index).schedule(DataMessage(sequenceNum(index), batches(index)))
+      // sequenceNum(index) += 1
+      val retBatch = batches(index)
       batches(index) = new Array[ITuple](batchSize)
+      return Some((receivers(index),retBatch))
     }
+    None
   }
 
-  override def initialize(tag: LinkTag, next: Array[BaseRoutee])(implicit
+  override def initialize(tag: LinkTag, _receivers: Array[ActorRef])(implicit
       ac: ActorContext,
       sender: ActorRef,
       timeout: Timeout,
       ec: ExecutionContext,
       log: LoggingAdapter
   ): Unit = {
-    super.initialize(tag, next)
-    assert(next != null)
-    routees = next
-    routees.foreach(_.initialize(tag))
-    batches = new Array[Array[ITuple]](next.length)
-    for (i <- next.indices) {
+    super.initialize(tag, _receivers)
+    assert(_receivers != null)
+    this.receivers = _receivers
+    // routees.foreach(_.initialize(tag))
+    batches = new Array[Array[ITuple]](_receivers.length)
+    for (i <- _receivers.indices) {
       batches(i) = new Array[ITuple](batchSize)
     }
-    currentSizes = new Array[Int](routees.length)
-    sequenceNum = new Array[Long](routees.length)
-  }
-
-  override def dispose(): Unit = {
-    routees.foreach(_.dispose())
+    currentSizes = new Array[Int](_receivers.length)
+    // sequenceNum = new Array[Long](routees.length)
   }
 
   override def reset(): Unit = {
-    routees.foreach(_.reset())
-    batches = new Array[Array[ITuple]](routees.length)
-    for (i <- routees.indices) {
+    // routees.foreach(_.reset())
+    batches = new Array[Array[ITuple]](receivers.length)
+    for (i <- receivers.indices) {
       batches(i) = new Array[ITuple](batchSize)
     }
-    currentSizes = new Array[Int](routees.length)
-    sequenceNum = new Array[Long](routees.length)
+    currentSizes = new Array[Int](receivers.length)
+    // sequenceNum = new Array[Long](routees.length)
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/HashBasedShufflePolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/HashBasedShufflePolicy.scala
@@ -1,10 +1,8 @@
 package edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy
 
-import edu.uci.ics.amber.engine.architecture.sendsemantics.routees.BaseRoutee
-import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.{DataMessage, EndSending}
 import edu.uci.ics.amber.engine.common.ambertag.LinkTag
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import akka.actor.{Actor, ActorContext, ActorRef}
+import akka.actor.{ActorContext, ActorRef}
 import akka.event.LoggingAdapter
 import akka.util.Timeout
 
@@ -13,8 +11,6 @@ import scala.concurrent.ExecutionContext
 
 class HashBasedShufflePolicy(batchSize: Int, val hashFunc: ITuple => Int)
     extends DataTransferPolicy(batchSize) {
-  // var routees: Array[BaseRoutee] = _
-  // var sequenceNum: Array[Long] = _
   var batches: Array[Array[ITuple]] = _
   var receivers: Array[ActorRef] = _
   var currentSizes: Array[Int] = _
@@ -23,8 +19,6 @@ class HashBasedShufflePolicy(batchSize: Int, val hashFunc: ITuple => Int)
     var receiversAndBatches = new ArrayBuffer[(ActorRef,Array[ITuple])]
     for (k <- receivers.indices) {
       if (currentSizes(k) > 0) {
-        //routees(k).schedule(DataMessage(sequenceNum(k), batches(k).slice(0, currentSizes(k))))
-        //sequenceNum(k) += 1
         receiversAndBatches.append((receivers(k), batches(k).slice(0, currentSizes(k))))
       }
     }
@@ -38,8 +32,6 @@ class HashBasedShufflePolicy(batchSize: Int, val hashFunc: ITuple => Int)
     currentSizes(index) += 1
     if (currentSizes(index) == batchSize) {
       currentSizes(index) = 0
-      // routees(index).schedule(DataMessage(sequenceNum(index), batches(index)))
-      // sequenceNum(index) += 1
       val retBatch = batches(index)
       batches(index) = new Array[ITuple](batchSize)
       return Some((receivers(index),retBatch))
@@ -57,22 +49,18 @@ class HashBasedShufflePolicy(batchSize: Int, val hashFunc: ITuple => Int)
     super.initialize(tag, _receivers)
     assert(_receivers != null)
     this.receivers = _receivers
-    // routees.foreach(_.initialize(tag))
     batches = new Array[Array[ITuple]](_receivers.length)
     for (i <- _receivers.indices) {
       batches(i) = new Array[ITuple](batchSize)
     }
     currentSizes = new Array[Int](_receivers.length)
-    // sequenceNum = new Array[Long](routees.length)
   }
 
   override def reset(): Unit = {
-    // routees.foreach(_.reset())
     batches = new Array[Array[ITuple]](receivers.length)
     for (i <- receivers.indices) {
       batches(i) = new Array[ITuple](batchSize)
     }
     currentSizes = new Array[Int](receivers.length)
-    // sequenceNum = new Array[Long](routees.length)
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/OneToOnePolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/OneToOnePolicy.scala
@@ -1,17 +1,14 @@
 package edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy
 
-import edu.uci.ics.amber.engine.architecture.sendsemantics.routees.BaseRoutee
-import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.{DataMessage, EndSending}
 import edu.uci.ics.amber.engine.common.ambertag.LinkTag
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import akka.actor.{Actor, ActorContext, ActorRef}
+import akka.actor.{ActorContext, ActorRef}
 import akka.event.LoggingAdapter
 import akka.util.Timeout
 
 import scala.concurrent.ExecutionContext
 
 class OneToOnePolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
-  // var sequenceNum: Long = 0
   var receiver: ActorRef  = _
   var batch: Array[ITuple] = _
   var currentSize = 0
@@ -21,8 +18,6 @@ class OneToOnePolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
     currentSize += 1
     if (currentSize == batchSize) {
       currentSize = 0
-      // routee.schedule(DataMessage(sequenceNum, batch))
-      // sequenceNum += 1
       val retBatch = batch
       batch = new Array[ITuple](batchSize)
       return Some((receiver,retBatch))
@@ -33,11 +28,8 @@ class OneToOnePolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
   override def noMore()(implicit sender: ActorRef): Array[(ActorRef,Array[ITuple])] = {
     if (currentSize > 0) {
       return Array[(ActorRef,Array[ITuple])]((receiver,batch.slice(0, currentSize)))
-      // routee.schedule(DataMessage(sequenceNum, batch.slice(0, currentSize)))
-      // sequenceNum += 1
     }
     return Array[(ActorRef,Array[ITuple])]()
-    // routee.schedule(EndSending(sequenceNum))
   }
 
   override def initialize(tag: LinkTag, _receivers: Array[ActorRef])(implicit
@@ -50,14 +42,11 @@ class OneToOnePolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
     super.initialize(tag, _receivers)
     assert(_receivers != null && _receivers.length == 1)
     receiver = _receivers(0)
-    // routee.initialize(tag)
     batch = new Array[ITuple](batchSize)
   }
 
   override def reset(): Unit = {
-    // routee.reset()
     batch = new Array[ITuple](batchSize)
     currentSize = 0
-    // sequenceNum = 0L
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/OneToOnePolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/OneToOnePolicy.scala
@@ -11,59 +11,53 @@ import akka.util.Timeout
 import scala.concurrent.ExecutionContext
 
 class OneToOnePolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
-  var sequenceNum: Long = 0
-  var routee: BaseRoutee = _
+  // var sequenceNum: Long = 0
+  var receiver: ActorRef  = _
   var batch: Array[ITuple] = _
   var currentSize = 0
-  override def accept(tuple: ITuple)(implicit sender: ActorRef): Unit = {
+
+  override def addToBatch(tuple: ITuple)(implicit sender: ActorRef): Option[(ActorRef,Array[ITuple])] = {
     batch(currentSize) = tuple
     currentSize += 1
     if (currentSize == batchSize) {
       currentSize = 0
-      routee.schedule(DataMessage(sequenceNum, batch))
-      sequenceNum += 1
+      // routee.schedule(DataMessage(sequenceNum, batch))
+      // sequenceNum += 1
+      val retBatch = batch
       batch = new Array[ITuple](batchSize)
+      return Some((receiver,retBatch))
     }
+    None
   }
 
-  override def noMore()(implicit sender: ActorRef): Unit = {
+  override def noMore()(implicit sender: ActorRef): Array[(ActorRef,Array[ITuple])] = {
     if (currentSize > 0) {
-      routee.schedule(DataMessage(sequenceNum, batch.slice(0, currentSize)))
-      sequenceNum += 1
+      return Array[(ActorRef,Array[ITuple])]((receiver,batch.slice(0, currentSize)))
+      // routee.schedule(DataMessage(sequenceNum, batch.slice(0, currentSize)))
+      // sequenceNum += 1
     }
-    routee.schedule(EndSending(sequenceNum))
+    return Array[(ActorRef,Array[ITuple])]()
+    // routee.schedule(EndSending(sequenceNum))
   }
 
-  override def pause(): Unit = {
-    routee.pause()
-  }
-
-  override def resume()(implicit sender: ActorRef): Unit = {
-    routee.resume()
-  }
-
-  override def initialize(tag: LinkTag, next: Array[BaseRoutee])(implicit
+  override def initialize(tag: LinkTag, _receivers: Array[ActorRef])(implicit
       ac: ActorContext,
       sender: ActorRef,
       timeout: Timeout,
       ec: ExecutionContext,
       log: LoggingAdapter
   ): Unit = {
-    super.initialize(tag, next)
-    assert(next != null && next.length == 1)
-    routee = next(0)
-    routee.initialize(tag)
+    super.initialize(tag, _receivers)
+    assert(_receivers != null && _receivers.length == 1)
+    receiver = _receivers(0)
+    // routee.initialize(tag)
     batch = new Array[ITuple](batchSize)
-  }
-
-  override def dispose(): Unit = {
-    routee.dispose()
   }
 
   override def reset(): Unit = {
-    routee.reset()
+    // routee.reset()
     batch = new Array[ITuple](batchSize)
     currentSize = 0
-    sequenceNum = 0L
+    // sequenceNum = 0L
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/RoundRobinPolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/RoundRobinPolicy.scala
@@ -1,10 +1,8 @@
 package edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy
 
-import edu.uci.ics.amber.engine.architecture.sendsemantics.routees.BaseRoutee
-import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.{DataMessage, EndSending}
 import edu.uci.ics.amber.engine.common.ambertag.LinkTag
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import akka.actor.{Actor, ActorContext, ActorRef}
+import akka.actor.{ActorContext, ActorRef}
 import akka.event.LoggingAdapter
 import akka.util.Timeout
 
@@ -12,17 +10,12 @@ import scala.concurrent.ExecutionContext
 
 class RoundRobinPolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
   var receivers: Array[ActorRef] = _
-  // var sequenceNum: Array[Long] = _
   var roundRobinIndex = 0
   var batch: Array[ITuple] = _
   var currentSize = 0
 
   override def noMore()(implicit sender: ActorRef): Array[(ActorRef,Array[ITuple])] = {
     if (currentSize > 0) {
-//      routees(roundRobinIndex).schedule(
-//        DataMessage(sequenceNum(roundRobinIndex), batch.slice(0, currentSize))
-//      )
-//      sequenceNum(roundRobinIndex) += 1
       return Array[(ActorRef,Array[ITuple])]((receivers(roundRobinIndex), batch.slice(0, currentSize)))
     }
     return Array[(ActorRef,Array[ITuple])]()
@@ -33,8 +26,6 @@ class RoundRobinPolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
     currentSize += 1
     if (currentSize == batchSize) {
       currentSize = 0
-      // routees(roundRobinIndex).schedule(DataMessage(sequenceNum(roundRobinIndex), batch))
-      // sequenceNum(roundRobinIndex) += 1
       val retBatch = batch
       roundRobinIndex = (roundRobinIndex + 1) % receivers.length
       batch = new Array[ITuple](batchSize)
@@ -53,15 +44,11 @@ class RoundRobinPolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
     super.initialize(tag, _receivers)
     assert(_receivers != null)
     this.receivers = _receivers
-    // routees.foreach(_.initialize(tag))
     batch = new Array[ITuple](batchSize)
-    // sequenceNum = new Array[Long](routees.length)
   }
 
   override def reset(): Unit = {
-    // routees.foreach(_.reset())
     batch = new Array[ITuple](batchSize)
-    // sequenceNum = new Array[Long](routees.length)
     roundRobinIndex = 0
     currentSize = 0
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Generator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Generator.scala
@@ -71,7 +71,7 @@ class Generator(var operator: IOperatorExecutor, val tag: WorkerTag)
   override def onResumeTuple(faultedTuple: FaultedTuple): Unit = {
     var i = 0
     while (i < tupleOutput.output.length) {
-      tupleOutput.output(i).accept(faultedTuple.tuple)
+      tupleOutput.output(i).addToBatch(faultedTuple.tuple)
       i += 1
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
@@ -71,7 +71,7 @@ class Processor(var operator: IOperatorExecutor, val tag: WorkerTag) extends Wor
     if (!faultedTuple.isInput) {
       var i = 0
       while (i < tupleOutput.output.length) {
-        tupleOutput.output(i).accept(faultedTuple.tuple)
+        tupleOutput.output(i).addToBatch(faultedTuple.tuple)
         i += 1
       }
     } else {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
@@ -130,10 +130,9 @@ class Processor(var operator: IOperatorExecutor, val tag: WorkerTag) extends Wor
 
   def onSaveDataMessage(seq: Long, payload: Array[ITuple]): Unit = {
     messagingManager.receiveMessage(DataMessage(seq, payload), sender)
-    val currentEdge = input.actorToEdge(sender)
 
-    while (messagingManager.hasNextDataBatch()) {
-      workerInternalQueue.addDataPayload(currentEdge, messagingManager.getNextDataBatch())
+    while (messagingManager.hasNextDataPayload()) {
+      workerInternalQueue.addDataPayload(messagingManager.getNextDataPayload())
     }
   }
 
@@ -150,10 +149,9 @@ class Processor(var operator: IOperatorExecutor, val tag: WorkerTag) extends Wor
 
   def onReceiveDataMessage(seq: Long, payload: Array[ITuple]): Unit = {
     messagingManager.receiveMessage(DataMessage(seq, payload), sender)
-    val currentEdge = input.actorToEdge(sender)
 
-    while (messagingManager.hasNextDataBatch()) {
-      workerInternalQueue.addDataPayload(currentEdge, messagingManager.getNextDataBatch())
+    while (messagingManager.hasNextDataPayload()) {
+      workerInternalQueue.addDataPayload(messagingManager.getNextDataPayload())
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/TupleToBatchConverter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/TupleToBatchConverter.scala
@@ -13,7 +13,7 @@ import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.util.control.Breaks
 
-class DataTransferSupport(val sender: ActorRef) extends BreakpointSupport {
+class TupleToBatchConverter(val sender: ActorRef) extends BreakpointSupport {
   var output = new Array[DataTransferPolicy](0)
   var skippedInputTuples = new mutable.HashSet[ITuple]
   var skippedOutputTuples = new mutable.HashSet[ITuple]

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/TupleToBatchConverter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/TupleToBatchConverter.scala
@@ -3,6 +3,7 @@ package edu.uci.ics.amber.engine.architecture.worker
 import akka.actor.{ActorContext, ActorRef}
 import akka.event.LoggingAdapter
 import akka.util.Timeout
+import edu.uci.ics.amber.engine.architecture.messaginglayer.MessagingManager
 import edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy.DataTransferPolicy
 import edu.uci.ics.amber.engine.architecture.sendsemantics.routees.BaseRoutee
 import edu.uci.ics.amber.engine.common.amberexception.BreakpointException
@@ -13,45 +14,35 @@ import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 import scala.util.control.Breaks
 
-class TupleToBatchConverter(val sender: ActorRef) extends BreakpointSupport {
+class TupleToBatchConverter(val sender: ActorRef, val messagingManager: MessagingManager) extends BreakpointSupport {
   var output = new Array[DataTransferPolicy](0)
   var skippedInputTuples = new mutable.HashSet[ITuple]
   var skippedOutputTuples = new mutable.HashSet[ITuple]
-
+  // updated
   def pauseDataTransfer(): Unit = {
-    var i = 0
-    while (i < output.length) {
-      output(i).pause()
-      i += 1
-    }
+    messagingManager.pauseDataSending()
   }
-
+  // updated
   def resumeDataTransfer(): Unit = {
-    var i = 0
-    while (i < output.length) {
-      output(i).resume()(sender)
-      i += 1
-    }
+    messagingManager.resumeDataSending()(sender)
   }
-
+  // updated
   def endDataTransfer(): Unit = {
     var i = 0
     while (i < output.length) {
-      output(i).noMore()(sender)
+      val receiversAndBatches: Array[(ActorRef,Array[ITuple])] = output(i).noMore()(sender)
+      receiversAndBatches.foreach(rb => messagingManager.sendDataMessage(rb._1, rb._2)(sender))
       i += 1
     }
+    messagingManager.sendEndDataMessage()(sender)
   }
-
+  // updated
   def cleanUpDataTransfer(): Unit = {
-    var i = 0
-    while (i < output.length) {
-      output(i).dispose()
-      i += 1
-    }
     //clear all data transfer policies
     output = Array()
+    messagingManager.disposeDataSenders()
   }
-
+  // updated
   def transferTuple(tuple: ITuple, tupleId: Long): Unit = {
     if (tuple != null && !skippedOutputTuples.contains(tuple)) {
       var i = 1
@@ -75,8 +66,8 @@ class TupleToBatchConverter(val sender: ActorRef) extends BreakpointSupport {
       }
     }
   }
-
-  def updateOutput(policy: DataTransferPolicy, tag: LinkTag, receivers: Array[BaseRoutee])(implicit
+  //updated
+  def updateOutput(policy: DataTransferPolicy, tag: LinkTag, senders: Array[BaseRoutee])(implicit
       ac: ActorContext,
       sender: ActorRef,
       timeout: Timeout,
@@ -84,11 +75,11 @@ class TupleToBatchConverter(val sender: ActorRef) extends BreakpointSupport {
       log: LoggingAdapter
   ): Unit = {
     var i = 0
-    policy.initialize(tag, receivers)
+    policy.initialize(tag, senders.map(_.receiver))
+    messagingManager.updateReceiverAndSender(senders, tag)(ac,sender,timeout,ec,log)
     Breaks.breakable {
       while (i < output.length) {
         if (output(i).tag == policy.tag) {
-          output(i).dispose()
           output(i) = policy
           Breaks.break()
         }
@@ -97,17 +88,25 @@ class TupleToBatchConverter(val sender: ActorRef) extends BreakpointSupport {
       output = output :+ policy
     }
   }
-
+  // updated
   def resetOutput(): Unit = {
     output.foreach {
       _.reset()
     }
+    messagingManager.resetDataSending()
   }
-
+  // updated
   def passTupleToDownstream(tuple: ITuple): Unit = {
     var i = 0
     while (i < output.length) {
-      output(i).accept(tuple)(sender)
+      val receiverAndbatch: Option[(ActorRef,Array[ITuple])] = output(i).addToBatch(tuple)(sender)
+      receiverAndbatch match {
+        case Some(rb)=>
+          // send it to messaging layer to be sent downstream
+          messagingManager.sendDataMessage(rb._1, rb._2)(sender)
+        case None =>
+          // Do nothing
+      }
       i += 1
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/TupleToBatchConverter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/TupleToBatchConverter.scala
@@ -18,15 +18,15 @@ class TupleToBatchConverter(val sender: ActorRef, val messagingManager: Messagin
   var output = new Array[DataTransferPolicy](0)
   var skippedInputTuples = new mutable.HashSet[ITuple]
   var skippedOutputTuples = new mutable.HashSet[ITuple]
-  // updated
+
   def pauseDataTransfer(): Unit = {
     messagingManager.pauseDataSending()
   }
-  // updated
+
   def resumeDataTransfer(): Unit = {
     messagingManager.resumeDataSending()(sender)
   }
-  // updated
+
   def endDataTransfer(): Unit = {
     var i = 0
     while (i < output.length) {
@@ -36,13 +36,13 @@ class TupleToBatchConverter(val sender: ActorRef, val messagingManager: Messagin
     }
     messagingManager.sendEndDataMessage()(sender)
   }
-  // updated
+
   def cleanUpDataTransfer(): Unit = {
     //clear all data transfer policies
     output = Array()
     messagingManager.disposeDataSenders()
   }
-  // updated
+
   def transferTuple(tuple: ITuple, tupleId: Long): Unit = {
     if (tuple != null && !skippedOutputTuples.contains(tuple)) {
       var i = 1
@@ -66,7 +66,7 @@ class TupleToBatchConverter(val sender: ActorRef, val messagingManager: Messagin
       }
     }
   }
-  //updated
+
   def updateOutput(policy: DataTransferPolicy, tag: LinkTag, senders: Array[BaseRoutee])(implicit
       ac: ActorContext,
       sender: ActorRef,
@@ -88,14 +88,14 @@ class TupleToBatchConverter(val sender: ActorRef, val messagingManager: Messagin
       output = output :+ policy
     }
   }
-  // updated
+
   def resetOutput(): Unit = {
     output.foreach {
       _.reset()
     }
     messagingManager.resetDataSending()
   }
-  // updated
+
   def passTupleToDownstream(tuple: ITuple): Unit = {
     var i = 0
     while (i < output.length) {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/DataProcessor.scala
@@ -5,6 +5,7 @@ import java.util.concurrent.Executors
 import akka.actor.ActorRef
 import edu.uci.ics.amber.engine.architecture.breakpoint.localbreakpoint.ExceptionBreakpoint
 import edu.uci.ics.amber.engine.architecture.worker.BreakpointSupport
+import edu.uci.ics.amber.engine.architecture.worker.TupleToBatchConverter
 import edu.uci.ics.amber.engine.common.amberexception.BreakpointException
 import edu.uci.ics.amber.engine.common.ambermessage.ControlMessage.LocalBreakpointTriggered
 import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.ExecutionCompleted

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/TupleToBatchConverter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/TupleToBatchConverter.scala
@@ -1,7 +1,0 @@
-package edu.uci.ics.amber.engine.architecture.worker.neo
-
-import akka.actor.ActorRef
-import edu.uci.ics.amber.engine.architecture.worker.DataTransferSupport
-
-// use the old data transfer support for now since I don't want to change too much
-class TupleToBatchConverter(sender: ActorRef) extends DataTransferSupport(sender)


### PR DESCRIPTION
This PR puts the data message sending part in the `Messaging Manager`.

What we had earlier:
`DataProcessor` called `TupleToBatchConverter`, which called `transferTuple()` function. Inside the transferTuple function, the corresponding `DataTransferPolicy` (HashBased, RoundRobin, LocalOneToOne) _accepted_ the data. Inside `accept`, the data tuple was added to a `batch` inside the `DataTransferPolicy`. When the batch was full, the `DataTransferPolicy` appended a sequence number to the data batch and used a `routee` to send the data message to the appropriate receiver.

What we have now:
The data sending part has been moved out of `TupleToBatchConverter` and into the `Messaging Manager`. The TupleToBatchConverter inserts tuples into batches according to the `DataTransferPolicy`. When the batch is ready, the `Receiver` ActorRef and the data batch is sent to the MessagingManager. The MessagingManager adds sequence number to the data batch according to the receiver. The  MessagingManager also has a map of `receivers` to `routees`. So, the MessagingManager is able to send the data message to the correct receiver through the routee. This also helps us in maintaining a single routee for a particular receiver compared to the earlier implementation where each `DataTransferPolicy` had its own routee for receivers. 

The image below shows the updated version.
![image](https://user-images.githubusercontent.com/3867317/102177104-a4a0a380-3e57-11eb-8066-e7b69b6beeb3.png)

