### PR TITLE
Make e2e data processing workflow result visible to the test body

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerEventListener.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerEventListener.scala
@@ -12,7 +12,7 @@ import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{
 }
 
 case class ControllerEventListener(
-    workflowCompletedListener: WorkflowCompleted => Unit = null,
+    var workflowCompletedListener: WorkflowCompleted => Unit = null,
     workflowStatusUpdateListener: WorkflowStatusUpdate => Unit = null,
     modifyLogicCompletedListener: ModifyLogicCompleted => Unit = null,
     breakpointTriggeredListener: BreakpointTriggered => Unit = null,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/WorkerExecutionCompletedHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/WorkerExecutionCompletedHandler.scala
@@ -60,7 +60,6 @@ trait WorkerExecutionCompletedHandler {
       future.flatMap { ret =>
         updateFrontendWorkflowStatus()
         if (workflow.isCompleted) {
-          actorContext.parent ! ControllerState.Completed // for testing
           //send result to frontend
           if (eventListener.workflowCompletedListener != null) {
             eventListener.workflowCompletedListener
@@ -71,6 +70,7 @@ trait WorkerExecutionCompletedHandler {
               )
           }
           disableStatusUpdate()
+          actorContext.parent ! ControllerState.Completed // for testing
           // clean up all workers and terminate self
           execute(KillWorkflow(), ActorVirtualIdentity.Controller)
         } else {

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
@@ -54,7 +54,6 @@ class DataProcessingSpec
       WorkflowInfo(operators, links, mutable.MutableList[BreakpointInfo]()),
       context
     )
-    texeraWorkflowCompiler.init()
     val workflow = texeraWorkflowCompiler.amberWorkflow
     val workflowTag = WorkflowIdentity("workflow-test")
     (workflowTag, workflow)


### PR DESCRIPTION
This PR:

1. made the workflow result visible to the test itself so we can check the correctness of the result.