### PR TITLE
Configure log level to WARN

### DIFF
--- a/core/amber/src/main/resources/log4j.properties
+++ b/core/amber/src/main/resources/log4j.properties
@@ -1,0 +1,16 @@
+#Log to Console as STDOUT
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c %3x - %m%n
+#Log to file FILE
+log4j.appender.file=org.apache.log4j.DailyRollingFileAppender
+log4j.appender.file.File=logfile.log
+log4j.appender.file.DatePattern='.'yyyy-MM-dd
+log4j.appender.file.append=true
+log4j.appender.file.layout=org.apache.log4j.PatternLayout
+log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c %3x - %m%n
+#Root Logger
+log4j.rootLogger=INFO, stdout
+#Optionally, log to file directly
+#log4j.rootLogger=INFO, stdout, file

--- a/core/amber/src/main/resources/log4j.properties
+++ b/core/amber/src/main/resources/log4j.properties
@@ -11,6 +11,6 @@ log4j.appender.file.append=true
 log4j.appender.file.layout=org.apache.log4j.PatternLayout
 log4j.appender.file.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss} %-5p %c %3x - %m%n
 #Root Logger
-log4j.rootLogger=INFO, stdout
+log4j.rootLogger=WARN, stdout
 #Optionally, log to file directly
-#log4j.rootLogger=INFO, stdout, file
+#log4j.rootLogger=WARN, stdout, file

--- a/core/amber/src/main/resources/logback.xml
+++ b/core/amber/src/main/resources/logback.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <logger name="org.apache" level="WARN"/>
+    <logger name="httpclient" level="WARN"/>
+</configuration>

--- a/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
@@ -1,15 +1,9 @@
 package edu.uci.ics.amber.clustering
 
-import edu.uci.ics.amber.engine.common.Constants
 import akka.actor.{Actor, ActorLogging, Address, ExtendedActorSystem}
 import akka.cluster.Cluster
-import akka.cluster.ClusterEvent.{
-  InitialStateAsEvents,
-  MemberEvent,
-  MemberRemoved,
-  MemberUp,
-  UnreachableMember
-}
+import akka.cluster.ClusterEvent._
+import edu.uci.ics.amber.engine.common.Constants
 
 import scala.collection.mutable
 
@@ -53,10 +47,10 @@ class ClusterListener extends Actor with ActorLogging {
           Constants.defaultNumWorkers += Constants.numWorkerPerNode
         }
       }
-      println(
+      log.info(
         "---------Now we have " + availableNodeAddresses.size + " nodes in the cluster---------"
       )
-      println("dataset: " + Constants.dataset + " numWorkers: " + Constants.defaultNumWorkers)
+      log.info("dataset: " + Constants.dataset + " numWorkers: " + Constants.defaultNumWorkers)
     case UnreachableMember(member) =>
       if (
         context.system


### PR DESCRIPTION
Some modules using HTTPClients which would generate a lot of DEBUG logs, that also affects performance. This PR configures the log level to be WARN or above.

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>