### PR TITLE
Progressive MySQL Source Operator (Step 1)

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
@@ -153,7 +153,7 @@ public class MysqlSourceOpDesc extends SourceOperatorDescriptor {
             return schemaBuilder.build();
         } catch (SQLException | InstantiationException | IllegalAccessException | ClassNotFoundException | ClassCastException e) {
             e.printStackTrace();
-            throw new RuntimeException("Mysql Source failed to connect to mysql database." + e.getMessage());
+            throw new RuntimeException("Mysql Source failed to connect to mysql database. " + e.getMessage());
         }
     }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
@@ -55,8 +55,8 @@ public class MysqlSourceOpDesc extends SourceOperatorDescriptor {
     public String keywords;
 
     @JsonProperty(value = "progressive")
-    @JsonPropertyDescription("progressively yield outputs")
-    public Boolean progressive;
+    @JsonPropertyDescription("progressively yield outputs by batches")
+    public Boolean progressive = false;
 
     @Override
     public OpExecConfig operatorExecutor() {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
@@ -54,6 +54,10 @@ public class MysqlSourceOpDesc extends SourceOperatorDescriptor {
     @JsonPropertyDescription("search terms in boolean expression")
     public String keywords;
 
+    @JsonProperty(value = "progressive")
+    @JsonPropertyDescription("progressively yield outputs")
+    public Boolean progressive;
+
     @Override
     public OpExecConfig operatorExecutor() {
         return new MysqlSourceOpExecConfig(this.operatorIdentifier(), worker -> new MysqlSourceOpExec(
@@ -67,7 +71,8 @@ public class MysqlSourceOpDesc extends SourceOperatorDescriptor {
                 limit,
                 offset,
                 column,
-                keywords
+                keywords,
+                progressive
         ));
     }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpExec.java
@@ -8,6 +8,8 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.Schema;
 import scala.collection.Iterator;
 
 import java.sql.*;
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingDeque;
 
 public class MysqlSourceOpExec implements SourceOperatorExecutor {
     private final Schema schema;
@@ -23,7 +25,8 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
     private final String keywords;
 
     private Connection connection;
-    private PreparedStatement preparedStatement;
+    private final Queue<PreparedStatement> miniQueries;
+    private PreparedStatement currentPreparedStatement;
     private ResultSet resultSet;
     private boolean querySent = false;
     private boolean hasNext = true;
@@ -39,16 +42,9 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
         this.password = password;
         this.limit = limit;
         this.offset = offset;
-        if (column!=null) {
-            this.column = column.trim();
-        } else {
-            this.column = null;
-        }
-        if(keywords!=null) {
-            this.keywords = keywords.trim();
-        } else {
-            this.keywords = null;
-        }
+        this.column = column == null ? null : column.trim();
+        this.keywords = keywords == null ? null : keywords.trim();
+        this.miniQueries = new LinkedBlockingDeque<>();
     }
 
     /**
@@ -76,14 +72,14 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
             @Override
             public Tuple next() {
                 try {
-                    if (resultSet.next()) {
+                    if (resultSet != null && resultSet.next()) {
                         Tuple.Builder tupleBuilder = Tuple.newBuilder();
                         for (Attribute attr : schema.getAttributes()) {
                             String columnName = attr.getName();
                             AttributeType columnType = attr.getType();
                             String value = resultSet.getString(columnName);
                             if (value == null) {
-                                tupleBuilder.add(attr,null);
+                                tupleBuilder.add(attr, null);
                                 continue;
                             }
                             switch (columnType) {
@@ -105,10 +101,23 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
                             }
                         }
                         return tupleBuilder.build();
+                    } else if (!miniQueries.isEmpty()) {
+                        if (resultSet != null) {
+                            resultSet.close();
+                        }
+                        if (currentPreparedStatement != null) {
+                            currentPreparedStatement.close();
+                        }
+                        currentPreparedStatement = miniQueries.poll();
+                        if (currentPreparedStatement != null) {
+                            resultSet = currentPreparedStatement.executeQuery();
+                        }
+                        return next();
                     } else {
                         hasNext = false;
                         return null;
                     }
+
                 } catch (SQLException e) {
                     throw new RuntimeException(e);
                 }
@@ -122,7 +131,7 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
      * A prepared statement is used to prevent sql injection attacks
      * Since user might provide info in a combination of column, keywords, limit and offset
      * the prepared statement can have different number of parameters.
-     * A varaible curIndex is used to keep track of there the next parameter should be filled in
+     * A variable curIndex is used to keep track of the next parameter should be filled in
      */
     @Override
     public void open() {
@@ -134,21 +143,25 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
                 this.connection = DriverManager.getConnection(url, this.username, this.password);
                 // set to readonly to improve efficiency
                 connection.setReadOnly(true);
-                preparedStatement = this.connection.prepareStatement(generateSqlQuery());
-                int curIndex = 1;
-                if (this.column != null && this.keywords != null) {
-                    preparedStatement.setString(curIndex, this.keywords);
-                    curIndex += 1;
+                for (int i = 0; i < 10; i++) {
+                    PreparedStatement preparedStatement = this.connection.prepareStatement(generateSqlQuery(i));
+                    int curIndex = 1;
+                    if (this.column != null && this.keywords != null) {
+                        preparedStatement.setString(curIndex, this.keywords);
+                        curIndex += 1;
+                    }
+                    if (this.limit != null) {
+                        preparedStatement.setInt(curIndex, this.limit);
+                        curIndex += 1;
+                    }
+                    if (this.offset != null) {
+                        preparedStatement.setObject(curIndex, this.offset, Types.INTEGER);
+                    }
+                    miniQueries.add(preparedStatement);
+
                 }
-                if (this.limit != null) {
-                    preparedStatement.setInt(curIndex, this.limit);
-                    curIndex += 1;
-                }
-                if (this.offset != null) {
-                    preparedStatement.setObject(curIndex, this.offset, Types.INTEGER);
-                }
-                this.resultSet = preparedStatement.executeQuery();
                 querySent = true;
+
             }
         } catch (Exception e) {
             throw new RuntimeException("MysqlSource failed to connect to mysql database." + e.getMessage());
@@ -165,13 +178,13 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
             if (resultSet != null) {
                 resultSet.close();
             }
-            if (preparedStatement != null) {
-                preparedStatement.close();
+            if (currentPreparedStatement != null) {
+                currentPreparedStatement.close();
             }
             if (connection != null) {
                 connection.close();
             }
-        }catch (SQLException e) {
+        } catch (SQLException e) {
             throw new RuntimeException("Mysql source fail to close. " + e.getMessage());
         }
     }
@@ -186,28 +199,32 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
      * select * from TableName where 1 = 1 LIMIT 999999999999999 OFFSET ?;
      * select * from TableName where 1 = 1 LIMIT ?;
      * select * from TableName where 1 = 1;
+     *
      * @return string of sql query
      */
-    private String generateSqlQuery() {
+    private String generateSqlQuery(int batch) {
         // in sql prepared statement, table name cannot be inserted using preparedstatement.setString
         // so it has to be inserted here during sql query generation
-        String query =  "\n" + "select * from "+ this.table +" where 1 = 1 ";
+        String query = "\n" + "SELECT * FROM " + this.table + " where 1 = 1";
         // in sql prepared statement, column name cannot be inserted using preparedstatement.setString either
-        if(this.column != null && this.keywords != null) {
-            query += " AND  MATCH( " + this.column + " )  AGAINST ( ? IN BOOLEAN MODE)";
+        if (this.column != null && this.keywords != null) {
+            query += " AND MATCH(" + this.column + ") AGAINST (? IN BOOLEAN MODE)";
         }
-        if(this.limit != null){
+        query += " AND create_at >= '" + (2014 + batch) + "-01-01T00:00:00.000Z' and create_at < '" + (2015 + batch) + "-01-01T00:00:00.000Z'";
+
+        if (this.limit != null) {
             query += " LIMIT ?";
         }
-        if(this.offset != null) {
-            if(this.limit == null) {
+        if (this.offset != null) {
+            if (this.limit == null) {
                 // if there is no limit, for OFFSET to work, a arbitrary LARGE number
                 // need to be manually provided
-                query += "LIMIT 999999999999999";
+                query += " LIMIT 999999999999999";
             }
             query += " OFFSET ?";
         }
-        query+=";";
+        query += ";";
         return query;
     }
 }
+


### PR DESCRIPTION
In this PR, it hardcoded the MySQL Source Operator to execute the SQL against tweets table with batches split by create_at (datetime/timestamp TYPE). 

As an effect, there are multiple mini queries split and sent to database sequentially, and the results are yield in batches sequentially. Frontend will see new batches getting updated once a while.

This is the first step to do progressive source operators. There is a toggle button on the frontend MySQL Source Operator Desc to enable/disable progressiveness. 