### PR TITLE
Change roundrobin from per batch to per tuple

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/HashBasedShufflePolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/HashBasedShufflePolicy.scala
@@ -12,50 +12,10 @@ class HashBasedShufflePolicy(
     batchSize: Int,
     val hashFunc: ITuple => Int,
     receivers: Array[ActorVirtualIdentity]
-) extends DataSendingPolicy(policyTag, batchSize, receivers) {
-  var batches: Array[Array[ITuple]] = _
-  var currentSizes: Array[Int] = _
+) extends ParallelBatchingPolicy(policyTag, batchSize, receivers) {
 
-  initializeInternalState(receivers)
-
-  override def noMore(): Array[(ActorVirtualIdentity, DataPayload)] = {
-    val receiversAndBatches = new ArrayBuffer[(ActorVirtualIdentity, DataPayload)]
-    for (k <- receivers.indices) {
-      if (currentSizes(k) > 0) {
-        receiversAndBatches.append(
-          (receivers(k), DataFrame(batches(k).slice(0, currentSizes(k))))
-        )
-      }
-      receiversAndBatches.append((receivers(k), EndOfUpstream()))
-    }
-    receiversAndBatches.toArray
-  }
-
-  override def addTupleToBatch(
-      tuple: ITuple
-  ): Option[(ActorVirtualIdentity, DataPayload)] = {
+  override def selectBatchingIndex(tuple: ITuple): Int = {
     val numBuckets = receivers.length
-    val index = (hashFunc(tuple) % numBuckets + numBuckets) % numBuckets
-    batches(index)(currentSizes(index)) = tuple
-    currentSizes(index) += 1
-    if (currentSizes(index) == batchSize) {
-      currentSizes(index) = 0
-      val retBatch = batches(index)
-      batches(index) = new Array[ITuple](batchSize)
-      return Some((receivers(index), DataFrame(retBatch)))
-    }
-    None
-  }
-
-  override def reset(): Unit = {
-    initializeInternalState(receivers)
-  }
-
-  private[this] def initializeInternalState(_receivers: Array[ActorVirtualIdentity]): Unit = {
-    batches = new Array[Array[ITuple]](_receivers.length)
-    for (i <- _receivers.indices) {
-      batches(i) = new Array[ITuple](batchSize)
-    }
-    currentSizes = new Array[Int](_receivers.length)
+    (hashFunc(tuple) % numBuckets + numBuckets) % numBuckets
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/ParallelBatchingPolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/ParallelBatchingPolicy.scala
@@ -35,7 +35,6 @@ abstract class ParallelBatchingPolicy(
   override def addTupleToBatch(
       tuple: ITuple
   ): Option[(ActorVirtualIdentity, DataPayload)] = {
-    val numBuckets = receivers.length
     val index = selectBatchingIndex(tuple)
     batches(index)(currentSizes(index)) = tuple
     currentSizes(index) += 1

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/ParallelBatchingPolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/ParallelBatchingPolicy.scala
@@ -6,17 +6,18 @@ import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, Li
 
 import scala.collection.mutable.ArrayBuffer
 
-abstract class ParallelBatchingPolicy( policyTag: LinkIdentity,
-                                       batchSize: Int,
-                                       receivers: Array[ActorVirtualIdentity]) extends DataSendingPolicy(policyTag, batchSize, receivers) {
-
+abstract class ParallelBatchingPolicy(
+    policyTag: LinkIdentity,
+    batchSize: Int,
+    receivers: Array[ActorVirtualIdentity]
+) extends DataSendingPolicy(policyTag, batchSize, receivers) {
 
   var batches: Array[Array[ITuple]] = _
   var currentSizes: Array[Int] = _
 
   initializeInternalState(receivers)
 
-  def selectBatchingIndex(tuple:ITuple):Int
+  def selectBatchingIndex(tuple: ITuple): Int
 
   override def noMore(): Array[(ActorVirtualIdentity, DataPayload)] = {
     val receiversAndBatches = new ArrayBuffer[(ActorVirtualIdentity, DataPayload)]
@@ -32,8 +33,8 @@ abstract class ParallelBatchingPolicy( policyTag: LinkIdentity,
   }
 
   override def addTupleToBatch(
-                                tuple: ITuple
-                              ): Option[(ActorVirtualIdentity, DataPayload)] = {
+      tuple: ITuple
+  ): Option[(ActorVirtualIdentity, DataPayload)] = {
     val numBuckets = receivers.length
     val index = selectBatchingIndex(tuple)
     batches(index)(currentSizes(index)) = tuple

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/ParallelBatchingPolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/ParallelBatchingPolicy.scala
@@ -1,0 +1,62 @@
+package edu.uci.ics.amber.engine.architecture.sendsemantics.datatransferpolicy
+
+import edu.uci.ics.amber.engine.common.ambermessage.{DataFrame, DataPayload, EndOfUpstream}
+import edu.uci.ics.amber.engine.common.tuple.ITuple
+import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LinkIdentity}
+
+import scala.collection.mutable.ArrayBuffer
+
+abstract class ParallelBatchingPolicy( policyTag: LinkIdentity,
+                                       batchSize: Int,
+                                       receivers: Array[ActorVirtualIdentity]) extends DataSendingPolicy(policyTag, batchSize, receivers) {
+
+
+  var batches: Array[Array[ITuple]] = _
+  var currentSizes: Array[Int] = _
+
+  initializeInternalState(receivers)
+
+  def selectBatchingIndex(tuple:ITuple):Int
+
+  override def noMore(): Array[(ActorVirtualIdentity, DataPayload)] = {
+    val receiversAndBatches = new ArrayBuffer[(ActorVirtualIdentity, DataPayload)]
+    for (k <- receivers.indices) {
+      if (currentSizes(k) > 0) {
+        receiversAndBatches.append(
+          (receivers(k), DataFrame(batches(k).slice(0, currentSizes(k))))
+        )
+      }
+      receiversAndBatches.append((receivers(k), EndOfUpstream()))
+    }
+    receiversAndBatches.toArray
+  }
+
+  override def addTupleToBatch(
+                                tuple: ITuple
+                              ): Option[(ActorVirtualIdentity, DataPayload)] = {
+    val numBuckets = receivers.length
+    val index = selectBatchingIndex(tuple)
+    batches(index)(currentSizes(index)) = tuple
+    currentSizes(index) += 1
+    if (currentSizes(index) == batchSize) {
+      currentSizes(index) = 0
+      val retBatch = batches(index)
+      batches(index) = new Array[ITuple](batchSize)
+      return Some((receivers(index), DataFrame(retBatch)))
+    }
+    None
+  }
+
+  override def reset(): Unit = {
+    initializeInternalState(receivers)
+  }
+
+  private[this] def initializeInternalState(_receivers: Array[ActorVirtualIdentity]): Unit = {
+    batches = new Array[Array[ITuple]](_receivers.length)
+    for (i <- _receivers.indices) {
+      batches(i) = new Array[ITuple](batchSize)
+    }
+    currentSizes = new Array[Int](_receivers.length)
+  }
+
+}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/RoundRobinPolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/datatransferpolicy/RoundRobinPolicy.scala
@@ -11,40 +11,11 @@ class RoundRobinPolicy(
     policyTag: LinkIdentity,
     batchSize: Int,
     receivers: Array[ActorVirtualIdentity]
-) extends DataSendingPolicy(policyTag, batchSize, receivers) {
+) extends ParallelBatchingPolicy(policyTag, batchSize, receivers) {
   var roundRobinIndex = 0
-  var batch: Array[ITuple] = new Array[ITuple](batchSize)
-  var currentSize = 0
 
-  override def noMore(): Array[(ActorVirtualIdentity, DataPayload)] = {
-    val ret = new ArrayBuffer[(ActorVirtualIdentity, DataPayload)]
-    if (currentSize > 0) {
-      ret.append((receivers(roundRobinIndex), DataFrame(batch.slice(0, currentSize))))
-    }
-    receivers.foreach { receiver =>
-      ret.append((receiver, EndOfUpstream())) // send end to all receivers
-    }
-    ret.toArray
-  }
-
-  override def addTupleToBatch(
-      tuple: ITuple
-  ): Option[(ActorVirtualIdentity, DataPayload)] = {
-    batch(currentSize) = tuple
-    currentSize += 1
-    if (currentSize == batchSize) {
-      currentSize = 0
-      val retBatch = batch
-      roundRobinIndex = (roundRobinIndex + 1) % receivers.length
-      batch = new Array[ITuple](batchSize)
-      return Some((receivers(roundRobinIndex), DataFrame(retBatch)))
-    }
-    None
-  }
-
-  override def reset(): Unit = {
-    batch = new Array[ITuple](batchSize)
-    roundRobinIndex = 0
-    currentSize = 0
+  override def selectBatchingIndex(tuple: ITuple): Int = {
+    roundRobinIndex = (roundRobinIndex + 1) % receivers.length
+    roundRobinIndex
   }
 }


### PR DESCRIPTION
This PR:
1. changed roundrobin policy from doing roundrobin per batch to per tuple to solve an issue for limit operator.