### PR TITLE
Generalize AsterixDB Schema

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeTypeUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeTypeUtils.scala
@@ -185,7 +185,7 @@ object AttributeTypeUtils extends Serializable {
       // Timestamp is considered to be illegal here.
       case _ =>
         throw new AttributeTypeException(
-          s"not able to parse type ${fieldValue.getClass} to Integer."
+          s"not able to parse type ${fieldValue.getClass} to Integer: ${fieldValue.toString}"
         )
     }
   }
@@ -193,7 +193,7 @@ object AttributeTypeUtils extends Serializable {
   @throws[AttributeTypeException]
   def parseBoolean(fieldValue: Object): java.lang.Boolean = {
     val parseError = new AttributeTypeException(
-      s"not able to parse type ${fieldValue.getClass} to Boolean."
+      s"not able to parse type ${fieldValue.getClass} to Boolean: ${fieldValue.toString}"
     )
     fieldValue match {
       case str: String =>
@@ -219,7 +219,9 @@ object AttributeTypeUtils extends Serializable {
       case boolean: java.lang.Boolean => if (boolean) 1L else 0L
       case timestamp: Timestamp       => timestamp.toInstant.toEpochMilli
       case _ =>
-        throw new AttributeTypeException(s"not able to parse type ${fieldValue.getClass} to Long.")
+        throw new AttributeTypeException(
+          s"not able to parse type ${fieldValue.getClass} to Long: ${fieldValue.toString}"
+        )
     }
   }
 
@@ -234,7 +236,7 @@ object AttributeTypeUtils extends Serializable {
       // Timestamp is considered to be illegal here.
       case _ =>
         throw new AttributeTypeException(
-          s"not able to parse type ${fieldValue.getClass} to Double."
+          s"not able to parse type ${fieldValue.getClass} to Double: ${fieldValue.toString}"
         )
     }
   }
@@ -242,9 +244,10 @@ object AttributeTypeUtils extends Serializable {
   @throws[AttributeTypeException]
   def parseTimestamp(fieldValue: Object): Timestamp = {
     val parseError = new AttributeTypeException(
-      s"not able to parse type ${fieldValue.getClass} to Timestamp."
+      s"not able to parse type ${fieldValue.getClass} to Timestamp: ${fieldValue.toString}"
     )
-    val utcFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    val datetimeISOFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    val dateFormat = new SimpleDateFormat("yyyy-MM-dd")
     fieldValue match {
       case str: String =>
         (
@@ -255,7 +258,10 @@ object AttributeTypeUtils extends Serializable {
               Try(Timestamp.valueOf(str.trim))
             orElse
               // support ISO format with timezone {@code 2007-12-03T10:15:30.00.000Z}
-              Try(new Timestamp(utcFormat.parse(fieldValue.toString.trim).getTime))
+              Try(new Timestamp(datetimeISOFormat.parse(fieldValue.toString.trim).getTime))
+            orElse
+              // support date format with timezone {@code 2007-12-03}
+              Try(new Timestamp(dateFormat.parse(fieldValue.toString.trim).getTime))
         ).getOrElse(throw parseError)
 
       case long: java.lang.Long => new Timestamp(long)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/asterixdb/AsterixDBConnUtil.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/asterixdb/AsterixDBConnUtil.scala
@@ -15,7 +15,7 @@ object AsterixDBConnUtil {
       statement: String,
       format: String = "csv"
   ): Option[Iterator[AnyRef]] = {
-
+    println(statement)
     if (!asterixDBVersionMapping.contains(host)) updateAsterixDBVersionMapping(host, port)
 
     val asterixAPIEndpoint = "http://" + host + ":" + port + "/query/service"
@@ -32,10 +32,11 @@ object AsterixDBConnUtil {
       .asJson()
 
     // if status is 200 OK, store the results
-    if (response.getStatus == 200)
+    if (response.getStatus == 200) {
       // return results
+      println("response " + response.getBody.getObject.getJSONArray("results").toString())
       Option(response.getBody.getObject.getJSONArray("results").iterator().asScala)
-    else
+    } else
       throw new RuntimeException(
         "Send query to asterix failed: " + "error status: " + response.getStatusText + ", " +
           "error body: " + response.getBody.toString

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/asterixdb/AsterixDBSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/asterixdb/AsterixDBSourceOpExec.scala
@@ -15,6 +15,7 @@ import java.sql._
 import java.time.{ZoneId, ZoneOffset}
 import java.time.format.DateTimeFormatter
 import scala.collection.Iterator
+import scala.jdk.CollectionConverters.asScalaBufferConverter
 import scala.util.{Failure, Success, Try}
 import scala.util.control.Breaks.{break, breakable}
 
@@ -204,7 +205,7 @@ class AsterixDBSourceOpExec private[asterixdb] (
     var values: Option[List[String]] = None
     try values = CSVParser.parse(row, '\\', ',', '"')
     catch {
-      case _: Exception => return null
+      case e: Exception => e.printStackTrace()
     }
 
     for (i <- 0 until schema.getAttributes.size()) {
@@ -236,7 +237,7 @@ class AsterixDBSourceOpExec private[asterixdb] (
   }
 
   override def addBaseSelect(queryBuilder: StringBuilder): Unit = {
-    if (database.equals("twitter") && table.equals("ds_tweet")) {
+    if (database.equals("twitter") && table.equals("ds_tweet1")) {
       // special case, support flattened twitter.ds_tweet
 
       val user_mentions_flatten_query = Range(0, 100)
@@ -272,7 +273,7 @@ class AsterixDBSourceOpExec private[asterixdb] (
 
     } else {
       // general case, select everything, assuming the table is flattened.
-      queryBuilder ++= "\n" + s"SELECT * FROM $database.$table WHERE 1 = 1 "
+      queryBuilder ++= "\n" + s"SELECT ${schema.getAttributeNames.asScala.mkString(", ")} FROM $database.$table WHERE 1 = 1 "
     }
   }
 


### PR DESCRIPTION
This PR removes the hard-coded dependency on dataset `twitter.ds_tweet`. As a general solution, it now converts the correct type from AsterixDB's metadata, including nested types. This would fix #1070 .

It also removes the recursive `Iterator.next()` which could potentially result in StackOverflow issue. Now it uses a while loop iteration to retry the next tuple.

Note: The current schema supports nested structures, but not arrays. Thus `ds_tweet.hashtags` and `ds_tweet.user_mentions` are not going to be retrieved. We may need further discussion on how to support arrays.


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>