### PR TITLE
Incrementalize word cloud operator (Step 2)

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/QueryWorkerStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/QueryWorkerStatisticsHandler.scala
@@ -2,17 +2,12 @@ package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 
 import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
-import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.WorkflowStatusUpdate
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.QueryWorkerStatistics
-import edu.uci.ics.amber.engine.architecture.principal.OperatorStatistics
-import edu.uci.ics.amber.engine.architecture.worker.WorkerStatistics
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
 
-import scala.collection.mutable
-
 object QueryWorkerStatisticsHandler {
-  final case class QueryWorkerStatistics() extends ControlCommand[CommandCompleted]
+  final case class QueryWorkerStatistics() extends ControlCommand[Unit]
 }
 
 /** Get statistics from all the workers
@@ -35,7 +30,6 @@ trait QueryWorkerStatisticsHandler {
         .map { ret =>
           // update frontend status
           updateFrontendWorkflowStatus()
-          CommandCompleted()
         }
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerLayer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerLayer.scala
@@ -72,7 +72,11 @@ class WorkerLayer(
       )
       parentNetworkCommunicationActorRef ! RegisterActorRef(workerID, ref)
       workerToLayer(workerID) = this
-      workerID -> WorkerInfo(workerID, Uninitialized, WorkerStatistics(Uninitialized, 0, 0, Option.empty))
+      workerID -> WorkerInfo(
+        workerID,
+        Uninitialized,
+        WorkerStatistics(Uninitialized, 0, 0, Option.empty)
+      )
     }.toMap
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerLayer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerLayer.scala
@@ -72,7 +72,7 @@ class WorkerLayer(
       )
       parentNetworkCommunicationActorRef ! RegisterActorRef(workerID, ref)
       workerToLayer(workerID) = this
-      workerID -> WorkerInfo(workerID, Uninitialized, WorkerStatistics(Uninitialized, 0, 0))
+      workerID -> WorkerInfo(workerID, Uninitialized, WorkerStatistics(Uninitialized, 0, 0, Option.empty))
     }.toMap
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/principal/OperatorStatistics.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/principal/OperatorStatistics.scala
@@ -1,7 +1,10 @@
 package edu.uci.ics.amber.engine.architecture.principal
 
+import edu.uci.ics.amber.engine.common.tuple.ITuple
+
 case class OperatorStatistics(
     operatorState: OperatorState,
     aggregatedInputRowCount: Long,
-    aggregatedOutputRowCount: Long
+    aggregatedOutputRowCount: Long,
+    aggregatedOutputResults: Option[List[ITuple]] // in case of a sink operator
 )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerStatistics.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerStatistics.scala
@@ -1,9 +1,11 @@
 package edu.uci.ics.amber.engine.architecture.worker
 
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.WorkerState
+import edu.uci.ics.amber.engine.common.tuple.ITuple
 
 case class WorkerStatistics(
     workerState: WorkerState,
     inputRowCount: Long,
-    outputRowCount: Long
+    outputRowCount: Long,
+    outputResults: Option[List[ITuple]] // in case of a sink operator
 )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
@@ -1,6 +1,9 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
-import edu.uci.ics.amber.engine.architecture.worker.{WorkerAsyncRPCHandlerInitializer, WorkerStatistics}
+import edu.uci.ics.amber.engine.architecture.worker.{
+  WorkerAsyncRPCHandlerInitializer,
+  WorkerStatistics
+}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
 import edu.uci.ics.amber.engine.common.ITupleSinkOperatorExecutor
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
@@ -1,10 +1,8 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
-import edu.uci.ics.amber.engine.architecture.worker.{
-  WorkerAsyncRPCHandlerInitializer,
-  WorkerStatistics
-}
+import edu.uci.ics.amber.engine.architecture.worker.{WorkerAsyncRPCHandlerInitializer, WorkerStatistics}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
+import edu.uci.ics.amber.engine.common.ITupleSinkOperatorExecutor
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
 
 object QueryStatisticsHandler {
@@ -17,7 +15,13 @@ trait QueryStatisticsHandler {
   registerHandler { (msg: QueryStatistics, sender) =>
     val (in, out) = dataProcessor.collectStatistics()
     val state = stateManager.getCurrentState
-    WorkerStatistics(state, in, out)
+    val result = operator match {
+      case sink: ITupleSinkOperatorExecutor =>
+        Option(sink.getResultTuples())
+      case _ =>
+        Option.empty
+    }
+    WorkerStatistics(state, in, out, result)
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -204,7 +204,8 @@ class WorkflowWebsocketResource {
           val sinkStatistics = OperatorStatistics(
             inputStatistics.operatorState,
             inputStatistics.aggregatedOutputRowCount,
-            inputStatistics.aggregatedOutputRowCount
+            inputStatistics.aggregatedOutputRowCount,
+            inputStatistics.aggregatedOutputResults
           )
           updateMutable(sinkID) = sinkStatistics
         }


### PR DESCRIPTION
This is the part 2 of the Word Cloud incrementalization project. See https://github.com/Texera/texera/issues/936

After incrementalize the word cloud operator, we want to pass the results update from the worker to the controller and web server.

We will reuse the existing logic of QueryStatistics. Whenever the controller query for statistics updates, it will also ask if there are any new updates for the output data if the operator is a sink operator.

Old design:

![Texera Overall Infrastructure-WordCloud](https://user-images.githubusercontent.com/12578068/104516487-4297a300-55a9-11eb-9869-9116dac5e7ed.png)


New design, differences marked in red:
![Texera Overall Infrastructure-WordCloud (1)](https://user-images.githubusercontent.com/12578068/104516500-462b2a00-55a9-11eb-850b-630b614f549d.png)

