### PR TITLE
[BUG-FIX] Hash Join getOutputSchema bugfix

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpDesc.scala
@@ -76,7 +76,7 @@ class HashJoinOpDesc[K] extends OperatorDescriptor {
         .getAttributes()
         .forEach(attr => {
           if (schemas(0).containsAttribute(attr.getName())) {
-            builder.add(new Attribute(s"${attr.getName()}1", attr.getType()))
+            builder.add(new Attribute(s"${attr.getName()}#@1", attr.getType()))
           } else if (!attr.getName().equalsIgnoreCase(probeAttributeName)) {
             builder.add(attr)
           }


### PR DESCRIPTION
In HashJoin getOutputschema(), we add `1` to the column if it's present iin both build and probe tuple. But if the build tuple already has a column named `11`, then it becomes a problem. This bug fix solves that.