### PR TITLE
Upgrade Akka version to 2.6.12 and fix some memory issues

### DIFF
--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -12,7 +12,7 @@ scalacOptions ++= Seq("-feature")
 // ensuring no parallel execution of multiple tasks
 concurrentRestrictions in Global += Tags.limit(Tags.Test, 1)
 
-val akkaVersion = "2.5.24"
+val akkaVersion = "2.6.12"
 val hadoopVersion = "3.2.0"
 
 libraryDependencies ++= Seq(

--- a/core/amber/src/main/resources/clustered.conf
+++ b/core/amber/src/main/resources/clustered.conf
@@ -12,25 +12,11 @@ akka {
 
   }
   remote {
-  maximum-payload-bytes = 30000000 bytes
-    netty.tcp {
-      hostname = "0.0.0.0"
-      port = 0
-      message-frame-size =  30000000b
-      send-buffer-size =  30000000b
-      receive-buffer-size =  30000000b
-      maximum-frame-size = 30000000b
-    }
-
-
     artery {
-      # change this to enabled=on to use Artery instead of netty
-      # see https://doc.akka.io/docs/akka/current/remoting-artery.html
-      enabled = off
-      transport = tcp
-      canonical.hostname = "0.0.0.0"
-      canonical.port = 0
-    }
+          transport = tcp
+          canonical.hostname = "0.0.0.0"
+          canonical.port = 0
+        }
   }
   cluster {
     seed-nodes = []

--- a/core/amber/src/main/resources/clustered.conf
+++ b/core/amber/src/main/resources/clustered.conf
@@ -16,6 +16,8 @@ akka {
           transport = tcp
           canonical.hostname = "0.0.0.0"
           canonical.port = 0
+          advanced.maximum-frame-size = 30 MiB
+          advanced.maximum-large-frame-size = 120 MiB
         }
   }
   cluster {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
@@ -135,6 +135,7 @@ class Controller(
     if (statusUpdateAskHandle != null) {
       statusUpdateAskHandle.cancel()
     }
+    workflow.cleanupResults()
     logger.logInfo("stopped!")
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Workflow.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Workflow.scala
@@ -106,6 +106,12 @@ class Workflow(
 
   def isCompleted: Boolean = operators.values.forall(op => op.getState == Completed)
 
+  def cleanupResults(): Unit ={
+    operators.values.foreach{
+      op => op.results = null
+    }
+  }
+
   def buildOperator(
       allNodes: Array[Address],
       prev: Array[(OpExecConfig, WorkerLayer)],

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Workflow.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Workflow.scala
@@ -106,9 +106,9 @@ class Workflow(
 
   def isCompleted: Boolean = operators.values.forall(op => op.getState == Completed)
 
-  def cleanupResults(): Unit ={
-    operators.values.foreach{
-      op => op.results = null
+  def cleanupResults(): Unit = {
+    operators.values.foreach { op =>
+      op.results = null
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
@@ -51,7 +51,7 @@ class CongestionControl {
       }
     } else {
       ssThreshold /= 2
-      if(ssThreshold < 1){
+      if (ssThreshold < 1) {
         ssThreshold = 1
       }
       windowSize = ssThreshold

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
@@ -51,6 +51,9 @@ class CongestionControl {
       }
     } else {
       ssThreshold /= 2
+      if(ssThreshold < 1){
+        ssThreshold = 1
+      }
       windowSize = ssThreshold
     }
     sentTime.remove(id)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberUtils.scala
@@ -30,11 +30,9 @@ object AmberUtils {
 
     val config = ConfigFactory
       .parseString(s"""
-        akka.remote.netty.tcp.hostname = $localIpAddress
-        akka.remote.netty.tcp.port = 2552
         akka.remote.artery.canonical.port = 2552
         akka.remote.artery.canonical.hostname = $localIpAddress
-        akka.cluster.seed-nodes = [ "akka.tcp://Amber@$localIpAddress:2552" ]
+        akka.cluster.seed-nodes = [ "akka://Amber@$localIpAddress:2552" ]
         akka.actor.serialization-bindings."java.lang.Throwable" = akka-misc
         """)
       .withFallback(ConfigFactory.load("clustered"))
@@ -53,9 +51,9 @@ object AmberUtils {
     val localIpAddress = "localhost"
     val config = ConfigFactory
       .parseString(s"""
-        akka.remote.netty.tcp.hostname = $localIpAddress
         akka.remote.artery.canonical.hostname = $localIpAddress
-        akka.cluster.seed-nodes = [ "akka.tcp://Amber@$addr:2552" ]
+        akka.remote.artery.canonical.port = 0
+        akka.cluster.seed-nodes = [ "akka://Amber@$addr:2552" ]
         akka.actor.serialization-bindings."java.lang.Throwable" = akka-misc
         """)
       .withFallback(ConfigFactory.load("clustered"))

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -15,7 +15,11 @@ import edu.uci.ics.amber.engine.common.virtualidentity.WorkflowIdentity
 import edu.uci.ics.texera.web.TexeraWebApplication
 import edu.uci.ics.texera.web.model.event._
 import edu.uci.ics.texera.web.model.request._
-import edu.uci.ics.texera.web.resource.WorkflowWebsocketResource.{sessionJobs, sessionMap, sessionResults}
+import edu.uci.ics.texera.web.resource.WorkflowWebsocketResource.{
+  sessionJobs,
+  sessionMap,
+  sessionResults
+}
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.workflow.{WorkflowCompiler, WorkflowInfo}
 import edu.uci.ics.texera.workflow.common.{Utils, WorkflowContext}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -15,7 +15,7 @@ import edu.uci.ics.amber.engine.common.virtualidentity.WorkflowIdentity
 import edu.uci.ics.texera.web.TexeraWebApplication
 import edu.uci.ics.texera.web.model.event._
 import edu.uci.ics.texera.web.model.request._
-import edu.uci.ics.texera.web.resource.WorkflowWebsocketResource.{sessionJobs, sessionResults}
+import edu.uci.ics.texera.web.resource.WorkflowWebsocketResource.{sessionJobs, sessionMap, sessionResults}
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.workflow.{WorkflowCompiler, WorkflowInfo}
 import edu.uci.ics.texera.workflow.common.{Utils, WorkflowContext}
@@ -89,6 +89,8 @@ class WorkflowWebsocketResource {
     }
 
     sessionResults.remove(session.getId)
+    sessionJobs.remove(session.getId)
+    sessionMap.remove(session.getId)
   }
 
   def send(session: Session, event: TexeraWebSocketEvent): Unit = {


### PR DESCRIPTION
This PR:
1. upgraded Akka version to 2.6.12 where it uses Artery TCP instead of Netty TCP. 
2. fixed a bug that congestion control lowers the sending window size to 0, which will allow no further message to be sent. Now the minimum window size is 1.
3. removed the session entry from sessionMap, sessionJobs, and sessionResults to release the reference to actors and workflow results. However. Akka will keep the reference to actors in its own cache even if that actor is killed, so GC needs to wait until that reference to get replaced.
4. released the reference to the operator results when the controller is killed by calling `workflow.cleanupResults()`