### PR TITLE
Fix AsteridDB auto progressive mode

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/SQLSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/SQLSourceOpExec.scala
@@ -321,13 +321,10 @@ abstract class SQLSourceOpExec(
   /**
     * Fetch for a numeric value of the boundary of the batchByColumn.
     * @param side either "MAX" or "MIN" for boundary
-    * @throws SQLException all possible exceptions from JDBC
-    * @throws RuntimeException all possible exceptions from HTTP connection
     * @return a numeric value, could be Int, Long or Double
     */
-  @throws[SQLException]
-  @throws[RuntimeException]
-  protected def fetchBatchByBoundary(side: String): Option[Number] = {
+
+  protected def fetchBatchByBoundary(side: String): Number = {
     batchByAttribute match {
       case Some(attribute) =>
         var result: Number = null
@@ -350,8 +347,9 @@ abstract class SQLSourceOpExec(
         }
         resultSet.close()
         preparedStatement.close()
-        Option(result)
-      case None => None
+        result
+
+      case None => 0
     }
   }
 
@@ -487,7 +485,7 @@ abstract class SQLSourceOpExec(
     // TODO: add interval
     if (batchByAttribute.isDefined && min.isDefined && max.isDefined) {
 
-      if (min.get.equalsIgnoreCase("auto")) curLowerBound = fetchBatchByBoundary("MIN").getOrElse(0)
+      if (min.get.equalsIgnoreCase("auto")) curLowerBound = fetchBatchByBoundary("MIN")
       else
         batchByAttribute.get.getType match {
           case TIMESTAMP => curLowerBound = parseTimestamp(min.get).getTime
@@ -495,7 +493,7 @@ abstract class SQLSourceOpExec(
           case _         => throw new RuntimeException(s"Unsupported type ${batchByAttribute.get.getType}")
         }
 
-      if (max.get.equalsIgnoreCase("auto")) upperBound = fetchBatchByBoundary("MAX").getOrElse(0)
+      if (max.get.equalsIgnoreCase("auto")) upperBound = fetchBatchByBoundary("MAX")
       else
         batchByAttribute.get.getType match {
           case TIMESTAMP => upperBound = parseTimestamp(max.get).getTime

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/asterixdb/AsterixDBSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/asterixdb/AsterixDBSourceOpExec.scala
@@ -178,9 +178,13 @@ class AsterixDBSourceOpExec private[asterixdb] (
 
         Option(
           parseField(
-            resultString.stripSuffix("\"").stripPrefix("\""),
+            parseField(
+              resultString.stripSuffix("\"").stripPrefix("\""),
+              TIMESTAMP
+            ),
             LONG
-          ).asInstanceOf[Number]
+          )
+            .asInstanceOf[Number]
         )
       case None => None
     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/asterixdb/AsterixDBSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/asterixdb/AsterixDBSourceOpExec.scala
@@ -15,6 +15,7 @@ import java.sql._
 import java.time.{ZoneId, ZoneOffset}
 import java.time.format.DateTimeFormatter
 import scala.collection.Iterator
+import scala.util.{Failure, Success, Try}
 import scala.util.control.Breaks.{break, breakable}
 
 class AsterixDBSourceOpExec private[asterixdb] (
@@ -163,11 +164,10 @@ class AsterixDBSourceOpExec private[asterixdb] (
   /**
     * Fetch for a numeric value of the boundary of the batchByColumn.
     * @param side either "MAX" or "MIN" for boundary
-    * @throws RuntimeException all possible exceptions from HTTP connection
     * @return a numeric value, could be Int, Long or Double
     */
   @throws[RuntimeException]
-  override def fetchBatchByBoundary(side: String): Option[Number] = {
+  override def fetchBatchByBoundary(side: String): Number = {
     batchByAttribute match {
       case Some(attribute) =>
         val resultString = queryAsterixDB(
@@ -175,18 +175,18 @@ class AsterixDBSourceOpExec private[asterixdb] (
           port,
           "SELECT " + side + "(" + attribute.getName + ") FROM " + database + "." + table + ";"
         ).get.next().toString.stripLineEnd
-
-        Option(
+        Try(
           parseField(
-            parseField(
-              resultString.stripSuffix("\"").stripPrefix("\""),
-              TIMESTAMP
-            ),
-            LONG
+            resultString.stripSuffix("\"").stripPrefix("\""),
+            attribute.getType
           )
-            .asInstanceOf[Number]
-        )
-      case None => None
+        ) match {
+          case Success(timestamp: Timestamp) => parseField(timestamp, LONG).asInstanceOf[Number]
+          case Success(otherTypes)           => otherTypes.asInstanceOf[Number]
+          case Failure(_)                    => 0
+        }
+
+      case None => 0
     }
   }
 


### PR DESCRIPTION
The issue #1071 is caused by change of `AttributeTypeUtils.parseField`. Now it does not parse a timestamp string into LONG directly, but TIMESTAMP. One needs to parse the TIMESTAMP into LONG later explicitly. 

This PR fixes #1071 and changes the logic of handling exceptions while getting boundary information from AsterixDB.

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>