### PR TITLE
Let Network Communication Actors directly talk to each other

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
@@ -30,9 +30,12 @@ abstract class WorkflowActor(
     with Stash {
 
   protected val logger: WorkflowLogger = WorkflowLogger(s"$identifier")
-  logger.setErrorLogAction(err => {
-    throw new WorkflowRuntimeException(err)
-  })
+
+//  For now, just log it to the console
+//  TODO: enable throwing of the exception when all control messages have been handled properly
+//  logger.setErrorLogAction(err => {
+//    throw new WorkflowRuntimeException(err)
+//  })
 
   val networkCommunicationActor: NetworkSenderActorRef = NetworkSenderActorRef(
     context.actorOf(NetworkCommunicationActor.props(parentNetworkCommunicationActorRef))

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
@@ -30,6 +30,9 @@ abstract class WorkflowActor(
     with Stash {
 
   protected val logger: WorkflowLogger = WorkflowLogger(s"$identifier")
+  logger.setErrorLogAction(err => {
+    throw new WorkflowRuntimeException(err)
+  })
 
   val networkCommunicationActor: NetworkSenderActorRef = NetworkSenderActorRef(
     context.actorOf(NetworkCommunicationActor.props(parentNetworkCommunicationActorRef))
@@ -44,7 +47,7 @@ abstract class WorkflowActor(
 
   def disallowActorRefRelatedMessages: Receive = {
     case GetActorRef(id, replyTo) =>
-      throw new WorkflowRuntimeException(
+      logger.logError(
         WorkflowRuntimeError(
           "workflow actor should never receive get actor ref message",
           identifier.toString,
@@ -52,7 +55,7 @@ abstract class WorkflowActor(
         )
       )
     case RegisterActorRef(id, ref) =>
-      throw new WorkflowRuntimeException(
+      logger.logError(
         WorkflowRuntimeError(
           "workflow actor should never receive register actor ref message",
           identifier.toString,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerLayer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerLayer.scala
@@ -40,7 +40,7 @@ class WorkerLayer(
   def build(
       prev: Array[(OpExecConfig, WorkerLayer)],
       all: Array[Address],
-      parentSenderActorRef: ActorRef
+      parentNetworkCommunicationActorRef: ActorRef
   )(implicit
       context: ActorContext
   ): Unit = {
@@ -53,7 +53,9 @@ class WorkerLayer(
       val id = WorkerActorVirtualIdentity(workerTag.getGlobalIdentity)
       val d = deployStrategy.next()
       layer(i) = context.actorOf(
-        WorkflowWorker.props(id, m, parentSenderActorRef).withDeploy(Deploy(scope = RemoteScope(d)))
+        WorkflowWorker
+          .props(id, m, parentNetworkCommunicationActorRef)
+          .withDeploy(Deploy(scope = RemoteScope(d)))
       )
       identifiers(i) = WorkerActorVirtualIdentity(workerTag.getGlobalIdentity)
     }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerLayer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerLayer.scala
@@ -37,7 +37,11 @@ class WorkerLayer(
 
   def isBuilt: Boolean = layer != null
 
-  def build(prev: Array[(OpExecConfig, WorkerLayer)], all: Array[Address])(implicit
+  def build(
+      prev: Array[(OpExecConfig, WorkerLayer)],
+      all: Array[Address],
+      parentSenderActorRef: ActorRef
+  )(implicit
       context: ActorContext
   ): Unit = {
     deployStrategy.initialize(deploymentFilter.filter(prev, all, context.self.path.address))
@@ -48,8 +52,9 @@ class WorkerLayer(
       val workerTag = WorkerTag(tag, i)
       val id = WorkerActorVirtualIdentity(workerTag.getGlobalIdentity)
       val d = deployStrategy.next()
-      layer(i) =
-        context.actorOf(WorkflowWorker.props(id, m).withDeploy(Deploy(scope = RemoteScope(d))))
+      layer(i) = context.actorOf(
+        WorkflowWorker.props(id, m, parentSenderActorRef).withDeploy(Deploy(scope = RemoteScope(d)))
+      )
       identifiers(i) = WorkerActorVirtualIdentity(workerTag.getGlobalIdentity)
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/principal/Principal.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/principal/Principal.scala
@@ -68,11 +68,15 @@ import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}
 
 object Principal {
-  def props(metadata: OpExecConfig): Props = Props(new Principal(metadata))
+  def props(metadata: OpExecConfig, parentNetworkCommunicationActorRef: ActorRef): Props =
+    Props(new Principal(metadata, parentNetworkCommunicationActorRef))
 }
 
-class Principal(val metadata: OpExecConfig)
-    extends WorkflowActor(WorkerActorVirtualIdentity(metadata.tag.getGlobalIdentity)) {
+class Principal(val metadata: OpExecConfig, parentNetworkCommunicationActorRef: ActorRef)
+    extends WorkflowActor(
+      WorkerActorVirtualIdentity(metadata.tag.getGlobalIdentity),
+      parentNetworkCommunicationActorRef
+    ) {
   implicit val ec: ExecutionContext = context.dispatcher
   implicit val timeout: Timeout = 5.seconds
 
@@ -167,7 +171,7 @@ class Principal(val metadata: OpExecConfig)
   }
 
   final def ready: Receive = {
-    routeActorRefRelatedMessages orElse [Any, Unit] {
+    disallowActorRefRelatedMessages orElse [Any, Unit] {
       case RecoveryPacket(amberTag, seq1, seq2) =>
         receivedRecoveryInformation(amberTag) = (seq1, seq2)
       case Start =>
@@ -375,7 +379,7 @@ class Principal(val metadata: OpExecConfig)
 //    Set(WorkerState.Completed, WorkerState.Paused, WorkerState.LocalBreakpointTriggered)
 
   final def pausing: Receive = {
-    routeActorRefRelatedMessages orElse [Any, Unit] {
+    disallowActorRefRelatedMessages orElse [Any, Unit] {
       case RecoveryPacket(amberTag, seq1, seq2) =>
         receivedRecoveryInformation(amberTag) = (seq1, seq2)
       case EnforceStateCheck =>
@@ -441,7 +445,7 @@ class Principal(val metadata: OpExecConfig)
   }
 
   final def collectingBreakpoints: Receive = {
-    routeActorRefRelatedMessages orElse [Any, Unit] {
+    disallowActorRefRelatedMessages orElse [Any, Unit] {
       case RecoveryPacket(amberTag, seq1, seq2) =>
         receivedRecoveryInformation(amberTag) = (seq1, seq2)
       case EnforceStateCheck =>
@@ -530,7 +534,7 @@ class Principal(val metadata: OpExecConfig)
 //    Set(WorkerState.Running, WorkerState.Ready, WorkerState.Completed)
 
   final def resuming: Receive = {
-    routeActorRefRelatedMessages orElse [Any, Unit] {
+    disallowActorRefRelatedMessages orElse [Any, Unit] {
       case RecoveryPacket(amberTag, seq1, seq2) =>
         receivedRecoveryInformation(amberTag) = (seq1, seq2)
       case EnforceStateCheck =>
@@ -582,7 +586,7 @@ class Principal(val metadata: OpExecConfig)
   }
 
   final def paused: Receive = {
-    routeActorRefRelatedMessages orElse [Any, Unit] {
+    disallowActorRefRelatedMessages orElse [Any, Unit] {
       case KillAndRecover =>
 //        workerLayers.foreach { x =>
 //          x.layer(0) ! Reset(x.getFirstMetadata, Seq(receivedRecoveryInformation(x.tagForFirst)))
@@ -633,7 +637,7 @@ class Principal(val metadata: OpExecConfig)
   }
 
   final def completed: Receive = {
-    routeActorRefRelatedMessages orElse [Any, Unit] {
+    disallowActorRefRelatedMessages orElse [Any, Unit] {
       case KillAndRecover =>
 //        workerLayers.foreach { x =>
 //          if (receivedRecoveryInformation.contains(x.tagForFirst)) {
@@ -688,7 +692,7 @@ class Principal(val metadata: OpExecConfig)
   }
 
   final override def receive: Receive = {
-    routeActorRefRelatedMessages orElse [Any, Unit] {
+    disallowActorRefRelatedMessages orElse [Any, Unit] {
       case AckedPrincipalInitialization(prev: Array[(OpExecConfig, WorkerLayer)]) =>
       //workerLayers = metadata.topology.layers
       //workerEdges = metadata.topology.links

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/TrivialControlSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/TrivialControlSpec.scala
@@ -53,7 +53,7 @@ class TrivialControlSpec
     val idMap = mutable.HashMap[ActorVirtualIdentity, ActorRef]()
     for (i <- 0 until numActors) {
       val id = WorkerActorVirtualIdentity(s"$i")
-      val ref = probe.childActorOf(Props(new TrivialControlTester(id)))
+      val ref = probe.childActorOf(Props(new TrivialControlTester(id, probe.ref)))
       idMap(id) = ref
     }
     idMap(VirtualIdentity.Controller) = probe.ref

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/TrivialControlTester.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/TrivialControlTester.scala
@@ -1,5 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.control.utils
 
+import akka.actor.ActorRef
 import com.softwaremill.macwire.wire
 import edu.uci.ics.amber.engine.architecture.common.WorkflowActor
 import edu.uci.ics.amber.engine.architecture.messaginglayer.ControlInputPort.WorkflowControlMessage
@@ -10,12 +11,13 @@ import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunication
 import edu.uci.ics.amber.engine.common.ambertag.neo.VirtualIdentity.ActorVirtualIdentity
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCHandlerInitializer
 
-class TrivialControlTester(id: ActorVirtualIdentity) extends WorkflowActor(id) {
+class TrivialControlTester(id: ActorVirtualIdentity, parentNetworkCommunicationActorRef: ActorRef)
+    extends WorkflowActor(id, parentNetworkCommunicationActorRef) {
   override val rpcHandlerInitializer: AsyncRPCHandlerInitializer =
     wire[TesterAsyncRPCHandlerInitializer]
 
   override def receive: Receive = {
-    routeActorRefRelatedMessages orElse {
+    disallowActorRefRelatedMessages orElse {
       case msg @ NetworkMessage(id, cmd: WorkflowControlMessage) =>
         logger.logInfo(s"received ${msg.internalMessage}")
         sender ! NetworkAck(id)


### PR DESCRIPTION
This PR:
1. prohibited `GetActorRef` and `RegisterActorRef` being received by any `WorkflowActor`. Worker actors should not route ActorRef related messages.
2. passed a `parentNetworkCommunicationActorRef` to `NetworkCommunicationActor` so that the worker's network communication actor can directly send messages to the controller's network communication actor.