### PR TITLE
Make schema autocomplete a backend annotation

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/annotations/AutofillAttributeName.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/annotations/AutofillAttributeName.java
@@ -1,0 +1,30 @@
+package edu.uci.ics.texera.workflow.common.metadata.annotations;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInt;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaString;
+
+import java.lang.annotation.*;
+
+import static edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+@JacksonAnnotationsInside
+@JsonSchemaInject(
+        strings = @JsonSchemaString(path = autofill, value = attributeName),
+        ints = @JsonSchemaInt(path = autofillAttributeOnPort, value = 0))
+public @interface AutofillAttributeName {
+
+    // JSON schema key
+    String autofill = "autofill";
+
+    // allowed JSON schema values for the key autoCompleteType
+    String attributeName = "attributeName";
+    String attributeNameList = "attributeNameList";
+
+    // JSON schema key to indicate which port
+    String autofillAttributeOnPort = "autofillAttributeOnPort";
+
+}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/annotations/AutofillAttributeNameList.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/annotations/AutofillAttributeNameList.java
@@ -1,0 +1,22 @@
+package edu.uci.ics.texera.workflow.common.metadata.annotations;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInt;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaString;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+@JacksonAnnotationsInside
+@JsonSchemaInject(
+        strings = @JsonSchemaString(path = autofill, value = attributeNameList),
+        ints = @JsonSchemaInt(path = autofillAttributeOnPort, value = 0))
+public @interface AutofillAttributeNameList {
+}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/annotations/AutofillAttributeNameOnPort1.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/annotations/AutofillAttributeNameOnPort1.java
@@ -1,0 +1,22 @@
+package edu.uci.ics.texera.workflow.common.metadata.annotations;
+
+import com.fasterxml.jackson.annotation.JacksonAnnotationsInside;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInt;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaString;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import static edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName.*;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+@JacksonAnnotationsInside
+@JsonSchemaInject(
+        strings = @JsonSchemaString(path = autofill, value = attributeName),
+        ints = @JsonSchemaInt(path = autofillAttributeOnPort, value = 1))
+public @interface AutofillAttributeNameOnPort1 {
+}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/aggregate/SpecializedAverageOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/aggregate/SpecializedAverageOpDesc.scala
@@ -3,6 +3,7 @@ package edu.uci.ics.texera.workflow.operators.aggregate
 import java.io.Serializable
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.texera.workflow.common.metadata.{
   InputPort,
   OperatorGroupConstants,
@@ -28,6 +29,7 @@ class SpecializedAverageOpDesc extends AggregateOpDesc {
 
   @JsonProperty(value = "attribute", required = true)
   @JsonPropertyDescription("column to calculate average value")
+  @AutofillAttributeName
   var attribute: String = _
 
   @JsonProperty(value = "result attribute", required = true)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/filter/FilterPredicate.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/filter/FilterPredicate.java
@@ -3,12 +3,14 @@ package edu.uci.ics.texera.workflow.operators.filter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.uci.ics.texera.workflow.common.WorkflowContext;
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName;
 import edu.uci.ics.texera.workflow.common.tuple.Tuple;
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeType;
 
 public class FilterPredicate {
 
     @JsonProperty(value = "attribute", required = true)
+    @AutofillAttributeName
     public String attribute;
 
     @JsonProperty(value = "condition", required = true)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/keywordSearch/KeywordSearchOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/keywordSearch/KeywordSearchOpDesc.scala
@@ -2,6 +2,7 @@ package edu.uci.ics.texera.workflow.operators.keywordSearch
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.texera.workflow.common.metadata.{
   InputPort,
   OperatorGroupConstants,
@@ -16,6 +17,7 @@ class KeywordSearchOpDesc extends FilterOpDesc {
   @JsonProperty(required = true)
   @JsonSchemaTitle("attribute")
   @JsonPropertyDescription("column to search keyword on")
+  @AutofillAttributeName
   var attribute: String = _
 
   @JsonProperty(required = true)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/linearregression/LinearRegressionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/linearregression/LinearRegressionOpDesc.scala
@@ -1,6 +1,7 @@
 package edu.uci.ics.texera.workflow.operators.linearregression
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.texera.workflow.common.metadata.{
   InputPort,
   OperatorGroupConstants,
@@ -13,10 +14,12 @@ class LinearRegressionOpDesc extends MLModelOpDesc {
 
   @JsonProperty(value = "x attribute", required = true)
   @JsonPropertyDescription("column representing x in y=wx+b")
+  @AutofillAttributeName
   var xAttr: String = _
 
   @JsonProperty(value = "y attribute", required = true)
   @JsonPropertyDescription("column representing y in y=wx+b")
+  @AutofillAttributeName
   var yAttr: String = _
 
   @JsonProperty(value = "learning rate", required = true)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/mysqlsource/MysqlSourceOpDesc.java
@@ -6,6 +6,7 @@ import edu.uci.ics.amber.engine.operators.OpExecConfig;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
 import edu.uci.ics.texera.workflow.common.metadata.OutputPort;
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName;
 import edu.uci.ics.texera.workflow.common.operators.source.SourceOperatorDescriptor;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Attribute;
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeType;
@@ -54,6 +55,7 @@ public class MysqlSourceOpDesc extends SourceOperatorDescriptor {
 
     @JsonProperty(value = "column name")
     @JsonPropertyDescription("the column to be keyword-searched")
+    @AutofillAttributeName
     public String column;
 
     @JsonProperty(value = "keywords")

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/projection/ProjectionOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/projection/ProjectionOpDesc.java
@@ -3,10 +3,8 @@ package edu.uci.ics.texera.workflow.operators.projection;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.google.common.base.Preconditions;
-import edu.uci.ics.texera.workflow.common.metadata.InputPort;
-import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
-import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
-import edu.uci.ics.texera.workflow.common.metadata.OutputPort;
+import edu.uci.ics.texera.workflow.common.metadata.*;
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeNameList;
 import edu.uci.ics.texera.workflow.common.operators.OneToOneOpExecConfig;
 import edu.uci.ics.texera.workflow.common.operators.map.MapOpDesc;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema;
@@ -20,6 +18,7 @@ import static scala.collection.JavaConverters.asScalaBuffer;
 public class ProjectionOpDesc extends MapOpDesc {
     @JsonProperty(value = "attributes", required = true)
     @JsonPropertyDescription("a subset of column to keeps")
+    @AutofillAttributeNameList
     public List<String> attributes;
 
     @Override

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/regex/RegexOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/regex/RegexOpDesc.scala
@@ -2,6 +2,7 @@ package edu.uci.ics.texera.workflow.operators.regex
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.texera.workflow.common.metadata.{
   InputPort,
   OperatorGroupConstants,
@@ -15,6 +16,7 @@ class RegexOpDesc extends FilterOpDesc {
 
   @JsonProperty(value = "attribute", required = true)
   @JsonPropertyDescription("column to search regex on")
+  @AutofillAttributeName
   var attribute: String = _
 
   @JsonProperty(value = "regex", required = true)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sentiment/SentimentAnalysisOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sentiment/SentimentAnalysisOpDesc.java
@@ -8,6 +8,7 @@ import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
 import edu.uci.ics.texera.workflow.common.metadata.OutputPort;
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName;
 import edu.uci.ics.texera.workflow.common.operators.OneToOneOpExecConfig;
 import edu.uci.ics.texera.workflow.common.operators.map.MapOpDesc;
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeType;
@@ -20,6 +21,7 @@ public class SentimentAnalysisOpDesc extends MapOpDesc {
 
     @JsonProperty(value = "attribute", required = true)
     @JsonPropertyDescription("column to perform sentiment analysis on")
+    @AutofillAttributeName
     public String attribute;
 
     @JsonProperty(value = "result attribute", required = true, defaultValue = "sentiment")

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/typecasting/TypeCastingOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/typecasting/TypeCastingOpDesc.java
@@ -8,6 +8,7 @@ import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
 import edu.uci.ics.texera.workflow.common.metadata.OutputPort;
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName;
 import edu.uci.ics.texera.workflow.common.operators.OneToOneOpExecConfig;
 import edu.uci.ics.texera.workflow.common.operators.map.MapOpDesc;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Attribute;
@@ -25,6 +26,7 @@ public class TypeCastingOpDesc extends MapOpDesc {
     @JsonProperty(required = true)
     @JsonSchemaTitle("attribute")
     @JsonPropertyDescription("Attribute for type casting")
+    @AutofillAttributeName
     public String attribute;
 
     @JsonProperty(required = true)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/union/UnionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/union/UnionOpDesc.scala
@@ -1,7 +1,12 @@
 package edu.uci.ics.texera.workflow.operators.union
 
+import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.google.common.base.Preconditions
 import edu.uci.ics.amber.engine.operators.OpExecConfig
+import edu.uci.ics.texera.workflow.common.metadata.annotations.{
+  AutofillAttributeName,
+  AutofillAttributeNameOnPort1
+}
 import edu.uci.ics.texera.workflow.common.metadata.{
   InputPort,
   OperatorGroupConstants,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/barChart/BarChartOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/barChart/BarChartOpDesc.java
@@ -6,6 +6,8 @@ import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
 import edu.uci.ics.texera.workflow.common.metadata.OutputPort;
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName;
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeNameList;
 import edu.uci.ics.texera.workflow.common.operators.OneToOneOpExecConfig;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Attribute;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema;
@@ -27,10 +29,12 @@ import static scala.collection.JavaConverters.asScalaBuffer;
 public class BarChartOpDesc extends VisualizationOperator {
     @JsonProperty(value = "name column", required = true)
     @JsonPropertyDescription("column of name (for x-axis)")
+    @AutofillAttributeName
     public String nameColumn;
 
     @JsonProperty(value = "data column(s)", required = true)
     @JsonPropertyDescription("column(s) of data (for y-axis)")
+    @AutofillAttributeNameList
     public List<String> dataColumns;
 
     @Override

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/lineChart/LineChartOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/lineChart/LineChartOpDesc.java
@@ -6,6 +6,8 @@ import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
 import edu.uci.ics.texera.workflow.common.metadata.OutputPort;
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName;
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeNameList;
 import edu.uci.ics.texera.workflow.common.operators.OneToOneOpExecConfig;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Attribute;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema;
@@ -26,10 +28,12 @@ import static scala.collection.JavaConverters.asScalaBuffer;
 public class LineChartOpDesc extends VisualizationOperator {
     @JsonProperty(value = "name column", required = true)
     @JsonPropertyDescription("column of name (for x-axis)")
+    @AutofillAttributeName
     public String nameColumn;
 
     @JsonProperty(value = "data column(s)", required = true)
     @JsonPropertyDescription("column(s) of data (for y-axis)")
+    @AutofillAttributeNameList
     public List<String> dataColumns;
 
     @JsonProperty(value = "chart style", required = true)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/pieChart/PieChartOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/pieChart/PieChartOpDesc.java
@@ -7,6 +7,7 @@ import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
 import edu.uci.ics.texera.workflow.common.metadata.OutputPort;
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName;
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeType;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema;
 import edu.uci.ics.texera.workflow.operators.visualization.VisualizationOperator;
@@ -25,9 +26,11 @@ import static scala.collection.JavaConverters.asScalaBuffer;
 public class PieChartOpDesc extends VisualizationOperator {
 
     @JsonProperty(value = "name column", required = true)
+    @AutofillAttributeName
     public String nameColumn;
 
     @JsonProperty(value = "data column", required = true)
+    @AutofillAttributeName
     public String dataColumn;
 
     @JsonProperty(value = "prune ratio", required = true)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpDesc.java
@@ -7,6 +7,7 @@ import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
 import edu.uci.ics.texera.workflow.common.metadata.OutputPort;
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Attribute;
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeType;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema;
@@ -25,6 +26,7 @@ import static scala.collection.JavaConverters.asScalaBuffer;
 
 public class WordCloudOpDesc extends VisualizationOperator {
     @JsonProperty(value = "text column", required = true)
+    @AutofillAttributeName
     public String textColumn;
 
     @Override

--- a/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.spec.ts
@@ -271,10 +271,12 @@ describe('SchemaPropagationService', () => {
     expect(attributeInSchema).toEqual({
       type: 'array',
       title: 'attributes',
+      uniqueItems: true,
+      autofill: 'attributeNameList',
+      autofillAttributeOnPort: 0,
       items: {
         type: 'string',
         enum: expectedEnum,
-        uniqueItems: true
       }
     });
   });
@@ -326,8 +328,10 @@ describe('SchemaPropagationService', () => {
             attribute: {
               type: 'string',
               title: 'attribute',
+              autofill: 'attributeName',
+              autofillAttributeOnPort: 0,
               enum: expectedEnum,
-              uniqueItems: true
+              uniqueItems: true,
             },
             aggregator: {
               title: 'aggregator',

--- a/core/new-gui/src/app/workspace/service/dynamic-schema/source-tables/source-tables.service.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/source-tables/source-tables.service.ts
@@ -109,13 +109,13 @@ export class SourceTablesService {
       newDynamicSchema = {
         ...schema,
         jsonSchema: DynamicSchemaService.mutateProperty(
-          schema.jsonSchema, key, () => ({ type: 'string', enum: enumArray, uniqueItems: true }))
+          schema.jsonSchema, (k, v) => k === key, () => ({ type: 'string', enum: enumArray, uniqueItems: true }))
       };
     } else {
       newDynamicSchema = {
         ...schema,
         jsonSchema: DynamicSchemaService.mutateProperty(
-          schema.jsonSchema, key, () => ({ type: 'string' }))
+          schema.jsonSchema, (k, v) => k === key, () => ({ type: 'string' }))
       };
     }
     return newDynamicSchema;

--- a/core/new-gui/src/app/workspace/service/operator-metadata/mock-operator-metadata.data.ts
+++ b/core/new-gui/src/app/workspace/service/operator-metadata/mock-operator-metadata.data.ts
@@ -1,6 +1,7 @@
 import { JSONSchema7 } from 'json-schema';
 import { OperatorSchema, OperatorMetadata, GroupInfo } from '../../types/operator-schema.interface';
 import { BreakpointSchema } from '../../types/workflow-common.interface';
+import { CustomJSONSchema7 } from '../../types/custom-json-schema.interface';
 
 
 // Exports constants related to operator schema and operator metadata for testing purposes.
@@ -52,7 +53,7 @@ export const mockNlpSentimentSchema: OperatorSchema = {
   },
   jsonSchema: {
     properties: {
-      attribute: { type: 'string', title: 'attribute' },
+      attribute: { type: 'string', title: 'attribute', autofill: 'attributeName', autofillAttributeOnPort: 0 },
       resultAttribute: { type: 'string', title: 'result attribute' }
     },
     required: ['attribute', 'resultAttribute'],
@@ -69,7 +70,9 @@ export const mockKeywordSourceSchema: OperatorSchema = {
       attributes: {
         type: 'array',
         items: { type: 'string' },
-        title: 'attributes'
+        title: 'attributes',
+        autofill: 'attributeNameList',
+        autofillAttributeOnPort: 0
       },
       tableName: { type: 'string', title: 'table name' },
       spanListName: { type: 'string', title: 'span list name' }
@@ -94,7 +97,9 @@ export const mockKeywordSearchSchema: OperatorSchema = {
       attributes: {
         type: 'array',
         items: { type: 'string' },
-        title: 'attributes'
+        title: 'attributes',
+        autofill: 'attributeNameList',
+        autofillAttributeOnPort: 0
       },
       spanListName: { type: 'string', title: 'span list name' }
     },
@@ -119,7 +124,7 @@ export const mockAggregationSchema: OperatorSchema = {
         items: {
           type: 'object',
           properties: {
-            attribute: { type: 'string', title: 'attribute' },
+            attribute: { type: 'string', title: 'attribute', autofill: 'attributeName', autofillAttributeOnPort: 0 },
             aggregator: {
               type: 'string',
               enum: ['min', 'max', 'average', 'sum', 'count'],
@@ -207,11 +212,13 @@ export const mockOperatorMetaData: OperatorMetadata = {
 };
 
 
-export const testJsonSchema: JSONSchema7 = {
+export const testJsonSchema: CustomJSONSchema7 = {
   properties: {
     attribute: {
       type: 'string',
-      title: 'attribute'
+      title: 'attribute',
+      autofill: 'attributeName',
+      autofillAttributeOnPort: 0
     },
     resultAttribute: {
       type: 'string',

--- a/core/new-gui/src/app/workspace/types/custom-json-schema.interface.ts
+++ b/core/new-gui/src/app/workspace/types/custom-json-schema.interface.ts
@@ -1,0 +1,12 @@
+import { JSONSchema7, JSONSchema7Definition } from 'json-schema';
+
+export interface CustomJSONSchema7 extends JSONSchema7 {
+  properties?: {
+    [key: string]: CustomJSONSchema7 | boolean;
+  };
+  items?: CustomJSONSchema7 | boolean | JSONSchema7Definition[];
+
+  // new custom properties:
+  autofill?: 'attributeName' | 'attributeNameList';
+  autofillAttributeOnPort?: number;
+}

--- a/core/new-gui/src/app/workspace/types/operator-schema.interface.ts
+++ b/core/new-gui/src/app/workspace/types/operator-schema.interface.ts
@@ -1,4 +1,5 @@
 import { JSONSchema7 } from 'json-schema';
+import { CustomJSONSchema7 } from './custom-json-schema.interface';
 
 /**
  * This file contains multiple type declarations related to operator schema.
@@ -28,7 +29,7 @@ export interface OperatorAdditionalMetadata extends Readonly<{
 
 export interface OperatorSchema extends Readonly<{
   operatorType: string;
-  jsonSchema: Readonly<JSONSchema7>;
+  jsonSchema: Readonly<CustomJSONSchema7>;
   additionalMetadata: OperatorAdditionalMetadata;
 }> { }
 


### PR DESCRIPTION
This PR adds a backend annotation `@AutofillAttributeName` and `@AutofillAttributeNameList` to make autocomplete on attribute names fully automated on backend. In the old implementation, in order to add autocomplete attribute name for an operator, the frontend code needs to be changed. 