### PR TITLE
Kill DP Thread when killing the worker

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -197,9 +197,11 @@ class DataProcessor( // dependencies:
     if (stateManager.confirmState(Running)) {
       pauseManager.pause().onSuccess { ret =>
         dpThread.cancel(true)
+        operator.close()
       }
     } else {
       dpThread.cancel(true)
+      operator.close()
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -194,7 +194,10 @@ class DataProcessor( // dependencies:
   }
 
   def shutdown(): Unit = {
-    dpThread.cancel(true)
+    pauseManager.pause().onSuccess{
+      ret =>
+      dpThread.cancel(true)
+    }
   }
 
   private[this] def outputAvailable(outputIterator: Iterator[ITuple]): Boolean = {


### PR DESCRIPTION
This PR:
1. stopped the dp thread when the worker kills itself. If the dp thread is running, a pause action will first be made and then the dp thread will be stopped.