### PR TITLE
Fix extra characters in uploaded file

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/file/UserFileResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/file/UserFileResource.scala
@@ -52,6 +52,9 @@ class UserFileResource {
             .entity(validationResult.getRight)
             .build()
 
+        UserFileUtils.storeFile(uploadedInputStream, fileName, userID.toString)
+
+        // insert record after completely storing the file on the file system.
         fileDao.insert(
           new File(
             userID,
@@ -62,7 +65,6 @@ class UserFileResource {
             description
           )
         )
-        UserFileUtils.storeFile(uploadedInputStream, fileName, userID.toString)
         Response.ok().build()
       case None =>
         Response.status(Response.Status.UNAUTHORIZED).build()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/file/UserFileUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/file/UserFileUtils.scala
@@ -53,7 +53,11 @@ object UserFileUtils {
     val charArray = new Array[Char](1024)
     val reader = new BufferedReader(new InputStreamReader(fileStream))
     val writer = new BufferedWriter(new FileWriter(filePath.toString))
-    try while ({ reader.read(charArray) != -1 }) writer.write(charArray)
+    var bytesRead = 0
+    try while ({
+      bytesRead = reader.read(charArray)
+      bytesRead
+    } != -1) writer.write(charArray, 0, bytesRead)
     catch {
       case e: IOException =>
         throw FileIOException("Error occurred while writing file on disk: " + e.getMessage)


### PR DESCRIPTION
Fixes #1064 by using exact bytes when write to file stream.

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>