### PR TITLE
[BUGFIX] remove fulfilled promises and acked messages

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
@@ -53,6 +53,7 @@ class CongestionControl {
       ssThreshold /= 2
       windowSize = ssThreshold
     }
+    sentTime.remove(id)
   }
 
   def getBufferedMessagesToSend: Array[NetworkMessage] = {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/control/ControlMessageSource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/control/ControlMessageSource.scala
@@ -51,6 +51,7 @@ class ControlMessageSource(controlOutputPort: ControlOutputPort) {
     if (unfulfilledPromises.contains(ret.originalCommandID)) {
       val p = unfulfilledPromises(ret.originalCommandID)
       p.setValue(ret.returnValue.asInstanceOf[p.returnType])
+      unfulfilledPromises.remove(ret.originalCommandID)
     }
   }
 


### PR DESCRIPTION
This PR:
1. fixed the inconsistency between inTransit and sentTime in congestion control. Now the message id will be removed in both maps when receiving the ack.
2. removed the promise when it is fulfilled.