### PR TITLE
[BUGFIX] Workflow cannot complete and Akka reports oversized payload

### DIFF
--- a/core/amber/src/main/resources/clustered.conf
+++ b/core/amber/src/main/resources/clustered.conf
@@ -12,9 +12,14 @@ akka {
 
   }
   remote {
+  maximum-payload-bytes = 30000000 bytes
     netty.tcp {
       hostname = "0.0.0.0"
       port = 0
+      message-frame-size =  30000000b
+      send-buffer-size =  30000000b
+      receive-buffer-size =  30000000b
+      maximum-frame-size = 30000000b
     }
 
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/RoundRobinPolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/RoundRobinPolicy.scala
@@ -24,7 +24,10 @@ class RoundRobinPolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
     if (currentSize > 0) {
       ret.append((receivers(roundRobinIndex), DataFrame(batch.slice(0, currentSize))))
     }
-    ret.append((receivers(roundRobinIndex), EndOfUpstream()))
+    receivers.foreach{
+      receiver =>
+        ret.append((receiver, EndOfUpstream())) // send end to all receivers
+    }
     ret.toArray
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/RoundRobinPolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/RoundRobinPolicy.scala
@@ -24,9 +24,8 @@ class RoundRobinPolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
     if (currentSize > 0) {
       ret.append((receivers(roundRobinIndex), DataFrame(batch.slice(0, currentSize))))
     }
-    receivers.foreach{
-      receiver =>
-        ret.append((receiver, EndOfUpstream())) // send end to all receivers
+    receivers.foreach { receiver =>
+      ret.append((receiver, EndOfUpstream())) // send end to all receivers
     }
     ret.toArray
   }


### PR DESCRIPTION
This PR fixes a bug on `RoundRobinPolicy` where it just sends `EndOfUpstream` to one of the downstream receivers. This will cause the workflow to remain in an uncompleted state forever. Also, after enlarging the batch size, Akka reports OversizedPayloadException because one batch is getting too big. I've set the maximum-payload-size to 30M to prevent Akka from dropping the message according to [this post](https://stackoverflow.com/questions/36685326/max-allowed-size-128000-bytes-actual-size-of-encoded-class-scala-error-in-akk). However, this is only a tentative solution, we need to have fix-sized data frames ASAP. 