### PR TITLE
Progressive MySQL Source Operator (Step 2)

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OperatorDescriptor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OperatorDescriptor.scala
@@ -1,9 +1,7 @@
 package edu.uci.ics.texera.workflow.common.operators
 
-import java.util.UUID
-
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type
-import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonProperty, JsonIgnore, JsonTypeInfo}
+import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonSubTypes, JsonTypeInfo}
 import edu.uci.ics.amber.engine.common.ambertag.OperatorIdentifier
 import edu.uci.ics.amber.engine.operators.OpExecConfig
 import edu.uci.ics.texera.workflow.common.metadata.{OperatorInfo, PropertyNameConstants}
@@ -11,6 +9,7 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.Schema
 import edu.uci.ics.texera.workflow.common.{ConstraintViolation, WorkflowContext}
 import edu.uci.ics.texera.workflow.operators.aggregate.SpecializedAverageOpDesc
 import edu.uci.ics.texera.workflow.operators.filter.SpecializedFilterOpDesc
+import edu.uci.ics.texera.workflow.operators.keywordSearch.KeywordSearchOpDesc
 import edu.uci.ics.texera.workflow.operators.limit.LimitOpDesc
 import edu.uci.ics.texera.workflow.operators.linearregression.LinearRegressionOpDesc
 import edu.uci.ics.texera.workflow.operators.localscan.LocalCsvFileScanOpDesc
@@ -21,15 +20,16 @@ import edu.uci.ics.texera.workflow.operators.regex.RegexOpDesc
 import edu.uci.ics.texera.workflow.operators.reservoirsampling.ReservoirSamplingOpDesc
 import edu.uci.ics.texera.workflow.operators.sentiment.SentimentAnalysisOpDesc
 import edu.uci.ics.texera.workflow.operators.sink.SimpleSinkOpDesc
-import edu.uci.ics.texera.workflow.operators.keywordSearch.KeywordSearchOpDesc
-import edu.uci.ics.texera.workflow.operators.mysqlsource.MysqlSourceOpDesc
+import edu.uci.ics.texera.workflow.operators.source.mysql.MysqlSourceOpDesc
 import edu.uci.ics.texera.workflow.operators.typecasting.TypeCastingOpDesc
 import edu.uci.ics.texera.workflow.operators.union.UnionOpDesc
 import edu.uci.ics.texera.workflow.operators.visualization.barChart.BarChartOpDesc
 import edu.uci.ics.texera.workflow.operators.visualization.lineChart.LineChartOpDesc
 import edu.uci.ics.texera.workflow.operators.visualization.pieChart.PieChartOpDesc
 import edu.uci.ics.texera.workflow.operators.visualization.wordCloud.WordCloudOpDesc
-import org.apache.commons.lang3.builder.{EqualsBuilder, ToStringBuilder, HashCodeBuilder}
+import org.apache.commons.lang3.builder.{EqualsBuilder, HashCodeBuilder, ToStringBuilder}
+
+import java.util.UUID
 
 @JsonTypeInfo(
   use = JsonTypeInfo.Id.NAME,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeType.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeType.java
@@ -12,7 +12,7 @@ public enum AttributeType implements Serializable {
     INTEGER("integer", Integer.class),
     DOUBLE("double", Double.class),
     BOOLEAN("boolean", Boolean.class),
-    TIMESTAMP("boolean", Timestamp.class),
+    TIMESTAMP("timestamp", Timestamp.class),
     ANY("ANY", Object.class);
 
     private final String name;

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeType.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeType.java
@@ -10,6 +10,7 @@ public enum AttributeType implements Serializable {
     // value is indexed as a single token
     STRING("string", String.class),
     INTEGER("integer", Integer.class),
+    LONG("long", Long.class),
     DOUBLE("double", Double.class),
     BOOLEAN("boolean", Boolean.class),
     TIMESTAMP("timestamp", Timestamp.class),

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeType.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeType.java
@@ -3,6 +3,7 @@ package edu.uci.ics.texera.workflow.common.tuple.schema;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.io.Serializable;
+import java.sql.Timestamp;
 
 public enum AttributeType implements Serializable {
     // A field that is indexed but not tokenized: the entire String
@@ -11,6 +12,7 @@ public enum AttributeType implements Serializable {
     INTEGER("integer", Integer.class),
     DOUBLE("double", Double.class),
     BOOLEAN("boolean", Boolean.class),
+    TIMESTAMP("boolean", Timestamp.class),
     ANY("ANY", Object.class);
 
     private final String name;

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
@@ -64,7 +64,7 @@ public class MysqlSourceOpDesc extends SourceOperatorDescriptor {
 
     @JsonProperty(value = "batch by interval")
     @JsonPropertyDescription("the interval between each batch")
-    public Integer interval;
+    public Long interval;
 
     @Override
     public OpExecConfig operatorExecutor() {
@@ -151,12 +151,14 @@ public class MysqlSourceOpDesc extends SourceOperatorDescriptor {
                     case Types.DATE: //91 Types.DATE
                     case Types.TIME: //92 Types.TIME
                     case Types.LONGVARCHAR: //-1 Types.LONGVARCHAR
-                    case Types.BIGINT: //-5 Types.BIGINT
                     case Types.CHAR: //1 Types.CHAR
                     case Types.VARCHAR: //12 Types.VARCHAR
                     case Types.NULL: //0 Types.NULL
                     case Types.OTHER: //1111 Types.OTHER
                         schemaBuilder.add(new Attribute(columnName, AttributeType.STRING));
+                        break;
+                    case Types.BIGINT: //-5 Types.BIGINT
+                        schemaBuilder.add(new Attribute(columnName, AttributeType.LONG));
                         break;
                     case Types.TIMESTAMP:  // 93 Types.TIMESTAMP
                         schemaBuilder.add(new Attribute(columnName, AttributeType.TIMESTAMP));

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
@@ -40,11 +40,11 @@ public class MysqlSourceOpDesc extends SourceOperatorDescriptor {
 
     @JsonProperty(value = "limit")
     @JsonPropertyDescription("query result count upper limit")
-    public Integer limit;
+    public Long limit;
 
     @JsonProperty(value = "offset")
     @JsonPropertyDescription("query offset")
-    public Integer offset;
+    public Long offset;
 
     @JsonProperty(value = "column name")
     @JsonPropertyDescription("the column to be keyword-searched")

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
@@ -55,8 +55,8 @@ public class MysqlSourceOpDesc extends SourceOperatorDescriptor {
     public String keywords;
 
     @JsonProperty(value = "progressive")
-    @JsonPropertyDescription("progressively yield outputs by batches")
-    public Boolean progressive = false;
+    @JsonPropertyDescription("progressively yield outputs")
+    public Boolean progressive;
 
     @Override
     public OpExecConfig operatorExecutor() {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
@@ -55,8 +55,8 @@ public class MysqlSourceOpDesc extends SourceOperatorDescriptor {
     public String keywords;
 
     @JsonProperty(value = "progressive")
-    @JsonPropertyDescription("progressively yield outputs")
-    public Boolean progressive;
+    @JsonPropertyDescription("progressively yield outputs by batches")
+    public Boolean progressive = false;
 
     @Override
     public OpExecConfig operatorExecutor() {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
@@ -55,15 +55,15 @@ public class MysqlSourceOpDesc extends SourceOperatorDescriptor {
     public String keywords;
 
     @JsonProperty(value = "progressive")
-    @JsonPropertyDescription("progressively yield outputs by batches")
+    @JsonPropertyDescription("progressively yield outputs")
     public Boolean progressive = false;
 
     @JsonProperty(value = "batch by column")
-    @JsonPropertyDescription("the column to separate batches")
+    @JsonPropertyDescription("batch by column")
     public String batchByColumn;
 
     @JsonProperty(value = "batch by interval")
-    @JsonPropertyDescription("the interval between each batch")
+    @JsonPropertyDescription("batch by interval")
     public Long interval;
 
     @Override

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpExec.java
@@ -18,8 +18,7 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
     private final String table;
     private final String username;
     private final String password;
-    private Integer currentLimit;
-    private Integer offset;
+
     private final String column;
     private final String keywords;
     private final Boolean progressive;
@@ -32,12 +31,14 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
     private boolean queriesPrepared = false;
     private boolean hasNext = true;
 
+    private Long currentLimit;
+    private Long currentOffset;
     private Number currentMin = 0;
     private Number max = 0;
     private Attribute batchByAttribute = null;
 
     MysqlSourceOpExec(Schema schema, String host, String port, String database, String table, String username,
-                      String password, Integer limit, Integer offset, String column, String keywords,
+                      String password, Long limit, Long offset, String column, String keywords,
                       Boolean progressive, String batchByColumn, Long interval) {
         this.schema = schema;
         this.host = host.trim();
@@ -47,7 +48,7 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
         this.username = username.trim();
         this.password = password;
         this.currentLimit = limit;
-        this.offset = offset;
+        this.currentOffset = offset;
         this.column = column == null ? null : column.trim();
         this.keywords = keywords == null ? null : keywords.trim();
         this.progressive = progressive;
@@ -85,8 +86,8 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
             public Tuple next() {
                 try {
                     if (resultSet != null && resultSet.next()) {
-                        if (offset != null && offset > 0) {
-                            offset--;
+                        if (currentOffset != null && currentOffset > 0) {
+                            currentOffset--;
                             return next();
                         }
                         Tuple.Builder tupleBuilder = Tuple.newBuilder();
@@ -225,7 +226,7 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
                 curIndex += 1;
             }
             if (currentLimit != null) {
-                preparedStatement.setInt(curIndex, currentLimit);
+                preparedStatement.setLong(curIndex, currentLimit);
             }
             return preparedStatement;
         } else return null;

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpExec.java
@@ -20,7 +20,7 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
     private final String table;
     private final String username;
     private final String password;
-    private final Integer limit;
+    private Integer limit;
     private final Integer offset;
     private final String column;
     private final String keywords;
@@ -119,6 +119,9 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
                                 default:
                                     throw new RuntimeException("MySQL Source: unhandled attribute type: " + columnType);
                             }
+                        }
+                        if (limit != null) {
+                            limit--;
                         }
                         return tupleBuilder.build();
                     } else {
@@ -322,6 +325,9 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
         }
         min += interval;
         if (this.limit != null) {
+            if (limit < 0) {
+                return null;
+            }
             query += " LIMIT ?";
         }
         if (this.offset != null) {
@@ -333,7 +339,6 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
             query += " OFFSET ?";
         }
         query += ";";
-        System.out.println(query);
         return query;
     }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/mysql/MysqlSourceOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/mysql/MysqlSourceOpDesc.java
@@ -11,7 +11,6 @@ import edu.uci.ics.texera.workflow.common.operators.source.SourceOperatorDescrip
 import edu.uci.ics.texera.workflow.common.tuple.schema.Attribute;
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeType;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema;
-import scala.collection.JavaConverters;
 import scala.collection.immutable.List;
 
 import java.sql.*;
@@ -68,6 +67,7 @@ public class MysqlSourceOpDesc extends SourceOperatorDescriptor {
 
     @JsonProperty(value = "batch by column")
     @JsonPropertyDescription("batch by column")
+    @AutofillAttributeName
     public String batchByColumn;
 
     @JsonProperty(value = "batch by interval", defaultValue = "1000000000")

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/mysql/MysqlSourceOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/mysql/MysqlSourceOpDesc.java
@@ -54,15 +54,15 @@ public class MysqlSourceOpDesc extends SourceOperatorDescriptor {
     @JsonPropertyDescription("search terms in boolean expression")
     public String keywords;
 
-    @JsonProperty(value = "progressive")
+    @JsonProperty(value = "progressive", defaultValue = "false")
     @JsonPropertyDescription("progressively yield outputs")
-    public Boolean progressive = false;
+    public Boolean progressive;
 
     @JsonProperty(value = "batch by column")
     @JsonPropertyDescription("batch by column")
     public String batchByColumn;
 
-    @JsonProperty(value = "batch by interval")
+    @JsonProperty(value = "batch by interval", defaultValue = "1000000000")
     @JsonPropertyDescription("batch by interval")
     public Long interval;
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/mysql/MysqlSourceOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/mysql/MysqlSourceOpDesc.java
@@ -1,4 +1,4 @@
-package edu.uci.ics.texera.workflow.operators.mysqlsource;
+package edu.uci.ics.texera.workflow.operators.source.mysql;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/mysql/MysqlSourceOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/mysql/MysqlSourceOpExec.java
@@ -421,7 +421,6 @@ public class MysqlSourceOpExec implements SourceOperatorExecutor {
             query += " LIMIT ?";
         }
         query += ";";
-        System.out.println(query);
         return query;
     }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/mysql/MysqlSourceOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/mysql/MysqlSourceOpExecConfig.scala
@@ -1,7 +1,6 @@
-package edu.uci.ics.texera.workflow.operators.mysqlsource
+package edu.uci.ics.texera.workflow.operators.source.mysql
 
 import akka.actor.ActorRef
-import akka.event.LoggingAdapter
 import akka.util.Timeout
 import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.GlobalBreakpoint
 import edu.uci.ics.amber.engine.architecture.deploysemantics.deploymentfilter.UseAll

--- a/core/scripts/sql/tweets.sql
+++ b/core/scripts/sql/tweets.sql
@@ -1,30 +1,31 @@
-create table TABLE_NAME
+CREATE TABLE TABLE_NAME
 (
-    id                   varchar(25)                  not null primary key,
-    create_at            varchar(50)                  null,
-    text                 varchar(500) charset utf8mb4 null,
-    in_reply_to_status   varchar(25)                  null,
-    in_reply_to_user     varchar(25)                  null,
-    favourites_count     int                          null,
-    retweet_count        int                          null,
-    lang                 varchar(10)                  null,
-    is_retweet           tinyint(1)                   null,
-    hashtags             varchar(500) charset utf8mb4 null,
-    user_mentions        varchar(500) charset utf8mb4 null,
-    user_id              varchar(25)                  null,
-    user_name            varchar(500) charset utf8mb4 null,
-    user_screen_name     varchar(500) charset utf8mb4 null,
-    user_location        varchar(500)                 null,
-    user_description     varchar(500) charset utf8mb4 null,
-    user_followers_count int                          null,
-    user_friends_count   int                          null,
-    user_statues_count   int                          null,
-    stateName            varchar(100)                 null,
-    countyName           varchar(100)                 null,
-    cityName             varchar(100)                 null,
-    country              varchar(100)                 null,
-    bounding_box         varchar(100)                 null
+    id                   BIGINT                       NOT NULL PRIMARY KEY,
+    create_at            DATETIME                     NULL,
+    text                 VARCHAR(500) charset utf8mb4 NULL,
+    in_reply_to_status   VARCHAR(25)                  NULL,
+    in_reply_to_user     VARCHAR(25)                  NULL,
+    favourites_count     INT                          NULL,
+    retweet_count        INT                          NULL,
+    lang                 VARCHAR(10)                  NULL,
+    is_retweet           TINYINT(1)                   NULL,
+    hashtags             VARCHAR(500) charset utf8mb4 NULL,
+    user_mentions        VARCHAR(500) charset utf8mb4 NULL,
+    user_id              VARCHAR(25)                  NULL,
+    user_name            VARCHAR(500) charset utf8mb4 NULL,
+    user_screen_name     VARCHAR(500) charset utf8mb4 NULL,
+    user_location        VARCHAR(500)                 NULL,
+    user_description     VARCHAR(500) charset utf8mb4 NULL,
+    user_followers_count INT                          NULL,
+    user_friends_count   INT                          NULL,
+    user_statues_count   INT                          NULL,
+    stateName            VARCHAR(100)                 NULL,
+    countyName           VARCHAR(100)                 NULL,
+    cityName             VARCHAR(100)                 NULL,
+    country              VARCHAR(100)                 NULL,
+    bounding_box         VARCHAR(100)                 NULL
 );
 
-create fulltext index text on TABLE_NAME (text);
+CREATE FULLTEXT INDEX text_index ON TABLE_NAME (text);
+CREATE INDEX create_at_index ON TABLE_NAME (create_at);
 


### PR DESCRIPTION
In this PR, the frontend can tune the following parameters on progressive MySQL source operator:

- `batchByColumn`: 
    A String field that defines the column to be used to separate for batches, as well as the mini-queries. An additional range condition will be appended to the query besides the existing WHERE clause. This does not affect the LIMIT and OFFSET clause as it takes count of each mini-batches.

The column AttributeType can be `INT`/`BIGINT`/`DATETIME`/`DOUBLE`.


- `interval`: 
    A long int field that defines a fixed mini queries size on separating the mini-queries. Note this does not define the result batch size as that may vary for each mini query depends on the data shape. The unit depends on the column AttributeType:
     - `INT`(Integer)/`BIGINT`(Long)/`DOUBLE`: this interval unit is the same as the type unit.
     - `DATETIME` (java.sql.Timestamp): this interval unit is each millisecond.
 
![2021-01-19 22 15 29](https://user-images.githubusercontent.com/17627829/105200212-71a39c80-5af4-11eb-9b37-6816d561d280.gif)
