### PR TITLE
Incrementalize word cloud operator Step 3

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/TexeraWebSocketEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/TexeraWebSocketEvent.scala
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
     new Type(value = classOf[WorkflowErrorEvent]),
     new Type(value = classOf[WorkflowStartedEvent]),
     new Type(value = classOf[WorkflowCompletedEvent]),
-    new Type(value = classOf[WorkflowStatusUpdateEvent]),
+    new Type(value = classOf[WebWorkflowStatusUpdateEvent]),
     new Type(value = classOf[WorkflowPausedEvent]),
     new Type(value = classOf[WorkflowResumedEvent]),
     new Type(value = classOf[RecoveryStartedEvent]),

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowCompletedEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowCompletedEvent.scala
@@ -66,19 +66,17 @@ object WorkflowCompletedEvent {
       workflowCompiler: WorkflowCompiler
   ): WorkflowCompletedEvent = {
     val resultList = new mutable.MutableList[OperatorResult]
-    workflowCompleted.result.foreach(pair => {
-      val operatorID = pair._1
+    for ((operatorID, resultTuples) <- workflowCompleted.result) {
       val chartType = OperatorResult.getChartType(operatorID, workflowCompiler)
 
-      val table = chartType match {
-        case Some(_) =>
-          pair._2
-        case None =>
-          pair._2.slice(0, defaultPageSize)
+      var table = resultTuples
+      // if not visualization result, then only return first page results
+      if (chartType.isEmpty) {
+        table = resultTuples.slice(0, defaultPageSize)
       }
 
-      resultList += OperatorResult.fromTuple(operatorID, table, chartType, pair._2.length)
-    })
+      resultList += OperatorResult.fromTuple(operatorID, table, chartType, resultTuples.length)
+    }
     WorkflowCompletedEvent(resultList.toList)
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowCompletedEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowCompletedEvent.scala
@@ -2,16 +2,58 @@ package edu.uci.ics.texera.web.model.event
 
 import com.fasterxml.jackson.databind.node.ObjectNode
 import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.WorkflowCompleted
+import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.workflow.WorkflowCompiler
 import edu.uci.ics.texera.workflow.operators.visualization.VisualizationOperator
 
 import scala.collection.mutable
 
+object OperatorResult {
+  def getChartType(operatorID: String, workflowCompiler: WorkflowCompiler): Option[String] = {
+    val outLinks =
+      workflowCompiler.workflowInfo.links.filter(link => link.origin.operatorID == operatorID)
+    val isSink = outLinks.isEmpty
+
+    if (!isSink) {
+      return None
+    }
+
+    // add chartType to result
+    val precedentOpID =
+      workflowCompiler.workflowInfo.links
+        .find(link => link.destination.operatorID == operatorID)
+        .get
+        .origin
+    val precedentOp =
+      workflowCompiler.workflowInfo.operators
+        .find(op => op.operatorID == precedentOpID.operatorID)
+        .get
+    precedentOp match {
+      case operator: VisualizationOperator => Option.apply(operator.chartType())
+      case _                               => Option.empty
+    }
+  }
+
+  def fromTuple(
+      operatorID: String,
+      table: List[ITuple],
+      chartType: Option[String],
+      totalRowCount: Int
+  ): OperatorResult = {
+    OperatorResult(
+      operatorID,
+      table.map(t => t.asInstanceOf[Tuple].asKeyValuePairJson()),
+      chartType,
+      totalRowCount
+    )
+  }
+}
+
 case class OperatorResult(
     operatorID: String,
     table: List[ObjectNode],
-    chartType: String,
+    chartType: Option[String],
     totalRowCount: Int
 )
 
@@ -26,32 +68,16 @@ object WorkflowCompletedEvent {
     val resultList = new mutable.MutableList[OperatorResult]
     workflowCompleted.result.foreach(pair => {
       val operatorID = pair._1
+      val chartType = OperatorResult.getChartType(operatorID, workflowCompiler)
 
-      // add chartType to result
-      val precedentOpID =
-        workflowCompiler.workflowInfo.links
-          .find(link => link.destination.operatorID == operatorID)
-          .get
-          .origin
-      val precedentOp =
-        workflowCompiler.workflowInfo.operators
-          .find(op => op.operatorID == precedentOpID.operatorID)
-          .get
-      val chartType = precedentOp match {
-        case operator: VisualizationOperator => operator.chartType()
-        case _                               => null
-      }
-
-      val table = precedentOp match {
-        case _: VisualizationOperator =>
-          pair._2.map(tuple => tuple.asInstanceOf[Tuple].asKeyValuePairJson())
-        case _ =>
+      val table = chartType match {
+        case Some(_) =>
           pair._2
-            .slice(0, defaultPageSize)
-            .map(tuple => tuple.asInstanceOf[Tuple].asKeyValuePairJson())
+        case None =>
+          pair._2.slice(0, defaultPageSize)
       }
 
-      resultList += OperatorResult(operatorID, table, chartType, pair._2.length)
+      resultList += OperatorResult.fromTuple(operatorID, table, chartType, pair._2.length)
     })
     WorkflowCompletedEvent(resultList.toList)
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
@@ -1,6 +1,52 @@
 package edu.uci.ics.texera.web.model.event
 
-import edu.uci.ics.amber.engine.architecture.principal.OperatorStatistics
+import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.WorkflowStatusUpdate
+import edu.uci.ics.amber.engine.architecture.principal.{OperatorState, OperatorStatistics}
+import edu.uci.ics.texera.workflow.common.workflow.WorkflowCompiler
 
-case class WorkflowStatusUpdateEvent(operatorStatistics: Map[String, OperatorStatistics])
+object WebOperatorStatistics {
+
+  def apply(
+      operatorID: String,
+      operatorStatistics: OperatorStatistics,
+      workflowCompiler: WorkflowCompiler
+  ): WebOperatorStatistics = {
+    val chartType = OperatorResult.getChartType(operatorID, workflowCompiler)
+    val results = operatorStatistics.aggregatedOutputResults
+      // if chartType is null (normal sink), don't send results as well
+      .flatMap(r => chartType.map(_ => r))
+      // convert tuple format
+      .map(r => OperatorResult.fromTuple(operatorID, r, chartType, r.size))
+
+    WebOperatorStatistics(
+      operatorStatistics.operatorState,
+      operatorStatistics.aggregatedInputRowCount,
+      operatorStatistics.aggregatedOutputRowCount,
+      results
+    )
+  }
+
+}
+
+case class WebOperatorStatistics(
+    operatorState: OperatorState,
+    aggregatedInputRowCount: Long,
+    aggregatedOutputRowCount: Long,
+    aggregatedOutputResults: Option[OperatorResult] // in case of a sink operator
+)
+
+object WebWorkflowStatusUpdateEvent {
+  def apply(
+      update: WorkflowStatusUpdate,
+      workflowCompiler: WorkflowCompiler
+  ): WebWorkflowStatusUpdateEvent = {
+    WebWorkflowStatusUpdateEvent(
+      update.operatorStatistics.map(e =>
+        (e._1, WebOperatorStatistics.apply(e._1, e._2, workflowCompiler))
+      )
+    )
+  }
+}
+
+case class WebWorkflowStatusUpdateEvent(operatorStatistics: Map[String, WebOperatorStatistics])
     extends TexeraWebSocketEvent

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.html
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.html
@@ -39,7 +39,7 @@
     </div>
   </div>
 
-  <div [hidden]="!chartType">
+  <div>
     <texera-visualization-panel [operatorID]="resultPanelOperatorID"></texera-visualization-panel>
   </div>
 

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -99,7 +99,7 @@ export class ResultPanelComponent {
       if (event.current.state === ExecutionState.Failed) {
         this.resultPanelToggleService.openResultPanel();
       }
-      if (event.current.state === ExecutionState.Completed) {
+      if (event.current.state === ExecutionState.Completed || event.current.state === ExecutionState.Running) {
         const sinkOperators = this.workflowActionService.getTexeraGraph().getAllOperators()
           .filter(op => op.operatorType.toLowerCase().includes('sink'));
         if (sinkOperators.length > 0) {

--- a/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.html
+++ b/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.html
@@ -3,11 +3,6 @@
 <div>
   <!-- this id should be identical to VisualizationPanelContentComponent.CHART_ID -->
   <div id="texera-result-chart-content">
-
-  </div>
-
-  <!-- this id should be identical to VisualizationPanelContentComponent.WORD_CLOUD_ID -->
-  <div id="texera-word-cloud" width="1000" height="800">
   </div>
 
 </div>

--- a/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.ts
+++ b/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.ts
@@ -23,8 +23,14 @@ import { Subscription } from 'rxjs';
 export class VisualizationPanelContentComponent implements AfterViewInit, OnDestroy {
   // this readonly variable must be the same as HTML element ID for visualization
   public static readonly CHART_ID = '#texera-result-chart-content';
+
+  // width and height of the canvas in px
   public static readonly WIDTH = 1000;
   public static readonly HEIGHT = 800;
+
+  // progressive visualization update and redraw interval in miliseconds
+  public static readonly UPDATE_INTERVAL_MS = 2000;
+
 
   @Input()
   operatorID: string | undefined;
@@ -49,9 +55,11 @@ export class VisualizationPanelContentComponent implements AfterViewInit, OnDest
 
     // setup an event lister that re-draws the chart content every (n) miliseconds
     // auditTime makes sure the first re-draw happens after (n) miliseconds has elapsed
-    this.updateSubscription = this.workflowStatusService.getResultUpdateStream().auditTime(2000).subscribe(update => {
-      this.drawChart();
-    });
+    this.updateSubscription = this.workflowStatusService.getResultUpdateStream()
+      .auditTime(VisualizationPanelContentComponent.UPDATE_INTERVAL_MS)
+      .subscribe(() => {
+        this.drawChart();
+      });
   }
 
   ngOnDestroy() {
@@ -166,7 +174,7 @@ export class VisualizationPanelContentComponent implements AfterViewInit, OnDest
 
     const layout = cloud()
       .size([VisualizationPanelContentComponent.WIDTH, VisualizationPanelContentComponent.HEIGHT])
-      .words(wordCloudTuples.map(t => ({text: t.word, size: d3Scale(t.count)})))
+      .words(wordCloudTuples.map(t => ({ text: t.word, size: d3Scale(t.count) })))
       .text(d => d.text ?? '')
       .padding(5)
       .rotate(() => 0)

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -80,7 +80,7 @@ export class ExecuteWorkflowService {
             break;
           } default: {
             // workflow status related event
-            if (event.type !== 'WorkflowStatusUpdateEvent') {
+            if (event.type !== 'WebWorkflowStatusUpdateEvent') {
               console.log(event);
             }
             const newState = this.handleExecutionEvent(event);

--- a/core/new-gui/src/app/workspace/types/execute-workflow.interface.ts
+++ b/core/new-gui/src/app/workspace/types/execute-workflow.interface.ts
@@ -91,7 +91,8 @@ export enum OperatorState {
 export interface OperatorStatistics extends Readonly<{
   operatorState: OperatorState,
   aggregatedInputRowCount: number,
-  aggregatedOutputRowCount: number
+  aggregatedOutputRowCount: number,
+  aggregatedOutputResults: ResultObject | undefined | null
 }> { }
 
 export interface WorkflowStatusUpdate extends Readonly<{

--- a/core/new-gui/src/app/workspace/types/execute-workflow.interface.ts
+++ b/core/new-gui/src/app/workspace/types/execute-workflow.interface.ts
@@ -92,7 +92,7 @@ export interface OperatorStatistics extends Readonly<{
   operatorState: OperatorState,
   aggregatedInputRowCount: number,
   aggregatedOutputRowCount: number,
-  aggregatedOutputResults: ResultObject | undefined | null
+  aggregatedOutputResults: ResultObject | undefined | null // undefined/null if operator is not sink
 }> { }
 
 export interface WorkflowStatusUpdate extends Readonly<{

--- a/core/new-gui/src/app/workspace/types/workflow-websocket.interface.ts
+++ b/core/new-gui/src/app/workspace/types/workflow-websocket.interface.ts
@@ -82,7 +82,7 @@ export type TexeraWebsocketEventTypeMap = {
   'WorkflowErrorEvent': WorkflowError,
   'WorkflowStartedEvent': {},
   'WorkflowCompletedEvent': {result: ReadonlyArray<ResultObject>},
-  'WorkflowStatusUpdateEvent': WorkflowStatusUpdate,
+  'WebWorkflowStatusUpdateEvent': WorkflowStatusUpdate,
   'WorkflowPausedEvent': {},
   'WorkflowResumedEvent': {},
   'RecoveryStartedEvent': {},


### PR DESCRIPTION
This is the step 3 of the Word Cloud incrementalization project. See #937

In step1, we have made the word cloud operators progressive. In step2, the controller and the web server can now access to the result update events. 

In this step, we are sending the result update events from the web server to the frontend, and make word cloud operator re-draw the visualization in fixed intervals.


Note: for the current implementation, the network batch size needs to be set to 1 in Constants.scala in backend.


![word_cloud](https://user-images.githubusercontent.com/12578068/115505017-b4792b80-a22d-11eb-869f-58c3f0c8235c.gif)
