### PR TITLE
Use linked blocking multi-queue in data processor

### DIFF
--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -101,3 +101,7 @@ libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
 libraryDependencies += "org.scalamock" %% "scalamock" % "4.4.0" % Test
 libraryDependencies += "org.scalactic" %% "scalactic" % "3.2.2"
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.2" % Test
+
+// https://mvnrepository.com/artifact/com.github.marianobarrios/lbmq
+libraryDependencies += "com.github.marianobarrios" % "lbmq" % "0.5.0"
+

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -6,14 +6,25 @@ import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.WorkerEx
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.LinkCompletedHandler.LinkCompleted
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.LocalOperatorExceptionHandler.LocalOperatorException
 import edu.uci.ics.amber.engine.architecture.messaginglayer.TupleToBatchConverter
-import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.{ControlElement, EndMarker, EndOfAllMarker, InputTuple, InternalQueueElement, SenderChangeMarker}
+import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.{
+  ControlElement,
+  EndMarker,
+  EndOfAllMarker,
+  InputTuple,
+  InternalQueueElement,
+  SenderChangeMarker
+}
 import edu.uci.ics.amber.engine.common.ambermessage.ControlPayload
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.{ControlInvocation, ReturnPayload}
 import edu.uci.ics.amber.engine.common.rpc.{AsyncRPCClient, AsyncRPCServer}
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{Completed, Running}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LinkIdentity, VirtualIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.{
+  ActorVirtualIdentity,
+  LinkIdentity,
+  VirtualIdentity
+}
 import edu.uci.ics.amber.engine.common.{IOperatorExecutor, InputExhausted, WorkflowLogger}
 import edu.uci.ics.amber.error.WorkflowRuntimeError
 import edu.uci.ics.amber.error.ErrorUtils.safely
@@ -224,7 +235,7 @@ class DataProcessor( // dependencies:
     processControlCommand(control.cmd, control.from)
   }
 
-  private[this] def processControlCommand(cmd:ControlPayload, from:VirtualIdentity): Unit ={
+  private[this] def processControlCommand(cmd: ControlPayload, from: VirtualIdentity): Unit = {
     cmd match {
       case invocation: ControlInvocation =>
         asyncRPCServer.logControlInvocation(invocation, from)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -6,20 +6,14 @@ import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.WorkerEx
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.LinkCompletedHandler.LinkCompleted
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.LocalOperatorExceptionHandler.LocalOperatorException
 import edu.uci.ics.amber.engine.architecture.messaginglayer.TupleToBatchConverter
-import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.{
-  EndMarker,
-  EndOfAllMarker,
-  InputTuple,
-  InternalQueueElement,
-  SenderChangeMarker,
-  UnblockForControlCommands
-}
+import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.{ControlElement, EndMarker, EndOfAllMarker, InputTuple, InternalQueueElement, SenderChangeMarker}
+import edu.uci.ics.amber.engine.common.ambermessage.ControlPayload
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.{ControlInvocation, ReturnPayload}
 import edu.uci.ics.amber.engine.common.rpc.{AsyncRPCClient, AsyncRPCServer}
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{Completed, Running}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LinkIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LinkIdentity, VirtualIdentity}
 import edu.uci.ics.amber.engine.common.{IOperatorExecutor, InputExhausted, WorkflowLogger}
 import edu.uci.ics.amber.error.WorkflowRuntimeError
 import edu.uci.ics.amber.error.ErrorUtils.safely
@@ -135,7 +129,7 @@ class DataProcessor( // dependencies:
     // main DP loop
     while (!isCompleted) {
       // take the next data element from internal queue, blocks if not available.
-      dataDeque.take() match {
+      getElement match {
         case InputTuple(tuple) =>
           currentInputTuple = Left(tuple)
           handleInputTuple()
@@ -151,14 +145,15 @@ class DataProcessor( // dependencies:
           // end of processing, break DP loop
           isCompleted = true
           batchProducer.emitEndOfUpstream()
-        case UnblockForControlCommands =>
-          processControlCommandsDuringExecution()
+        case ControlElement(cmd, from) =>
+          processControlCommand(cmd, from)
       }
     }
     // Send Completed signal to worker actor.
     logger.logInfo(s"${operator.toString} completed")
     asyncRPCClient.send(WorkerExecutionCompleted(), ActorVirtualIdentity.Controller)
     stateManager.transitTo(Completed)
+    disableDataQueue()
     processControlCommandsAfterCompletion()
   }
 
@@ -181,8 +176,6 @@ class DataProcessor( // dependencies:
   private[this] def handleInputTuple(): Unit = {
     // process controls before processing the input tuple.
     processControlCommandsDuringExecution()
-    // if the input tuple is not a dummy tuple, process it
-    // TODO: make sure this dummy batch feature works with fault tolerance
     if (currentInputTuple != null) {
       // pass input tuple to operator logic.
       currentOutputIterator = processInputTuple()
@@ -215,8 +208,7 @@ class DataProcessor( // dependencies:
   }
 
   private[this] def processControlCommandsDuringExecution(): Unit = {
-    while (!controlQueue.isEmpty || pauseManager.isPaused) {
-      // if paused, dp thread will wait for resume control command here.
+    while (!isControlQueueEmpty) {
       takeOneControlCommandAndProcess()
     }
   }
@@ -228,7 +220,11 @@ class DataProcessor( // dependencies:
   }
 
   private[this] def takeOneControlCommandAndProcess(): Unit = {
-    val (cmd, from) = controlQueue.take()
+    val control = getElement.asInstanceOf[ControlElement]
+    processControlCommand(control.cmd, control.from)
+  }
+
+  private[this] def processControlCommand(cmd:ControlPayload, from:VirtualIdentity): Unit ={
     cmd match {
       case invocation: ControlInvocation =>
         asyncRPCServer.logControlInvocation(invocation, from)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/PauseManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/PauseManager.scala
@@ -15,7 +15,7 @@ object PauseManager {
   final case class ExecutionPaused()
 }
 
-class PauseManager(controlOutputPort: ControlOutputPort) {
+class PauseManager {
 
   protected val logger: WorkflowLogger = WorkflowLogger("PauseManager")
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerInternalQueue.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerInternalQueue.scala
@@ -2,12 +2,21 @@ package edu.uci.ics.amber.engine.architecture.worker
 
 import java.util.concurrent.{LinkedBlockingDeque, LinkedBlockingQueue}
 
-import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.{CONTROL_QUEUE, ControlElement, DATA_QUEUE, InternalQueueElement}
+import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.{
+  CONTROL_QUEUE,
+  ControlElement,
+  DATA_QUEUE,
+  InternalQueueElement
+}
 import edu.uci.ics.amber.engine.common.ambermessage.ControlPayload
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LinkIdentity, VirtualIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.{
+  ActorVirtualIdentity,
+  LinkIdentity,
+  VirtualIdentity
+}
 import lbmq.LinkedBlockingMultiQueue
 
 object WorkerInternalQueue {
@@ -18,7 +27,7 @@ object WorkerInternalQueue {
   case class SenderChangeMarker(newUpstreamLink: LinkIdentity) extends InternalQueueElement
   case object EndMarker extends InternalQueueElement
   case object EndOfAllMarker extends InternalQueueElement
-  case class ControlElement(cmd:ControlPayload, from:VirtualIdentity) extends InternalQueueElement
+  case class ControlElement(cmd: ControlPayload, from: VirtualIdentity) extends InternalQueueElement
 
   final val DATA_QUEUE = 1
   final val CONTROL_QUEUE = 0
@@ -30,10 +39,10 @@ object WorkerInternalQueue {
   */
 trait WorkerInternalQueue {
 
-  private val lbmq = new LinkedBlockingMultiQueue[Int,InternalQueueElement]()
+  private val lbmq = new LinkedBlockingMultiQueue[Int, InternalQueueElement]()
 
-  lbmq.addSubQueue(DATA_QUEUE,DATA_QUEUE)
-  lbmq.addSubQueue(CONTROL_QUEUE,CONTROL_QUEUE)
+  lbmq.addSubQueue(DATA_QUEUE, DATA_QUEUE)
+  lbmq.addSubQueue(CONTROL_QUEUE, CONTROL_QUEUE)
 
   private val dataQueue = lbmq.getSubQueue(DATA_QUEUE)
 
@@ -47,11 +56,11 @@ trait WorkerInternalQueue {
     controlQueue.add(ControlElement(cmd, from))
   }
 
-  def getElement:InternalQueueElement = lbmq.take()
+  def getElement: InternalQueueElement = lbmq.take()
 
   def disableDataQueue(): Unit = dataQueue.enable(false)
 
-  def enableDataQueue():Unit = dataQueue.enable(true)
+  def enableDataQueue(): Unit = dataQueue.enable(true)
 
   def isControlQueueEmpty: Boolean = controlQueue.isEmpty
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerInternalQueue.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerInternalQueue.scala
@@ -2,69 +2,57 @@ package edu.uci.ics.amber.engine.architecture.worker
 
 import java.util.concurrent.{LinkedBlockingDeque, LinkedBlockingQueue}
 
-import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.{
-  InternalQueueElement,
-  UnblockForControlCommands
-}
+import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.{CONTROL_QUEUE, ControlElement, DATA_QUEUE, InternalQueueElement}
 import edu.uci.ics.amber.engine.common.ambermessage.ControlPayload
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.virtualidentity.{
-  ActorVirtualIdentity,
-  LinkIdentity,
-  VirtualIdentity
-}
+import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LinkIdentity, VirtualIdentity}
+import lbmq.LinkedBlockingMultiQueue
 
 object WorkerInternalQueue {
   // 4 kinds of elements can be accepted by internal queue
   sealed trait InternalQueueElement
 
-  //TODO: check if this is creating overhead
   case class InputTuple(tuple: ITuple) extends InternalQueueElement
   case class SenderChangeMarker(newUpstreamLink: LinkIdentity) extends InternalQueueElement
   case object EndMarker extends InternalQueueElement
   case object EndOfAllMarker extends InternalQueueElement
+  case class ControlElement(cmd:ControlPayload, from:VirtualIdentity) extends InternalQueueElement
 
-  /**
-    * Used to unblock the dp thread when pause arrives but
-    * dp thread is blocked waiting for the next element in the
-    * worker-internal-queue
-    */
-  case object UnblockForControlCommands extends InternalQueueElement
+  final val DATA_QUEUE = 1
+  final val CONTROL_QUEUE = 0
+
 }
 
 /** Inspired by the mailbox-ed thread, the internal queue should
   * be a part of DP thread.
   */
 trait WorkerInternalQueue {
-  // blocking deque for batches:
-  // main thread put batches into this queue
-  // tuple input (dp thread) take batches from this queue
-  protected val dataDeque = new LinkedBlockingDeque[InternalQueueElement]
 
-  protected val controlQueue = new LinkedBlockingQueue[(ControlPayload, VirtualIdentity)]
+  private val lbmq = new LinkedBlockingMultiQueue[Int,InternalQueueElement]()
 
-  def isDataDequeEmpty: Boolean = dataDeque.isEmpty
+  lbmq.addSubQueue(DATA_QUEUE,DATA_QUEUE)
+  lbmq.addSubQueue(CONTROL_QUEUE,CONTROL_QUEUE)
 
-  def isControlQueueEmpty: Boolean = controlQueue.isEmpty
+  private val dataQueue = lbmq.getSubQueue(DATA_QUEUE)
+
+  private val controlQueue = lbmq.getSubQueue(CONTROL_QUEUE)
 
   def appendElement(elem: InternalQueueElement): Unit = {
-    dataDeque.add(elem)
-  }
-
-  /* called when user want to fix/resume current tuple */
-  def prependElement(elem: InternalQueueElement): Unit = {
-    dataDeque.addFirst(elem)
+    dataQueue.add(elem)
   }
 
   def enqueueCommand(cmd: ControlPayload, from: VirtualIdentity): Unit = {
-    // this enqueue operation MUST happen before checking data queue.
-    controlQueue.add((cmd, from))
-    // enqueue a unblock data message if data queue is empty.
-    if (isDataDequeEmpty) {
-      appendElement(UnblockForControlCommands)
-    }
+    controlQueue.add(ControlElement(cmd, from))
   }
+
+  def getElement:InternalQueueElement = lbmq.take()
+
+  def disableDataQueue(): Unit = dataQueue.enable(false)
+
+  def enableDataQueue():Unit = dataQueue.enable(true)
+
+  def isControlQueueEmpty: Boolean = controlQueue.isEmpty
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkflowWorker.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkflowWorker.scala
@@ -21,7 +21,6 @@ import edu.uci.ics.amber.engine.architecture.messaginglayer.{
   DataOutputPort,
   TupleToBatchConverter
 }
-import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.UnblockForControlCommands
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.ShutdownDPThreadHandler.ShutdownDPThread
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
 import edu.uci.ics.amber.engine.common.rpc.{

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/PauseHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/PauseHandler.scala
@@ -2,7 +2,6 @@ package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
 import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.worker.WorkerAsyncRPCHandlerInitializer
-import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.UnblockForControlCommands
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.PauseHandler.PauseWorker
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{
@@ -25,6 +24,7 @@ trait PauseHandler {
   registerHandler { (pause: PauseWorker, sender) =>
     if (stateManager.confirmState(Running, Ready)) {
       pauseManager.pause()
+      dataProcessor.disableDataQueue()
       stateManager.transitTo(Paused)
     }
     stateManager.getCurrentState

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ResumeHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ResumeHandler.scala
@@ -21,6 +21,7 @@ trait ResumeHandler {
       if (pauseManager.isPaused) {
         pauseManager.resume()
       }
+      dataProcessor.enableDataQueue()
       stateManager.transitTo(Running)
     }
     stateManager.getCurrentState

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -205,6 +205,7 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
       (operator.close _).expects().once()
     }
     dp.appendElement(InputTuple(ITuple(1)))
+    Thread.sleep(500)
     dp.enqueueCommand(ControlInvocation(0, PauseWorker()), ActorVirtualIdentity.Controller)
     dp.appendElement(InputTuple(ITuple(2)))
     dp.enqueueCommand(ControlInvocation(1, QueryStatistics()), ActorVirtualIdentity.Controller)

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -1,34 +1,25 @@
 package edu.uci.ics.amber.engine.architecture.worker
 
+import akka.actor.ActorContext
 import com.softwaremill.macwire.wire
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.WorkerExecutionCompletedHandler.WorkerExecutionCompleted
-import edu.uci.ics.amber.engine.architecture.messaginglayer.{
-  BatchToTupleConverter,
-  ControlInputPort,
-  ControlOutputPort,
-  DataInputPort,
-  DataOutputPort,
-  TupleToBatchConverter
-}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.{BatchToTupleConverter, ControlInputPort, ControlOutputPort, DataInputPort, DataOutputPort, TupleToBatchConverter}
 import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue._
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.PauseHandler.PauseWorker
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.ResumeHandler.ResumeWorker
 import edu.uci.ics.amber.engine.common.ambermessage.ControlPayload
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
 import edu.uci.ics.amber.engine.common.{InputExhausted, WorkflowLogger}
 import edu.uci.ics.amber.engine.common.rpc.{AsyncRPCClient, AsyncRPCServer}
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager
-import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{
-  Completed,
-  Ready,
-  Running
-}
+import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{Completed, Ready, Running}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.virtualidentity.{
-  ActorVirtualIdentity,
-  LayerIdentity,
-  LinkIdentity
-}
+import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity.WorkerActorVirtualIdentity
+import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LayerIdentity, LinkIdentity}
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
+import lbmq.LinkedBlockingMultiQueue
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
@@ -38,11 +29,10 @@ import scala.concurrent.{Await, ExecutionContext, Future}
 
 class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfterEach {
   lazy val logger: WorkflowLogger = WorkflowLogger("testDP")
-  lazy val pauseManager: PauseManager = mock[PauseManager]
+  lazy val pauseManager: PauseManager = wire[PauseManager]
   lazy val dataOutputPort: DataOutputPort = mock[DataOutputPort]
   lazy val batchProducer: TupleToBatchConverter = mock[TupleToBatchConverter]
   lazy val breakpointManager: BreakpointManager = mock[BreakpointManager]
-  lazy val controlInputPort: ControlInputPort = mock[WorkerControlInputPort]
   lazy val controlOutputPort: ControlOutputPort = mock[ControlOutputPort]
   val linkID: LinkIdentity =
     LinkIdentity(LayerIdentity("testDP", "mockOp", "src"), LayerIdentity("testDP", "mockOp", "dst"))
@@ -104,7 +94,6 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     val asyncRPCServer: AsyncRPCServer = null
     val workerStateManager: WorkerStateManager = new WorkerStateManager(Running)
     inAnyOrder {
-      (pauseManager.isPaused _).expects().anyNumberOfTimes()
       (batchProducer.emitEndOfUpstream _).expects().anyNumberOfTimes()
       (asyncRPCClient.send[CommandCompleted] _).expects(*, *).anyNumberOfTimes()
       inSequence {
@@ -130,7 +119,6 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     val workerStateManager: WorkerStateManager = new WorkerStateManager(Running)
     val asyncRPCServer: AsyncRPCServer = mock[AsyncRPCServer]
     inAnyOrder {
-      (pauseManager.isPaused _).expects().anyNumberOfTimes()
       (asyncRPCServer.logControlInvocation _).expects(*, *).anyNumberOfTimes()
       (asyncRPCClient.send[CommandCompleted] _).expects(*, *).anyNumberOfTimes()
       inSequence {
@@ -168,7 +156,6 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     val asyncRPCServer: AsyncRPCServer = mock[AsyncRPCServer]
     inAnyOrder {
       (operator.open _).expects().once()
-      (pauseManager.isPaused _).expects().anyNumberOfTimes()
       (asyncRPCServer.logControlInvocation _).expects(*, *).anyNumberOfTimes()
       (asyncRPCClient.send[CommandCompleted] _).expects(*, *).anyNumberOfTimes()
       (asyncRPCServer.receive _).expects(*, *).repeat(3)
@@ -181,6 +168,42 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     )
     waitForControlProcessing(dp)
     dp.shutdown()
+  }
+
+  "data processor" should "process only control commands while paused" in{
+    val id = WorkerActorVirtualIdentity("test")
+    val operator = mock[OperatorExecutor]
+    (operator.open _).expects().once()
+    val ctx:ActorContext = null
+    val batchToTupleConverter = mock[BatchToTupleConverter]
+    val asyncRPCClient: AsyncRPCClient = mock[AsyncRPCClient]
+    (asyncRPCClient.send _).expects(*,*).anyNumberOfTimes()
+    val asyncRPCServer: AsyncRPCServer = wire[AsyncRPCServer]
+    val workerStateManager: WorkerStateManager = new WorkerStateManager(Running)
+    val dp:DataProcessor = wire[DataProcessor]
+    val handlerInitializer = wire[WorkerAsyncRPCHandlerInitializer]
+    inSequence {
+      (operator.processTuple _).expects(*,*).once()
+      (controlOutputPort.sendTo _).expects(*,*).repeat(4)
+      (operator.processTuple _).expects(*,*).repeat(4)
+      (batchProducer.emitEndOfUpstream _).expects().once()
+      (operator.close _).expects().once()
+    }
+    dp.appendElement(InputTuple(ITuple(1)))
+    dp.enqueueCommand(ControlInvocation(0,PauseWorker()),ActorVirtualIdentity.Controller)
+    dp.appendElement(InputTuple(ITuple(2)))
+    dp.enqueueCommand(ControlInvocation(1,QueryStatistics()),ActorVirtualIdentity.Controller)
+    Thread.sleep(1000)
+    dp.appendElement(InputTuple(ITuple(3)))
+    dp.enqueueCommand(ControlInvocation(2,QueryStatistics()),ActorVirtualIdentity.Controller)
+    dp.appendElement(InputTuple(ITuple(4)))
+    dp.enqueueCommand(ControlInvocation(3,ResumeWorker()),ActorVirtualIdentity.Controller)
+    dp.appendElement(EndMarker)
+    dp.appendElement(EndOfAllMarker)
+    waitForControlProcessing(dp)
+    waitForDataProcessing(workerStateManager)
+    dp.shutdown()
+
   }
 
 }

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -3,7 +3,14 @@ package edu.uci.ics.amber.engine.architecture.worker
 import akka.actor.ActorContext
 import com.softwaremill.macwire.wire
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.WorkerExecutionCompletedHandler.WorkerExecutionCompleted
-import edu.uci.ics.amber.engine.architecture.messaginglayer.{BatchToTupleConverter, ControlInputPort, ControlOutputPort, DataInputPort, DataOutputPort, TupleToBatchConverter}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.{
+  BatchToTupleConverter,
+  ControlInputPort,
+  ControlOutputPort,
+  DataInputPort,
+  DataOutputPort,
+  TupleToBatchConverter
+}
 import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue._
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.PauseHandler.PauseWorker
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
@@ -14,10 +21,18 @@ import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, Con
 import edu.uci.ics.amber.engine.common.{InputExhausted, WorkflowLogger}
 import edu.uci.ics.amber.engine.common.rpc.{AsyncRPCClient, AsyncRPCServer}
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager
-import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{Completed, Ready, Running}
+import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{
+  Completed,
+  Ready,
+  Running
+}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity.WorkerActorVirtualIdentity
-import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LayerIdentity, LinkIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.{
+  ActorVirtualIdentity,
+  LayerIdentity,
+  LinkIdentity
+}
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import lbmq.LinkedBlockingMultiQueue
 import org.scalamock.scalatest.MockFactory
@@ -170,34 +185,34 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     dp.shutdown()
   }
 
-  "data processor" should "process only control commands while paused" in{
+  "data processor" should "process only control commands while paused" in {
     val id = WorkerActorVirtualIdentity("test")
     val operator = mock[OperatorExecutor]
     (operator.open _).expects().once()
-    val ctx:ActorContext = null
+    val ctx: ActorContext = null
     val batchToTupleConverter = mock[BatchToTupleConverter]
     val asyncRPCClient: AsyncRPCClient = mock[AsyncRPCClient]
-    (asyncRPCClient.send _).expects(*,*).anyNumberOfTimes()
+    (asyncRPCClient.send _).expects(*, *).anyNumberOfTimes()
     val asyncRPCServer: AsyncRPCServer = wire[AsyncRPCServer]
     val workerStateManager: WorkerStateManager = new WorkerStateManager(Running)
-    val dp:DataProcessor = wire[DataProcessor]
+    val dp: DataProcessor = wire[DataProcessor]
     val handlerInitializer = wire[WorkerAsyncRPCHandlerInitializer]
     inSequence {
-      (operator.processTuple _).expects(*,*).once()
-      (controlOutputPort.sendTo _).expects(*,*).repeat(4)
-      (operator.processTuple _).expects(*,*).repeat(4)
+      (operator.processTuple _).expects(*, *).once()
+      (controlOutputPort.sendTo _).expects(*, *).repeat(4)
+      (operator.processTuple _).expects(*, *).repeat(4)
       (batchProducer.emitEndOfUpstream _).expects().once()
       (operator.close _).expects().once()
     }
     dp.appendElement(InputTuple(ITuple(1)))
-    dp.enqueueCommand(ControlInvocation(0,PauseWorker()),ActorVirtualIdentity.Controller)
+    dp.enqueueCommand(ControlInvocation(0, PauseWorker()), ActorVirtualIdentity.Controller)
     dp.appendElement(InputTuple(ITuple(2)))
-    dp.enqueueCommand(ControlInvocation(1,QueryStatistics()),ActorVirtualIdentity.Controller)
+    dp.enqueueCommand(ControlInvocation(1, QueryStatistics()), ActorVirtualIdentity.Controller)
     Thread.sleep(1000)
     dp.appendElement(InputTuple(ITuple(3)))
-    dp.enqueueCommand(ControlInvocation(2,QueryStatistics()),ActorVirtualIdentity.Controller)
+    dp.enqueueCommand(ControlInvocation(2, QueryStatistics()), ActorVirtualIdentity.Controller)
     dp.appendElement(InputTuple(ITuple(4)))
-    dp.enqueueCommand(ControlInvocation(3,ResumeWorker()),ActorVirtualIdentity.Controller)
+    dp.enqueueCommand(ControlInvocation(3, ResumeWorker()), ActorVirtualIdentity.Controller)
     dp.appendElement(EndMarker)
     dp.appendElement(EndOfAllMarker)
     waitForControlProcessing(dp)


### PR DESCRIPTION
This PR:

1. unifies data and control queue in data processor by using [linked blocking multi-queue](https://github.com/marianobarrios/linked-blocking-multi-queue).
2. removed unnecessary dummy data message type.
3. added a new test case for data processor