### PR TITLE
Let Amber catch common throwables during runtime

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
@@ -78,8 +78,8 @@ abstract class WorkflowActor(
         // use control input port to pass control messages
         controlInputPort.handleControlMessage(cmd)
       } catch {
-        case exception: Exception =>
-          logger.logError(WorkflowRuntimeError(exception, identifier.toString))
+        case e @ (_: Exception | _: AssertionError | _: StackOverflowError | _: OutOfMemoryError) =>
+          logger.logError(WorkflowRuntimeError(e, identifier.toString))
       }
 
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LocalOperatorExceptionHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LocalOperatorExceptionHandler.scala
@@ -15,7 +15,7 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 object LocalOperatorExceptionHandler {
-  final case class LocalOperatorException(triggeredTuple: ITuple, e: Exception)
+  final case class LocalOperatorException(triggeredTuple: ITuple, e: Throwable)
       extends ControlCommand[CommandCompleted]
 }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -49,7 +49,7 @@ class DataProcessor( // dependencies:
         operator.open()
         runDPThreadMainLogic()
       } catch {
-        case e: Exception =>
+        case e @ (_: Exception | _: AssertionError | _: StackOverflowError | _: OutOfMemoryError) =>
           val error = WorkflowRuntimeError(e, "DP Thread internal logic")
           logger.logError(error)
         // dp thread will stop here
@@ -89,7 +89,7 @@ class DataProcessor( // dependencies:
         inputTupleCount += 1
       }
     } catch {
-      case e: Exception =>
+      case e @ (_: Exception | _: AssertionError | _: StackOverflowError | _: OutOfMemoryError) =>
         // forward input tuple to the user and pause DP thread
         handleOperatorException(e)
     }
@@ -104,7 +104,7 @@ class DataProcessor( // dependencies:
     try {
       outputTuple = currentOutputIterator.next
     } catch {
-      case e: Exception =>
+      case e @ (_: Exception | _: AssertionError | _: StackOverflowError | _: OutOfMemoryError) =>
         // invalidate current output tuple
         outputTuple = null
         // also invalidate outputIterator
@@ -157,7 +157,7 @@ class DataProcessor( // dependencies:
     asyncRPCClient.send(WorkerExecutionCompleted(), ActorVirtualIdentity.Controller)
   }
 
-  private[this] def handleOperatorException(e: Exception): Unit = {
+  private[this] def handleOperatorException(e: Throwable): Unit = {
     if (currentInputTuple.isLeft) {
       asyncRPCClient.send(
         LocalOperatorException(currentInputTuple.left.get, e),

--- a/core/amber/src/main/scala/edu/uci/ics/amber/error/WorkflowRuntimeError.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/error/WorkflowRuntimeError.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.amber.error
 
 object WorkflowRuntimeError {
-  def apply(exception: Exception, source: String): WorkflowRuntimeError = {
+  def apply(exception: Throwable, source: String): WorkflowRuntimeError = {
     WorkflowRuntimeError(
       exception.getMessage,
       source,


### PR DESCRIPTION
This PR:
1. made worker logic catch 3 common throwables that we didn't catch before. Namely `AssertionError`, `StackOverflowError`, and `OutOfMemoryError`.