### PR TITLE
Reconfigure JOOQ Codegen

### DIFF
--- a/core/conf/jooq-conf.xml
+++ b/core/conf/jooq-conf.xml
@@ -31,15 +31,15 @@
                  (A Java regular expression. Use the pipe to separate several expressions).
                  Excludes match before includes, i.e. excludes have a higher priority -->
             <excludes></excludes>
+
         </database>
 
         <target>
             <!-- The destination package of your generated classes (within the destination directory) -->
-            <packageName>edu.uci.ics.texera.dataflow.jooq.generated</packageName>
+            <packageName>edu.uci.ics.texera.web.model.jooq.generated</packageName>
 
             <!-- The destination directory of your generated classes. Using Maven directory layout here -->
-            <!-- might need to be changed to dataflow/src/main/java if the auto generated files are in wrong directory-->
-            <directory>core/dataflow/src/main/java</directory>
+            <directory>core/amber/src/main/scala</directory>
         </target>
     </generator>
 </configuration>

--- a/core/conf/jooq-conf.xml
+++ b/core/conf/jooq-conf.xml
@@ -30,7 +30,7 @@
             <!-- All elements that are excluded from your schema
                  (A Java regular expression. Use the pipe to separate several expressions).
                  Excludes match before includes, i.e. excludes have a higher priority -->
-            <excludes></excludes>
+            <excludes>(test_.*)|(ignore_.*)</excludes>
 
         </database>
 

--- a/core/dataflow/pom.xml
+++ b/core/dataflow/pom.xml
@@ -121,17 +121,17 @@
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq</artifactId>
-            <version>3.14.3</version>
+            <version>3.12.4</version>
         </dependency>
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq-meta</artifactId>
-            <version>3.14.3</version>
+            <version>3.12.4</version>
         </dependency>
         <dependency>
             <groupId>org.jooq</groupId>
             <artifactId>jooq-codegen</artifactId>
-            <version>3.14.3</version>
+            <version>3.12.4</version>
         </dependency>
         <dependency>
             <groupId>mysql</groupId>


### PR DESCRIPTION
- Make JOOQ Codegen directly work with new engine.

- Downgrade to 3.12.4 to use Timestamp.

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>