### PR TITLE
Incrementalize word cloud operator (Step 1-2)

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/ProgressiveUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/ProgressiveUtils.scala
@@ -1,0 +1,35 @@
+package edu.uci.ics.texera.workflow.common
+
+import edu.uci.ics.texera.workflow.common.tuple.Tuple
+import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType}
+
+object ProgressiveUtils {
+
+  // boolean attribute to indicate insertion / retraction
+  // true  indicates insertion  (+)
+  // false indicates retraction (-)
+  val insertRetractFlagAttr = new Attribute("__internal_is_insertion", AttributeType.BOOLEAN)
+
+  def addInsertionFlag(tuple: Tuple): Tuple = {
+    assert(! tuple.getSchema.containsAttribute(insertRetractFlagAttr.getName))
+    Tuple.newBuilder.add(insertRetractFlagAttr, true).add(tuple).build
+  }
+
+  def addRetractionFlag(tuple: Tuple): Tuple = {
+    assert(! tuple.getSchema.containsAttribute(insertRetractFlagAttr.getName))
+    Tuple.newBuilder.add(insertRetractFlagAttr, false).add(tuple).build
+  }
+
+  def isInsertion(tuple: Tuple): Boolean = {
+    if (tuple.getSchema.containsAttribute(insertRetractFlagAttr.getName)) {
+      tuple.getField[Boolean](insertRetractFlagAttr.getName)
+    } else {
+      true
+    }
+  }
+
+  def getTupleFlagAndValue(tuple: Tuple): (Boolean, Tuple) = {
+    (isInsertion(tuple), Tuple.newBuilder().add(tuple).removeIfExists(insertRetractFlagAttr.getName).build())
+  }
+
+}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/ProgressiveUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/ProgressiveUtils.scala
@@ -11,12 +11,12 @@ object ProgressiveUtils {
   val insertRetractFlagAttr = new Attribute("__internal_is_insertion", AttributeType.BOOLEAN)
 
   def addInsertionFlag(tuple: Tuple): Tuple = {
-    assert(! tuple.getSchema.containsAttribute(insertRetractFlagAttr.getName))
+    assert(!tuple.getSchema.containsAttribute(insertRetractFlagAttr.getName))
     Tuple.newBuilder.add(insertRetractFlagAttr, true).add(tuple).build
   }
 
   def addRetractionFlag(tuple: Tuple): Tuple = {
-    assert(! tuple.getSchema.containsAttribute(insertRetractFlagAttr.getName))
+    assert(!tuple.getSchema.containsAttribute(insertRetractFlagAttr.getName))
     Tuple.newBuilder.add(insertRetractFlagAttr, false).add(tuple).build
   }
 
@@ -29,7 +29,10 @@ object ProgressiveUtils {
   }
 
   def getTupleFlagAndValue(tuple: Tuple): (Boolean, Tuple) = {
-    (isInsertion(tuple), Tuple.newBuilder().add(tuple).removeIfExists(insertRetractFlagAttr.getName).build())
+    (
+      isInsertion(tuple),
+      Tuple.newBuilder().add(tuple).removeIfExists(insertRetractFlagAttr.getName).build()
+    )
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpExec.scala
@@ -2,12 +2,14 @@ package edu.uci.ics.texera.workflow.operators.sink
 
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.{ITupleSinkOperatorExecutor, InputExhausted}
+import edu.uci.ics.texera.workflow.common.ProgressiveUtils
+import edu.uci.ics.texera.workflow.common.tuple.Tuple
 
 import scala.collection.mutable
 
 class SimpleSinkOpExec extends ITupleSinkOperatorExecutor {
 
-  val results: mutable.MutableList[ITuple] = mutable.MutableList()
+  val results: mutable.ListBuffer[Tuple] = mutable.ListBuffer()
 
   def getResultTuples(): Array[ITuple] = {
     results.toArray
@@ -23,10 +25,19 @@ class SimpleSinkOpExec extends ITupleSinkOperatorExecutor {
   ): scala.Iterator[ITuple] = {
     tuple match {
       case Left(t) =>
-        this.results += t
+        updateResult(t.asInstanceOf[Tuple])
         Iterator()
       case Right(_) =>
         Iterator()
+    }
+  }
+
+  private def updateResult(tuple: Tuple): Unit = {
+    val (isInsertion, tupleValue) = ProgressiveUtils.getTupleFlagAndValue(tuple)
+    if (isInsertion) {
+      results += tupleValue
+    } else {
+      results -= tupleValue
     }
   }
 


### PR DESCRIPTION
This is the part 2 of step 1 of the Word Cloud incrementalization project. See https://github.com/Texera/texera/issues/935

We want to change word cloud operator to be incremental.
In this PR, we
 - change word cloud final operator to output current snapshot upon receiving a new batch update from partial opeartor
 - change the sink operator: make the sink operator discard the previous snapshot and stores the new snapshot for every input