### PR TITLE
Shutdown Executor when canceling DP thread

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -198,6 +198,7 @@ class DataProcessor( // dependencies:
     if (stateManager.confirmState(Running)) {
       pauseManager.pause().onSuccess { ret =>
         // this block will be executed inside DP Thread
+        // when pauseManager.blockDPThread() is called
         dpThread.cancel(true) // try to interrupt the DP Thread
         operator.close() // close operator
         dpThreadExecutor.shutdownNow() // destroy thread

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -212,7 +212,7 @@ class DataProcessor( // dependencies:
       // note that in above cases, an interrupt exception will be thrown
       // 3. completed
       dpThread.cancel(true) // interrupt
-      operator.close()// close operator
+      operator.close() // close operator
       dpThreadExecutor.shutdownNow() // destroy thread
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -50,6 +50,8 @@ class DataProcessor( // dependencies:
         operator.open()
         runDPThreadMainLogic()
       } catch {
+        case e:InterruptedException =>
+          logger.logInfo("DP Thread exits")
         case e @ (_: Exception | _: AssertionError | _: StackOverflowError | _: OutOfMemoryError) =>
           val error = WorkflowRuntimeError(e, "DP Thread internal logic")
           logger.logError(error)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -50,7 +50,7 @@ class DataProcessor( // dependencies:
         operator.open()
         runDPThreadMainLogic()
       } catch {
-        case e:InterruptedException =>
+        case e: InterruptedException =>
           logger.logInfo("DP Thread exits")
         case e @ (_: Exception | _: AssertionError | _: StackOverflowError | _: OutOfMemoryError) =>
           val error = WorkflowRuntimeError(e, "DP Thread internal logic")

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -197,13 +197,13 @@ class DataProcessor( // dependencies:
   def shutdown(): Unit = {
     if (stateManager.confirmState(Running)) {
       pauseManager.pause().onSuccess { ret =>
-        // this block will be executed inside DP Thread
+        // this block of code will be executed inside DP Thread
         // when pauseManager.blockDPThread() is called
         dpThread.cancel(true) // try to interrupt the DP Thread
         operator.close() // close operator
         dpThreadExecutor.shutdownNow() // destroy thread
         // ideally, DP thread will block on
-        // PauseManager.dpThreadBlocker.get call
+        // dpThreadBlocker.get (see PauseManager.blockDPThread)
         // then get interrupted and exit
       }
     } else {
@@ -211,7 +211,7 @@ class DataProcessor( // dependencies:
       // 1. blocks on blockingDeque.take() because worker is in ready state
       // 2. blocks on PauseManager.dpThreadBlocker.get because worker is paused
       // note that in above cases, an interrupt exception will be thrown
-      // 3. completed
+      // 3. already completed
       dpThread.cancel(true) // interrupt
       operator.close() // close operator
       dpThreadExecutor.shutdownNow() // destroy thread

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -42,7 +42,8 @@ class DataProcessor( // dependencies:
   private var isCompleted = false
 
   // initialize dp thread upon construction
-  private val dpThread = Executors.newSingleThreadExecutor.submit(new Runnable() {
+  private val dpThreadExecutor = Executors.newSingleThreadExecutor
+  private val dpThread = dpThreadExecutor.submit(new Runnable() {
     def run(): Unit = {
       try {
         // initialize operator
@@ -198,10 +199,12 @@ class DataProcessor( // dependencies:
       pauseManager.pause().onSuccess { ret =>
         dpThread.cancel(true)
         operator.close()
+        dpThreadExecutor.shutdownNow()
       }
     } else {
       dpThread.cancel(true)
       operator.close()
+      dpThreadExecutor.shutdownNow()
     }
   }
 


### PR DESCRIPTION
According to [this post](https://blog.fastthread.io/2015/10/23/memory-leak-in-java-executor-2/) and my own observation, the thread object remains in memory after we killed the worker.

So this PR:
1. explicitly destroyed ` Executors.newSingleThreadExecutor` by calling `executor.shutdownNow()` after pause the DP thread to prevent a possible memory leak.