### PR TITLE
[BUGFIX] Source worker state changes to Completed before Running

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/StartHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/StartHandler.scala
@@ -23,9 +23,9 @@ trait StartHandler {
   registerHandler { (msg: StartWorker, sender) =>
     stateManager.assertState(Ready)
     if (operator.isInstanceOf[ISourceOperatorExecutor]) {
+      stateManager.transitTo(Running)
       dataProcessor.appendElement(EndMarker)
       dataProcessor.appendElement(EndOfAllMarker)
-      stateManager.transitTo(Running)
       stateManager.getCurrentState
     } else {
       throw new WorkflowRuntimeException(


### PR DESCRIPTION
This PR fixes a bug when the source operator completes before we change the worker state to running. This behavior usually means source operators do not have any output tuples. However, we observed it randomly happens on our test cases, which is weird.