### PR TITLE
Change PythonUDF server termination to blocking

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
@@ -16,8 +16,8 @@ import org.apache.arrow.vector.types.FloatingPointPrecision;
 import org.apache.arrow.vector.types.pojo.ArrowType;
 import org.apache.arrow.vector.types.pojo.Field;
 import scala.collection.Iterator;
-import scala.util.Either;
 import scala.collection.JavaConverters;
+import scala.util.Either;
 
 import java.io.File;
 import java.io.FileWriter;

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
@@ -482,7 +482,7 @@ public class PythonUDFOpExec implements OperatorExecutor {
             client.doAction(new Action("shutdown")).next();
             globalRootAllocator.close();
             client.close();
-        } catch (Exception e) {
+        } catch (InterruptedException e) {
             e.printStackTrace();
         }
     }


### PR DESCRIPTION
This PR fixes #1059, where an async termination would take some time and Java side closes the pipe un-peacefully, which would result in broken pipe and interruption exceptions. 

Now I changed it back to blocking termination, Java side will wait for Python UDF server to terminate before it can close the pipe during operator close().

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>