### PR TITLE
Fix serializataion error of guava immutable list

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/Tuple.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/Tuple.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Streams;
@@ -24,7 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class Tuple implements ITuple, Serializable {
 
     private final Schema schema;
-    private final ImmutableList<Object> fields;
+    private final List<Object> fields;
 
     public Tuple(Schema schema, Object... fields) {
         this(schema, Arrays.asList(fields));
@@ -44,7 +43,7 @@ public class Tuple implements ITuple, Serializable {
         checkSchemaMatchesFields(schema.getAttributes(), fields);
 
         this.schema = schema;
-        this.fields = ImmutableList.copyOf(fields);
+        this.fields = Collections.unmodifiableList(fields);
     }
 
     @Override

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/Schema.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/Schema.java
@@ -4,8 +4,6 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import java.io.Serializable;
 import java.util.*;
@@ -17,8 +15,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
  * A schema is a list of attributes that describe all the columns of a table.
  */
 public class Schema implements Serializable {
-    private final ImmutableList<Attribute> attributes;
-    private final ImmutableMap<String, Integer> attributeIndex;
+    private final List<Attribute> attributes;
+    private final Map<String, Integer> attributeIndex;
 
     public Schema(Attribute... attributes) {
         this(Arrays.asList(attributes));
@@ -29,12 +27,12 @@ public class Schema implements Serializable {
             @JsonProperty(value = "attributes", required = true)
                     List<Attribute> attributes) {
         checkNotNull(attributes);
-        this.attributes = ImmutableList.copyOf(attributes);
+        this.attributes = Collections.unmodifiableList(attributes);
         HashMap<String, Integer> attributeIndexTemp = new HashMap<String, Integer>();
         for (int i = 0; i < attributes.size(); i++) {
             attributeIndexTemp.put(attributes.get(i).getName().toLowerCase(), i);
         }
-        this.attributeIndex = ImmutableMap.copyOf(attributeIndexTemp);
+        this.attributeIndex = Collections.unmodifiableMap(attributeIndexTemp);
     }
 
     @JsonProperty(value = "attributes")


### PR DESCRIPTION
In #967, we changed the collections in tuple and schema to be immutable collections from guava. However it causes serialization errors because the library we are using https://github.com/twitter/chill doesn't support guava immutable collections. This PR changes them to use equivalent java collections to fix the issue.