### PR TITLE
Optimize PythonUDF input/output columns and life cycle 

### DIFF
--- a/core/amber/src/main/resources/python_udf/demo_map_udf.py
+++ b/core/amber/src/main/resources/python_udf/demo_map_udf.py
@@ -1,11 +1,11 @@
 def map_function(row, *args):
-	"""
-	This is a demo map UDF. Takes exactly 1 tuple as input and outputs exactly 1 tuple as output. This function is
-	automatically recognized as the input of a `TexeraMapOperator`. Specifically, This function simply copies the input
-	field to the output field, both specified in `args`.
-	:param row: Input tuple.
-	:param args: Argument(s), including the name that specify the input field and additional output field.
-	:return: The output tuple.
-	"""
-	row[args[1]] = row[args[0]]
-	return row
+    """
+    This is a demo map UDF. Takes exactly 1 tuple as input and outputs exactly 1 tuple as output. This function is
+    automatically recognized as the input of a `TexeraMapOperator`. Specifically, This function simply copies the input
+    field to the output field, both specified in `args`.
+    :param row: Input tuple.
+    :param args: Argument(s), including the name that specify the input field and additional output field.
+    :return: The output tuple.
+    """
+    input_col, output_col, *_ = args
+    return {output_col: row[input_col]}

--- a/core/amber/src/main/resources/python_udf/nltk_sentiment_classify.py
+++ b/core/amber/src/main/resources/python_udf/nltk_sentiment_classify.py
@@ -22,9 +22,8 @@ class NLTKSentimentOperator(texera_udf_operator_base.TexeraMapOperator):
         self._model_file.close()
 
     def predict(self, row: pandas.Series, *args):
-        p = 1 if self._sentiment_model.classify(row[args[0]]) == 'pos' else 0
-        row[args[1]] = p
-        return row
+        input_col, output_col, *_ = args
+        return {output_col: int(self._sentiment_model.classify(row[input_col]) == 'pos')}
 
 
 operator_instance = NLTKSentimentOperator()

--- a/core/amber/src/main/resources/python_udf/svm_classifier.py
+++ b/core/amber/src/main/resources/python_udf/svm_classifier.py
@@ -20,10 +20,9 @@ class SVMClassifier(texera_udf_operator_base.TexeraMapOperator):
         with open(self._model_file_path, 'rb') as file:
             self._vc, self._clf = pickle.load(file)
 
-    def predict(self, row: pandas.Series, *args) -> pandas.Series:
+    def predict(self, row: pandas.Series, *args) -> dict:
         input_col, output_col, *_ = args
-        row[output_col] = self._clf.predict(self._vc.transform([row[input_col]]))[0]
-        return row
+        return {output_col: self._clf.predict(self._vc.transform([row[input_col]]))[0]}
 
 
 operator_instance = SVMClassifier()

--- a/core/amber/src/main/resources/python_udf/tobacco_relevancy_classify.py
+++ b/core/amber/src/main/resources/python_udf/tobacco_relevancy_classify.py
@@ -64,9 +64,9 @@ class TobaccoRelevancyOperator(texera_udf_operator_base.TexeraMapOperator):
         self._classifier_model_path = args[3]
         self._classifier = TobaccoClassifier(cv_dir=self._cv_model_path, model_dir=self._classifier_model_path)
 
-    def predict(self, row: pandas.Series, *args):
+    def predict(self, row: pandas.Series, *args) -> dict:
         input_col, output_col, *_ = args
-        row[output_col] = self._classifier.predict(row, input_col)[0]
+        return {output_col: self._classifier.predict(row, input_col)[0]}
 
 
 operator_instance = TobaccoRelevancyOperator()

--- a/core/amber/src/main/resources/python_udf/topic_modeling_trainer.py
+++ b/core/amber/src/main/resources/python_udf/topic_modeling_trainer.py
@@ -45,12 +45,12 @@ class TopicModeling(texera_udf_operator_base.TexeraBlockingUnsupervisedTrainerOp
 
     def report(self, model):
         for id, topic in model.print_topics(num_topics=self._train_args["num_topics"]):
-            self._result_tuples.append(pandas.Series({"output": topic}))
+            self._result_tuples.append({"output": topic})
 
 
 operator_instance = TopicModeling()
 if __name__ == '__main__':
-    '''
+    """
     The following lines can be put in the file and name it tokenized.txt:
 
     yes unfortunately use tobacco wrap
@@ -59,7 +59,7 @@ if __name__ == '__main__':
     dutch backwoods hemp wrap
     damn need wrap hemparillo cali fire please
 
-    '''
+    """
 
     file1 = open("tokenized.txt", "r+")
     df = file1.readlines()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpDesc.java
@@ -80,7 +80,8 @@ public class PythonUDFOpDesc extends OperatorDescriptor {
                 JavaConverters.asScalaIteratorConverter(this.outputColumns.iterator()).asScala().toBuffer(),
                 JavaConverters.asScalaIteratorConverter(this.arguments.iterator()).asScala().toBuffer(),
                 JavaConverters.asScalaIteratorConverter(this.outerFiles.iterator()).asScala().toBuffer(),
-                batchSize);
+                batchSize,
+                pythonUDFType);
     }
 
     @Override

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpDesc.java
@@ -9,6 +9,7 @@ import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
 import edu.uci.ics.texera.workflow.common.metadata.OutputPort;
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeNameList;
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Attribute;
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeType;
@@ -38,6 +39,7 @@ public class PythonUDFOpDesc extends OperatorDescriptor {
     @JsonProperty()
     @JsonSchemaTitle("Input column(s)")
     @JsonPropertyDescription("name of the input column(s) that the UDF will use, if any")
+    @AutofillAttributeNameList
     public List<String> inputColumns;
 
     @JsonProperty(required = true)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExecConfig.scala
@@ -25,7 +25,8 @@ class PythonUDFOpExecConfig(
     outputColumns: mutable.Buffer[Attribute],
     arguments: mutable.Buffer[String],
     outerFiles: mutable.Buffer[String],
-    batchSize: Int
+    batchSize: Int,
+    pythonUDFType: PythonUDFType
 ) extends OpExecConfig(tag) {
   override lazy val topology: Topology = {
     new Topology(
@@ -40,7 +41,8 @@ class PythonUDFOpExecConfig(
               new util.ArrayList[Attribute](outputColumns.asJava),
               new util.ArrayList[String](arguments.asJava),
               new util.ArrayList[String](outerFiles.asJava),
-              batchSize
+              batchSize,
+              pythonUDFType
             ),
           numWorkers,
           FollowPrevious(),

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFType.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFType.java
@@ -2,7 +2,6 @@ package edu.uci.ics.texera.workflow.operators.pythonUDF;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -16,6 +15,7 @@ public enum PythonUDFType {
     UnsupervisedTraining("unsupervised_training");
 
     public static List<PythonUDFType> supportsParallel = Arrays.asList(Map, Filter);
+    public static List<PythonUDFType> preservesSchema = Arrays.asList(Map, Filter);
 
     private final String name;
 


### PR DESCRIPTION
This PR redesigns the input/output schema of PythonUDF the schema used for communication between Java and Python through Apache Arrow.

Old design:
1. PythonUDF Desc needs manually enter input column names.
2. Java sends all fields to Python through Apache Arrow, python end selects defined input columns to use.
3. Python appends output columns and returns to Java through Apache Arrow.

Issues of the old design:
1. Unused fields are also passed through Apache Arrow, which is a waste of resources.
2. When returned from the Python side, it sends input columns through Apache Arrow as well, which is again a waste of resources.
3. Since unnecessary fields are exchanged during the life cycle, PythonUDF always depends on an extra Projection operator to prepare the fields. This workaround would drop the fields that are not used by PythonUDF but could be useful in downstream operators.

New design:
1. Integrated schema propagation to automatically let users choose input columns with a dropdown menu.
2. Cached the input tuples on the Java side for each batch.
2. Send only selected input columns to the Python side. 
3. Return only the necessary output columns from the Python side.
4. For `PythonUDFType`s that need to preserve the input Schema, i.e., `Map` and `Filter`, Assemble a new Tuple with the original input tuples with the optional output columns.

