### PR TITLE
Log every exception inside DataProcessor

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/DataProcessor.scala
@@ -178,7 +178,7 @@ class DataProcessor( // dependencies:
       // check pause before outputting tuples.
       pauseManager.checkForPause()
       // output loop: take one tuple from iterator at a time.
-      while (outputIterator != null && outputIterator.hasNext) {
+      while (outputAvailable(outputIterator)) {
         // send tuple to downstream.
         outputOneTuple(outputIterator)
         // check pause after one tuple has been outputted.
@@ -187,13 +187,24 @@ class DataProcessor( // dependencies:
     }
   }
 
+  private[this] def outputAvailable(outputIterator: Iterator[ITuple]): Boolean = {
+    try {
+      outputIterator != null && outputIterator.hasNext
+    } catch {
+      case e: Exception =>
+        handleOperatorException(e, isInput = true)
+        false
+    }
+  }
 
-  private[this] def logException(e:Exception): Unit ={
-    logger.logError(WorkflowRuntimeError(
-      s"Exception in operator logic: ${e.getMessage()}",
-      "Dataprocessor",
-      Map("Stacktrace" -> e.getStackTrace().mkString("\n\t"))
-    ))
+  private[this] def logException(e: Exception): Unit = {
+    logger.logError(
+      WorkflowRuntimeError(
+        s"Exception in operator logic: ${e.getMessage()}",
+        "Dataprocessor",
+        Map("Stacktrace" -> e.getStackTrace().mkString("\n\t"))
+      )
+    )
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/neo/DataProcessor.scala
@@ -45,6 +45,7 @@ class DataProcessor( // dependencies:
         runDPThreadMainLogic()
       } catch {
         case e: Exception =>
+          logException(e)
           throw new RuntimeException(e)
       }
     }
@@ -88,13 +89,6 @@ class DataProcessor( // dependencies:
       }
     } catch {
       case e: Exception =>
-        logger.logError(
-          WorkflowRuntimeError(
-            s"Exception in operator logic: ${e.getMessage()}",
-            "Dataprocessor",
-            Map("Stacktrace" -> e.getStackTrace().mkString("\n\t"))
-          )
-        )
         handleOperatorException(e, isInput = true)
     }
     outputIterator
@@ -167,6 +161,7 @@ class DataProcessor( // dependencies:
   }
 
   private[this] def handleOperatorException(e: Exception, isInput: Boolean): Unit = {
+    logException(e)
     pauseManager.pause()
     assignExceptionBreakpoint(currentInputTuple.left.getOrElse(null), e, isInput)
     controlOutputChannel.sendTo(VirtualIdentity.Self, LocalBreakpointTriggered())
@@ -190,6 +185,15 @@ class DataProcessor( // dependencies:
         pauseManager.checkForPause()
       }
     }
+  }
+
+
+  private[this] def logException(e:Exception): Unit ={
+    logger.logError(WorkflowRuntimeError(
+      s"Exception in operator logic: ${e.getMessage()}",
+      "Dataprocessor",
+      Map("Stacktrace" -> e.getStackTrace().mkString("\n\t"))
+    ))
   }
 
 }


### PR DESCRIPTION
Throw an exception in Akka actor won't log anything on the console, so we MUST manually log all the exception for a better debugging experience for developers. An operator can throw an exception in `processTuple`, `hasNext` and `next` calls. 
This PR:
1. caught and logged every exception on the 3 cases above and also logged dp-thread level exception. Previously, the exception thrown by `hasNext` and `next` calls would not be logged.