### PR TITLE
Configure HTTP log level separately

### DIFF
--- a/core/amber/src/main/resources/logback.xml
+++ b/core/amber/src/main/resources/logback.xml
@@ -1,5 +1,16 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <!-- Appender -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type ch.qos.logback.classic.encoder.PatternLayoutEncoder
+            by default -->
+        <encoder>
+            <pattern>[%d{dd-MM-yyyy HH:mm:ss.SSS}] [%-5level] [%logger{36}.%M\(%line\)] - %msg %n</pattern>
+        </encoder>
+    </appender>
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
     <logger name="org.apache" level="WARN"/>
     <logger name="httpclient" level="WARN"/>
 </configuration>


### PR DESCRIPTION
This PR configs the root level of worker to be `DEBUG` to expose more insides, while surpassing the HTTP related log with `WARN` as the log level.

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>