### PR TITLE
Add workflow_dispatch option in GitHub Action

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -11,6 +11,8 @@ on:
       - '**.md'
       - '**.csv'
       - '**.txt'
+  workflow_dispatch:
+  
 jobs:
   gui:
     runs-on: ubuntu-latest


### PR DESCRIPTION
So one can manually invoke a GitHub Action workflow to execute on Action UI.