### PR TITLE
Move Control processing functionality into DP Thread

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/PauseManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/PauseManager.scala
@@ -20,93 +20,30 @@ class PauseManager(controlOutputPort: ControlOutputPort) {
   protected val logger: WorkflowLogger = WorkflowLogger("PauseManager")
 
   // current pause privilege level
-  private val pausePrivilegeLevel = new AtomicInteger(PauseManager.NoPause)
-  // yielded control of the dp thread
-  // volatile is necessary otherwise main thread cannot notice the change.
-  // volatile means read/writes are through memory rather than CPU cache
-  @volatile private var dpThreadBlocker: CompletableFuture[Void] = _
-  @volatile private var pausePromise: Promise[ExecutionPaused] = _
+  private var pausePrivilegeLevel = PauseManager.NoPause
 
   /** pause functionality
     * both dp thread and actor can call this function
     * @param
     */
-  def pause(): Future[ExecutionPaused] = {
+  def pause(): Unit = {
 
     /*this line atomically applies the following logic:
       Level = Paused
       if(level >= pausePrivilegeLevel.get())
         pausePrivilegeLevel.set(level)
      */
-    pausePromise = Promise[ExecutionPaused]()
-    if (isPaused) {
-      pausePromise.setValue(ExecutionPaused())
-    }
-    pausePrivilegeLevel.getAndUpdate { i =>
-      if (PauseManager.Paused >= i) {
-        PauseManager.Paused
-      } else i
-    }
-
-    pausePromise
+    pausePrivilegeLevel = PauseManager.Paused
   }
 
-  def isPaused: Boolean = isPauseSet() && dpThreadBlocker != null && !dpThreadBlocker.isDone
+  def isPaused: Boolean = pausePrivilegeLevel == PauseManager.Paused
 
   /** resume functionality
     * only actor calls this function for now
     * @param
     */
   def resume(): Unit = {
-    if (pausePrivilegeLevel.get() == PauseManager.NoPause) {
-      logger.logInfo("already resumed")
-      return
-    }
-    // only privilege level >= current pause privilege level can resume the worker
-    pausePrivilegeLevel.set(PauseManager.NoPause)
-    unblockDPThread()
-  }
-
-  /** check for pause in dp thread
-    * only dp thread and operator logic can call this function
-    * @throws
-    */
-  @throws[Exception]
-  def checkForPause(): Unit = {
-    // returns if not paused
-    if (isPauseSet()) {
-      blockDPThread()
-    }
-  }
-
-  def isPauseSet(): Boolean = {
-    (pausePrivilegeLevel.get() != PauseManager.NoPause)
-  }
-
-  /** block the thread by creating CompletableFuture and wait for completion
-    */
-  private[this] def blockDPThread(): Unit = {
-    // create a future and wait for its completion
-    this.dpThreadBlocker = new CompletableFuture[Void]
-    // notify main actor thread
-    if (pausePromise != null) {
-      pausePromise.setValue(ExecutionPaused())
-      pausePromise = null
-    }
-    // thread blocks here
-    logger.logInfo(s"dp thread blocked")
-    this.dpThreadBlocker.get
-    logger.logInfo(s"dp thread resumed")
-  }
-
-  /** unblock DP thread by resolving the CompletableFuture
-    */
-  private[this] def unblockDPThread(): Unit = {
-    // If dp thread suspended, release it
-    if (dpThreadBlocker != null) {
-      logger.logInfo("resume the worker by complete the future")
-      this.dpThreadBlocker.complete(null)
-    }
+    pausePrivilegeLevel = PauseManager.NoPause
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerControlInputPort.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerControlInputPort.scala
@@ -1,0 +1,41 @@
+package edu.uci.ics.amber.engine.architecture.worker
+
+import edu.uci.ics.amber.engine.architecture.messaginglayer.ControlInputPort
+import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.UnblockForControlCommands
+import edu.uci.ics.amber.engine.common.WorkflowLogger
+import edu.uci.ics.amber.engine.common.rpc.{AsyncRPCClient, AsyncRPCServer}
+import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, VirtualIdentity}
+
+class WorkerControlInputPort(
+    dataProcessor: DataProcessor,
+    logger: WorkflowLogger,
+    asyncRPCClient: AsyncRPCClient,
+    asyncRPCServer: AsyncRPCServer
+) extends ControlInputPort(logger, asyncRPCClient, asyncRPCServer) {
+
+  override def processControlInvocation(
+      invocation: AsyncRPCClient.ControlInvocation,
+      from: VirtualIdentity
+  ): Unit = {
+    // let dp thread process it
+    assert(from.isInstanceOf[ActorVirtualIdentity])
+    // this enqueue operation MUST happen before checking data queue.
+    dataProcessor.enqueueCommand(invocation, from)
+    if (dataProcessor.isDataQueueEmpty) {
+      dataProcessor.appendElement(UnblockForControlCommands)
+    }
+  }
+
+  override def processReturnPayload(
+      ret: AsyncRPCClient.ReturnPayload,
+      from: VirtualIdentity
+  ): Unit = {
+    // let dp thread process it
+    // this enqueue operation MUST happen before checking data queue.
+    dataProcessor.enqueueCommand(ret, from)
+    if (dataProcessor.isDataQueueEmpty) {
+      dataProcessor.appendElement(UnblockForControlCommands)
+    }
+  }
+
+}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerControlInputPort.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerControlInputPort.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.worker
 
 import edu.uci.ics.amber.engine.architecture.messaginglayer.ControlInputPort
-import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.UnblockForControlCommands
 import edu.uci.ics.amber.engine.common.WorkflowLogger
 import edu.uci.ics.amber.engine.common.rpc.{AsyncRPCClient, AsyncRPCServer}
 import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, VirtualIdentity}
@@ -19,11 +18,7 @@ class WorkerControlInputPort(
   ): Unit = {
     // let dp thread process it
     assert(from.isInstanceOf[ActorVirtualIdentity])
-    // this enqueue operation MUST happen before checking data queue.
     dataProcessor.enqueueCommand(invocation, from)
-    if (dataProcessor.isDataQueueEmpty) {
-      dataProcessor.appendElement(UnblockForControlCommands)
-    }
   }
 
   override def processReturnPayload(
@@ -31,11 +26,7 @@ class WorkerControlInputPort(
       from: VirtualIdentity
   ): Unit = {
     // let dp thread process it
-    // this enqueue operation MUST happen before checking data queue.
     dataProcessor.enqueueCommand(ret, from)
-    if (dataProcessor.isDataQueueEmpty) {
-      dataProcessor.appendElement(UnblockForControlCommands)
-    }
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkflowWorker.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkflowWorker.scala
@@ -16,11 +16,18 @@ import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunication
 }
 import edu.uci.ics.amber.engine.architecture.messaginglayer.{
   BatchToTupleConverter,
+  ControlInputPort,
   DataInputPort,
   DataOutputPort,
   TupleToBatchConverter
 }
-import edu.uci.ics.amber.engine.common.rpc.{AsyncRPCHandlerInitializer, AsyncRPCServer}
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.ShutdownDPThreadHandler.ShutdownDPThread
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
+import edu.uci.ics.amber.engine.common.rpc.{
+  AsyncRPCClient,
+  AsyncRPCHandlerInitializer,
+  AsyncRPCServer
+}
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager._
 import edu.uci.ics.amber.engine.common.tuple.ITuple
@@ -55,14 +62,17 @@ class WorkflowWorker(
   implicit val ec: ExecutionContext = context.dispatcher
   implicit val timeout: Timeout = 5.seconds
 
+  val workerStateManager: WorkerStateManager = new WorkerStateManager()
+
   lazy val pauseManager: PauseManager = wire[PauseManager]
   lazy val dataProcessor: DataProcessor = wire[DataProcessor]
   lazy val dataInputPort: DataInputPort = wire[DataInputPort]
   lazy val dataOutputPort: DataOutputPort = wire[DataOutputPort]
   lazy val batchProducer: TupleToBatchConverter = wire[TupleToBatchConverter]
   lazy val tupleProducer: BatchToTupleConverter = wire[BatchToTupleConverter]
-  lazy val workerStateManager: WorkerStateManager = wire[WorkerStateManager]
   lazy val breakpointManager: BreakpointManager = wire[BreakpointManager]
+
+  override lazy val controlInputPort: ControlInputPort = wire[WorkerControlInputPort]
 
   val rpcHandlerInitializer: AsyncRPCHandlerInitializer =
     wire[WorkerAsyncRPCHandlerInitializer]
@@ -104,7 +114,16 @@ class WorkflowWorker(
   }
 
   override def postStop(): Unit = {
-    dataProcessor.shutdown()
+    if (workerStateManager.confirmState(Running)) {
+      // shutdown dp thread by sending a command
+      dataProcessor.enqueueCommand(
+        ControlInvocation(AsyncRPCClient.IgnoreReply, ShutdownDPThread()),
+        ActorVirtualIdentity.Self
+      )
+    } else {
+      // shutdown directly because dp thread is either blocked or completed
+      dataProcessor.shutdown()
+    }
     logger.logInfo("stopped!")
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkflowWorker.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkflowWorker.scala
@@ -120,9 +120,6 @@ class WorkflowWorker(
       ControlInvocation(AsyncRPCClient.IgnoreReply, ShutdownDPThread()),
       ActorVirtualIdentity.Self
     )
-    if (dataProcessor.isDataQueueEmpty) {
-      dataProcessor.appendElement(UnblockForControlCommands)
-    }
     logger.logInfo("stopped!")
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ShutdownDPThreadHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ShutdownDPThreadHandler.scala
@@ -1,0 +1,24 @@
+package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
+
+import java.util.concurrent.CompletableFuture
+
+import edu.uci.ics.amber.engine.architecture.worker.WorkerAsyncRPCHandlerInitializer
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.ShutdownDPThreadHandler.ShutdownDPThread
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+
+object ShutdownDPThreadHandler {
+  final case class ShutdownDPThread() extends ControlCommand[CommandCompleted]
+}
+
+trait ShutdownDPThreadHandler {
+  this: WorkerAsyncRPCHandlerInitializer =>
+
+  registerHandler { (msg: ShutdownDPThread, sender) =>
+    {
+      dataProcessor.shutdown()
+      new CompletableFuture[Void]().get // wait here to be interrupted
+      CommandCompleted() // this will actually never be called
+    }
+  }
+
+}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/statetransition/StateManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/statetransition/StateManager.scala
@@ -35,7 +35,7 @@ object StateManager {
 
 class StateManager[T](stateTransitionGraph: Map[T, Set[T]], initialState: T) {
 
-  private var currentState: T = initialState
+  @volatile private var currentState: T = initialState
   private val stateStack = mutable.Stack[T]()
 
   if (!initialState.isInstanceOf[IntermediateState]) {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/statetransition/WorkerStateManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/statetransition/WorkerStateManager.scala
@@ -14,26 +14,20 @@ object WorkerStateManager {
   case object Ready extends WorkerState
   case object Running extends WorkerState
   case object Paused extends WorkerState
-  case object Pausing extends WorkerState with IntermediateState
   case object Completed extends WorkerState
   case object Recovering extends WorkerState with IntermediateState
 
 }
 
-class WorkerStateManager
+class WorkerStateManager(initialState: WorkerState = Uninitialized)
     extends StateManager[WorkerState](
       Map(
         Uninitialized -> Set(Ready, Recovering),
-        Ready -> Set(Pausing, Running, Recovering),
-        Running -> Set(Pausing, Completed, Recovering),
-        Pausing -> Set(Paused, Recovering),
+        Ready -> Set(Paused, Running, Recovering),
+        Running -> Set(Paused, Completed, Recovering),
         Paused -> Set(Running, Recovering),
         Completed -> Set(Recovering),
-        Recovering -> Set(Uninitialized, Ready, Running, Pausing, Paused, Completed)
+        Recovering -> Set(Uninitialized, Ready, Running, Paused, Completed)
       ),
-      Uninitialized
-    ) {
-
-  private var isStarted = false
-
-}
+      initialState
+    ) {}

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -1,0 +1,178 @@
+package edu.uci.ics.amber.engine.architecture.worker
+
+import com.softwaremill.macwire.wire
+import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.WorkerExecutionCompletedHandler.WorkerExecutionCompleted
+import edu.uci.ics.amber.engine.architecture.messaginglayer.{
+  BatchToTupleConverter,
+  ControlInputPort,
+  ControlOutputPort,
+  DataInputPort,
+  DataOutputPort,
+  TupleToBatchConverter
+}
+import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue._
+import edu.uci.ics.amber.engine.common.ambermessage.ControlPayload
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.{InputExhausted, WorkflowLogger}
+import edu.uci.ics.amber.engine.common.rpc.{AsyncRPCClient, AsyncRPCServer}
+import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager
+import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{
+  Completed,
+  Ready,
+  Running
+}
+import edu.uci.ics.amber.engine.common.tuple.ITuple
+import edu.uci.ics.amber.engine.common.virtualidentity.{
+  ActorVirtualIdentity,
+  LayerIdentity,
+  LinkIdentity
+}
+import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.flatspec.AnyFlatSpec
+
+class DataProcessorSpec extends AnyFlatSpec with MockFactory {
+  lazy val logger: WorkflowLogger = WorkflowLogger("testDP")
+  lazy val pauseManager: PauseManager = mock[PauseManager]
+  lazy val dataOutputPort: DataOutputPort = mock[DataOutputPort]
+  lazy val batchProducer: TupleToBatchConverter = mock[TupleToBatchConverter]
+  lazy val breakpointManager: BreakpointManager = mock[BreakpointManager]
+  lazy val controlInputPort: ControlInputPort = mock[WorkerControlInputPort]
+  lazy val controlOutputPort: ControlOutputPort = mock[ControlOutputPort]
+  val linkID: LinkIdentity =
+    LinkIdentity(LayerIdentity("testDP", "mockOp", "src"), LayerIdentity("testDP", "mockOp", "dst"))
+  val tuples: Seq[ITuple] = (0 until 400).map(ITuple(_))
+
+  case class DummyControl() extends ControlCommand[CommandCompleted]
+
+  def sendDataToDP(dp: DataProcessor, data: Seq[ITuple], interval: Long = -1): Unit = {
+    new Thread {
+      override def run {
+        dp.appendElement(SenderChangeMarker(linkID))
+        data.foreach { x =>
+          dp.appendElement(InputTuple(x))
+          if (interval > 0) {
+            Thread.sleep(interval)
+          }
+        }
+        dp.appendElement(EndMarker)
+        dp.appendElement(EndOfAllMarker)
+      }
+    }.start()
+  }
+
+  def sendControlToDP(
+      dp: DataProcessor,
+      control: Seq[ControlPayload],
+      interval: Long = -1
+  ): Unit = {
+    new Thread {
+      override def run {
+        control.foreach { x =>
+          dp.enqueueCommand(x, ActorVirtualIdentity.Controller)
+          if (interval > 0) {
+            Thread.sleep(interval)
+          }
+        }
+      }
+    }.start()
+  }
+
+  def waitForDataProcessing(workerStateManager: WorkerStateManager): Unit = {
+    while (workerStateManager.getCurrentState != Completed) {
+      //wait
+    }
+  }
+
+  def waitForControlProcessing(dp: DataProcessor): Unit = {
+    while (!dp.isControlQueueEmpty) {
+      //wait
+    }
+  }
+
+  "data processor" should "process data messages" in {
+    val asyncRPCClient: AsyncRPCClient = mock[AsyncRPCClient]
+    val operator = mock[OperatorExecutor]
+    val asyncRPCServer: AsyncRPCServer = null
+    val workerStateManager: WorkerStateManager = new WorkerStateManager(Running)
+    inAnyOrder {
+      (pauseManager.isPaused _).expects().anyNumberOfTimes()
+      (batchProducer.emitEndOfUpstream _).expects().anyNumberOfTimes()
+      (asyncRPCClient.send[CommandCompleted] _).expects(*, *).anyNumberOfTimes()
+      inSequence {
+        (operator.open _).expects().once()
+        tuples.foreach { x =>
+          (operator.processTuple _).expects(Left(x), linkID)
+        }
+        (operator.processTuple _).expects(Right(InputExhausted()), linkID)
+        (operator.close _).expects().once()
+      }
+    }
+
+    val dp = wire[DataProcessor]
+    sendDataToDP(dp, tuples)
+    waitForDataProcessing(workerStateManager)
+    dp.shutdown()
+
+  }
+
+  "data processor" should "prioritize control messages" in {
+    val asyncRPCClient: AsyncRPCClient = mock[AsyncRPCClient]
+    val operator = mock[OperatorExecutor]
+    val workerStateManager: WorkerStateManager = new WorkerStateManager(Running)
+    val asyncRPCServer: AsyncRPCServer = mock[AsyncRPCServer]
+    inAnyOrder {
+      (pauseManager.isPaused _).expects().anyNumberOfTimes()
+      (asyncRPCServer.logControlInvocation _).expects(*, *).anyNumberOfTimes()
+      (asyncRPCClient.send[CommandCompleted] _).expects(*, *).anyNumberOfTimes()
+      inSequence {
+        (operator.open _).expects().once()
+        inAnyOrder {
+          tuples.map { x =>
+            (operator.processTuple _).expects(Left(x), linkID)
+          }
+          (asyncRPCServer.receive _).expects(*, *).atLeastOnce() //process controls during execution
+        }
+        (operator.processTuple _).expects(Right(InputExhausted()), linkID)
+        (asyncRPCServer.receive _)
+          .expects(*, *)
+          .anyNumberOfTimes() // process controls before execution completes
+        (batchProducer.emitEndOfUpstream _).expects().once()
+        (asyncRPCServer.receive _)
+          .expects(*, *)
+          .anyNumberOfTimes() // process controls after execution
+        (operator.close _).expects().once()
+      }
+    }
+    val dp = wire[DataProcessor]
+    sendDataToDP(dp, tuples, 2)
+    sendControlToDP(dp, (0 until 100).map(_ => ControlInvocation(0, DummyControl())), 3)
+    waitForDataProcessing(workerStateManager)
+    waitForControlProcessing(dp)
+    dp.shutdown()
+  }
+
+  "data processor" should "unblock once getting special message" in {
+    val asyncRPCClient: AsyncRPCClient = mock[AsyncRPCClient]
+    val operator = mock[OperatorExecutor]
+    val workerStateManager: WorkerStateManager = new WorkerStateManager(Running)
+    val asyncRPCServer: AsyncRPCServer = mock[AsyncRPCServer]
+    inAnyOrder {
+      (operator.open _).expects().once()
+      (pauseManager.isPaused _).expects().anyNumberOfTimes()
+      (asyncRPCServer.logControlInvocation _).expects(*, *).anyNumberOfTimes()
+      (asyncRPCClient.send[CommandCompleted] _).expects(*, *).anyNumberOfTimes()
+      (operator.close _).expects().once()
+    }
+    val dp = wire[DataProcessor]
+    (asyncRPCServer.receive _).expects(*, *).never()
+    sendControlToDP(dp, (0 until 3).map(_ => ControlInvocation(0, DummyControl())))
+    Thread.sleep(3000)
+    (asyncRPCServer.receive _).expects(*, *).repeat(3)
+    dp.appendElement(UnblockForControlCommands)
+    waitForControlProcessing(dp)
+    dp.shutdown()
+  }
+
+}

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
@@ -79,6 +79,9 @@ class WorkerSpec
       0,
       WorkflowControlMessage(ActorVirtualIdentity.Controller, 0, invocation)
     )
+
+    //wait test to finish
+    Thread.sleep(3000)
   }
 
 }


### PR DESCRIPTION
In order to implement fault-tolerance and recovery. We must synchronize control processing with data processing since we need to record the data tuple cursor when receiving a control message. If the DP thread is running while we are recording, then we can never recover correctly. 

This PR moves the control processing functionality into `DataProcessor`. Now we have 2 queues: one for control and the other for data. Once the main thread receives a control message and guarantees FIFO, it will be queued in the control internal queue. DP Thread will process all queued control messages at the point we used to do pause-checking. 

Note that:
1. Pausing state is not valid anymore. Since we put all the processing into DP thread, we won't wait for it to pause. Now DP thread pauses and blocks itself on the next control message until it receives a resume.
2. Main thread will send a shutdown control message to DP thread when we kill the worker and will not wait for it to complete. DP thread will always kill itself after it processes the shutdown message.
3. DP thread sometimes will block itself on the next data message, which will prevent it from processing any queued control messages. So we need to use our dummy input mechanism to unblock the DP thread.