### PR TITLE
Google sheet type fix

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/ResultDownloadResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/ResultDownloadResource.scala
@@ -182,7 +182,7 @@ object ResultDownloadResource {
         .execute()
     } catch {
       case e: GoogleJsonResponseException => {
-        // This exception maybe caused the deletion of the target folder and the folder id cache is not updated yet.
+        // This exception maybe caused by the deletion of the target folder and the folder id cache is not updated yet.
         // try again to update the cache
         WORKFLOW_RESULT_FOLDER_ID = null;
         val targetFolderId: String = retrieveResultFolderId(driveService)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/ResultDownloadResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/ResultDownloadResource.scala
@@ -1,5 +1,6 @@
 package edu.uci.ics.texera.web.resource
 
+import com.google.api.client.googleapis.json.GoogleJsonResponseException
 import com.google.api.client.util.Lists
 import com.google.api.services.drive.Drive
 import com.google.api.services.drive.model.{File, FileList, Permission}
@@ -18,10 +19,8 @@ import edu.uci.ics.texera.web.resource.WorkflowWebsocketResource.{
   sessionResults
 }
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
+
 import java.util
-
-import com.google.api.client.googleapis.json.GoogleJsonResponseException
-
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 
@@ -234,7 +233,7 @@ object ResultDownloadResource {
           .asInstanceOf[Tuple]
           .getFields
           .stream()
-          .map(tuple => convertUnsupported(tuple))
+          .map(convertUnsupported)
           .toArray
           .toList
           .asJava
@@ -260,12 +259,18 @@ object ResultDownloadResource {
     * convert the tuple content into the type the Google Sheet API supports
     */
   private def convertUnsupported(content: AnyRef): AnyRef = {
-    // Google Sheet API supports String and number(long, int, double and so on)
-    if (content.isInstanceOf[String] || content.isInstanceOf[Number]) {
-      return content
+    content match {
+
+      // if null, use empty string to represent.
+      case null => ""
+
+      // Google Sheet API supports String and number(long, int, double and so on)
+      case _: String | _: Number => content
+
+      // convert all the other type into String
+      case _ => content.toString
     }
-    // convert all the other type into String
-    content.toString
+
   }
 
   /**


### PR DESCRIPTION
This PR makes two changes:
1. Fix the bug that some types fail to upload to google sheet. Google sheet API only allows specific type to upload (e.g. String and number). This PR solves the problems by converting all the types other than String and number into String before uploading.
2. Move the workflow results to a specific folder when uploading to make the drive look tide.