### PR TITLE
Changing the signature of UpdateOutputLinking and DateTransferPolicy

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/linksemantics/AllToOne.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/linksemantics/AllToOne.scala
@@ -9,7 +9,7 @@ import edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy.{
 import edu.uci.ics.amber.engine.common.AdvancedMessageSending
 import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.{
   UpdateInputLinking,
-  UpdateOutputLinking
+  AddDataSendingPolicy
 }
 import akka.actor.ActorRef
 import akka.event.LoggingAdapter
@@ -29,7 +29,9 @@ class AllToOne(from: WorkerLayer, to: WorkerLayer, batchSize: Int, inputNum: Int
 //      val routee = if(x.path.address.hostPort == toActor.path.address.hostPort) new DirectRoutee(toActor) else new FlowControlRoutee(toActor)
       AdvancedMessageSending.blockingAskWithRetry(
         x,
-        UpdateOutputLinking(new OneToOnePolicy(batchSize), tag, Array(toActor)),
+        AddDataSendingPolicy(
+          new OneToOnePolicy(tag, batchSize, Array(toActor))
+        ),
         10
       )
     })

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/linksemantics/FullRoundRobin.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/linksemantics/FullRoundRobin.scala
@@ -5,7 +5,7 @@ import edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy.Ro
 import edu.uci.ics.amber.engine.common.AdvancedMessageSending
 import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.{
   UpdateInputLinking,
-  UpdateOutputLinking
+  AddDataSendingPolicy
 }
 import akka.event.LoggingAdapter
 import akka.util.Timeout
@@ -23,10 +23,8 @@ class FullRoundRobin(from: WorkerLayer, to: WorkerLayer, batchSize: Int, inputNu
     from.layer.foreach(x =>
       AdvancedMessageSending.blockingAskWithRetry(
         x,
-        UpdateOutputLinking(
-          new RoundRobinPolicy(batchSize),
-          tag,
-          to.identifiers
+        AddDataSendingPolicy(
+          new RoundRobinPolicy(tag, batchSize, to.identifiers)
         ),
         10
       )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/linksemantics/HashBasedShuffle.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/linksemantics/HashBasedShuffle.scala
@@ -8,7 +8,7 @@ import edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy.{
 import edu.uci.ics.amber.engine.common.AdvancedMessageSending
 import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.{
   UpdateInputLinking,
-  UpdateOutputLinking
+  AddDataSendingPolicy
 }
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import akka.event.LoggingAdapter
@@ -31,10 +31,8 @@ class HashBasedShuffle(
     from.layer.foreach(x =>
       AdvancedMessageSending.blockingAskWithRetry(
         x,
-        UpdateOutputLinking(
-          new HashBasedShufflePolicy(batchSize, hashFunc),
-          tag,
-          to.identifiers
+        AddDataSendingPolicy(
+          new HashBasedShufflePolicy(tag, batchSize, hashFunc, to.identifiers)
         ),
         10
       )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/linksemantics/LocalOneToOne.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/linksemantics/LocalOneToOne.scala
@@ -5,7 +5,7 @@ import akka.util.Timeout
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.WorkerLayer
 import edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy.OneToOnePolicy
 import edu.uci.ics.amber.engine.common.AdvancedMessageSending
-import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.UpdateOutputLinking
+import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.AddDataSendingPolicy
 
 import scala.concurrent.ExecutionContext
 
@@ -26,10 +26,8 @@ class LocalOneToOne(from: WorkerLayer, to: WorkerLayer, batchSize: Int, inputNum
       for (i <- x._2.indices) {
         AdvancedMessageSending.blockingAskWithRetry(
           x._2(i),
-          UpdateOutputLinking(
-            new OneToOnePolicy(batchSize),
-            tag,
-            Array(actorToIdentifier(tos(x._1)(i)))
+          AddDataSendingPolicy(
+            new OneToOnePolicy(tag, batchSize, Array(actorToIdentifier(tos(x._1)(i))))
           ),
           10
         )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/linksemantics/LocalPartialToOne.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/linksemantics/LocalPartialToOne.scala
@@ -8,7 +8,7 @@ import edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy.{
 import edu.uci.ics.amber.engine.common.AdvancedMessageSending
 import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.{
   UpdateInputLinking,
-  UpdateOutputLinking
+  AddDataSendingPolicy
 }
 import akka.event.LoggingAdapter
 import akka.util.Timeout
@@ -32,10 +32,8 @@ class LocalPartialToOne(from: WorkerLayer, to: WorkerLayer, batchSize: Int, inpu
       for (i <- x._2.indices) {
         AdvancedMessageSending.blockingAskWithRetry(
           x._2(i),
-          UpdateOutputLinking(
-            new OneToOnePolicy(batchSize),
-            tag,
-            Array(actorToIdentifier(tos(x._1).head))
+          AddDataSendingPolicy(
+            new OneToOnePolicy(tag, batchSize, Array(actorToIdentifier(tos(x._1).head)))
           ),
           10
         )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/linksemantics/LocalRoundRobin.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/linksemantics/LocalRoundRobin.scala
@@ -3,7 +3,7 @@ package edu.uci.ics.amber.engine.architecture.linksemantics
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.WorkerLayer
 import edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy.RoundRobinPolicy
 import edu.uci.ics.amber.engine.common.AdvancedMessageSending
-import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.UpdateOutputLinking
+import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.AddDataSendingPolicy
 import edu.uci.ics.amber.engine.common.ambertag.LinkTag
 import akka.event.LoggingAdapter
 import akka.util.Timeout
@@ -33,7 +33,7 @@ class LocalRoundRobin(from: WorkerLayer, to: WorkerLayer, batchSize: Int, inputN
       froms(x).foreach(y =>
         AdvancedMessageSending.blockingAskWithRetry(
           y,
-          UpdateOutputLinking(new RoundRobinPolicy(batchSize), tag, receivers),
+          AddDataSendingPolicy(new RoundRobinPolicy(tag, batchSize, receivers)),
           10
         )
       )
@@ -42,7 +42,7 @@ class LocalRoundRobin(from: WorkerLayer, to: WorkerLayer, batchSize: Int, inputN
       froms(x).foreach(y =>
         AdvancedMessageSending.blockingAskWithRetry(
           y,
-          UpdateOutputLinking(new RoundRobinPolicy(batchSize), tag, to.identifiers),
+          AddDataSendingPolicy(new RoundRobinPolicy(tag, batchSize, to.identifiers)),
           10
         )
       )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/TupleToBatchConverter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/TupleToBatchConverter.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.messaginglayer
 
-import edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy.DataTransferPolicy
+import edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy.DataSendingPolicy
 import edu.uci.ics.amber.engine.common.ambermessage.WorkerMessage.UpdateInputLinking
 import edu.uci.ics.amber.engine.common.ambermessage.neo.DataPayload
 import edu.uci.ics.amber.engine.common.ambertag.LinkTag
@@ -19,7 +19,7 @@ class TupleToBatchConverter(
     dataOutputPort: DataOutputPort,
     controlOutputPort: ControlOutputPort
 ) {
-  private var policies = new Array[DataTransferPolicy](0)
+  private var policies = new Array[DataSendingPolicy](0)
 
   /** Add down stream operator and its transfer policy
     * @param policy
@@ -27,18 +27,12 @@ class TupleToBatchConverter(
     * @param receivers
     */
   def addPolicy(
-      policy: DataTransferPolicy,
-      linkTag: LinkTag,
-      receivers: Array[ActorVirtualIdentity]
+      policy: DataSendingPolicy
   ): Unit = {
     var i = 0
-    receivers.foreach { x =>
-      controlOutputPort.sendTo(x, UpdateInputLinking(selfID, linkTag.inputNum))
-    }
-    policy.initialize(linkTag, receivers)
     Breaks.breakable {
       while (i < policies.length) {
-        if (policies(i).tag == policy.tag) {
+        if (policies(i).policyTag == policy.policyTag) {
           policies(i) = policy
           Breaks.break()
         }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/TupleToBatchConverter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/TupleToBatchConverter.scala
@@ -16,8 +16,7 @@ import scala.util.control.Breaks
   */
 class TupleToBatchConverter(
     selfID: ActorVirtualIdentity,
-    dataOutputPort: DataOutputPort,
-    controlOutputPort: ControlOutputPort
+    dataOutputPort: DataOutputPort
 ) {
   private var policies = new Array[DataSendingPolicy](0)
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/DataSendingPolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/DataSendingPolicy.scala
@@ -11,8 +11,13 @@ import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.ActorVirtual
 
 import scala.concurrent.ExecutionContext
 
-abstract class DataTransferPolicy(var batchSize: Int) extends Serializable {
-  var tag: LinkTag = _
+// Sending policy used by a worker to send data to the downstream workers.
+abstract class DataSendingPolicy(
+    val policyTag: LinkTag,
+    var batchSize: Int,
+    var receivers: Array[ActorVirtualIdentity]
+) extends Serializable {
+  assert(receivers != null)
 
   /**
     * Keeps on adding tuples to the batch. When the batch_size is reached, the batch is returned along with the receiver
@@ -24,10 +29,6 @@ abstract class DataTransferPolicy(var batchSize: Int) extends Serializable {
   def addTupleToBatch(tuple: ITuple): Option[(ActorVirtualIdentity, DataPayload)]
 
   def noMore(): Array[(ActorVirtualIdentity, DataPayload)]
-
-  def initialize(linkTag: LinkTag, receivers: Array[ActorVirtualIdentity]): Unit = {
-    this.tag = linkTag
-  }
 
   def reset(): Unit
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/HashBasedShufflePolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/HashBasedShufflePolicy.scala
@@ -13,11 +13,16 @@ import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.ActorVirtual
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionContext
 
-class HashBasedShufflePolicy(batchSize: Int, val hashFunc: ITuple => Int)
-    extends DataTransferPolicy(batchSize) {
+class HashBasedShufflePolicy(
+    policyTag: LinkTag,
+    batchSize: Int,
+    val hashFunc: ITuple => Int,
+    receivers: Array[ActorVirtualIdentity]
+) extends DataSendingPolicy(policyTag, batchSize, receivers) {
   var batches: Array[Array[ITuple]] = _
-  var receivers: Array[ActorVirtualIdentity] = _
   var currentSizes: Array[Int] = _
+
+  initializeInternalState(receivers)
 
   override def noMore(): Array[(ActorVirtualIdentity, DataPayload)] = {
     val receiversAndBatches = new ArrayBuffer[(ActorVirtualIdentity, DataPayload)]
@@ -46,13 +51,6 @@ class HashBasedShufflePolicy(batchSize: Int, val hashFunc: ITuple => Int)
       return Some((receivers(index), DataFrame(retBatch)))
     }
     None
-  }
-
-  override def initialize(tag: LinkTag, _receivers: Array[ActorVirtualIdentity]): Unit = {
-    super.initialize(tag, _receivers)
-    assert(_receivers != null)
-    this.receivers = _receivers
-    initializeInternalState(receivers)
   }
 
   override def reset(): Unit = {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/OneToOnePolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/OneToOnePolicy.scala
@@ -9,10 +9,15 @@ import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.ActorVirtual
 
 import scala.collection.mutable.ArrayBuffer
 
-class OneToOnePolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
-  var receiver: ActorVirtualIdentity = _
-  var batch: Array[ITuple] = _
+class OneToOnePolicy(
+    policyTag: LinkTag,
+    batchSize: Int,
+    receivers: Array[ActorVirtualIdentity]
+) extends DataSendingPolicy(policyTag, batchSize, receivers) {
+  var batch: Array[ITuple] = new Array[ITuple](batchSize)
   var currentSize = 0
+
+  assert(receivers.length == 1)
 
   override def addTupleToBatch(
       tuple: ITuple
@@ -23,7 +28,7 @@ class OneToOnePolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
       currentSize = 0
       val retBatch = batch
       batch = new Array[ITuple](batchSize)
-      return Some((receiver, DataFrame(retBatch)))
+      return Some((receivers(0), DataFrame(retBatch)))
     }
     None
   }
@@ -31,17 +36,10 @@ class OneToOnePolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
   override def noMore(): Array[(ActorVirtualIdentity, DataPayload)] = {
     val ret = new ArrayBuffer[(ActorVirtualIdentity, DataPayload)]
     if (currentSize > 0) {
-      ret.append((receiver, DataFrame(batch.slice(0, currentSize))))
+      ret.append((receivers(0), DataFrame(batch.slice(0, currentSize))))
     }
-    ret.append((receiver, EndOfUpstream()))
+    ret.append((receivers(0), EndOfUpstream()))
     ret.toArray
-  }
-
-  override def initialize(tag: LinkTag, _receivers: Array[ActorVirtualIdentity]): Unit = {
-    super.initialize(tag, _receivers)
-    assert(_receivers != null && _receivers.length == 1)
-    receiver = _receivers(0)
-    batch = new Array[ITuple](batchSize)
   }
 
   override def reset(): Unit = {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/RoundRobinPolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/RoundRobinPolicy.scala
@@ -13,10 +13,13 @@ import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.ActorVirtual
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionContext
 
-class RoundRobinPolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
-  var receivers: Array[ActorVirtualIdentity] = _
+class RoundRobinPolicy(
+    policyTag: LinkTag,
+    batchSize: Int,
+    receivers: Array[ActorVirtualIdentity]
+) extends DataSendingPolicy(policyTag, batchSize, receivers) {
   var roundRobinIndex = 0
-  var batch: Array[ITuple] = _
+  var batch: Array[ITuple] = new Array[ITuple](batchSize)
   var currentSize = 0
 
   override def noMore(): Array[(ActorVirtualIdentity, DataPayload)] = {
@@ -43,13 +46,6 @@ class RoundRobinPolicy(batchSize: Int) extends DataTransferPolicy(batchSize) {
       return Some((receivers(roundRobinIndex), DataFrame(retBatch)))
     }
     None
-  }
-
-  override def initialize(tag: LinkTag, _receivers: Array[ActorVirtualIdentity]): Unit = {
-    super.initialize(tag, _receivers)
-    assert(_receivers != null)
-    this.receivers = _receivers
-    batch = new Array[ITuple](batchSize)
   }
 
   override def reset(): Unit = {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkflowWorker.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkflowWorker.scala
@@ -284,9 +284,13 @@ class WorkflowWorker(identifier: ActorVirtualIdentity, operator: IOperatorExecut
         dataProcessor.unhandledFaultedTuples.remove(f.id)
         onResumeTuple(f)
       }
-    case UpdateOutputLinking(policy, tag, receivers) =>
+    case AddDataSendingPolicy(policy) =>
       sender ! Ack
-      batchProducer.addPolicy(policy, tag, receivers)
+      // send message to receivers to add this worker to their expected inputs
+      policy.receivers.foreach { x =>
+        controlOutputPort.sendTo(x, UpdateInputLinking(identifier, policy.policyTag.inputNum))
+      }
+      batchProducer.addPolicy(policy)
   }
 
   final def receiveDataMessages: Receive = {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/ambermessage/WorkerMessage.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/ambermessage/WorkerMessage.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.amber.engine.common.ambermessage
 
 import edu.uci.ics.amber.engine.architecture.breakpoint.localbreakpoint.LocalBreakpoint
-import edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy.DataTransferPolicy
+import edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy.DataSendingPolicy
 import edu.uci.ics.amber.engine.architecture.worker.{WorkerState, WorkerStatistics}
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.ambertag.{LayerTag, LinkTag, WorkerTag}
@@ -22,10 +22,8 @@ object WorkerMessage {
   final case class UpdateInputLinking(fromLayer: VirtualIdentity, inputNum: Int)
       extends ControlPayload
 
-  final case class UpdateOutputLinking(
-      policy: DataTransferPolicy,
-      link: LinkTag,
-      receivers: Array[ActorVirtualIdentity]
+  final case class AddDataSendingPolicy(
+      policy: DataSendingPolicy
   ) extends ControlPayload
 
   final case class EndSending(sequenceNumber: Long)

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/TupleToBatchConverterSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/TupleToBatchConverterSpec.scala
@@ -18,7 +18,6 @@ import edu.uci.ics.amber.engine.common.tuple.ITuple
 
 class TupleToBatchConverterSpec extends AnyFlatSpec with MockFactory {
   private val mockDataOutputPort = mock[DataOutputPort]
-  private val mockControlOutputPort = mock[ControlOutputPort]
   private val identifier = WorkerActorVirtualIdentity("batch producer mock")
 
   "TupleToBatchConverter" should "aggregate tuples and output" in {
@@ -26,7 +25,6 @@ class TupleToBatchConverterSpec extends AnyFlatSpec with MockFactory {
     val tuples = Array.fill(21)(ITuple(1, 2, 3, 4, "5", 9.8))
     val fakeID = WorkerActorVirtualIdentity("testReceiver")
     inSequence {
-      (mockControlOutputPort.sendTo _).expects(fakeID, UpdateInputLinking(identifier, 0))
       (mockDataOutputPort.sendTo _).expects(fakeID, DataFrame(tuples.slice(0, 10)))
       (mockDataOutputPort.sendTo _).expects(fakeID, DataFrame(tuples.slice(10, 20)))
       (mockDataOutputPort.sendTo _).expects(fakeID, DataFrame(tuples.slice(20, 21)))
@@ -34,6 +32,7 @@ class TupleToBatchConverterSpec extends AnyFlatSpec with MockFactory {
     }
     val fakeLink = LinkTag(LayerTag("", "", ""), LayerTag("", "", ""), 0)
     val fakeReceiver = Array[ActorVirtualIdentity](fakeID)
+
     batchProducer.addPolicy(new OneToOnePolicy(fakeLink, 10, fakeReceiver))
     tuples.foreach { t =>
       batchProducer.passTupleToDownstream(t)

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/TupleToBatchConverterSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/TupleToBatchConverterSpec.scala
@@ -34,7 +34,7 @@ class TupleToBatchConverterSpec extends AnyFlatSpec with MockFactory {
     }
     val fakeLink = LinkTag(LayerTag("", "", ""), LayerTag("", "", ""), 0)
     val fakeReceiver = Array[ActorVirtualIdentity](fakeID)
-    batchProducer.addPolicy(new OneToOnePolicy(10), fakeLink, fakeReceiver)
+    batchProducer.addPolicy(new OneToOnePolicy(fakeLink, 10, fakeReceiver))
     tuples.foreach { t =>
       batchProducer.passTupleToDownstream(t)
     }


### PR DESCRIPTION
Two changes:
1. Renamed DataTransferPolicy to DataSendingPolicy. Changed its signature to accept a policy, receivers and batchSize. Removed the initialize function inside it to the constructor. Accordingly the derived classes have also changed.
2. Changed UpdateOutputLinking to AddDataSendingPolicy and its signature accepts only a policy.