### PR TITLE
Fix issues when running Python UDF with multiple workers

### DIFF
--- a/core/amber/src/main/resources/python_udf/svm_classifier.py
+++ b/core/amber/src/main/resources/python_udf/svm_classifier.py
@@ -20,7 +20,7 @@ class SVMClassifier(texera_udf_operator_base.TexeraMapOperator):
         with open(self._model_file_path, 'rb') as file:
             self._vc, self._clf = pickle.load(file)
 
-    def predict(self, row: pandas.Series, *args):
+    def predict(self, row: pandas.Series, *args) -> pandas.Series:
         input_col, output_col, *_ = args
         row[output_col] = self._clf.predict(self._vc.transform([row[input_col]]))[0]
         return row

--- a/core/amber/src/main/resources/python_udf/svm_classifier.py
+++ b/core/amber/src/main/resources/python_udf/svm_classifier.py
@@ -1,4 +1,4 @@
-import shelve
+import pickle
 
 import pandas
 
@@ -11,27 +11,24 @@ class SVMClassifier(texera_udf_operator_base.TexeraMapOperator):
     def __init__(self):
         super(SVMClassifier, self).__init__(self.predict)
         self._model_file_path = None
-        self._model = None
         self._vc = None
+        self._clf = None
 
     def open(self, *args):
         super(SVMClassifier, self).open(*args)
         self._model_file_path = args[-1]
+        with open(self._model_file_path, 'rb') as file:
+            self._vc, self._clf = pickle.load(file)
 
     def predict(self, row: pandas.Series, *args):
-        if not self._model and not self._vc:
-            with shelve.open(self._model_file_path) as db:
-                self._model = db['model']
-                self._vc = db['vc']
-        row[args[1]] = self._model.predict(self._vc.transform([row[args[0]]]))[0]
+        input_col, output_col, *_ = args
+        row[output_col] = self._clf.predict(self._vc.transform([row[input_col]]))[0]
         return row
 
 
 operator_instance = SVMClassifier()
 if __name__ == '__main__':
     df = df_from_mysql("select text from texera_db.test_tweets")
-    print(df)
-
     operator_instance.open("text", "inferred_output", "tobacco_svm.model")
     for index, row in df.iterrows():
         operator_instance.accept(row)

--- a/core/amber/src/main/resources/python_udf/svm_trainer.py
+++ b/core/amber/src/main/resources/python_udf/svm_trainer.py
@@ -37,6 +37,11 @@ class SVMTrainer(texera_udf_operator_base.TexeraBlockingSupervisedTrainerOperato
         clf.fit(x_train, y_train)
         return vectorizer, clf
 
+    @staticmethod
+    def test(model, x_test, y_test, **kwargs):
+        vc, clf = model
+        return clf.predict(vc.transform(x_test))
+
 
 operator_instance = SVMTrainer()
 if __name__ == '__main__':

--- a/core/amber/src/main/resources/python_udf/svm_trainer.py
+++ b/core/amber/src/main/resources/python_udf/svm_trainer.py
@@ -18,7 +18,7 @@ class SVMTrainer(texera_udf_operator_base.TexeraBlockingSupervisedTrainerOperato
         self._model_file_path = args[-1]
 
     @staticmethod
-    def train(x_train, y_train, **train_args):
+    def train(x_train, y_train, *args, **kwargs):
         vectorizer = CountVectorizer()
 
         x_train = vectorizer.fit_transform(x_train)
@@ -38,7 +38,7 @@ class SVMTrainer(texera_udf_operator_base.TexeraBlockingSupervisedTrainerOperato
         return vectorizer, clf
 
     @staticmethod
-    def test(model, x_test, y_test, **kwargs):
+    def test(model, x_test, y_test, *args, **kwargs):
         vc, clf = model
         return clf.predict(vc.transform(x_test))
 

--- a/core/amber/src/main/resources/python_udf/texera_udf_operator_base.py
+++ b/core/amber/src/main/resources/python_udf/texera_udf_operator_base.py
@@ -96,7 +96,6 @@ class TexeraFilterOperator(TexeraUDFOperator):
         if filter_function is None:
             raise NotImplementedError
         self._filter_function: Callable = filter_function
-        self._result_tuples: List = []
 
     def accept(self, row: pandas.Series, nth_child: int = 0) -> None:
         if self._filter_function(row, *self._args):
@@ -109,7 +108,6 @@ class TexeraBlockingSupervisedTrainerOperator(TexeraUDFOperator):
         super().__init__()
         self._x = []
         self._y = []
-        self._result_tuples: List = []
         self._test_ratio = None
         self._train_args = dict()
         self._model_file_path = None
@@ -153,7 +151,6 @@ class TexeraBlockingUnsupervisedTrainerOperator(TexeraUDFOperator):
     def __init__(self):
         super().__init__()
         self._data = []
-        self._result_tuples: List = []
         self._train_args = dict()
 
     def accept(self, row: pandas.Series, nth_child: int = 0) -> None:

--- a/core/amber/src/main/resources/python_udf/texera_udf_operator_base.py
+++ b/core/amber/src/main/resources/python_udf/texera_udf_operator_base.py
@@ -1,4 +1,4 @@
-import shelve
+import pickle
 from abc import ABC
 from typing import Dict, Optional, Tuple, Callable, List
 
@@ -82,7 +82,7 @@ class TexeraMapOperator(TexeraUDFOperator):
         return bool(self._result_tuples)
 
     def next(self) -> pandas.Series:
-        return self._result_tuples.pop()
+        return self._result_tuples.pop(0)
 
     def close(self) -> None:
         pass
@@ -129,16 +129,15 @@ class TexeraBlockingSupervisedTrainerOperator(TexeraUDFOperator):
         self._train_args = dict()
         self._model_file_path = None
 
-    def input_exhausted(self, *args):
+    def input_exhausted(self, *args, **kwargs):
         x_train, x_test, y_train, y_test = train_test_split(self._x, self._y, test_size=self._test_ratio, random_state=1)
-        vc, model = self.train(x_train, y_train, **self._train_args)
+        model = self.train(x_train, y_train, **self._train_args)
+        with open(self._model_file_path, "wb") as file:
+            pickle.dump(model, file)
 
-        with shelve.open(self._model_file_path) as db:
-            db['model'] = model
-            db['vc'] = vc
         if x_test:
-            y_pred = model.predict(vc.transform(x_test))
-            self.report_matrix(y_test, y_pred)
+            y_pred = self.test(model, x_test, y_test)
+            self.report(y_test, y_pred)
 
     def accept(self, row: pandas.Series, nth_child: int = 0) -> None:
         self._x.append(row[0])
@@ -148,7 +147,7 @@ class TexeraBlockingSupervisedTrainerOperator(TexeraUDFOperator):
         return bool(self._result_tuples)
 
     def next(self) -> pandas.Series:
-        return self._result_tuples.pop()
+        return self._result_tuples.pop(0)
 
     def close(self) -> None:
         pass
@@ -157,16 +156,21 @@ class TexeraBlockingSupervisedTrainerOperator(TexeraUDFOperator):
     def train(x_train, y_train, **kwargs):
         raise NotImplementedError
 
-    def report_matrix(self, y_test, y_pred, *args):
+    @staticmethod
+    def test(model, x_test, y_test, *args, **kwargs):
+        pass
+
+    def report(self, y_test, y_pred, *args, **kwargs):
         from sklearn.metrics import classification_report
         matrix = pandas.DataFrame(classification_report(y_test, y_pred, output_dict=True)).transpose()
         matrix['class'] = [label for label, row in matrix.iterrows()]
         cols = matrix.columns.to_list()
         cols = [cols[-1]] + cols[:-1]
         matrix = matrix[cols].round(3)
-        for index, row in list(matrix.iterrows())[::-1]:
+        for index, row in matrix.iterrows():
             if index != 1:
                 self._result_tuples.append(row)
+
 
 class TexeraBlockingUnsupervisedTrainerOperator(TexeraUDFOperator):
 
@@ -198,4 +202,3 @@ class TexeraBlockingUnsupervisedTrainerOperator(TexeraUDFOperator):
 
     def report(self, model) -> None:
         pass
-

--- a/core/amber/src/main/resources/python_udf/texera_udf_operator_base.py
+++ b/core/amber/src/main/resources/python_udf/texera_udf_operator_base.py
@@ -15,6 +15,7 @@ class TexeraUDFOperator(ABC):
     def __init__(self):
         self._args: Tuple = tuple()
         self._kwargs: Optional[Dict] = None
+        self._result_tuples: List = []
 
     def open(self, *args) -> None:
         """
@@ -41,13 +42,13 @@ class TexeraUDFOperator(ABC):
         """
         Return a boolean value that indicates whether there will be a next result.
         """
-        pass
+        return bool(self._result_tuples)
 
     def next(self) -> pandas.Series:
         """
         Get the next result row. This will be called after accept(), so result should be prepared.
         """
-        pass
+        return self._result_tuples.pop(0)
 
     def close(self) -> None:
         """
@@ -55,7 +56,10 @@ class TexeraUDFOperator(ABC):
         """
         pass
 
-    def input_exhausted(self, *args):
+    def input_exhausted(self, *args, **kwargs):
+        """
+        Executes when the input is exhausted, useful for some blocking execution like training.
+        """
         pass
 
 
@@ -73,19 +77,9 @@ class TexeraMapOperator(TexeraUDFOperator):
         if map_function is None:
             raise NotImplementedError
         self._map_function: Callable = map_function
-        self._result_tuples: List = []
 
     def accept(self, row: pandas.Series, nth_child: int = 0) -> None:
         self._result_tuples.append(self._map_function(row, *self._args))  # must take args
-
-    def has_next(self) -> bool:
-        return bool(self._result_tuples)
-
-    def next(self) -> pandas.Series:
-        return self._result_tuples.pop(0)
-
-    def close(self) -> None:
-        pass
 
 
 class TexeraFilterOperator(TexeraUDFOperator):
@@ -107,15 +101,6 @@ class TexeraFilterOperator(TexeraUDFOperator):
     def accept(self, row: pandas.Series, nth_child: int = 0) -> None:
         if self._filter_function(row, *self._args):
             self._result_tuples.append(row)
-
-    def has_next(self) -> bool:
-        return len(self._result_tuples) != 0
-
-    def next(self) -> pandas.Series:
-        return self._result_tuples.pop()
-
-    def close(self) -> None:
-        pass
 
 
 class TexeraBlockingSupervisedTrainerOperator(TexeraUDFOperator):
@@ -143,17 +128,8 @@ class TexeraBlockingSupervisedTrainerOperator(TexeraUDFOperator):
         self._x.append(row[0])
         self._y.append(row[1])
 
-    def has_next(self) -> bool:
-        return bool(self._result_tuples)
-
-    def next(self) -> pandas.Series:
-        return self._result_tuples.pop(0)
-
-    def close(self) -> None:
-        pass
-
     @staticmethod
-    def train(x_train, y_train, **kwargs):
+    def train(x_train, y_train, *args, **kwargs):
         raise NotImplementedError
 
     @staticmethod
@@ -180,25 +156,19 @@ class TexeraBlockingUnsupervisedTrainerOperator(TexeraUDFOperator):
         self._result_tuples: List = []
         self._train_args = dict()
 
-    def input_exhausted(self, *args):
-        model = self.train(self._data, **self._train_args)
-        self.report(model)
-
     def accept(self, row: pandas.Series, nth_child: int = 0) -> None:
         self._data.append(row[0])
-
-    def has_next(self) -> bool:
-        return bool(self._result_tuples)
-
-    def next(self) -> pandas.Series:
-        return self._result_tuples.pop(0)
 
     def close(self) -> None:
         pass
 
     @staticmethod
-    def train(data, **kwargs):
+    def train(data, *args, **kwargs):
         raise NotImplementedError
 
     def report(self, model) -> None:
         pass
+
+    def input_exhausted(self, *args):
+        model = self.train(self._data, **self._train_args)
+        self.report(model)

--- a/core/amber/src/main/resources/python_udf/texera_udf_server_main.py
+++ b/core/amber/src/main/resources/python_udf/texera_udf_server_main.py
@@ -140,6 +140,7 @@ class UDFServer(pyarrow.flight.FlightServerBase):
 
         elif action.type == "terminate":
             # Shut down on background thread to avoid blocking current request
+            # this is to be invoked by java end whenever it needs to terminate the server on python end
             threading.Thread(target=self._delayed_shutdown).start()
 
         else:

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
@@ -353,11 +353,11 @@ public class PythonUDFOpExec implements OperatorExecutor {
             // close context on the Python end.
             if (sendClose) communicate(client, CLOSE);
 
-            // clean memory allocation.
-            memoryAllocator.close();
-
             // terminate the python server.
             communicate(client, TERMINATE);
+
+            // clean memory allocation.
+            memoryAllocator.close();
 
             // close client socket.
             client.close();

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
@@ -32,14 +32,21 @@ import java.util.*;
 
 import static edu.uci.ics.texera.workflow.operators.pythonUDF.PythonUDFOpExec.Channel.FROM_PYTHON;
 import static edu.uci.ics.texera.workflow.operators.pythonUDF.PythonUDFOpExec.Channel.TO_PYTHON;
-import static edu.uci.ics.texera.workflow.operators.pythonUDF.PythonUDFOpExec.MSG.CLOSE;
-import static edu.uci.ics.texera.workflow.operators.pythonUDF.PythonUDFOpExec.MSG.INPUT_EXHAUSTED;
+import static edu.uci.ics.texera.workflow.operators.pythonUDF.PythonUDFOpExec.MSG.*;
 
 public class PythonUDFOpExec implements OperatorExecutor {
     @NotNull
     private static byte[] communicate(@NotNull FlightClient client, @NotNull MSG message) {
         return client.doAction(new Action(message.content)).next().getBody();
     }
+
+    private Process pythonServerProcess;
+
+    private static final int MAX_TRY_COUNT = 20;
+    private static final long WAIT_TIME_MS = 500;
+    private static final String DAEMON_SCRIPT_PATH = getPythonResourcePath("texera_udf_server_main.py");
+    private static final RootAllocator memoryAllocator = new RootAllocator();
+    private static final ObjectMapper objectMapper = Utils.objectMapper();
 
     /**
      * For every batch, the operator converts list of {@code Tuple}s into Arrow stream data in almost the exact same
@@ -58,9 +65,9 @@ public class PythonUDFOpExec implements OperatorExecutor {
      *                    although they may seem similar. This doesn't actually affect serialization speed that much,
      *                    so in general it can be the same as {@code batchSize}.
      */
-    private static void writeArrowStream(FlightClient client, Queue<Tuple> values,
-                                         org.apache.arrow.vector.types.pojo.Schema arrowSchema,
-                                         Channel channel, int chunkSize) throws RuntimeException {
+    private void writeArrowStream(FlightClient client, Queue<Tuple> values,
+                                  org.apache.arrow.vector.types.pojo.Schema arrowSchema,
+                                  Channel channel, int chunkSize) throws RuntimeException {
         SyncPutListener flightListener = new SyncPutListener();
         VectorSchemaRoot schemaRoot = VectorSchemaRoot.create(arrowSchema, PythonUDFOpExec.memoryAllocator);
         FlightClient.ClientStreamListener streamWriter = client.startPut(FlightDescriptor.path(Collections.singletonList(channel.name)), schemaRoot, flightListener);
@@ -84,13 +91,6 @@ public class PythonUDFOpExec implements OperatorExecutor {
             closeAndThrow(client, e);
         }
     }
-
-    private static final int MAX_TRY_COUNT = 20;
-    private static final long WAIT_TIME_MS = 500;
-    private static final String DAEMON_SCRIPT_PATH = getPythonResourcePath("texera_udf_server_main.py");
-    private static final RootAllocator memoryAllocator = new RootAllocator();
-    private static final ObjectMapper objectMapper = Utils.objectMapper();
-    private static Process pythonServerProcess;
     private final String PYTHON = WebUtils.config().getString("python.path").trim();
     private String pythonScriptPath;
     private final String pythonScriptText;
@@ -127,7 +127,7 @@ public class PythonUDFOpExec implements OperatorExecutor {
      *
      * @param client The FlightClient that manages this.
      */
-    private static void executeUDF(FlightClient client) {
+    private void executeUDF(FlightClient client) {
         try {
             FlightResponseMap result = PythonUDFOpExec.objectMapper.readValue(communicate(client, MSG.COMPUTE),
                     FlightResponseMap.class);
@@ -318,7 +318,7 @@ public class PythonUDFOpExec implements OperatorExecutor {
      * @param channel     The predefined path that specifies where to read the data in Flight Serve.
      * @param resultQueue resultQueue To store the results. Must be empty when it is passed here.
      */
-    private static void readArrowStream(FlightClient client, Channel channel, Queue<Tuple> resultQueue) {
+    private void readArrowStream(FlightClient client, Channel channel, Queue<Tuple> resultQueue) {
         try {
             FlightInfo info = client.getInfo(FlightDescriptor.path(Collections.singletonList(channel.name)));
             Ticket ticket = info.getEndpoints().get(0).getTicket();
@@ -348,7 +348,7 @@ public class PythonUDFOpExec implements OperatorExecutor {
      *
      * @param client The client to close that is still connected to the Arrow Flight server.
      */
-    private static void closeClientAndServer(FlightClient client, boolean sendClose) {
+    private void closeClientAndServer(FlightClient client, boolean sendClose) {
         try {
             // close context on the Python end.
             if (sendClose) communicate(client, CLOSE);
@@ -356,14 +356,20 @@ public class PythonUDFOpExec implements OperatorExecutor {
             // clean memory allocation.
             memoryAllocator.close();
 
+            // terminate the python server.
+            communicate(client, TERMINATE);
+
             // close client socket.
             client.close();
 
-            // destroy Python server process.
-            pythonServerProcess.destroy();
-
         } catch (InterruptedException e) {
             e.printStackTrace();
+        } finally {
+            // python server should terminate by itself peacefully, this is to ensure it gets terminated
+            // even in error cases.
+
+            // destroy Python server process
+            pythonServerProcess.destroy();
         }
     }
 
@@ -374,7 +380,7 @@ public class PythonUDFOpExec implements OperatorExecutor {
      * @param client    FlightClient.
      * @param exception the exception to be wrapped into Amber Exception.
      */
-    private static void closeAndThrow(FlightClient client, Exception exception) throws RuntimeException {
+    private void closeAndThrow(FlightClient client, Exception exception) throws RuntimeException {
         closeClientAndServer(client, false);
         throw new RuntimeException(exception.getMessage());
     }
@@ -558,7 +564,8 @@ public class PythonUDFOpExec implements OperatorExecutor {
         HEALTH_CHECK("health_check"),
         COMPUTE("compute"),
         INPUT_EXHAUSTED("input_exhausted"),
-        CLOSE("close");
+        CLOSE("close"),
+        TERMINATE("terminate");
 
         String content;
 


### PR DESCRIPTION
This PR fixes issues with Python UDF when running in parallel workers:
1. for `svm_classifier.py`, let the model file to be read by multiple processes at the same time.
2. make Python process managed by each `PythonUDFOpExec` actor, besides peacefully termination, each worker double ensures its Python process gets destroyed. 

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>