### PR TITLE
Refine Amber Messaging Layer (2/2)

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
@@ -32,6 +32,8 @@ abstract class WorkflowActor(identifier: ActorVirtualIdentity)
       if (replyTo.contains(networkSenderActor.ref)) {
         context.parent ! QueryActorRef(id, replyTo)
       } else {
+        // we direct this message to the NetworkSenderActor
+        // because it has the VirtualIdentityToActorRef for each actor.
         networkSenderActor ! QueryActorRef(id, replyTo)
       }
     case RegisterActorRef(id, ref) =>

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
@@ -1,28 +1,34 @@
 package edu.uci.ics.amber.engine.architecture.common
 
-import akka.actor.{Actor, ActorLogging, Stash}
+import akka.actor.{Actor, ActorLogging, ActorRef, Stash}
 import com.softwaremill.macwire.wire
-import edu.uci.ics.amber.engine.architecture.messaginglayer.{
-  ControlInputPort,
-  ControlOutputPort,
-  NetworkOutputGate
-}
-import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{NetworkSenderActorRef, QueryActorRef, RegisterActorRef}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.{ControlInputPort, ControlOutputPort, NetworkSenderActor}
+import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.ActorVirtualIdentity
+import edu.uci.ics.amber.error.WorkflowRuntimeError
 
-class WorkflowActor(identifier: ActorVirtualIdentity)
+abstract class WorkflowActor(identifier: ActorVirtualIdentity)
     extends Actor
     with ActorLogging
-    with Stash
-    with NetworkOutputGate {
+    with Stash {
 
-  val networkOutput: NetworkOutputGate = this
+  val networkSenderActor: NetworkSenderActorRef = NetworkSenderActorRef(context.actorOf(NetworkSenderActor.props()))
   lazy val controlInputPort: ControlInputPort = wire[ControlInputPort]
   lazy val controlOutputPort: ControlOutputPort = wire[ControlOutputPort]
 
-  // Not being used right now.
-  override def receive: Receive = {
-    case other =>
-      throw new NotImplementedError("Message other than data message reached WorkflowActor receive")
+  def routeActorRefRelatedMessages:Receive = {
+    case QueryActorRef(id, replyTo) =>
+      if(replyTo.contains(networkSenderActor.ref)){
+        context.parent ! QueryActorRef(id, replyTo)
+      }else{
+        networkSenderActor ! QueryActorRef(id, replyTo)
+      }
+    case RegisterActorRef(id, ref) =>
+      throw WorkflowRuntimeException(
+        WorkflowRuntimeError(
+          "workflow actor should never receive register actor ref message",
+          identifier.toString,
+          Map.empty))
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
@@ -2,8 +2,16 @@ package edu.uci.ics.amber.engine.architecture.common
 
 import akka.actor.{Actor, ActorLogging, ActorRef, Stash}
 import com.softwaremill.macwire.wire
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{NetworkSenderActorRef, QueryActorRef, RegisterActorRef}
-import edu.uci.ics.amber.engine.architecture.messaginglayer.{ControlInputPort, ControlOutputPort, NetworkSenderActor}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{
+  NetworkSenderActorRef,
+  QueryActorRef,
+  RegisterActorRef
+}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.{
+  ControlInputPort,
+  ControlOutputPort,
+  NetworkSenderActor
+}
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.ActorVirtualIdentity
 import edu.uci.ics.amber.error.WorkflowRuntimeError
@@ -13,15 +21,17 @@ abstract class WorkflowActor(identifier: ActorVirtualIdentity)
     with ActorLogging
     with Stash {
 
-  val networkSenderActor: NetworkSenderActorRef = NetworkSenderActorRef(context.actorOf(NetworkSenderActor.props()))
+  val networkSenderActor: NetworkSenderActorRef = NetworkSenderActorRef(
+    context.actorOf(NetworkSenderActor.props())
+  )
   lazy val controlInputPort: ControlInputPort = wire[ControlInputPort]
   lazy val controlOutputPort: ControlOutputPort = wire[ControlOutputPort]
 
-  def routeActorRefRelatedMessages:Receive = {
+  def routeActorRefRelatedMessages: Receive = {
     case QueryActorRef(id, replyTo) =>
-      if(replyTo.contains(networkSenderActor.ref)){
+      if (replyTo.contains(networkSenderActor.ref)) {
         context.parent ! QueryActorRef(id, replyTo)
-      }else{
+      } else {
         networkSenderActor ! QueryActorRef(id, replyTo)
       }
     case RegisterActorRef(id, ref) =>
@@ -29,6 +39,8 @@ abstract class WorkflowActor(identifier: ActorVirtualIdentity)
         WorkflowRuntimeError(
           "workflow actor should never receive register actor ref message",
           identifier.toString,
-          Map.empty))
+          Map.empty
+        )
+      )
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
@@ -1,84 +1,27 @@
 package edu.uci.ics.amber.engine.architecture.controller
 
 import edu.uci.ics.amber.clustering.ClusterListener.GetAvailableNodeAddresses
-import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.{
-  ExceptionGlobalBreakpoint,
-  GlobalBreakpoint
-}
+import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.{ExceptionGlobalBreakpoint, GlobalBreakpoint}
 import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.GlobalBreakpoint
-import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{
-  BreakpointTriggered,
-  ErrorOccurred,
-  ModifyLogicCompleted,
-  SkipTupleResponse,
-  WorkflowCompleted,
-  WorkflowPaused,
-  WorkflowStatusUpdate
-}
+import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{BreakpointTriggered, ErrorOccurred, ModifyLogicCompleted, SkipTupleResponse, WorkflowCompleted, WorkflowPaused, WorkflowStatusUpdate}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.deploystrategy.OneOnEach
 import edu.uci.ics.amber.engine.architecture.deploysemantics.deploymentfilter.FollowPrevious
-import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{
-  ActorLayer,
-  GeneratorWorkerLayer,
-  ProcessorWorkerLayer
-}
-import edu.uci.ics.amber.engine.faulttolerance.materializer.{
-  HashBasedMaterializer,
-  OutputMaterializer
-}
-import edu.uci.ics.amber.engine.architecture.linksemantics.{
-  FullRoundRobin,
-  HashBasedShuffle,
-  LocalPartialToOne,
-  OperatorLink
-}
-import edu.uci.ics.amber.engine.architecture.principal.{
-  Principal,
-  PrincipalState,
-  PrincipalStatistics
-}
+import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{ActorLayer, GeneratorWorkerLayer, ProcessorWorkerLayer}
+import edu.uci.ics.amber.engine.faulttolerance.materializer.{HashBasedMaterializer, OutputMaterializer}
+import edu.uci.ics.amber.engine.architecture.linksemantics.{FullRoundRobin, HashBasedShuffle, LocalPartialToOne, OperatorLink}
+import edu.uci.ics.amber.engine.architecture.principal.{Principal, PrincipalState, PrincipalStatistics}
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.ambermessage.ControllerMessage._
 import edu.uci.ics.amber.engine.common.ambermessage.ControlMessage._
 import edu.uci.ics.amber.engine.common.ambermessage.PrincipalMessage
-import edu.uci.ics.amber.engine.common.ambermessage.PrincipalMessage.{
-  AckedPrincipalInitialization,
-  AssignBreakpoint,
-  GetOutputLayer,
-  ReportCurrentProcessingTuple,
-  ReportOutputResult,
-  ReportPrincipalPartialCompleted
-}
+import edu.uci.ics.amber.engine.common.ambermessage.PrincipalMessage.{AckedPrincipalInitialization, AssignBreakpoint, GetOutputLayer, ReportCurrentProcessingTuple, ReportOutputResult, ReportPrincipalPartialCompleted}
 import edu.uci.ics.amber.engine.common.ambermessage.StateMessage.EnforceStateCheck
-import edu.uci.ics.amber.engine.common.ambertag.{
-  AmberTag,
-  LayerTag,
-  LinkTag,
-  OperatorIdentifier,
-  WorkflowTag
-}
+import edu.uci.ics.amber.engine.common.ambertag.{AmberTag, LayerTag, LinkTag, OperatorIdentifier, WorkflowTag}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.{
-  AdvancedMessageSending,
-  AmberUtils,
-  Constants,
-  ISourceOperatorExecutor,
-  WorkflowLogger
-}
+import edu.uci.ics.amber.engine.common.{AdvancedMessageSending, AmberUtils, Constants, ISourceOperatorExecutor, WorkflowLogger}
 import edu.uci.ics.amber.engine.faulttolerance.scanner.HDFSFolderScanSourceOperatorExecutor
 import edu.uci.ics.amber.engine.operators.OpExecConfig
-import akka.actor.{
-  Actor,
-  ActorLogging,
-  ActorRef,
-  ActorSelection,
-  Address,
-  Cancellable,
-  Deploy,
-  PoisonPill,
-  Props,
-  Stash
-}
+import akka.actor.{Actor, ActorLogging, ActorRef, ActorSelection, Address, Cancellable, Deploy, PoisonPill, Props, Stash}
 import akka.dispatch.Futures
 import akka.event.LoggingAdapter
 import akka.pattern.ask
@@ -90,8 +33,11 @@ import play.api.libs.json.{JsArray, JsValue, Json}
 import com.google.common.collect.BiMap
 import com.google.common.collect.HashBiMap
 import com.typesafe.scalalogging.Logger
+import edu.uci.ics.amber.engine.architecture.common.WorkflowActor
 import edu.uci.ics.amber.error.WorkflowRuntimeError
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkOutputGate
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.RegisterActorRef
+import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity
 
 import collection.JavaConverters._
 import scala.collection.mutable
@@ -234,10 +180,7 @@ class Controller(
     val withCheckpoint: Boolean,
     val eventListener: ControllerEventListener = ControllerEventListener(),
     val statisticsUpdateIntervalMs: Option[Long]
-) extends Actor
-    with ActorLogging
-    with Stash
-    with NetworkOutputGate {
+) extends WorkflowActor(VirtualIdentity.Controller){
   implicit val ec: ExecutionContext = context.dispatcher
   implicit val timeout: Timeout = 5.seconds
   implicit val logAdapter: LoggingAdapter = log
@@ -376,7 +319,7 @@ class Controller(
   }
 
   override def receive: Receive = {
-    findActorRefFromVirtualIdentity orElse [Any, Unit] {
+    routeActorRefRelatedMessages orElse [Any, Unit] {
       case LogErrorToFrontEnd(err: WorkflowRuntimeError) =>
         log.error(err.convertToMap().mkString(" | "))
         eventListener.workflowExecutionErrorListener.apply(ErrorOccurred(err))
@@ -413,7 +356,7 @@ class Controller(
                     val layers = workflow.operators(x).topology.layers
                     layers.foreach { layer =>
                       layer.identifiers.indices.foreach(i =>
-                        registerActorRef(layer.identifiers(i), layer.layer(i))
+                        networkSenderActor ! RegisterActorRef(layer.identifiers(i), layer.layer(i))
                       )
                     }
                     //assign exception breakpoint before all breakpoints
@@ -480,7 +423,7 @@ class Controller(
                   val layers = workflow.operators(x).topology.layers
                   layers.foreach { layer =>
                     layer.identifiers.indices.foreach(i =>
-                      registerActorRef(layer.identifiers(i), layer.layer(i))
+                      networkSenderActor ! RegisterActorRef(layer.identifiers(i), layer.layer(i))
                     )
                   }
                   //assign exception breakpoint before all breakpoints
@@ -603,7 +546,7 @@ class Controller(
                     val layers = workflow.operators(k).topology.layers
                     layers.foreach { layer =>
                       layer.identifiers.indices.foreach(i =>
-                        registerActorRef(layer.identifiers(i), layer.layer(i))
+                        networkSenderActor ! RegisterActorRef(layer.identifiers(i), layer.layer(i))
                       )
                     }
                     //assign exception breakpoint before all breakpoints
@@ -652,7 +595,7 @@ class Controller(
   }
 
   private[this] def ready: Receive = {
-    findActorRefFromVirtualIdentity orElse [Any, Unit] {
+    routeActorRefRelatedMessages orElse [Any, Unit] {
       case LogErrorToFrontEnd(err: WorkflowRuntimeError) =>
         log.error(err.convertToMap().mkString(" | "))
         eventListener.workflowExecutionErrorListener.apply(ErrorOccurred(err))
@@ -724,7 +667,7 @@ class Controller(
   }
 
   private[this] def running: Receive = {
-    findActorRefFromVirtualIdentity orElse [Any, Unit] {
+    routeActorRefRelatedMessages orElse [Any, Unit] {
       case LogErrorToFrontEnd(err: WorkflowRuntimeError) =>
         log.error(err.convertToMap().mkString(" | "))
         eventListener.workflowExecutionErrorListener.apply(ErrorOccurred(err))
@@ -838,7 +781,7 @@ class Controller(
   }
 
   private[this] def pausing: Receive = {
-    findActorRefFromVirtualIdentity orElse [Any, Unit] {
+    routeActorRefRelatedMessages orElse [Any, Unit] {
       case LogErrorToFrontEnd(err: WorkflowRuntimeError) =>
         log.error(err.convertToMap().mkString(" | "))
         eventListener.workflowExecutionErrorListener.apply(ErrorOccurred(err))
@@ -910,7 +853,7 @@ class Controller(
   }
 
   private[this] def paused: Receive = {
-    findActorRefFromVirtualIdentity orElse [Any, Unit] {
+    routeActorRefRelatedMessages orElse [Any, Unit] {
       case LogErrorToFrontEnd(err: WorkflowRuntimeError) =>
         log.error(err.convertToMap().mkString(" | "))
         eventListener.workflowExecutionErrorListener.apply(ErrorOccurred(err))
@@ -979,7 +922,7 @@ class Controller(
   }
 
   private[this] def resuming: Receive = {
-    findActorRefFromVirtualIdentity orElse [Any, Unit] {
+    routeActorRefRelatedMessages orElse [Any, Unit] {
       case LogErrorToFrontEnd(err: WorkflowRuntimeError) =>
         log.error(err.convertToMap().mkString(" | "))
         eventListener.workflowExecutionErrorListener.apply(ErrorOccurred(err))
@@ -1029,7 +972,7 @@ class Controller(
   }
 
   private[this] def completed: Receive = {
-    findActorRefFromVirtualIdentity orElse [Any, Unit] {
+    routeActorRefRelatedMessages orElse [Any, Unit] {
       case LogErrorToFrontEnd(err: WorkflowRuntimeError) =>
         log.error(err.convertToMap().mkString(" | "))
         eventListener.workflowExecutionErrorListener.apply(ErrorOccurred(err))

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
@@ -1,27 +1,84 @@
 package edu.uci.ics.amber.engine.architecture.controller
 
 import edu.uci.ics.amber.clustering.ClusterListener.GetAvailableNodeAddresses
-import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.{ExceptionGlobalBreakpoint, GlobalBreakpoint}
+import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.{
+  ExceptionGlobalBreakpoint,
+  GlobalBreakpoint
+}
 import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.GlobalBreakpoint
-import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{BreakpointTriggered, ErrorOccurred, ModifyLogicCompleted, SkipTupleResponse, WorkflowCompleted, WorkflowPaused, WorkflowStatusUpdate}
+import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{
+  BreakpointTriggered,
+  ErrorOccurred,
+  ModifyLogicCompleted,
+  SkipTupleResponse,
+  WorkflowCompleted,
+  WorkflowPaused,
+  WorkflowStatusUpdate
+}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.deploystrategy.OneOnEach
 import edu.uci.ics.amber.engine.architecture.deploysemantics.deploymentfilter.FollowPrevious
-import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{ActorLayer, GeneratorWorkerLayer, ProcessorWorkerLayer}
-import edu.uci.ics.amber.engine.faulttolerance.materializer.{HashBasedMaterializer, OutputMaterializer}
-import edu.uci.ics.amber.engine.architecture.linksemantics.{FullRoundRobin, HashBasedShuffle, LocalPartialToOne, OperatorLink}
-import edu.uci.ics.amber.engine.architecture.principal.{Principal, PrincipalState, PrincipalStatistics}
+import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{
+  ActorLayer,
+  GeneratorWorkerLayer,
+  ProcessorWorkerLayer
+}
+import edu.uci.ics.amber.engine.faulttolerance.materializer.{
+  HashBasedMaterializer,
+  OutputMaterializer
+}
+import edu.uci.ics.amber.engine.architecture.linksemantics.{
+  FullRoundRobin,
+  HashBasedShuffle,
+  LocalPartialToOne,
+  OperatorLink
+}
+import edu.uci.ics.amber.engine.architecture.principal.{
+  Principal,
+  PrincipalState,
+  PrincipalStatistics
+}
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.ambermessage.ControllerMessage._
 import edu.uci.ics.amber.engine.common.ambermessage.ControlMessage._
 import edu.uci.ics.amber.engine.common.ambermessage.PrincipalMessage
-import edu.uci.ics.amber.engine.common.ambermessage.PrincipalMessage.{AckedPrincipalInitialization, AssignBreakpoint, GetOutputLayer, ReportCurrentProcessingTuple, ReportOutputResult, ReportPrincipalPartialCompleted}
+import edu.uci.ics.amber.engine.common.ambermessage.PrincipalMessage.{
+  AckedPrincipalInitialization,
+  AssignBreakpoint,
+  GetOutputLayer,
+  ReportCurrentProcessingTuple,
+  ReportOutputResult,
+  ReportPrincipalPartialCompleted
+}
 import edu.uci.ics.amber.engine.common.ambermessage.StateMessage.EnforceStateCheck
-import edu.uci.ics.amber.engine.common.ambertag.{AmberTag, LayerTag, LinkTag, OperatorIdentifier, WorkflowTag}
+import edu.uci.ics.amber.engine.common.ambertag.{
+  AmberTag,
+  LayerTag,
+  LinkTag,
+  OperatorIdentifier,
+  WorkflowTag
+}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.{AdvancedMessageSending, AmberUtils, Constants, ISourceOperatorExecutor, WorkflowLogger}
+import edu.uci.ics.amber.engine.common.{
+  AdvancedMessageSending,
+  AmberUtils,
+  Constants,
+  ISourceOperatorExecutor,
+  WorkflowLogger
+}
 import edu.uci.ics.amber.engine.faulttolerance.scanner.HDFSFolderScanSourceOperatorExecutor
 import edu.uci.ics.amber.engine.operators.OpExecConfig
-import akka.actor.{Actor, ActorLogging, ActorRef, ActorSelection, Address, Cancellable, Deploy, PoisonPill, Props, Stash}
+import akka.actor.{
+  Actor,
+  ActorLogging,
+  ActorRef,
+  ActorSelection,
+  Address,
+  Cancellable,
+  Deploy,
+  PoisonPill,
+  Props,
+  Stash
+}
 import akka.dispatch.Futures
 import akka.event.LoggingAdapter
 import akka.pattern.ask
@@ -180,7 +237,7 @@ class Controller(
     val withCheckpoint: Boolean,
     val eventListener: ControllerEventListener = ControllerEventListener(),
     val statisticsUpdateIntervalMs: Option[Long]
-) extends WorkflowActor(VirtualIdentity.Controller){
+) extends WorkflowActor(VirtualIdentity.Controller) {
   implicit val ec: ExecutionContext = context.dispatcher
   implicit val timeout: Timeout = 5.seconds
   implicit val logAdapter: LoggingAdapter = log

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
@@ -38,13 +38,11 @@ class CongestionControl {
   private val inTransit = new mutable.LongMap[NetworkMessage]()
   private val sentTime = new mutable.TreeMap[Long, Long]()
 
-  def canSend(data: NetworkMessage): Boolean = {
-    if (inTransit.size < windowSize) {
-      true
-    } else {
-      toBeSent.enqueue(data)
-      false
-    }
+  // Note that toBeSent buffer is always empty if inTransit.size < windowSize
+  def canSend: Boolean = inTransit.size < windowSize
+
+  def enqueueMessage(data: NetworkMessage): Unit = {
+    toBeSent.enqueue(data)
   }
 
   def ack(id: Long): Unit = {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
@@ -76,9 +76,8 @@ class CongestionControl {
   def getTimedOutInTransitMessages: Iterable[NetworkMessage] = {
     val timeCap = System.currentTimeMillis() - resendTimeLimit
     sentTime.collect {
-      case (id, timeStamp)
-        if timeStamp < timeCap =>
-          inTransit(id)
+      case (id, timeStamp) if timeStamp < timeCap =>
+        inTransit(id)
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
@@ -67,9 +67,6 @@ class CongestionControl {
 
   def markMessageInTransit(data: NetworkMessage): Unit = {
     inTransit(data.messageID) = data
-  }
-
-  def markSentTime(data: NetworkMessage): Unit = {
     sentTime(data.messageID) = System.currentTimeMillis()
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
@@ -1,10 +1,5 @@
 package edu.uci.ics.amber.engine.architecture.messaginglayer
 
-import edu.uci.ics.amber.engine.architecture.messaginglayer.CongestionControl.{
-  maxWindowSize,
-  minWindowSize,
-  timeGap
-}
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.NetworkMessage
 
 import scala.collection.mutable
@@ -71,18 +66,25 @@ class CongestionControl {
   }
 
   def markMessageInTransit(data: NetworkMessage): Unit = {
-    sentTime(System.currentTimeMillis()) = data.messageID
     inTransit(data.messageID) = data
   }
 
-  def getTimedOutInTransitMessages: Array[NetworkMessage] = {
+  def markSentTime(data: NetworkMessage): Unit = {
+    sentTime(System.currentTimeMillis()) = data.messageID
+  }
+
+  def getTimedOutInTransitMessages: Iterable[NetworkMessage] = {
     val timeCap = System.currentTimeMillis() - resendTimeLimit
     sentTime.valuesIterator
       .takeWhile(_ < timeCap)
       .map { id =>
         inTransit(id)
       }
-      .toArray
+      .toIterable
+  }
+
+  def getInTransitMessages: Iterable[NetworkMessage] = {
+    inTransit.values
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
@@ -11,39 +11,46 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
-object CongestionControl {
-  final val maxWindowSize = 64
-  final val minWindowSize = 2
-  final val expendThreshold = 4
-  final val sendingTimeout: FiniteDuration = 30.seconds
-  final val timeGap = 3000 // 3s
-}
-
 class CongestionControl {
 
-  var ssThreshold = 16
-  var windowSize = minWindowSize
-  var sentTimeStamp = 0L
-  val toBeSent = new mutable.Queue[NetworkMessage]
-  val messageBuffer = new ArrayBuffer[NetworkMessage]()
-  private val inTransit = new mutable.LongMap[NetworkMessage]
+  // ack should be received within 3s,
+  // otherwise, network congestion occurs.
+  final val ackTimeLimit = 3000
 
-  def canBeSent(data: NetworkMessage): Boolean = {
+  // if the ack for a message is not received after 60s,
+  // we trigger the resending logic.
+  // Note that the resend is not guaranteed to happen
+  // after sending the message for 60s
+  final val resendTimeLimit = 60000 // 60s
+
+  // slow start threshold
+  // after windowSize > ssThreshold,
+  // we increment windowSize by one every time,
+  // otherwise, we multiply windowSize by 2.
+  private var ssThreshold = 16
+
+  // initial window size = 1
+  // it represents how many messages can be sent concurrently
+  private var windowSize = 1
+
+  private val toBeSent = new mutable.Queue[NetworkMessage]
+  private val messageBuffer = new ArrayBuffer[NetworkMessage]()
+  private val inTransit = new mutable.LongMap[NetworkMessage]()
+  private val sentTime = new mutable.TreeMap[Long, Long]()
+
+  def canSend(data: NetworkMessage): Boolean = {
     if (inTransit.size < windowSize) {
-      sentTimeStamp = System.currentTimeMillis()
-      inTransit(data.messageID) = data
       true
     } else {
-      //println(s"queued $data")
       toBeSent.enqueue(data)
       false
     }
   }
 
-  def ack(id: Long): Array[NetworkMessage] = {
-    messageBuffer.clear()
+  def ack(id: Long): Unit = {
+    if (!inTransit.contains(id)) return
     inTransit.remove(id)
-    if (System.currentTimeMillis() - sentTimeStamp < timeGap) {
+    if (System.currentTimeMillis() - sentTime(id) < ackTimeLimit) {
       if (windowSize < ssThreshold) {
         windowSize = Math.min(windowSize * 2, ssThreshold)
       } else {
@@ -51,14 +58,33 @@ class CongestionControl {
       }
     } else {
       ssThreshold /= 2
-      windowSize = Math.max(minWindowSize, Math.min(ssThreshold, maxWindowSize))
+      windowSize = ssThreshold
     }
+  }
+
+  def getBufferedMessagesToSend: Array[NetworkMessage] = {
+    messageBuffer.clear()
     while (inTransit.size < windowSize && toBeSent.nonEmpty) {
       val msg = toBeSent.dequeue()
       inTransit(msg.messageID) = msg
       messageBuffer.append(msg)
     }
     messageBuffer.toArray
+  }
+
+  def markMessageInTransit(data: NetworkMessage): Unit = {
+    sentTime(System.currentTimeMillis()) = data.messageID
+    inTransit(data.messageID) = data
+  }
+
+  def getTimedOutInTransitMessages: Array[NetworkMessage] = {
+    val timeCap = System.currentTimeMillis() - resendTimeLimit
+    sentTime.valuesIterator
+      .takeWhile(_ < timeCap)
+      .map { id =>
+        inTransit(id)
+      }
+      .toArray
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
@@ -34,7 +34,7 @@ class CongestionControl {
       inTransit(data.messageID) = data
       true
     } else {
-      println(s"queued $data")
+      //println(s"queued $data")
       toBeSent.enqueue(data)
       false
     }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
@@ -1,0 +1,61 @@
+package edu.uci.ics.amber.engine.architecture.messaginglayer
+
+import edu.uci.ics.amber.engine.architecture.messaginglayer.CongestionControl.{maxWindowSize, minWindowSize, timeGap}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.NetworkMessage
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
+
+object CongestionControl{
+  final val maxWindowSize = 64
+  final val minWindowSize = 2
+  final val expendThreshold = 4
+  final val sendingTimeout: FiniteDuration = 30.seconds
+  final val timeGap = 3000 // 3s
+}
+
+
+class CongestionControl {
+
+  var ssThreshold = 16
+  var windowSize = minWindowSize
+  var sentTimeStamp = 0L
+  val toBeSent = new mutable.Queue[NetworkMessage]
+  val messageBuffer = new ArrayBuffer[NetworkMessage]()
+  private val inTransit = new mutable.LongMap[NetworkMessage]
+
+  def canBeSent(data:NetworkMessage):Boolean = {
+    if (inTransit.size < windowSize) {
+      sentTimeStamp = System.currentTimeMillis()
+      inTransit(data.messageID) = data
+      true
+    }else{
+      println(s"queued $data")
+      toBeSent.enqueue(data)
+      false
+    }
+  }
+
+  def ack(id:Long):Array[NetworkMessage] = {
+    messageBuffer.clear()
+    inTransit.remove(id)
+    if (System.currentTimeMillis() - sentTimeStamp < timeGap) {
+      if (windowSize < ssThreshold) {
+        windowSize = Math.min(windowSize * 2, ssThreshold)
+      } else {
+        windowSize += 1
+      }
+    } else {
+      ssThreshold /= 2
+      windowSize = Math.max(minWindowSize, Math.min(ssThreshold, maxWindowSize))
+    }
+    while(inTransit.size < windowSize && toBeSent.nonEmpty) {
+      val msg = toBeSent.dequeue()
+      inTransit(msg.messageID) = msg
+      messageBuffer.append(msg)
+    }
+    messageBuffer.toArray
+  }
+
+}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
@@ -1,20 +1,23 @@
 package edu.uci.ics.amber.engine.architecture.messaginglayer
 
-import edu.uci.ics.amber.engine.architecture.messaginglayer.CongestionControl.{maxWindowSize, minWindowSize, timeGap}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.CongestionControl.{
+  maxWindowSize,
+  minWindowSize,
+  timeGap
+}
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.NetworkMessage
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
-object CongestionControl{
+object CongestionControl {
   final val maxWindowSize = 64
   final val minWindowSize = 2
   final val expendThreshold = 4
   final val sendingTimeout: FiniteDuration = 30.seconds
   final val timeGap = 3000 // 3s
 }
-
 
 class CongestionControl {
 
@@ -25,19 +28,19 @@ class CongestionControl {
   val messageBuffer = new ArrayBuffer[NetworkMessage]()
   private val inTransit = new mutable.LongMap[NetworkMessage]
 
-  def canBeSent(data:NetworkMessage):Boolean = {
+  def canBeSent(data: NetworkMessage): Boolean = {
     if (inTransit.size < windowSize) {
       sentTimeStamp = System.currentTimeMillis()
       inTransit(data.messageID) = data
       true
-    }else{
+    } else {
       println(s"queued $data")
       toBeSent.enqueue(data)
       false
     }
   }
 
-  def ack(id:Long):Array[NetworkMessage] = {
+  def ack(id: Long): Array[NetworkMessage] = {
     messageBuffer.clear()
     inTransit.remove(id)
     if (System.currentTimeMillis() - sentTimeStamp < timeGap) {
@@ -50,7 +53,7 @@ class CongestionControl {
       ssThreshold /= 2
       windowSize = Math.max(minWindowSize, Math.min(ssThreshold, maxWindowSize))
     }
-    while(inTransit.size < windowSize && toBeSent.nonEmpty) {
+    while (inTransit.size < windowSize && toBeSent.nonEmpty) {
       val msg = toBeSent.dequeue()
       inTransit(msg.messageID) = msg
       messageBuffer.append(msg)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/ControlOutputPort.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/ControlOutputPort.scala
@@ -2,7 +2,9 @@ package edu.uci.ics.amber.engine.architecture.messaginglayer
 
 import java.util.concurrent.atomic.AtomicLong
 
+import akka.actor.ActorRef
 import edu.uci.ics.amber.engine.architecture.messaginglayer.ControlInputPort.WorkflowControlMessage
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{NetworkSenderActorRef, SendRequest}
 import edu.uci.ics.amber.engine.common.ambermessage.neo.ControlPayload
 import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.ActorVirtualIdentity
 
@@ -12,13 +14,13 @@ import scala.collection.mutable
   * The internal logic can send control messages to other actor without knowing
   * where the actor is and without determining the sequence number.
   */
-class ControlOutputPort(selfID: ActorVirtualIdentity, networkOutput: NetworkOutputGate) {
+class ControlOutputPort(selfID: ActorVirtualIdentity, networkSenderActor: NetworkSenderActorRef) {
   private val idToSequenceNums = new mutable.AnyRefMap[ActorVirtualIdentity, AtomicLong]()
 
   def sendTo(to: ActorVirtualIdentity, event: ControlPayload): Unit = {
     val seqNum = idToSequenceNums.getOrElseUpdate(to, new AtomicLong()).getAndIncrement()
     val msg = WorkflowControlMessage(selfID, seqNum, event)
-    networkOutput.forwardMessage(to, msg)
+    networkSenderActor ! SendRequest(to, msg)
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/ControlOutputPort.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/ControlOutputPort.scala
@@ -4,7 +4,10 @@ import java.util.concurrent.atomic.AtomicLong
 
 import akka.actor.ActorRef
 import edu.uci.ics.amber.engine.architecture.messaginglayer.ControlInputPort.WorkflowControlMessage
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{NetworkSenderActorRef, SendRequest}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{
+  NetworkSenderActorRef,
+  SendRequest
+}
 import edu.uci.ics.amber.engine.common.ambermessage.neo.ControlPayload
 import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.ActorVirtualIdentity
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/DataOutputPort.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/DataOutputPort.scala
@@ -4,7 +4,10 @@ import java.util.concurrent.atomic.AtomicLong
 
 import akka.actor.ActorRef
 import edu.uci.ics.amber.engine.architecture.messaginglayer.DataInputPort.WorkflowDataMessage
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{NetworkSenderActorRef, SendRequest}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{
+  NetworkSenderActorRef,
+  SendRequest
+}
 import edu.uci.ics.amber.engine.common.ambermessage.neo.DataPayload
 import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.ActorVirtualIdentity
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/DataOutputPort.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/DataOutputPort.scala
@@ -2,9 +2,10 @@ package edu.uci.ics.amber.engine.architecture.messaginglayer
 
 import java.util.concurrent.atomic.AtomicLong
 
+import akka.actor.ActorRef
 import edu.uci.ics.amber.engine.architecture.messaginglayer.DataInputPort.WorkflowDataMessage
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{NetworkSenderActorRef, SendRequest}
 import edu.uci.ics.amber.engine.common.ambermessage.neo.DataPayload
-import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity
 import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.ActorVirtualIdentity
 
 import scala.collection.mutable
@@ -13,7 +14,7 @@ import scala.collection.mutable
   * The internal logic can send data messages to other actor without knowing
   * where the actor is and without determining the sequence number.
   */
-class DataOutputPort(selfID: ActorVirtualIdentity, networkOutput: NetworkOutputGate) {
+class DataOutputPort(selfID: ActorVirtualIdentity, networkSenderActor: NetworkSenderActorRef) {
 
   private val idToSequenceNums = new mutable.AnyRefMap[ActorVirtualIdentity, AtomicLong]()
 
@@ -23,7 +24,7 @@ class DataOutputPort(selfID: ActorVirtualIdentity, networkOutput: NetworkOutputG
       idToSequenceNums.getOrElseUpdate(to, new AtomicLong()).getAndIncrement(),
       event
     )
-    networkOutput.forwardMessage(to, msg)
+    networkSenderActor ! SendRequest(to, msg)
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/DeadLetterMonitorActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/DeadLetterMonitorActor.scala
@@ -1,0 +1,17 @@
+package edu.uci.ics.amber.engine.architecture.messaginglayer
+
+import akka.actor.{Actor, DeadLetter}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{MessageBecomesDeadLetter, NetworkMessage}
+
+class DeadLetterMonitorActor extends Actor {
+  override def receive: Receive = {
+    case d: DeadLetter =>
+      d.message match{
+        case networkMessage: NetworkMessage =>
+          d.sender ! MessageBecomesDeadLetter(networkMessage)
+        case other =>
+          // skip for now
+      }
+    case _ =>
+  }
+}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/DeadLetterMonitorActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/DeadLetterMonitorActor.scala
@@ -1,16 +1,20 @@
 package edu.uci.ics.amber.engine.architecture.messaginglayer
 
 import akka.actor.{Actor, DeadLetter}
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{MessageBecomesDeadLetter, NetworkMessage}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{
+  MessageBecomesDeadLetter,
+  NetworkMessage
+}
 
 class DeadLetterMonitorActor extends Actor {
   override def receive: Receive = {
     case d: DeadLetter =>
-      d.message match{
+      d.message match {
         case networkMessage: NetworkMessage =>
+          // d.sender is the NetworkSenderActor
           d.sender ! MessageBecomesDeadLetter(networkMessage)
         case other =>
-          // skip for now
+        // skip for now
       }
     case _ =>
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkSenderActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkSenderActor.scala
@@ -131,7 +131,7 @@ class NetworkSenderActor extends Actor with LazyLogging {
     */
   def registerActorRef(actorID: ActorVirtualIdentity, ref: ActorRef): Unit = {
     idToActorRefs(actorID) = ref
-    val ctrl = idToCongestionControls(actorID)
+    val ctrl = idToCongestionControls.getOrElseUpdate(actorID, new CongestionControl())
     ctrl.getInTransitMessages.foreach { msg =>
       ctrl.markSentTime(msg)
       ref ! msg // directly send it

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkSenderActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkSenderActor.scala
@@ -180,10 +180,6 @@ class NetworkSenderActor extends Actor with LazyLogging {
       idToActorRefs(actorID) ! msg
     } else {
       // otherwise, we ask the parent for the actorRef.
-      // Note that congestion control doesn't know the
-      // message is not sent yet. We will send the
-      // message when we get the actorRef and update
-      // the sent time.
       getActorRefMappingFromParent(actorID)
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkSenderActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkSenderActor.scala
@@ -108,7 +108,7 @@ class NetworkSenderActor extends Actor with LazyLogging {
   /** This method forward a message by using tell pattern
     * if the map from Identifier to ActorRef is known,
     * forward the message immediately,
-    * otherwise stash the message and ask parent for help.
+    * otherwise it asks parent for help.
     */
   def forwardMessage(to: ActorVirtualIdentity, msg: WorkflowMessage): Unit = {
     val congestionControl = idToCongestionControls.getOrElseUpdate(to, new CongestionControl())

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkSenderActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkSenderActor.scala
@@ -112,7 +112,7 @@ class NetworkSenderActor extends Actor {
     val data = NetworkMessage(messageID, message)
     messageIDToIdentity(messageID) = to
     if (congestionControl.canBeSent(data)) {
-      println(s"send $data")
+      //println(s"send $data")
       idToActorRefs(to) ! data
     }
     messageID += 1

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkSenderActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkSenderActor.scala
@@ -139,7 +139,7 @@ class NetworkSenderActor extends Actor {
     case NetworkAck(id) =>
       val actorID = messageIDToIdentity(id)
       idToCongestionControls(actorID).ack(id).foreach { msg =>
-        println(s"send $msg")
+        //println(s"send $msg")
         idToActorRefs(actorID) ! msg
       }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/TupleToBatchConverter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/TupleToBatchConverter.scala
@@ -4,7 +4,6 @@ import edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy.Da
 import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.UpdateInputLinking
 import edu.uci.ics.amber.engine.common.ambermessage.neo.DataPayload
 import edu.uci.ics.amber.engine.common.ambertag.LinkTag
-import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity
 import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.ActorVirtualIdentity
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/principal/Principal.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/principal/Principal.scala
@@ -9,16 +9,67 @@ import edu.uci.ics.amber.engine.architecture.worker.{WorkerState, WorkerStatisti
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.ambermessage.PrincipalMessage.{AssignBreakpoint, _}
 import edu.uci.ics.amber.engine.common.ambermessage.StateMessage._
-import edu.uci.ics.amber.engine.common.ambermessage.ControlMessage.{Ack, AckWithInformation, CollectSinkResults, KillAndRecover, LocalBreakpointTriggered, LogErrorToFrontEnd, ModifyLogic, ModifyTuple, Pause, QueryState, QueryStatistics, ReleaseOutput, RequireAck, Resume, ResumeTuple, SkipTuple, Start, StashOutput}
+import edu.uci.ics.amber.engine.common.ambermessage.ControlMessage.{
+  Ack,
+  AckWithInformation,
+  CollectSinkResults,
+  KillAndRecover,
+  LocalBreakpointTriggered,
+  LogErrorToFrontEnd,
+  ModifyLogic,
+  ModifyTuple,
+  Pause,
+  QueryState,
+  QueryStatistics,
+  ReleaseOutput,
+  RequireAck,
+  Resume,
+  ResumeTuple,
+  SkipTuple,
+  Start,
+  StashOutput
+}
 import edu.uci.ics.amber.engine.common.ambermessage.ControllerMessage.ReportGlobalBreakpointTriggered
 import edu.uci.ics.amber.engine.common.ambermessage.{PrincipalMessage, WorkerMessage}
-import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.{AckedWorkerInitialization, CheckRecovery, EndSending, ExecutionCompleted, ExecutionPaused, QueryBreakpoint, QueryTriggeredBreakpoints, RemoveBreakpoint, ReportFailure, ReportWorkerPartialCompleted, ReportedQueriedBreakpoint, ReportedTriggeredBreakpoints, Reset, UpdateOutputLinking}
+import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.{
+  AckedWorkerInitialization,
+  CheckRecovery,
+  EndSending,
+  ExecutionCompleted,
+  ExecutionPaused,
+  QueryBreakpoint,
+  QueryTriggeredBreakpoints,
+  RemoveBreakpoint,
+  ReportFailure,
+  ReportWorkerPartialCompleted,
+  ReportedQueriedBreakpoint,
+  ReportedTriggeredBreakpoints,
+  Reset,
+  UpdateOutputLinking
+}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.ambertag.{AmberTag, LayerTag, OperatorIdentifier, WorkerTag}
-import edu.uci.ics.amber.engine.common.{AdvancedMessageSending, AmberUtils, Constants, ITupleSinkOperatorExecutor, TableMetadata, WorkflowLogger}
+import edu.uci.ics.amber.engine.common.{
+  AdvancedMessageSending,
+  AmberUtils,
+  Constants,
+  ITupleSinkOperatorExecutor,
+  TableMetadata,
+  WorkflowLogger
+}
 import edu.uci.ics.amber.engine.faulttolerance.recovery.RecoveryPacket
 import edu.uci.ics.amber.engine.operators.OpExecConfig
-import akka.actor.{Actor, ActorLogging, ActorPath, ActorRef, Address, Cancellable, PoisonPill, Props, Stash}
+import akka.actor.{
+  Actor,
+  ActorLogging,
+  ActorPath,
+  ActorRef,
+  Address,
+  Cancellable,
+  PoisonPill,
+  Props,
+  Stash
+}
 import akka.event.LoggingAdapter
 import akka.util.Timeout
 import akka.pattern.after

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
@@ -3,23 +3,15 @@ package edu.uci.ics.amber.engine.architecture.worker
 import akka.actor.Props
 import edu.uci.ics.amber.engine.architecture.breakpoint.FaultedTuple
 import edu.uci.ics.amber.engine.architecture.messaginglayer.DataInputPort.WorkflowDataMessage
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.NetworkMessage
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{NetworkAck, NetworkMessage}
 import edu.uci.ics.amber.engine.architecture.worker.neo.WorkerInternalQueue.InputTuple
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.ambermessage.ControlMessage.{QueryState, _}
 import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage._
-import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.{
-  ActorVirtualIdentity,
-  NamedActorVirtualIdentity
-}
+import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.{ActorVirtualIdentity, NamedActorVirtualIdentity}
 import edu.uci.ics.amber.engine.common.ambertag.{LayerTag, WorkerTag}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.{
-  AdvancedMessageSending,
-  ElidableStatement,
-  IOperatorExecutor,
-  ITupleSinkOperatorExecutor
-}
+import edu.uci.ics.amber.engine.common.{AdvancedMessageSending, ElidableStatement, IOperatorExecutor, ITupleSinkOperatorExecutor}
 import edu.uci.ics.amber.engine.faulttolerance.recovery.RecoveryPacket
 import edu.uci.ics.amber.engine.operators.OpExecConfig
 import edu.uci.ics.amber.error.WorkflowRuntimeError
@@ -163,7 +155,8 @@ class Processor(var operator: IOperatorExecutor, val tag: WorkerTag)
   }
 
   final def receiveDataMessages: Receive = {
-    case msg @ NetworkMessage(_, data: WorkflowDataMessage) =>
+    case msg @ NetworkMessage(id, data: WorkflowDataMessage) =>
+      sender ! NetworkAck(id)
       dataInputPort.handleDataMessage(data)
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
@@ -3,15 +3,26 @@ package edu.uci.ics.amber.engine.architecture.worker
 import akka.actor.Props
 import edu.uci.ics.amber.engine.architecture.breakpoint.FaultedTuple
 import edu.uci.ics.amber.engine.architecture.messaginglayer.DataInputPort.WorkflowDataMessage
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{NetworkAck, NetworkMessage}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{
+  NetworkAck,
+  NetworkMessage
+}
 import edu.uci.ics.amber.engine.architecture.worker.neo.WorkerInternalQueue.InputTuple
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.ambermessage.ControlMessage.{QueryState, _}
 import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage._
-import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.{ActorVirtualIdentity, NamedActorVirtualIdentity}
+import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.{
+  ActorVirtualIdentity,
+  NamedActorVirtualIdentity
+}
 import edu.uci.ics.amber.engine.common.ambertag.{LayerTag, WorkerTag}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.{AdvancedMessageSending, ElidableStatement, IOperatorExecutor, ITupleSinkOperatorExecutor}
+import edu.uci.ics.amber.engine.common.{
+  AdvancedMessageSending,
+  ElidableStatement,
+  IOperatorExecutor,
+  ITupleSinkOperatorExecutor
+}
 import edu.uci.ics.amber.engine.faulttolerance.recovery.RecoveryPacket
 import edu.uci.ics.amber.engine.operators.OpExecConfig
 import edu.uci.ics.amber.error.WorkflowRuntimeError

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/Processor.scala
@@ -3,7 +3,7 @@ package edu.uci.ics.amber.engine.architecture.worker
 import akka.actor.Props
 import edu.uci.ics.amber.engine.architecture.breakpoint.FaultedTuple
 import edu.uci.ics.amber.engine.architecture.messaginglayer.DataInputPort.WorkflowDataMessage
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkOutputGate.NetworkMessage
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.NetworkMessage
 import edu.uci.ics.amber.engine.architecture.worker.neo.WorkerInternalQueue.InputTuple
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.ambermessage.ControlMessage.{QueryState, _}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerBase.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerBase.scala
@@ -511,7 +511,7 @@ abstract class WorkerBase(identifier: ActorVirtualIdentity) extends WorkflowActo
       context.become(completed)
       unstashAll()
     case ExecutionPaused() =>
-      log.info(s"received Excution Pause message")
+      log.info(s"received Execution Pause message")
       onPaused()
       context.become(paused)
       unstashAll()

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerBase.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerBase.scala
@@ -7,7 +7,7 @@ import com.softwaremill.macwire.wire
 import edu.uci.ics.amber.engine.architecture.breakpoint.FaultedTuple
 import edu.uci.ics.amber.engine.architecture.common.WorkflowActor
 import edu.uci.ics.amber.engine.architecture.messaginglayer.ControlInputPort.WorkflowControlMessage
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{NetworkMessage, QueryActorRef, RegisterActorRef}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{NetworkAck, NetworkMessage, QueryActorRef, RegisterActorRef}
 import edu.uci.ics.amber.engine.architecture.messaginglayer.{BatchToTupleConverter, DataInputPort, DataOutputPort, TupleToBatchConverter}
 import edu.uci.ics.amber.engine.architecture.worker.neo.WorkerInternalQueue.DummyInput
 import edu.uci.ics.amber.engine.architecture.worker.neo._
@@ -508,8 +508,9 @@ abstract class WorkerBase(identifier: ActorVirtualIdentity) extends WorkflowActo
   }
 
   def processNewControlMessages: Receive = {
-    case msg @ NetworkMessage(_, cmd: WorkflowControlMessage) =>
+    case msg @ NetworkMessage(id, cmd: WorkflowControlMessage) =>
       println(s"received $msg")
+      sender ! NetworkAck(id)
       controlInputPort.handleControlMessage(cmd)
       newControlMessageHandler(cmd.payload)
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerBase.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerBase.scala
@@ -519,7 +519,7 @@ abstract class WorkerBase(identifier: ActorVirtualIdentity) extends WorkflowActo
 
   def processNewControlMessages: Receive = {
     case msg @ NetworkMessage(id, cmd: WorkflowControlMessage) =>
-      println(s"received $msg")
+      //println(s"received $msg")
       sender ! NetworkAck(id)
       controlInputPort.handleControlMessage(cmd)
       newControlMessageHandler(cmd.payload)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerBase.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerBase.scala
@@ -7,8 +7,18 @@ import com.softwaremill.macwire.wire
 import edu.uci.ics.amber.engine.architecture.breakpoint.FaultedTuple
 import edu.uci.ics.amber.engine.architecture.common.WorkflowActor
 import edu.uci.ics.amber.engine.architecture.messaginglayer.ControlInputPort.WorkflowControlMessage
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{NetworkAck, NetworkMessage, QueryActorRef, RegisterActorRef}
-import edu.uci.ics.amber.engine.architecture.messaginglayer.{BatchToTupleConverter, DataInputPort, DataOutputPort, TupleToBatchConverter}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkSenderActor.{
+  NetworkAck,
+  NetworkMessage,
+  QueryActorRef,
+  RegisterActorRef
+}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.{
+  BatchToTupleConverter,
+  DataInputPort,
+  DataOutputPort,
+  TupleToBatchConverter
+}
 import edu.uci.ics.amber.engine.architecture.worker.neo.WorkerInternalQueue.DummyInput
 import edu.uci.ics.amber.engine.architecture.worker.neo._
 import edu.uci.ics.amber.engine.common.IOperatorExecutor
@@ -283,9 +293,9 @@ abstract class WorkerBase(identifier: ActorVirtualIdentity) extends WorkflowActo
   }
 
   def ready: Receive =
-      allowStashOrReleaseOutput orElse
-        routeActorRefRelatedMessages orElse
-        processNewControlMessages orElse
+    allowStashOrReleaseOutput orElse
+      routeActorRefRelatedMessages orElse
+      processNewControlMessages orElse
       allowUpdateOutputLinking orElse //update linking
       allowModifyBreakpoints orElse //modify break points
       disallowQueryBreakpoint orElse //query specific breakpoint
@@ -307,9 +317,9 @@ abstract class WorkerBase(identifier: ActorVirtualIdentity) extends WorkflowActo
     } orElse discardOthers
 
   def pausedBeforeStart: Receive =
-      allowReset orElse allowStashOrReleaseOutput orElse
-        routeActorRefRelatedMessages orElse
-        processNewControlMessages orElse
+    allowReset orElse allowStashOrReleaseOutput orElse
+      routeActorRefRelatedMessages orElse
+      processNewControlMessages orElse
       allowUpdateOutputLinking orElse
       allowModifyBreakpoints orElse
       disallowQueryTriggeredBreakpoints orElse [Any, Unit] {
@@ -335,11 +345,11 @@ abstract class WorkerBase(identifier: ActorVirtualIdentity) extends WorkflowActo
     } orElse discardOthers
 
   def paused: Receive =
-      allowReset orElse
+    allowReset orElse
       allowStashOrReleaseOutput orElse
       processNewControlMessages orElse
-        routeActorRefRelatedMessages orElse
-        allowUpdateOutputLinking orElse
+      routeActorRefRelatedMessages orElse
+      allowUpdateOutputLinking orElse
       allowModifyBreakpoints orElse
       disallowQueryTriggeredBreakpoints orElse [Any, Unit] {
       case Resume =>
@@ -398,7 +408,7 @@ abstract class WorkerBase(identifier: ActorVirtualIdentity) extends WorkflowActo
     } orElse discardOthers
 
   def running: Receive =
-      processNewControlMessages orElse [Any, Unit] {
+    processNewControlMessages orElse [Any, Unit] {
       case ReportFailure(e) =>
         log.info(s"received failure message")
         throw e
@@ -427,10 +437,10 @@ abstract class WorkerBase(identifier: ActorVirtualIdentity) extends WorkflowActo
     } orElse discardOthers
 
   def breakpointTriggered: Receive =
-      allowStashOrReleaseOutput orElse
+    allowStashOrReleaseOutput orElse
       processNewControlMessages orElse
-        routeActorRefRelatedMessages orElse
-        allowUpdateOutputLinking orElse
+      routeActorRefRelatedMessages orElse
+      allowUpdateOutputLinking orElse
       allowQueryBreakpoint orElse
       allowQueryTriggeredBreakpoints orElse [Any, Unit] {
       case AssignBreakpoint(bp) =>
@@ -465,8 +475,8 @@ abstract class WorkerBase(identifier: ActorVirtualIdentity) extends WorkflowActo
     } orElse stashOthers
 
   def completed: Receive =
-      allowReset orElse allowStashOrReleaseOutput orElse
-        routeActorRefRelatedMessages orElse
+    allowReset orElse allowStashOrReleaseOutput orElse
+      routeActorRefRelatedMessages orElse
       disallowUpdateOutputLinking orElse
       processNewControlMessages orElse
       allowModifyBreakpoints orElse
@@ -487,7 +497,7 @@ abstract class WorkerBase(identifier: ActorVirtualIdentity) extends WorkflowActo
     }
 
   def pausing: Receive = {
-    processNewControlMessages orElse{
+    processNewControlMessages orElse {
       case msg =>
         //stash all other messages
         stash()
@@ -514,6 +524,5 @@ abstract class WorkerBase(identifier: ActorVirtualIdentity) extends WorkflowActo
       controlInputPort.handleControlMessage(cmd)
       newControlMessageHandler(cmd.payload)
   }
-
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/DataProcessor.scala
@@ -129,6 +129,7 @@ class DataProcessor( // dependencies:
       }
     }
     // Send Completed signal to worker actor.
+    println(s"${operator.toString} completed")
     controlOutputChannel.sendTo(VirtualIdentity.Self, ExecutionCompleted())
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/PauseManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/PauseManager.scala
@@ -4,15 +4,17 @@ import java.util.concurrent.CompletableFuture
 import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.ActorRef
+import edu.uci.ics.amber.engine.architecture.messaginglayer.ControlOutputPort
 import edu.uci.ics.amber.engine.architecture.worker.neo.PauseManager.{NoPause, Paused}
 import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.ExecutionPaused
+import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity
 
 object PauseManager {
   final val NoPause = 0
   final val Paused = 1
 }
 
-class PauseManager(val mainActor: ActorRef) {
+class PauseManager(controlOutputPort: ControlOutputPort) {
 
   // current pause privilege level
   private val pausePrivilegeLevel = new AtomicInteger(PauseManager.NoPause)
@@ -69,7 +71,7 @@ class PauseManager(val mainActor: ActorRef) {
     // create a future and wait for its completion
     this.dpThreadBlocker = new CompletableFuture[Void]
     // notify main actor thread
-    mainActor ! ExecutionPaused
+    controlOutputPort.sendTo(VirtualIdentity.Self, ExecutionPaused())
     // thread blocks here
     this.dpThreadBlocker.get
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberUtils.scala
@@ -42,11 +42,8 @@ object AmberUtils {
     val system = ActorSystem("Amber", config)
     val info = system.actorOf(Props[ClusterListener], "cluster-info")
     val deadLetterMonitorActor =
-      system.actorOf(Props[DeadLetterMonitorActor],
-        name = "dead-letter-monitor-actor")
-    system.eventStream.subscribe(
-      deadLetterMonitorActor, classOf[DeadLetter])
-
+      system.actorOf(Props[DeadLetterMonitorActor], name = "dead-letter-monitor-actor")
+    system.eventStream.subscribe(deadLetterMonitorActor, classOf[DeadLetter])
 
     system
   }
@@ -65,10 +62,8 @@ object AmberUtils {
     val system = ActorSystem("Amber", config)
     val info = system.actorOf(Props[ClusterListener], "cluster-info")
     val deadLetterMonitorActor =
-      system.actorOf(Props[DeadLetterMonitorActor],
-        name = "dead-letter-monitor-actor")
-    system.eventStream.subscribe(
-      deadLetterMonitorActor, classOf[DeadLetter])
+      system.actorOf(Props[DeadLetterMonitorActor], name = "dead-letter-monitor-actor")
+    system.eventStream.subscribe(deadLetterMonitorActor, classOf[DeadLetter])
     Constants.masterNodeAddr = addr
     system
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberUtils.scala
@@ -4,8 +4,9 @@ import java.io.{BufferedReader, InputStreamReader}
 import java.net.{InetAddress, URL}
 
 import edu.uci.ics.amber.clustering.ClusterListener
-import akka.actor.{ActorSystem, Props}
+import akka.actor.{ActorSystem, DeadLetter, Props}
 import com.typesafe.config.ConfigFactory
+import edu.uci.ics.amber.engine.architecture.messaginglayer.DeadLetterMonitorActor
 
 object AmberUtils {
 
@@ -40,6 +41,12 @@ object AmberUtils {
 
     val system = ActorSystem("Amber", config)
     val info = system.actorOf(Props[ClusterListener], "cluster-info")
+    val deadLetterMonitorActor =
+      system.actorOf(Props[DeadLetterMonitorActor],
+        name = "dead-letter-monitor-actor")
+    system.eventStream.subscribe(
+      deadLetterMonitorActor, classOf[DeadLetter])
+
 
     system
   }
@@ -57,6 +64,11 @@ object AmberUtils {
       .withFallback(ConfigFactory.load("clustered"))
     val system = ActorSystem("Amber", config)
     val info = system.actorOf(Props[ClusterListener], "cluster-info")
+    val deadLetterMonitorActor =
+      system.actorOf(Props[DeadLetterMonitorActor],
+        name = "dead-letter-monitor-actor")
+    system.eventStream.subscribe(
+      deadLetterMonitorActor, classOf[DeadLetter])
     Constants.masterNodeAddr = addr
     system
   }


### PR DESCRIPTION
This PR is the second part of refining the messaging layer:
1. Changed `NetworkOutputGate` to a single actor for sending messages and receiving acks.
2. For each receiver, applied congestion control.

![Texera Overall Infrastructure-第 5 页 (1)](https://user-images.githubusercontent.com/13672781/103388037-d3f01b00-4abb-11eb-84aa-8a58b4574a8f.png)

