### PR TITLE
Fix result pagination key error that overwrites actual exception

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -1,17 +1,15 @@
 package edu.uci.ics.texera.web.resource
 
-import java.util.concurrent.atomic.AtomicInteger
-
 import akka.actor.{ActorRef, PoisonPill}
+import edu.uci.ics.amber.engine.architecture.controller.{Controller, ControllerEventListener}
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.PauseHandler.PauseWorkflow
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.ResumeHandler.ResumeWorkflow
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.StartWorkflowHandler.StartWorkflow
-import edu.uci.ics.amber.engine.architecture.controller.{Controller, ControllerEventListener}
-import edu.uci.ics.amber.engine.architecture.principal.OperatorStatistics
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.WorkflowIdentity
+import edu.uci.ics.texera.web.{ServletAwareConfigurator, TexeraWebApplication}
 import edu.uci.ics.texera.web.model.event._
 import edu.uci.ics.texera.web.model.request._
 import edu.uci.ics.texera.web.resource.WorkflowWebsocketResource.{
@@ -21,15 +19,14 @@ import edu.uci.ics.texera.web.resource.WorkflowWebsocketResource.{
   sessionResults
 }
 import edu.uci.ics.texera.web.resource.auth.UserResource
-import edu.uci.ics.texera.web.{ServletAwareConfigurator, TexeraWebApplication}
+import edu.uci.ics.texera.workflow.common.{Utils, WorkflowContext}
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.workflow.{WorkflowCompiler, WorkflowInfo}
-import edu.uci.ics.texera.workflow.common.{Utils, WorkflowContext}
-import edu.uci.ics.texera.workflow.operators.sink.SimpleSinkOpDesc
-import javax.servlet.http.HttpSession
-import javax.websocket.server.ServerEndpoint
-import javax.websocket.{EndpointConfig, _}
 
+import java.util.concurrent.atomic.AtomicInteger
+import javax.servlet.http.HttpSession
+import javax.websocket.{EndpointConfig, _}
+import javax.websocket.server.ServerEndpoint
 import scala.collection.mutable
 
 object WorkflowWebsocketResource {
@@ -97,17 +94,17 @@ class WorkflowWebsocketResource {
           downloadResult(session, resultDownloadRequest)
       }
     } catch {
-      case e: Throwable => {
+      case e: Throwable =>
         send(session, WorkflowErrorEvent(generalErrors = Map("exception" -> e.getMessage)))
         throw e
-      }
     }
 
   }
 
   def resultPagination(session: Session, request: ResultPaginationRequest): Unit = {
     val paginatedResultEvent = PaginatedResultEvent(
-      sessionResults(session.getId)
+      sessionResults
+        .getOrElse(session.getId, Map.empty[String, List[ITuple]])
         .map {
           case (operatorID, table) =>
             (
@@ -125,7 +122,10 @@ class WorkflowWebsocketResource {
             PaginatedOperatorResult(
               operatorID,
               objNodes,
-              sessionResults(session.getId)(operatorID).size
+              sessionResults
+                .getOrElse(session.getId, Map.empty[String, List[ITuple]])
+                .getOrElse(operatorID, List.empty[ITuple])
+                .size
             )
         }
         .toList


### PR DESCRIPTION
This PR fixes #1089. When a workflow triggered an exception during execution, the actual exception is often overwritten by the Key Error. This is due to a failed attempt to get paginated results when there is no result: because the workflow raised an exception before generating any results.

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>