### PR TITLE
Make multiple view result operators have their own states for page index

### DIFF
--- a/core/new-gui/src/app/workspace/types/result-table.interface.ts
+++ b/core/new-gui/src/app/workspace/types/result-table.interface.ts
@@ -36,16 +36,20 @@ export interface TableColumn extends Readonly<{
 
 export const PAGINATION_INFO_STORAGE_KEY = 'result-panel-pagination-info';
 
-/**
- * ResultPaginationInfo stores pagination information
- *   that is needed for status retainment of the result panel
- */
-export interface ResultPaginationInfo extends Readonly<{
-  newWorkflowExecuted: boolean;
+export interface ViewResultOperatorInfo extends Readonly<{
   currentResult: object[];
   currentPageIndex: number;
   currentPageSize: number;
   total: number;
   columnKeys: string[];
   operatorID: string
+}> {}
+
+/**
+ * ResultPaginationInfo stores pagination information
+ *   that is needed for status retainment of the result panel
+ */
+export interface ResultPaginationInfo extends Readonly<{
+  newWorkflowExecuted: boolean;
+  viewResultOperatorInfoMap: Map<string, ViewResultOperatorInfo>
 }> {}


### PR DESCRIPTION
Changing the structure of ResultPaginationInfo so that each view result operator has its own state for the current page index

Demo
![2021-01-13 01-33-27](https://user-images.githubusercontent.com/21030118/104434421-0da33600-5540-11eb-864e-a44e953d0ac6.gif)
