### PR TITLE
Make sink operator output result incrementally in set delta semantics

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
@@ -31,13 +31,21 @@ import edu.uci.ics.amber.error.WorkflowRuntimeError
 import scala.concurrent.duration._
 import scala.concurrent.{Await, ExecutionContext}
 
+object ControllerConfig {
+  def default: ControllerConfig = ControllerConfig(Option(100), Option(1000))
+}
+final case class ControllerConfig(
+    statisticsUpdateIntervalMs: Option[Long],
+    resultUpdateIntervalMs: Option[Long]
+)
+
 object Controller {
 
   def props(
       id: WorkflowIdentity,
       workflow: Workflow,
       eventListener: ControllerEventListener,
-      statusUpdateInterval: Long,
+      controllerConfig: ControllerConfig = ControllerConfig.default,
       parentNetworkCommunicationActorRef: ActorRef = null
   ): Props =
     Props(
@@ -45,7 +53,7 @@ object Controller {
         id,
         workflow,
         eventListener,
-        Option.apply(statusUpdateInterval),
+        controllerConfig,
         parentNetworkCommunicationActorRef
       )
     )
@@ -55,7 +63,7 @@ class Controller(
     val id: WorkflowIdentity,
     val workflow: Workflow,
     val eventListener: ControllerEventListener = ControllerEventListener(),
-    val statisticsUpdateIntervalMs: Option[Long],
+    val controllerConfig: ControllerConfig,
     parentNetworkCommunicationActorRef: ActorRef
 ) extends WorkflowActor(ActorVirtualIdentity.Controller, parentNetworkCommunicationActorRef) {
   implicit val ec: ExecutionContext = context.dispatcher

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerEvent.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.amber.engine.architecture.controller
 
 import edu.uci.ics.amber.engine.architecture.breakpoint.FaultedTuple
-import edu.uci.ics.amber.engine.architecture.principal.{OperatorState, OperatorStatistics}
+import edu.uci.ics.amber.engine.architecture.principal.{OperatorResult, OperatorState, OperatorStatistics}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 import edu.uci.ics.amber.error.WorkflowRuntimeError
@@ -21,6 +21,8 @@ object ControllerEvent {
   case class WorkflowStatusUpdate(
       operatorStatistics: Map[String, OperatorStatistics]
   )
+
+  case class WorkflowResultUpdate(operatorResults: Map[String, OperatorResult])
 
   case class ModifyLogicCompleted()
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerEvent.scala
@@ -1,7 +1,11 @@
 package edu.uci.ics.amber.engine.architecture.controller
 
 import edu.uci.ics.amber.engine.architecture.breakpoint.FaultedTuple
-import edu.uci.ics.amber.engine.architecture.principal.{OperatorResult, OperatorState, OperatorStatistics}
+import edu.uci.ics.amber.engine.architecture.principal.{
+  OperatorResult,
+  OperatorState,
+  OperatorStatistics
+}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 import edu.uci.ics.amber.error.WorkflowRuntimeError

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerEventListener.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerEventListener.scala
@@ -1,6 +1,16 @@
 package edu.uci.ics.amber.engine.architecture.controller
 
-import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{BreakpointTriggered, ErrorOccurred, ModifyLogicCompleted, ReportCurrentProcessingTuple, SkipTupleResponse, WorkflowCompleted, WorkflowPaused, WorkflowResultUpdate, WorkflowStatusUpdate}
+import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{
+  BreakpointTriggered,
+  ErrorOccurred,
+  ModifyLogicCompleted,
+  ReportCurrentProcessingTuple,
+  SkipTupleResponse,
+  WorkflowCompleted,
+  WorkflowPaused,
+  WorkflowResultUpdate,
+  WorkflowStatusUpdate
+}
 
 case class ControllerEventListener(
     var workflowCompletedListener: WorkflowCompleted => Unit = null,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerEventListener.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerEventListener.scala
@@ -1,19 +1,11 @@
 package edu.uci.ics.amber.engine.architecture.controller
 
-import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{
-  BreakpointTriggered,
-  ErrorOccurred,
-  ModifyLogicCompleted,
-  ReportCurrentProcessingTuple,
-  SkipTupleResponse,
-  WorkflowCompleted,
-  WorkflowPaused,
-  WorkflowStatusUpdate
-}
+import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{BreakpointTriggered, ErrorOccurred, ModifyLogicCompleted, ReportCurrentProcessingTuple, SkipTupleResponse, WorkflowCompleted, WorkflowPaused, WorkflowResultUpdate, WorkflowStatusUpdate}
 
 case class ControllerEventListener(
     var workflowCompletedListener: WorkflowCompleted => Unit = null,
     workflowStatusUpdateListener: WorkflowStatusUpdate => Unit = null,
+    workflowResultUpdateListener: WorkflowResultUpdate => Unit = null,
     modifyLogicCompletedListener: ModifyLogicCompleted => Unit = null,
     breakpointTriggeredListener: BreakpointTriggered => Unit = null,
     workflowPausedListener: WorkflowPaused => Unit = null,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/PauseHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/PauseHandler.scala
@@ -1,14 +1,13 @@
 package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 
 import com.twitter.util.Future
-import edu.uci.ics.amber.engine.architecture.controller.{ControllerAsyncRPCHandlerInitializer, ControllerState}
-import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{ReportCurrentProcessingTuple, WorkflowPaused, WorkflowStatusUpdate}
+import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{ReportCurrentProcessingTuple, WorkflowPaused}
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.PauseHandler.PauseWorkflow
-import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.{ControllerInitiateQueryStatistics, QueryWorkerStatistics}
+import edu.uci.ics.amber.engine.architecture.controller.{ControllerAsyncRPCHandlerInitializer, ControllerState}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.PauseHandler.PauseWorker
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryCurrentInputTupleHandler.QueryCurrentInputTuple
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryWorkerStatistics
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
-import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{Completed, Paused, Running}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/PauseHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/PauseHandler.scala
@@ -1,26 +1,14 @@
 package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 
 import com.twitter.util.Future
-import edu.uci.ics.amber.engine.architecture.controller.{
-  ControllerAsyncRPCHandlerInitializer,
-  ControllerState
-}
-import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{
-  ReportCurrentProcessingTuple,
-  WorkflowPaused,
-  WorkflowStatusUpdate
-}
+import edu.uci.ics.amber.engine.architecture.controller.{ControllerAsyncRPCHandlerInitializer, ControllerState}
+import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{ReportCurrentProcessingTuple, WorkflowPaused, WorkflowStatusUpdate}
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.PauseHandler.PauseWorkflow
-import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.QueryWorkerStatistics
+import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.{ControllerInitiateQueryStatistics, QueryWorkerStatistics}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.PauseHandler.PauseWorker
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryCurrentInputTupleHandler.QueryCurrentInputTuple
-import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
-import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{
-  Completed,
-  Paused,
-  Running
-}
+import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{Completed, Paused, Running}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 
@@ -54,7 +42,7 @@ trait PauseHandler {
                   // send a pause message
                   send(PauseWorker(), worker).map { ret =>
                     operator.getWorker(worker).state = ret
-                    send(QueryStatistics(), worker)
+                    send(QueryWorkerStatistics(), worker)
                       .join(send(QueryCurrentInputTuple(), worker))
                       // get the stats and current input tuple from the worker
                       .map {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/PauseHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/PauseHandler.scala
@@ -1,9 +1,15 @@
 package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 
 import com.twitter.util.Future
-import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{ReportCurrentProcessingTuple, WorkflowPaused}
+import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{
+  ReportCurrentProcessingTuple,
+  WorkflowPaused
+}
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.PauseHandler.PauseWorkflow
-import edu.uci.ics.amber.engine.architecture.controller.{ControllerAsyncRPCHandlerInitializer, ControllerState}
+import edu.uci.ics.amber.engine.architecture.controller.{
+  ControllerAsyncRPCHandlerInitializer,
+  ControllerState
+}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.PauseHandler.PauseWorker
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryCurrentInputTupleHandler.QueryCurrentInputTuple
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryWorkerStatistics

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/QueryWorkerStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/QueryWorkerStatisticsHandler.scala
@@ -3,19 +3,30 @@ package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.WorkflowResultUpdate
-import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.{ControllerInitiateQueryResults, ControllerInitiateQueryStatistics, QueryWorkerResult, QueryWorkerStatistics}
+import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.{
+  ControllerInitiateQueryResults,
+  ControllerInitiateQueryStatistics
+}
 import edu.uci.ics.amber.engine.architecture.principal.OperatorResult
-import edu.uci.ics.amber.engine.architecture.worker.{WorkerResult, WorkerStatistics}
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.{
+  QueryWorkerResult,
+  QueryWorkerStatistics
+}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
+import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 
 import scala.collection.mutable
 
 object QueryWorkerStatisticsHandler {
-  final case class ControllerInitiateQueryStatistics() extends ControlCommand[Unit]
-  final case class QueryWorkerStatistics() extends ControlCommand[WorkerStatistics]
+  // ask the controller to initiate querying worker statistics
+  // optionally specify the workers to query, None indicates querying all workers
+  final case class ControllerInitiateQueryStatistics(workers: Option[List[ActorVirtualIdentity]])
+      extends ControlCommand[Unit]
 
-  final case class ControllerInitiateQueryResults() extends ControlCommand[Unit]
-  final case class QueryWorkerResult() extends ControlCommand[Option[WorkerResult]]
+  // ask the controller to initiate querying worker results
+  // optionally specify the workers to query, None indicates querying all sink workers
+  final case class ControllerInitiateQueryResults(workers: Option[List[ActorVirtualIdentity]])
+      extends ControlCommand[Unit]
 }
 
 /** Get statistics from all the workers
@@ -27,40 +38,49 @@ trait QueryWorkerStatisticsHandler {
 
   registerHandler((msg: ControllerInitiateQueryStatistics, sender) => {
 
+    val workers = msg.workers.getOrElse(workflow.getAllWorkers.toList)
+
     // send all worker QueryStatistics message
-    val requests = workflow.getAllWorkers.toList.map(worker => {
+    val requests = workers.map(worker => {
       send(QueryWorkerStatistics(), worker)
+        .onSuccess(stats => {
+          workflow.getWorkerInfo(stats.workerId).state = stats.workerState
+          workflow.getWorkerInfo(stats.workerId).stats = stats
+          // update the frontend statistics quickly after a worker responded
+          // since sending statistics is a cheap operation
+          updateFrontendWorkflowStatus()
+        })
     })
 
-    // wait for all reply and collect all response, then update statistics
-    Future
-      .collect(requests)
-      .map(res => {
-        res.foreach(r => workflow.getWorkerInfo(r.workerId).stats = r)
-        updateFrontendWorkflowStatus()
-      })
+    // request is considered complete after waiting for all workers to reply
+    Future.collect(requests).map(_ => {})
   })
 
   registerHandler((msg: ControllerInitiateQueryResults, sender) => {
-    val sinkWorkers = workflow.getSinkLayers.flatMap(l => l.workers.keys)
+    val sinkWorkers = workflow.getSinkLayers.flatMap(l => l.workers.keys).toList
+
+    val workers = msg.workers.getOrElse(sinkWorkers)
 
     // send all sink worker QueryResult message
-    val requests = sinkWorkers.toList.map(worker => {
+    val requests = workers.map(worker => {
       send(QueryWorkerResult(), worker)
     })
 
-    // wait for all reply and collect all response, then update operator results
+    // wait for all reply and collect all response, then send update result to frontend
+    // since sending result is heavy, we want to accumulate response from all workers
     Future
       .collect(requests)
       .map(res => {
         val operatorResultUpdate = new mutable.HashMap[String, OperatorResult]()
-        res.flatten.groupBy(r => workflow.getOperator(r.workerId).id).foreach(e => {
-          val opId = e._1.operator
-          val resultsPerWorker = e._2
-          val outputMode = resultsPerWorker.head.outputMode
-          val results = resultsPerWorker.flatMap(r => r.result).toList
-          operatorResultUpdate(opId) = OperatorResult(outputMode, results)
-        })
+        res.flatten
+          .groupBy(r => workflow.getOperator(r.workerId).id)
+          .foreach(e => {
+            val opId = e._1.operator
+            val resultsPerWorker = e._2
+            val outputMode = resultsPerWorker.head.outputMode
+            val results = resultsPerWorker.flatMap(r => r.result).toList
+            operatorResultUpdate(opId) = OperatorResult(outputMode, results)
+          })
         updateFrontendWorkflowResult(WorkflowResultUpdate(operatorResultUpdate.toMap))
       })
   })

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/QueryWorkerStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/QueryWorkerStatisticsHandler.scala
@@ -2,12 +2,20 @@ package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 
 import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
-import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.QueryWorkerStatistics
-import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.WorkflowResultUpdate
+import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.{ControllerInitiateQueryResults, ControllerInitiateQueryStatistics, QueryWorkerResult, QueryWorkerStatistics}
+import edu.uci.ics.amber.engine.architecture.principal.OperatorResult
+import edu.uci.ics.amber.engine.architecture.worker.{WorkerResult, WorkerStatistics}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
+
+import scala.collection.mutable
 
 object QueryWorkerStatisticsHandler {
-  final case class QueryWorkerStatistics() extends ControlCommand[Unit]
+  final case class ControllerInitiateQueryStatistics() extends ControlCommand[Unit]
+  final case class QueryWorkerStatistics() extends ControlCommand[WorkerStatistics]
+
+  final case class ControllerInitiateQueryResults() extends ControlCommand[Unit]
+  final case class QueryWorkerResult() extends ControlCommand[Option[WorkerResult]]
 }
 
 /** Get statistics from all the workers
@@ -17,20 +25,43 @@ object QueryWorkerStatisticsHandler {
 trait QueryWorkerStatisticsHandler {
   this: ControllerAsyncRPCHandlerInitializer =>
 
-  registerHandler { (msg: QueryWorkerStatistics, sender) =>
-    {
-      // send all worker QueryStatistics message
-      Future
-        .collect(workflow.getAllWorkers.map { worker =>
-          send(QueryStatistics(), worker).map { stats =>
-            // update worker stats
-            workflow.getOperator(worker).getWorker(worker).stats = stats
-          }
-        }.toSeq)
-        .map { ret =>
-          // update frontend status
-          updateFrontendWorkflowStatus()
-        }
-    }
-  }
+  registerHandler((msg: ControllerInitiateQueryStatistics, sender) => {
+
+    // send all worker QueryStatistics message
+    val requests = workflow.getAllWorkers.toList.map(worker => {
+      send(QueryWorkerStatistics(), worker)
+    })
+
+    // wait for all reply and collect all response, then update statistics
+    Future
+      .collect(requests)
+      .map(res => {
+        res.foreach(r => workflow.getWorkerInfo(r.workerId).stats = r)
+        updateFrontendWorkflowStatus()
+      })
+  })
+
+  registerHandler((msg: ControllerInitiateQueryResults, sender) => {
+    val sinkWorkers = workflow.getSinkLayers.flatMap(l => l.workers.keys)
+
+    // send all sink worker QueryResult message
+    val requests = sinkWorkers.toList.map(worker => {
+      send(QueryWorkerResult(), worker)
+    })
+
+    // wait for all reply and collect all response, then update operator results
+    Future
+      .collect(requests)
+      .map(res => {
+        val operatorResultUpdate = new mutable.HashMap[String, OperatorResult]()
+        res.flatten.groupBy(r => workflow.getOperator(r.workerId).id).foreach(e => {
+          val opId = e._1.operator
+          val resultsPerWorker = e._2
+          val outputMode = resultsPerWorker.head.outputMode
+          val results = resultsPerWorker.flatMap(r => r.result).toList
+          operatorResultUpdate(opId) = OperatorResult(outputMode, results)
+        })
+        updateFrontendWorkflowResult(WorkflowResultUpdate(operatorResultUpdate.toMap))
+      })
+  })
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/StartWorkflowHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/StartWorkflowHandler.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 
 import com.twitter.util.Future
-import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.QueryWorkerStatistics
+import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.ControllerInitiateQueryStatistics
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.StartWorkflowHandler.StartWorkflow
 import edu.uci.ics.amber.engine.architecture.controller.{
   Controller,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/WorkerExecutionCompletedHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/WorkerExecutionCompletedHandler.scala
@@ -1,19 +1,13 @@
 package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 
 import com.twitter.util.Future
-import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{
-  WorkflowCompleted,
-  WorkflowStatusUpdate
-}
-import edu.uci.ics.amber.engine.architecture.controller.{
-  ControllerAsyncRPCHandlerInitializer,
-  ControllerState
-}
+import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{WorkflowCompleted, WorkflowStatusUpdate}
+import edu.uci.ics.amber.engine.architecture.controller.{ControllerAsyncRPCHandlerInitializer, ControllerState}
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.WorkerExecutionCompletedHandler.WorkerExecutionCompleted
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.KillWorkflowHandler.KillWorkflow
+import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.QueryWorkerStatistics
 import edu.uci.ics.amber.engine.architecture.principal.OperatorState
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.CollectSinkResultsHandler.CollectSinkResults
-import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.Completed
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity.WorkerActorVirtualIdentity
@@ -42,7 +36,7 @@ trait WorkerExecutionCompletedHandler {
       val future =
         if (operator.isInstanceOf[SinkOpExecConfig]) {
           // if the operator is sink, first query stats then collect results of this worker.
-          send(QueryStatistics(), sender).join(send(CollectSinkResults(), sender)).map {
+          send(QueryWorkerStatistics(), sender).join(send(CollectSinkResults(), sender)).map {
             case (stats, results) =>
               val workerInfo = operator.getWorker(sender)
               workerInfo.stats = stats
@@ -51,7 +45,7 @@ trait WorkerExecutionCompletedHandler {
           }
         } else {
           // if the operator is not a sink, just query the stats
-          send(QueryStatistics(), sender).map { stats =>
+          send(QueryWorkerStatistics(), sender).map { stats =>
             val workerInfo = operator.getWorker(sender)
             workerInfo.stats = stats
             workerInfo.state = stats.workerState

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerLayer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerLayer.scala
@@ -75,7 +75,7 @@ class WorkerLayer(
       workerID -> WorkerInfo(
         workerID,
         Uninitialized,
-        WorkerStatistics(Uninitialized, 0, 0, Option.empty)
+        WorkerStatistics(workerID, Uninitialized, 0, 0)
       )
     }.toMap
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/principal/OperatorStatistics.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/principal/OperatorStatistics.scala
@@ -1,10 +1,15 @@
 package edu.uci.ics.amber.engine.architecture.principal
 
 import edu.uci.ics.amber.engine.common.tuple.ITuple
+import edu.uci.ics.texera.workflow.common.IncrementalOutputMode
 
 case class OperatorStatistics(
     operatorState: OperatorState,
     aggregatedInputRowCount: Long,
-    aggregatedOutputRowCount: Long,
-    aggregatedOutputResults: Option[List[ITuple]] // in case of a sink operator
+    aggregatedOutputRowCount: Long
+)
+
+case class OperatorResult(
+    outputMode: IncrementalOutputMode,
+    result: List[ITuple]
 )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerStatistics.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerStatistics.scala
@@ -2,10 +2,18 @@ package edu.uci.ics.amber.engine.architecture.worker
 
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.WorkerState
 import edu.uci.ics.amber.engine.common.tuple.ITuple
+import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
+import edu.uci.ics.texera.workflow.common.IncrementalOutputMode
 
 case class WorkerStatistics(
+    workerId: ActorVirtualIdentity,
     workerState: WorkerState,
     inputRowCount: Long,
-    outputRowCount: Long,
-    outputResults: Option[List[ITuple]] // in case of a sink operator
+    outputRowCount: Long
+)
+
+case class WorkerResult(
+    workerId: ActorVirtualIdentity,
+    outputMode: IncrementalOutputMode,
+    result: List[ITuple]
 )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
@@ -1,7 +1,14 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
-import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.{QueryWorkerResult, QueryWorkerStatistics}
-import edu.uci.ics.amber.engine.architecture.worker.{WorkerAsyncRPCHandlerInitializer, WorkerResult, WorkerStatistics}
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.{
+  QueryWorkerResult,
+  QueryWorkerStatistics
+}
+import edu.uci.ics.amber.engine.architecture.worker.{
+  WorkerAsyncRPCHandlerInitializer,
+  WorkerResult,
+  WorkerStatistics
+}
 import edu.uci.ics.amber.engine.common.ITupleSinkOperatorExecutor
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
@@ -1,15 +1,14 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
-import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.{
-  QueryWorkerResult,
-  QueryWorkerStatistics
-}
-import edu.uci.ics.amber.engine.architecture.worker.{
-  WorkerAsyncRPCHandlerInitializer,
-  WorkerResult,
-  WorkerStatistics
-}
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.{QueryWorkerResult, QueryWorkerStatistics}
+import edu.uci.ics.amber.engine.architecture.worker.{WorkerAsyncRPCHandlerInitializer, WorkerResult, WorkerStatistics}
 import edu.uci.ics.amber.engine.common.ITupleSinkOperatorExecutor
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
+
+object QueryStatisticsHandler {
+  final case class QueryWorkerStatistics() extends ControlCommand[WorkerStatistics]
+  final case class QueryWorkerResult() extends ControlCommand[Option[WorkerResult]]
+}
 
 trait QueryStatisticsHandler {
   this: WorkerAsyncRPCHandlerInitializer =>

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
@@ -1,42 +1,41 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
+import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.{
+  QueryWorkerResult,
+  QueryWorkerStatistics
+}
 import edu.uci.ics.amber.engine.architecture.worker.{
   WorkerAsyncRPCHandlerInitializer,
+  WorkerResult,
   WorkerStatistics
 }
-import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
 import edu.uci.ics.amber.engine.common.ITupleSinkOperatorExecutor
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
-
-object QueryStatisticsHandler {
-  final case class QueryStatistics() extends ControlCommand[WorkerStatistics]
-}
 
 trait QueryStatisticsHandler {
   this: WorkerAsyncRPCHandlerInitializer =>
 
-  registerHandler { (msg: QueryStatistics, sender) =>
+  registerHandler((msg: QueryWorkerStatistics, sender) => {
     // collect input and output row count
     val (in, out) = dataProcessor.collectStatistics()
+    val state = stateManager.getCurrentState
 
     // sink operator doesn't output to downstream so internal count is 0
     // but for user-friendliness we show its input count as output count
     val displayOut = operator match {
-      case sink: ITupleSinkOperatorExecutor =>
-        in
-      case _ =>
-        out
+      case _: ITupleSinkOperatorExecutor => in
+      case _                             => out
     }
 
-    val state = stateManager.getCurrentState
-    val result = operator match {
+    WorkerStatistics(selfID, state, in, displayOut)
+  })
+
+  registerHandler((msg: QueryWorkerResult, sender) => {
+    operator match {
       case sink: ITupleSinkOperatorExecutor =>
-        Option(sink.getResultTuples())
+        Option(WorkerResult(selfID, sink.getOutputMode(), sink.getResultTuples()))
       case _ =>
         Option.empty
     }
-
-    WorkerStatistics(state, in, displayOut, result)
-  }
+  })
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/ITupleSinkOperatorExecutor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/ITupleSinkOperatorExecutor.scala
@@ -1,9 +1,12 @@
 package edu.uci.ics.amber.engine.common
 
 import edu.uci.ics.amber.engine.common.tuple.ITuple
+import edu.uci.ics.texera.workflow.common.IncrementalOutputMode
 
 trait ITupleSinkOperatorExecutor extends IOperatorExecutor {
 
   def getResultTuples(): List[ITuple]
+
+  def getOutputMode(): IncrementalOutputMode
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCClient.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCClient.scala
@@ -2,7 +2,7 @@ package edu.uci.ics.amber.engine.common.rpc
 
 import com.twitter.util.{Future, Promise}
 import edu.uci.ics.amber.engine.architecture.messaginglayer.ControlOutputPort
-import edu.uci.ics.amber.engine.architecture.worker.WorkerStatistics
+import edu.uci.ics.amber.engine.architecture.worker.{WorkerResult, WorkerStatistics}
 import edu.uci.ics.amber.engine.common.WorkflowLogger
 import edu.uci.ics.amber.engine.common.ambermessage.ControlPayload
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.{ControlInvocation, ReturnPayload}
@@ -83,7 +83,7 @@ class AsyncRPCClient(controlOutputPort: ControlOutputPort, logger: WorkflowLogge
       return
     }
     if (ret.returnValue != null) {
-      if (ret.returnValue.isInstanceOf[WorkerStatistics]) {
+      if (ret.returnValue.isInstanceOf[WorkerStatistics] || ret.returnValue.isInstanceOf[WorkerResult]) {
         return
       }
       logger.logInfo(

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCClient.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCClient.scala
@@ -83,7 +83,9 @@ class AsyncRPCClient(controlOutputPort: ControlOutputPort, logger: WorkflowLogge
       return
     }
     if (ret.returnValue != null) {
-      if (ret.returnValue.isInstanceOf[WorkerStatistics] || ret.returnValue.isInstanceOf[WorkerResult]) {
+      if (
+        ret.returnValue.isInstanceOf[WorkerStatistics] || ret.returnValue.isInstanceOf[WorkerResult]
+      ) {
         return
       }
       logger.logInfo(

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCServer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCServer.scala
@@ -1,15 +1,10 @@
 package edu.uci.ics.amber.engine.common.rpc
 
 import com.twitter.util.Future
+import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.QueryWorkerStatistics
 import edu.uci.ics.amber.engine.architecture.messaginglayer.ControlOutputPort
-import edu.uci.ics.amber.engine.architecture.worker.WorkerStatistics
-import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
 import edu.uci.ics.amber.engine.common.WorkflowLogger
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.{
-  ControlInvocation,
-  ReturnPayload,
-  noReplyNeeded
-}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.{ControlInvocation, ReturnPayload, noReplyNeeded}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, VirtualIdentity}
 
@@ -91,7 +86,7 @@ class AsyncRPCServer(controlOutputPort: ControlOutputPort, logger: WorkflowLogge
     if (call.commandID == AsyncRPCClient.IgnoreReplyAndDoNotLog) {
       return
     }
-    if (call.command.isInstanceOf[QueryStatistics]) {
+    if (call.command.isInstanceOf[QueryWorkerStatistics]) {
       return
     }
     logger.logInfo(

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCServer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCServer.scala
@@ -1,8 +1,8 @@
 package edu.uci.ics.amber.engine.common.rpc
 
 import com.twitter.util.Future
-import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.QueryWorkerStatistics
 import edu.uci.ics.amber.engine.architecture.messaginglayer.ControlOutputPort
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.{QueryWorkerResult, QueryWorkerStatistics}
 import edu.uci.ics.amber.engine.common.WorkflowLogger
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.{ControlInvocation, ReturnPayload, noReplyNeeded}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
@@ -86,11 +86,11 @@ class AsyncRPCServer(controlOutputPort: ControlOutputPort, logger: WorkflowLogge
     if (call.commandID == AsyncRPCClient.IgnoreReplyAndDoNotLog) {
       return
     }
-    if (call.command.isInstanceOf[QueryWorkerStatistics]) {
+    if (call.command.isInstanceOf[QueryWorkerStatistics] || call.command.isInstanceOf[QueryWorkerResult]) {
       return
     }
     logger.logInfo(
-      s"receive command: ${call.command} from ${sender.toString} (controlID: ${call.commandID})"
+      s"AsyncRPCServer: receive command: ${call.command} from ${sender.toString} (controlID: ${call.commandID})"
     )
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCServer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCServer.scala
@@ -2,9 +2,16 @@ package edu.uci.ics.amber.engine.common.rpc
 
 import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.messaginglayer.ControlOutputPort
-import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.{QueryWorkerResult, QueryWorkerStatistics}
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.{
+  QueryWorkerResult,
+  QueryWorkerStatistics
+}
 import edu.uci.ics.amber.engine.common.WorkflowLogger
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.{ControlInvocation, ReturnPayload, noReplyNeeded}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.{
+  ControlInvocation,
+  ReturnPayload,
+  noReplyNeeded
+}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, VirtualIdentity}
 
@@ -86,7 +93,10 @@ class AsyncRPCServer(controlOutputPort: ControlOutputPort, logger: WorkflowLogge
     if (call.commandID == AsyncRPCClient.IgnoreReplyAndDoNotLog) {
       return
     }
-    if (call.command.isInstanceOf[QueryWorkerStatistics] || call.command.isInstanceOf[QueryWorkerResult]) {
+    if (
+      call.command.isInstanceOf[QueryWorkerStatistics] || call.command
+        .isInstanceOf[QueryWorkerResult]
+    ) {
       return
     }
     logger.logInfo(

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/operators/OpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/operators/OpExecConfig.scala
@@ -8,7 +8,12 @@ import edu.uci.ics.amber.engine.architecture.principal.{OperatorState, OperatorS
 import edu.uci.ics.amber.engine.common.WorkflowLogger
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager._
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LayerIdentity, LinkIdentity, OperatorIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.{
+  ActorVirtualIdentity,
+  LayerIdentity,
+  LinkIdentity,
+  OperatorIdentity
+}
 import edu.uci.ics.texera.workflow.common.IncrementalOutputMode
 
 import scala.collection.mutable
@@ -74,21 +79,6 @@ abstract class OpExecConfig(val id: OperatorIdentity) extends Serializable {
   def getInputRowCount: Long = topology.layers.head.statistics.map(_.inputRowCount).sum
 
   def getOutputRowCount: Long = topology.layers.last.statistics.map(_.outputRowCount).sum
-
-//  def getOutputResults: Option[(IncrementalOutputMode, List[ITuple])] = {
-//    val allEmpty = topology.layers.last.statistics.forall(e => e.outputResults.isEmpty)
-//    if (allEmpty) {
-//      Option.empty
-//    } else {
-//      val outputMode = topology.layers.last.statistics.headOption.flatMap(s => s.outputResults.map(i => i._1))
-//      val results = topology.layers.last.statistics.flatMap(e => e.outputResults.map(r => r._2)).flatten.toList
-//      if (outputMode.isEmpty) {
-//        Option.empty
-//      } else {
-//        Option(outputMode.get, results)
-//      }
-//    }
-//  }
 
   def getOperatorStatistics: OperatorStatistics =
     OperatorStatistics(getState, getInputRowCount, getOutputRowCount)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/operators/OpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/operators/OpExecConfig.scala
@@ -8,12 +8,8 @@ import edu.uci.ics.amber.engine.architecture.principal.{OperatorState, OperatorS
 import edu.uci.ics.amber.engine.common.WorkflowLogger
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager._
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.virtualidentity.{
-  ActorVirtualIdentity,
-  LayerIdentity,
-  LinkIdentity,
-  OperatorIdentity
-}
+import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LayerIdentity, LinkIdentity, OperatorIdentity}
+import edu.uci.ics.texera.workflow.common.IncrementalOutputMode
 
 import scala.collection.mutable
 
@@ -79,17 +75,23 @@ abstract class OpExecConfig(val id: OperatorIdentity) extends Serializable {
 
   def getOutputRowCount: Long = topology.layers.last.statistics.map(_.outputRowCount).sum
 
-  def getOutputResults: Option[List[ITuple]] = {
-    val allEmpty = topology.layers.last.statistics.forall(e => e.outputResults.isEmpty)
-    if (allEmpty) {
-      Option.empty
-    } else {
-      Option(topology.layers.last.statistics.flatMap(e => e.outputResults).flatten.toList)
-    }
-  }
+//  def getOutputResults: Option[(IncrementalOutputMode, List[ITuple])] = {
+//    val allEmpty = topology.layers.last.statistics.forall(e => e.outputResults.isEmpty)
+//    if (allEmpty) {
+//      Option.empty
+//    } else {
+//      val outputMode = topology.layers.last.statistics.headOption.flatMap(s => s.outputResults.map(i => i._1))
+//      val results = topology.layers.last.statistics.flatMap(e => e.outputResults.map(r => r._2)).flatten.toList
+//      if (outputMode.isEmpty) {
+//        Option.empty
+//      } else {
+//        Option(outputMode.get, results)
+//      }
+//    }
+//  }
 
   def getOperatorStatistics: OperatorStatistics =
-    OperatorStatistics(getState, getInputRowCount, getOutputRowCount, getOutputResults)
+    OperatorStatistics(getState, getInputRowCount, getOutputRowCount)
 
   def checkStartDependencies(workflow: Workflow): Unit = {
     //do nothing by default

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/TexeraWebSocketEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/TexeraWebSocketEvent.scala
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
     new Type(value = classOf[WorkflowStartedEvent]),
     new Type(value = classOf[WorkflowCompletedEvent]),
     new Type(value = classOf[WebWorkflowStatusUpdateEvent]),
+    new Type(value = classOf[WebWorkflowResultUpdateEvent]),
     new Type(value = classOf[WorkflowPausedEvent]),
     new Type(value = classOf[WorkflowResumedEvent]),
     new Type(value = classOf[RecoveryStartedEvent]),

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowCompletedEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowCompletedEvent.scala
@@ -6,25 +6,16 @@ import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.texera.workflow.common.IncrementalOutputMode
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.workflow.WorkflowCompiler
+import edu.uci.ics.texera.workflow.operators.sink.SimpleSinkOpDesc
 import edu.uci.ics.texera.workflow.operators.visualization.VisualizationOperator
 
 import scala.collection.mutable
 
 object WebOperatorResult {
   def getChartType(operatorID: String, workflowCompiler: WorkflowCompiler): Option[String] = {
-    if (!WorkflowCompiler.isSink(operatorID, workflowCompiler)) {
-      return None
-    }
-
-    // add chartType to result
-    val upstreamOperators = WorkflowCompiler.getUpstreamOperators(operatorID, workflowCompiler)
-    upstreamOperators.headOption match {
-      case Some(op) =>
-        op match {
-          case visOp: VisualizationOperator => Option.apply(visOp.chartType())
-          case _                            => Option.empty
-        }
-      case _ => Option.empty
+    workflowCompiler.workflow.getOperator(operatorID) match {
+      case sink: SimpleSinkOpDesc => sink.getChartType
+      case _                      => Option.empty
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
@@ -16,8 +16,7 @@ object WebOperatorStatistics {
 
   def apply(
       operatorID: String,
-      operatorStatistics: OperatorStatistics,
-      workflowCompiler: WorkflowCompiler
+      operatorStatistics: OperatorStatistics
   ): WebOperatorStatistics = {
     WebOperatorStatistics(
       operatorStatistics.operatorState,
@@ -38,13 +37,10 @@ case class WebOperatorStatistics(
 
 object WebWorkflowStatusUpdateEvent {
   def apply(
-      update: WorkflowStatusUpdate,
-      workflowCompiler: WorkflowCompiler
+      update: WorkflowStatusUpdate
   ): WebWorkflowStatusUpdateEvent = {
     WebWorkflowStatusUpdateEvent(
-      update.operatorStatistics.map(e =>
-        (e._1, WebOperatorStatistics.apply(e._1, e._2, workflowCompiler))
-      )
+      update.operatorStatistics.map(e => (e._1, WebOperatorStatistics.apply(e._1, e._2)))
     )
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
@@ -73,7 +73,7 @@ object WebWorkflowResultUpdateEvent {
   ): WebWorkflowResultUpdateEvent = {
     val resultMap = update.operatorResults
       .map(e => (e._1, WebIncrementalOperatorResult.apply(e._1, e._2, workflowCompiler)))
-      .filter(e => e._2.isEmpty)
+      .filter(e => e._2.nonEmpty)
       .map(e => (e._1, e._2.get))
     WebWorkflowResultUpdateEvent(resultMap)
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
@@ -1,7 +1,14 @@
 package edu.uci.ics.texera.web.model.event
 
-import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{WorkflowResultUpdate, WorkflowStatusUpdate}
-import edu.uci.ics.amber.engine.architecture.principal.{OperatorResult, OperatorState, OperatorStatistics}
+import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{
+  WorkflowResultUpdate,
+  WorkflowStatusUpdate
+}
+import edu.uci.ics.amber.engine.architecture.principal.{
+  OperatorResult,
+  OperatorState,
+  OperatorStatistics
+}
 import edu.uci.ics.texera.workflow.common.IncrementalOutputMode
 import edu.uci.ics.texera.workflow.common.workflow.WorkflowCompiler
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -5,7 +5,11 @@ import akka.actor.{ActorRef, PoisonPill}
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.PauseHandler.PauseWorkflow
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.ResumeHandler.ResumeWorkflow
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.StartWorkflowHandler.StartWorkflow
-import edu.uci.ics.amber.engine.architecture.controller.{Controller, ControllerConfig, ControllerEventListener}
+import edu.uci.ics.amber.engine.architecture.controller.{
+  Controller,
+  ControllerConfig,
+  ControllerEventListener
+}
 import edu.uci.ics.amber.engine.architecture.principal.OperatorStatistics
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
@@ -13,7 +17,12 @@ import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.WorkflowIdentity
 import edu.uci.ics.texera.web.model.event._
 import edu.uci.ics.texera.web.model.request._
-import edu.uci.ics.texera.web.resource.WorkflowWebsocketResource.{sessionDownloadCache, sessionJobs, sessionMap, sessionResults}
+import edu.uci.ics.texera.web.resource.WorkflowWebsocketResource.{
+  sessionDownloadCache,
+  sessionJobs,
+  sessionMap,
+  sessionResults
+}
 import edu.uci.ics.texera.web.resource.auth.UserResource
 import edu.uci.ics.texera.web.{ServletAwareConfigurator, TexeraWebApplication}
 import edu.uci.ics.texera.workflow.common.tuple.Tuple

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -212,7 +212,7 @@ class WorkflowWebsocketResource {
         WorkflowWebsocketResource.sessionJobs.remove(session.getId)
       },
       workflowStatusUpdateListener = statusUpdate => {
-        send(session, WebWorkflowStatusUpdateEvent.apply(statusUpdate, texeraWorkflowCompiler))
+        send(session, WebWorkflowStatusUpdateEvent.apply(statusUpdate))
       },
       workflowResultUpdateListener = resultUpdate => {
         send(session, WebWorkflowResultUpdateEvent.apply(resultUpdate, texeraWorkflowCompiler))

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -1,12 +1,11 @@
 package edu.uci.ics.texera.web.resource
 
 import java.util.concurrent.atomic.AtomicInteger
-
 import akka.actor.{ActorRef, PoisonPill}
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.PauseHandler.PauseWorkflow
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.ResumeHandler.ResumeWorkflow
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.StartWorkflowHandler.StartWorkflow
-import edu.uci.ics.amber.engine.architecture.controller.{Controller, ControllerEventListener}
+import edu.uci.ics.amber.engine.architecture.controller.{Controller, ControllerConfig, ControllerEventListener}
 import edu.uci.ics.amber.engine.architecture.principal.OperatorStatistics
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
@@ -14,22 +13,17 @@ import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.WorkflowIdentity
 import edu.uci.ics.texera.web.model.event._
 import edu.uci.ics.texera.web.model.request._
-import edu.uci.ics.texera.web.resource.WorkflowWebsocketResource.{
-  sessionDownloadCache,
-  sessionJobs,
-  sessionMap,
-  sessionResults
-}
+import edu.uci.ics.texera.web.resource.WorkflowWebsocketResource.{sessionDownloadCache, sessionJobs, sessionMap, sessionResults}
 import edu.uci.ics.texera.web.resource.auth.UserResource
 import edu.uci.ics.texera.web.{ServletAwareConfigurator, TexeraWebApplication}
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.workflow.{WorkflowCompiler, WorkflowInfo}
 import edu.uci.ics.texera.workflow.common.{Utils, WorkflowContext}
 import edu.uci.ics.texera.workflow.operators.sink.SimpleSinkOpDesc
+
 import javax.servlet.http.HttpSession
 import javax.websocket.server.ServerEndpoint
 import javax.websocket.{EndpointConfig, _}
-
 import scala.collection.mutable
 
 object WorkflowWebsocketResource {
@@ -237,7 +231,7 @@ class WorkflowWebsocketResource {
     )
 
     val controllerActorRef = TexeraWebApplication.actorSystem.actorOf(
-      Controller.props(workflowTag, workflow, eventListener, 100)
+      Controller.props(workflowTag, workflow, eventListener, ControllerConfig.default)
     )
     texeraWorkflowCompiler.initializeBreakpoint(controllerActorRef)
     controllerActorRef ! ControlInvocation(AsyncRPCClient.IgnoreReply, StartWorkflow())

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -210,6 +210,9 @@ class WorkflowWebsocketResource {
       workflowStatusUpdateListener = statusUpdate => {
         send(session, WebWorkflowStatusUpdateEvent.apply(statusUpdate, texeraWorkflowCompiler))
       },
+      workflowResultUpdateListener = resultUpdate => {
+        send(session, WebWorkflowResultUpdateEvent.apply(resultUpdate, texeraWorkflowCompiler))
+      },
       modifyLogicCompletedListener = _ => {
         send(session, ModifyLogicCompletedEvent())
       },

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/IncrementalOutputMode.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/IncrementalOutputMode.java
@@ -1,0 +1,8 @@
+package edu.uci.ics.texera.workflow.common;
+
+public enum IncrementalOutputMode {
+    // sink outputs complete result set snapshot for each update
+    SET_SNAPSHOT,
+    // sink outputs incremental result set delta for each update
+    SET_DELTA
+}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/OperatorMetadataGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/OperatorMetadataGenerator.scala
@@ -8,7 +8,6 @@ import com.kjetland.jackson.jsonSchema.{JsonSchemaConfig, JsonSchemaDraft, JsonS
 import com.kjetland.jackson.jsonSchema.JsonSchemaConfig.html5EnabledSchema
 import edu.uci.ics.texera.workflow.common.Utils.objectMapper
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor
-import edu.uci.ics.texera.workflow.operators.sink.SimpleSinkOpDesc
 import edu.uci.ics.texera.workflow.operators.source.scan.csv.CSVScanSourceOpDesc
 
 import java.util
@@ -81,7 +80,7 @@ object OperatorMetadataGenerator {
   def main(args: Array[String]): Unit = {
     // run this if you want to check the json schema generated for an operator descriptor
     // replace the argument with the class of your operator descriptor
-    println(generateOperatorJsonSchema(classOf[SimpleSinkOpDesc]).toPrettyString)
+    println(generateOperatorJsonSchema(classOf[CSVScanSourceOpDesc]).toPrettyString)
   }
 
   def generateOperatorJsonSchema(opDescClass: Class[_ <: OperatorDescriptor]): JsonNode = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/OperatorMetadataGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/OperatorMetadataGenerator.scala
@@ -8,6 +8,7 @@ import com.kjetland.jackson.jsonSchema.{JsonSchemaConfig, JsonSchemaDraft, JsonS
 import com.kjetland.jackson.jsonSchema.JsonSchemaConfig.html5EnabledSchema
 import edu.uci.ics.texera.workflow.common.Utils.objectMapper
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor
+import edu.uci.ics.texera.workflow.operators.sink.SimpleSinkOpDesc
 import edu.uci.ics.texera.workflow.operators.source.scan.csv.CSVScanSourceOpDesc
 
 import java.util
@@ -80,7 +81,7 @@ object OperatorMetadataGenerator {
   def main(args: Array[String]): Unit = {
     // run this if you want to check the json schema generated for an operator descriptor
     // replace the argument with the class of your operator descriptor
-    println(generateOperatorJsonSchema(classOf[CSVScanSourceOpDesc]).toPrettyString)
+    println(generateOperatorJsonSchema(classOf[SimpleSinkOpDesc]).toPrettyString)
   }
 
   def generateOperatorJsonSchema(opDescClass: Class[_ <: OperatorDescriptor]): JsonNode = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
@@ -69,6 +69,7 @@ class WorkflowCompiler(val workflowInfo: WorkflowInfo, val context: WorkflowCont
       (upstream.head, sinkOp) match {
         case (viz: VisualizationOperator, sink: SimpleSinkOpDesc) =>
           sink.setOutputMode(viz.outputMode())
+          sink.setChartType(viz.chartType())
         case _ =>
       }
     })

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
@@ -13,6 +13,27 @@ import org.jgrapht.graph.{DefaultEdge, DirectedAcyclicGraph}
 
 import scala.collection.mutable
 
+object WorkflowCompiler {
+
+  def isSink(operatorID: String, workflowCompiler: WorkflowCompiler): Boolean = {
+    val outLinks =
+      workflowCompiler.workflowInfo.links.filter(link => link.origin.operatorID == operatorID)
+    outLinks.isEmpty
+  }
+
+  def getUpstreamOperators(
+      operatorID: String,
+      workflowCompiler: WorkflowCompiler
+  ): List[OperatorDescriptor] = {
+    workflowCompiler.workflowInfo.links
+      .filter(link => link.destination.operatorID == operatorID)
+      .flatMap(link =>
+        workflowCompiler.workflowInfo.operators.filter(o => o.operatorID == link.origin.operatorID)
+      ).toList
+  }
+
+}
+
 class WorkflowCompiler(val workflowInfo: WorkflowInfo, val context: WorkflowContext) {
 
   init()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
@@ -9,6 +9,8 @@ import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor
 import edu.uci.ics.texera.workflow.common.operators.source.SourceOperatorDescriptor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema
+import edu.uci.ics.texera.workflow.operators.sink.SimpleSinkOpDesc
+import edu.uci.ics.texera.workflow.operators.visualization.VisualizationOperator
 import org.jgrapht.graph.{DefaultEdge, DirectedAcyclicGraph}
 
 import scala.collection.mutable
@@ -29,12 +31,15 @@ object WorkflowCompiler {
       .filter(link => link.destination.operatorID == operatorID)
       .flatMap(link =>
         workflowCompiler.workflowInfo.operators.filter(o => o.operatorID == link.origin.operatorID)
-      ).toList
+      )
+      .toList
   }
 
 }
 
 class WorkflowCompiler(val workflowInfo: WorkflowInfo, val context: WorkflowContext) {
+
+  val workflow = new WorkflowDAG(workflowInfo)
 
   init()
 
@@ -57,6 +62,16 @@ class WorkflowCompiler(val workflowInfo: WorkflowInfo, val context: WorkflowCont
       .filter(pair => pair._2.nonEmpty)
 
   def amberWorkflow: Workflow = {
+    // pre-process: set output mode for sink based on the visualization operator before it
+    this.workflow.getSinkOperators.foreach(sinkOpId => {
+      val sinkOp = this.workflow.getOperator(sinkOpId)
+      val upstream = this.workflow.getUpstream(sinkOpId)
+      (upstream.head, sinkOp) match {
+        case (viz: VisualizationOperator, sink: SimpleSinkOpDesc) =>
+          sink.setOutputMode(viz.outputMode())
+      }
+    })
+
     val amberOperators: mutable.Map[OperatorIdentity, OpExecConfig] = mutable.Map()
     workflowInfo.operators.foreach(o => {
       val amberOperator: OpExecConfig = o.operatorExecutor
@@ -143,16 +158,6 @@ class WorkflowCompiler(val workflowInfo: WorkflowInfo, val context: WorkflowCont
   }
 
   def propagateWorkflowSchema(): Map[OperatorDescriptor, List[Option[Schema]]] = {
-    // construct the edu.uci.ics.texera.workflow DAG object using jGraphT
-    val workflowDag =
-      new DirectedAcyclicGraph[OperatorDescriptor, DefaultEdge](classOf[DefaultEdge])
-    this.workflowInfo.operators.foreach(op => workflowDag.addVertex(op))
-    this.workflowInfo.links.foreach(link => {
-      val origin = workflowInfo.operators.find(op => op.operatorID == link.origin.operatorID).get
-      val dest = workflowInfo.operators.find(op => op.operatorID == link.destination.operatorID).get
-      workflowDag.addEdge(origin, dest)
-    })
-
     // a map from an operator to the list of its input schema
     val inputSchemaMap =
       new mutable.HashMap[OperatorDescriptor, mutable.MutableList[Option[Schema]]]()
@@ -160,8 +165,9 @@ class WorkflowCompiler(val workflowInfo: WorkflowInfo, val context: WorkflowCont
 
     // propagate output schema following topological order
     // TODO: introduce the concept of port in TexeraOperatorDescriptor and propagate schema according to port
-    val topologicalOrderIterator = workflowDag.iterator()
-    topologicalOrderIterator.forEachRemaining(op => {
+    val topologicalOrderIterator = workflow.jgraphtDag.iterator()
+    topologicalOrderIterator.forEachRemaining(opID => {
+      val op = workflow.getOperator(opID)
       // infer output schema of this operator based on its input schema
       val outputSchema: Option[Schema] = {
         if (op.isInstanceOf[SourceOperatorDescriptor]) {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowInfo.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowInfo.scala
@@ -1,13 +1,64 @@
 package edu.uci.ics.texera.workflow.common.workflow
 
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor
+import org.jgrapht.graph.{DefaultEdge, DirectedAcyclicGraph}
 
 import scala.collection.mutable
 
 case class BreakpointInfo(operatorID: String, breakpoint: Breakpoint)
 
+object WorkflowInfo {
+
+  def toJgraphtDAG(workflowInfo: WorkflowInfo): DirectedAcyclicGraph[String, OperatorLink] = {
+    val workflowDag =
+      new DirectedAcyclicGraph[String, OperatorLink](classOf[OperatorLink])
+    workflowInfo.operators.foreach(op => workflowDag.addVertex(op.operatorID))
+    workflowInfo.links.foreach(l =>
+      workflowDag.addEdge(
+        l.origin.operatorID,
+        l.destination.operatorID,
+        l
+      )
+    )
+    workflowDag
+  }
+}
 case class WorkflowInfo(
     operators: mutable.MutableList[OperatorDescriptor],
     links: mutable.MutableList[OperatorLink],
     breakpoints: mutable.MutableList[BreakpointInfo]
 )
+
+class WorkflowDAG(workflowInfo: WorkflowInfo) {
+
+  val operators: Map[String, OperatorDescriptor] =
+    workflowInfo.operators.map(op => (op.operatorID, op)).toMap
+
+  val jgraphtDag: DirectedAcyclicGraph[String, OperatorLink] =
+    WorkflowInfo.toJgraphtDAG(workflowInfo)
+
+  val sourceOperators: List[String] =
+    operators.keys.filter(op => jgraphtDag.inDegreeOf(op) == 0).toList
+
+  val sinkOperators: List[String] =
+    operators.keys.filter(op => jgraphtDag.outDegreeOf(op) == 0).toList
+
+  def getOperator(operatorID: String): OperatorDescriptor = operators(operatorID)
+
+  def getSourceOperators: List[String] = this.sourceOperators;
+
+  def getSinkOperators: List[String] = this.sinkOperators;
+
+  def getUpstream(operatorID: String): List[OperatorDescriptor] = {
+    val upstream = new mutable.MutableList[OperatorDescriptor]
+    jgraphtDag.incomingEdgesOf(operatorID).forEach(e => upstream += operators(e.origin.operatorID))
+    upstream.toList
+  }
+
+  def getDownstream(operatorID: String): List[OperatorDescriptor] = {
+    val downstream = new mutable.MutableList[OperatorDescriptor]
+    jgraphtDag.outgoingEdgesOf(operatorID).forEach(e => downstream += operators(e.origin.operatorID))
+    downstream.toList
+  }
+
+}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowInfo.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowInfo.scala
@@ -57,7 +57,9 @@ class WorkflowDAG(workflowInfo: WorkflowInfo) {
 
   def getDownstream(operatorID: String): List[OperatorDescriptor] = {
     val downstream = new mutable.MutableList[OperatorDescriptor]
-    jgraphtDag.outgoingEdgesOf(operatorID).forEach(e => downstream += operators(e.origin.operatorID))
+    jgraphtDag
+      .outgoingEdgesOf(operatorID)
+      .forEach(e => downstream += operators(e.origin.operatorID))
     downstream.toList
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpDesc.java
@@ -9,6 +9,7 @@ import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema;
+import scala.Option;
 import scala.collection.immutable.List;
 
 import static java.util.Collections.singletonList;
@@ -21,9 +22,12 @@ public class SimpleSinkOpDesc extends OperatorDescriptor {
     @JsonIgnore
     private IncrementalOutputMode outputMode = IncrementalOutputMode.SET_SNAPSHOT;
 
+    @JsonIgnore
+    private Option<String> chartType = Option.empty();
+
     @Override
     public OpExecConfig operatorExecutor() {
-        return new SimpleSinkOpExecConfig(this.operatorIdentifier(), outputMode);
+        return new SimpleSinkOpExecConfig(this.operatorIdentifier(), outputMode, this.chartType);
     }
 
     @Override
@@ -50,6 +54,16 @@ public class SimpleSinkOpDesc extends OperatorDescriptor {
     @JsonIgnore
     public void setOutputMode(IncrementalOutputMode outputMode) {
         this.outputMode = outputMode;
+    }
+
+    @JsonIgnore
+    public Option<String> getChartType() {
+        return this.chartType;
+    }
+
+    @JsonIgnore
+    public void setChartType(String chartType) {
+        this.chartType = Option.apply(chartType);
     }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpDesc.java
@@ -2,12 +2,13 @@ package edu.uci.ics.texera.workflow.operators.sink;
 
 import com.google.common.base.Preconditions;
 import edu.uci.ics.amber.engine.operators.OpExecConfig;
+import edu.uci.ics.texera.workflow.common.IncrementalOutputMode;
 import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
-import edu.uci.ics.texera.workflow.common.metadata.OutputPort;
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema;
+import net.minidev.json.annotate.JsonIgnore;
 import scala.collection.immutable.List;
 
 import static java.util.Collections.singletonList;
@@ -15,9 +16,13 @@ import static scala.collection.JavaConverters.asScalaBuffer;
 
 public class SimpleSinkOpDesc extends OperatorDescriptor {
 
+    // use SET_SNAPSHOT as the default output mode
+    @JsonIgnore
+    public IncrementalOutputMode outputMode = IncrementalOutputMode.SET_SNAPSHOT;
+
     @Override
     public OpExecConfig operatorExecutor() {
-        return new SimpleSinkOpExecConfig(this.operatorIdentifier());
+        return new SimpleSinkOpExecConfig(this.operatorIdentifier(), outputMode);
     }
 
     @Override

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpDesc.java
@@ -1,5 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sink;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
 import edu.uci.ics.amber.engine.operators.OpExecConfig;
 import edu.uci.ics.texera.workflow.common.IncrementalOutputMode;
@@ -8,7 +9,6 @@ import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema;
-import net.minidev.json.annotate.JsonIgnore;
 import scala.collection.immutable.List;
 
 import static java.util.Collections.singletonList;
@@ -17,8 +17,9 @@ import static scala.collection.JavaConverters.asScalaBuffer;
 public class SimpleSinkOpDesc extends OperatorDescriptor {
 
     // use SET_SNAPSHOT as the default output mode
+    // this will be set internally by the workflow compiler
     @JsonIgnore
-    public IncrementalOutputMode outputMode = IncrementalOutputMode.SET_SNAPSHOT;
+    private IncrementalOutputMode outputMode = IncrementalOutputMode.SET_SNAPSHOT;
 
     @Override
     public OpExecConfig operatorExecutor() {
@@ -39,6 +40,16 @@ public class SimpleSinkOpDesc extends OperatorDescriptor {
     public Schema getOutputSchema(Schema[] schemas) {
         Preconditions.checkArgument(schemas.length == 1);
         return schemas[0];
+    }
+
+    @JsonIgnore
+    public IncrementalOutputMode getOutputMode() {
+        return outputMode;
+    }
+
+    @JsonIgnore
+    public void setOutputMode(IncrementalOutputMode outputMode) {
+        this.outputMode = outputMode;
     }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpExec.scala
@@ -9,7 +9,8 @@ import IncrementalOutputMode._
 
 import scala.collection.mutable
 
-class SimpleSinkOpExec(val outputMode: IncrementalOutputMode) extends ITupleSinkOperatorExecutor {
+class SimpleSinkOpExec(val outputMode: IncrementalOutputMode, val chartType: Option[String])
+    extends ITupleSinkOperatorExecutor {
 
   val results: mutable.ListBuffer[Tuple] = mutable.ListBuffer()
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpExecConfig.scala
@@ -18,13 +18,16 @@ import edu.uci.ics.texera.workflow.common.IncrementalOutputMode
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 
-class SimpleSinkOpExecConfig(tag: OperatorIdentity, outputMode: IncrementalOutputMode)
-    extends SinkOpExecConfig(tag) {
+class SimpleSinkOpExecConfig(
+    tag: OperatorIdentity,
+    outputMode: IncrementalOutputMode,
+    chartType: Option[String]
+) extends SinkOpExecConfig(tag) {
   override lazy val topology = new Topology(
     Array(
       new WorkerLayer(
         LayerIdentity(tag, "main"),
-        _ => new SimpleSinkOpExec(outputMode),
+        _ => new SimpleSinkOpExec(outputMode, chartType),
         1,
         ForceLocal(),
         RandomDeployment()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpExecConfig.scala
@@ -7,14 +7,19 @@ import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.GlobalB
 import edu.uci.ics.amber.engine.architecture.deploysemantics.deploymentfilter.ForceLocal
 import edu.uci.ics.amber.engine.architecture.deploysemantics.deploystrategy.RandomDeployment
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.WorkerLayer
-import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LayerIdentity, OperatorIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.{
+  ActorVirtualIdentity,
+  LayerIdentity,
+  OperatorIdentity
+}
 import edu.uci.ics.amber.engine.operators.SinkOpExecConfig
 import edu.uci.ics.texera.workflow.common.IncrementalOutputMode
 
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 
-class SimpleSinkOpExecConfig(tag: OperatorIdentity, outputMode: IncrementalOutputMode) extends SinkOpExecConfig(tag) {
+class SimpleSinkOpExecConfig(tag: OperatorIdentity, outputMode: IncrementalOutputMode)
+    extends SinkOpExecConfig(tag) {
   override lazy val topology = new Topology(
     Array(
       new WorkerLayer(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/SimpleSinkOpExecConfig.scala
@@ -7,22 +7,19 @@ import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.GlobalB
 import edu.uci.ics.amber.engine.architecture.deploysemantics.deploymentfilter.ForceLocal
 import edu.uci.ics.amber.engine.architecture.deploysemantics.deploystrategy.RandomDeployment
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.WorkerLayer
-import edu.uci.ics.amber.engine.common.virtualidentity.{
-  ActorVirtualIdentity,
-  LayerIdentity,
-  OperatorIdentity
-}
+import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LayerIdentity, OperatorIdentity}
 import edu.uci.ics.amber.engine.operators.SinkOpExecConfig
+import edu.uci.ics.texera.workflow.common.IncrementalOutputMode
 
 import scala.collection.mutable
 import scala.concurrent.ExecutionContext
 
-class SimpleSinkOpExecConfig(tag: OperatorIdentity) extends SinkOpExecConfig(tag) {
+class SimpleSinkOpExecConfig(tag: OperatorIdentity, outputMode: IncrementalOutputMode) extends SinkOpExecConfig(tag) {
   override lazy val topology = new Topology(
     Array(
       new WorkerLayer(
         LayerIdentity(tag, "main"),
-        _ => new SimpleSinkOpExec(),
+        _ => new SimpleSinkOpExec(outputMode),
         1,
         ForceLocal(),
         RandomDeployment()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/VisualizationOperator.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/VisualizationOperator.java
@@ -1,5 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.visualization;
 
+import edu.uci.ics.texera.workflow.common.IncrementalOutputMode;
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor;
 
 /**
@@ -8,4 +9,6 @@ import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor;
  */
 public abstract class VisualizationOperator extends OperatorDescriptor {
     public abstract String chartType();
+
+    public abstract IncrementalOutputMode outputMode();
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/barChart/BarChartOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/barChart/BarChartOpDesc.java
@@ -2,6 +2,7 @@ package edu.uci.ics.texera.workflow.operators.visualization.barChart;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import edu.uci.ics.texera.workflow.common.IncrementalOutputMode;
 import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
@@ -40,6 +41,11 @@ public class BarChartOpDesc extends VisualizationOperator {
     @Override
     public String chartType() {
         return VisualizationConstants.BAR;
+    }
+
+    @Override
+    public IncrementalOutputMode outputMode() {
+        return IncrementalOutputMode.SET_SNAPSHOT;
     }
 
     @Override

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/lineChart/LineChartOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/lineChart/LineChartOpDesc.java
@@ -2,6 +2,7 @@ package edu.uci.ics.texera.workflow.operators.visualization.lineChart;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import edu.uci.ics.texera.workflow.common.IncrementalOutputMode;
 import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
@@ -42,6 +43,11 @@ public class LineChartOpDesc extends VisualizationOperator {
     @Override
     public String chartType() {
         return lineChartEnum.getChartStyle();
+    }
+
+    @Override
+    public IncrementalOutputMode outputMode() {
+        return IncrementalOutputMode.SET_SNAPSHOT;
     }
 
     @Override

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/lineChart/LineChartOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/lineChart/LineChartOpDesc.java
@@ -47,7 +47,7 @@ public class LineChartOpDesc extends VisualizationOperator {
 
     @Override
     public IncrementalOutputMode outputMode() {
-        return IncrementalOutputMode.SET_SNAPSHOT;
+        return IncrementalOutputMode.SET_DELTA;
     }
 
     @Override

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/pieChart/PieChartOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/pieChart/PieChartOpDesc.java
@@ -2,7 +2,7 @@ package edu.uci.ics.texera.workflow.operators.visualization.pieChart;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.uci.ics.amber.engine.common.Constants;
-import edu.uci.ics.amber.engine.operators.OpExecConfig;
+import edu.uci.ics.texera.workflow.common.IncrementalOutputMode;
 import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
@@ -42,6 +42,11 @@ public class PieChartOpDesc extends VisualizationOperator {
     @Override
     public String chartType() {
         return pieChartEnum.getChartStyle();
+    }
+
+    @Override
+    public IncrementalOutputMode outputMode() {
+        return IncrementalOutputMode.SET_SNAPSHOT;
     }
 
     @Override

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpDesc.java
@@ -6,6 +6,7 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInt;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
 import edu.uci.ics.amber.engine.common.Constants;
 import edu.uci.ics.amber.engine.operators.OpExecConfig;
+import edu.uci.ics.texera.workflow.common.IncrementalOutputMode;
 import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
@@ -41,6 +42,11 @@ public class WordCloudOpDesc extends VisualizationOperator {
     @Override
     public String chartType() {
         return VisualizationConstants.WORD_CLOUD;
+    }
+
+    @Override
+    public IncrementalOutputMode outputMode() {
+        return IncrementalOutputMode.SET_SNAPSHOT;
     }
 
     @Override

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -2,29 +2,27 @@ package edu.uci.ics.amber.engine.architecture.worker
 
 import akka.actor.ActorContext
 import com.softwaremill.macwire.wire
-import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.QueryWorkerStatistics
-import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.WorkerExecutionCompletedHandler.WorkerExecutionCompleted
 import edu.uci.ics.amber.engine.architecture.messaginglayer.{BatchToTupleConverter, ControlOutputPort, DataOutputPort, TupleToBatchConverter}
 import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue._
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.PauseHandler.PauseWorker
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryWorkerStatistics
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.ResumeHandler.ResumeWorker
 import edu.uci.ics.amber.engine.common.ambermessage.ControlPayload
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
-import edu.uci.ics.amber.engine.common.{InputExhausted, WorkflowLogger}
 import edu.uci.ics.amber.engine.common.rpc.{AsyncRPCClient, AsyncRPCServer}
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager
-import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{Completed, Ready, Running}
+import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{Completed, Running}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity.WorkerActorVirtualIdentity
 import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LayerIdentity, LinkIdentity}
+import edu.uci.ics.amber.engine.common.{InputExhausted, WorkflowLogger}
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
-import lbmq.LinkedBlockingMultiQueue
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 
-import scala.concurrent.duration.{Duration, DurationInt, FiniteDuration}
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future}
 
 class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfterEach {

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -2,16 +2,11 @@ package edu.uci.ics.amber.engine.architecture.worker
 
 import akka.actor.ActorContext
 import com.softwaremill.macwire.wire
+import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.QueryWorkerStatistics
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.WorkerExecutionCompletedHandler.WorkerExecutionCompleted
-import edu.uci.ics.amber.engine.architecture.messaginglayer.{
-  BatchToTupleConverter,
-  ControlOutputPort,
-  DataOutputPort,
-  TupleToBatchConverter
-}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.{BatchToTupleConverter, ControlOutputPort, DataOutputPort, TupleToBatchConverter}
 import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue._
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.PauseHandler.PauseWorker
-import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.ResumeHandler.ResumeWorker
 import edu.uci.ics.amber.engine.common.ambermessage.ControlPayload
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
@@ -19,18 +14,10 @@ import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, Con
 import edu.uci.ics.amber.engine.common.{InputExhausted, WorkflowLogger}
 import edu.uci.ics.amber.engine.common.rpc.{AsyncRPCClient, AsyncRPCServer}
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager
-import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{
-  Completed,
-  Ready,
-  Running
-}
+import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{Completed, Ready, Running}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity.WorkerActorVirtualIdentity
-import edu.uci.ics.amber.engine.common.virtualidentity.{
-  ActorVirtualIdentity,
-  LayerIdentity,
-  LinkIdentity
-}
+import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LayerIdentity, LinkIdentity}
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import lbmq.LinkedBlockingMultiQueue
 import org.scalamock.scalatest.MockFactory
@@ -206,10 +193,10 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     Thread.sleep(500)
     dp.enqueueCommand(ControlInvocation(0, PauseWorker()), ActorVirtualIdentity.Controller)
     dp.appendElement(InputTuple(ITuple(2)))
-    dp.enqueueCommand(ControlInvocation(1, QueryStatistics()), ActorVirtualIdentity.Controller)
+    dp.enqueueCommand(ControlInvocation(1, QueryWorkerStatistics()), ActorVirtualIdentity.Controller)
     Thread.sleep(1000)
     dp.appendElement(InputTuple(ITuple(3)))
-    dp.enqueueCommand(ControlInvocation(2, QueryStatistics()), ActorVirtualIdentity.Controller)
+    dp.enqueueCommand(ControlInvocation(2, QueryWorkerStatistics()), ActorVirtualIdentity.Controller)
     dp.appendElement(InputTuple(ITuple(4)))
     dp.enqueueCommand(ControlInvocation(3, ResumeWorker()), ActorVirtualIdentity.Controller)
     dp.appendElement(EndMarker)

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -2,7 +2,12 @@ package edu.uci.ics.amber.engine.architecture.worker
 
 import akka.actor.ActorContext
 import com.softwaremill.macwire.wire
-import edu.uci.ics.amber.engine.architecture.messaginglayer.{BatchToTupleConverter, ControlOutputPort, DataOutputPort, TupleToBatchConverter}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.{
+  BatchToTupleConverter,
+  ControlOutputPort,
+  DataOutputPort,
+  TupleToBatchConverter
+}
 import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue._
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.PauseHandler.PauseWorker
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryWorkerStatistics
@@ -15,7 +20,11 @@ import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager.{Completed, Running}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity.WorkerActorVirtualIdentity
-import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LayerIdentity, LinkIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.{
+  ActorVirtualIdentity,
+  LayerIdentity,
+  LinkIdentity
+}
 import edu.uci.ics.amber.engine.common.{InputExhausted, WorkflowLogger}
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import org.scalamock.scalatest.MockFactory
@@ -191,10 +200,16 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     Thread.sleep(500)
     dp.enqueueCommand(ControlInvocation(0, PauseWorker()), ActorVirtualIdentity.Controller)
     dp.appendElement(InputTuple(ITuple(2)))
-    dp.enqueueCommand(ControlInvocation(1, QueryWorkerStatistics()), ActorVirtualIdentity.Controller)
+    dp.enqueueCommand(
+      ControlInvocation(1, QueryWorkerStatistics()),
+      ActorVirtualIdentity.Controller
+    )
     Thread.sleep(1000)
     dp.appendElement(InputTuple(ITuple(3)))
-    dp.enqueueCommand(ControlInvocation(2, QueryWorkerStatistics()), ActorVirtualIdentity.Controller)
+    dp.enqueueCommand(
+      ControlInvocation(2, QueryWorkerStatistics()),
+      ActorVirtualIdentity.Controller
+    )
     dp.appendElement(InputTuple(ITuple(4)))
     dp.enqueueCommand(ControlInvocation(3, ResumeWorker()), ActorVirtualIdentity.Controller)
     dp.appendElement(EndMarker)

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
@@ -71,7 +71,7 @@ class DataProcessingSpec
     val eventListener = ControllerEventListener()
     eventListener.workflowCompletedListener = evt => results = evt.result
     val controller = parent.childActorOf(
-      Controller.props(id, workflow, eventListener, 100)
+      Controller.props(id, workflow, eventListener)
     )
     parent.expectMsg(ControllerState.Ready)
     controller ! ControlInvocation(AsyncRPCClient.IgnoreReply, StartWorkflow())

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/Utils.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/Utils.scala
@@ -33,7 +33,7 @@ object Utils {
     Controller.props(
       WorkflowIdentity(workflowTag),
       texeraWorkflowCompiler.amberWorkflow,
-      ControllerEventListener(),
+      ControllerEventListener()
     )
   }
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/Utils.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/Utils.scala
@@ -34,7 +34,6 @@ object Utils {
       WorkflowIdentity(workflowTag),
       texeraWorkflowCompiler.amberWorkflow,
       ControllerEventListener(),
-      100
     )
   }
 

--- a/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.spec.ts
@@ -9,7 +9,7 @@ import { UndoRedoService } from '../../service/undo-redo/undo-redo.service';
 import { WorkflowActionService } from '../../service/workflow-graph/model/workflow-action.service';
 import { WorkflowUtilService } from '../../service/workflow-graph/util/workflow-util.service';
 import { WorkflowStatusService } from '../../service/workflow-status/workflow-status.service';
-import { ResultObject } from '../../types/execute-workflow.interface';
+import { IncrementalOutputResult } from '../../types/execute-workflow.interface';
 import { ChartType } from '../../types/visualization.interface';
 import { VisualizationPanelContentComponent } from './visualization-panel-content.component';
 
@@ -27,7 +27,7 @@ describe('VisualizationPanelContentComponent', () => {
         WorkflowUtilService,
         UndoRedoService,
         WorkflowActionService,
-        {provide: OperatorMetadataService, useClass: StubOperatorMetadataService},
+        { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
         WorkflowStatusService,
         ExecuteWorkflowService
       ]
@@ -47,11 +47,14 @@ describe('VisualizationPanelContentComponent', () => {
   });
 
   it('should draw the figure', () => {
-    const testData: Record<string, ResultObject> = {
-      'operator1': {operatorID: 'operator1', chartType: ChartType.PIE, table: [{'id': 1, 'data': 2}], totalRowCount: 1}
+    const testData: Record<string, IncrementalOutputResult> = {
+      'operator1': {
+        outputMode: 'SET_SNAPSHOT',
+        result: { operatorID: 'operator1', chartType: ChartType.PIE, table: [{ 'id': 1, 'data': 2 }], totalRowCount: 1 }
+      }
     };
     spyOn(component, 'generateChart');
-    spyOn(workflowStatusService, 'getCurrentResult').and.returnValue(testData);
+    spyOn(workflowStatusService, 'getCurrentIncrementalResult').and.returnValue(testData);
 
     component.operatorID = 'operator1';
     component.ngAfterViewInit();
@@ -60,14 +63,16 @@ describe('VisualizationPanelContentComponent', () => {
   });
 
   it('should draw the word cloud', () => {
-    const testData: Record<string, ResultObject> = {
+    const testData: Record<string, IncrementalOutputResult> = {
       'operator1': {
-        operatorID: 'operator1', chartType: ChartType.WORD_CLOUD,
-        table: [{'word': 'foo', 'count': 120}, {'word': 'bar', 'count': 100}], totalRowCount: 2
+        outputMode: 'SET_SNAPSHOT', result: {
+          operatorID: 'operator1', chartType: ChartType.WORD_CLOUD,
+          table: [{ 'word': 'foo', 'count': 120 }, { 'word': 'bar', 'count': 100 }], totalRowCount: 2
+        }
       }
     };
     spyOn(component, 'generateWordCloud');
-    spyOn(workflowStatusService, 'getCurrentResult').and.returnValue(testData);
+    spyOn(workflowStatusService, 'getCurrentIncrementalResult').and.returnValue(testData);
 
     component.operatorID = 'operator1';
     component.ngAfterViewInit();

--- a/core/new-gui/src/app/workspace/component/visualization-panel/visualization-panel.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/visualization-panel/visualization-panel.component.spec.ts
@@ -10,7 +10,7 @@ import { UndoRedoService } from '../../service/undo-redo/undo-redo.service';
 import { WorkflowActionService } from '../../service/workflow-graph/model/workflow-action.service';
 import { WorkflowUtilService } from '../../service/workflow-graph/util/workflow-util.service';
 import { WorkflowStatusService } from '../../service/workflow-status/workflow-status.service';
-import { ResultObject } from '../../types/execute-workflow.interface';
+import { IncrementalOutputResult } from '../../types/execute-workflow.interface';
 import { ChartType } from '../../types/visualization.interface';
 import { VisualizationPanelComponent } from './visualization-panel.component';
 
@@ -19,8 +19,11 @@ describe('VisualizationPanelComponent', () => {
   let fixture: ComponentFixture<VisualizationPanelComponent>;
   let workflowStatusService: WorkflowStatusService;
 
-  const testData: Record<string, ResultObject> = {
-    'operator1': {operatorID: 'operator1', chartType: ChartType.BAR, table: [], totalRowCount: 0}
+  const testData: Record<string, IncrementalOutputResult> = {
+    'operator1': {
+      outputMode: 'SET_SNAPSHOT',
+      result: { operatorID: 'operator1', chartType: ChartType.BAR, table: [], totalRowCount: 0 }
+    }
   };
 
   beforeEach(async(() => {
@@ -36,7 +39,7 @@ describe('VisualizationPanelComponent', () => {
         WorkflowUtilService,
         UndoRedoService,
         WorkflowActionService,
-        {provide: OperatorMetadataService, useClass: StubOperatorMetadataService},
+        { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
         WorkflowStatusService,
         ExecuteWorkflowService
       ]
@@ -50,7 +53,7 @@ describe('VisualizationPanelComponent', () => {
     fixture.detectChanges();
 
     workflowStatusService = TestBed.get(WorkflowStatusService);
-    spyOn(workflowStatusService, 'getCurrentResult').and.returnValue(testData);
+    spyOn(workflowStatusService, 'getCurrentIncrementalResult').and.returnValue(testData);
   });
 
   it('should create', () => {

--- a/core/new-gui/src/app/workspace/component/visualization-panel/visualization-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/visualization-panel/visualization-panel.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnChanges } from '@angular/core';
 import { NzModalRef, NzModalService } from 'ng-zorro-antd/modal';
 import { WorkflowStatusService } from '../../service/workflow-status/workflow-status.service';
-import { ResultObject } from '../../types/execute-workflow.interface';
+import { ResultObject, IncrementalOutputResult } from '../../types/execute-workflow.interface';
 import { VisualizationPanelContentComponent } from '../visualization-panel-content/visualization-panel-content.component';
 
 /**
@@ -41,8 +41,8 @@ export class VisualizationPanelComponent implements OnChanges {
       this.displayVisualizationPanel = false;
       return;
     }
-    const result: ResultObject | undefined = this.workflowStatusService.getCurrentResult()[this.operatorID];
-    this.displayVisualizationPanel = result?.chartType !== undefined;
+    const result: IncrementalOutputResult | undefined = this.workflowStatusService.getCurrentIncrementalResult()[this.operatorID];
+    this.displayVisualizationPanel = result?.result.chartType !== undefined;
   }
 
   onClickVisualize(): void {

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -80,7 +80,7 @@ export class ExecuteWorkflowService {
             break;
           } default: {
             // workflow status related event
-            if (event.type !== 'WebWorkflowStatusUpdateEvent') {
+            if (! (event.type === 'WebWorkflowStatusUpdateEvent' || event.type === 'WebWorkflowResultUpdateEvent')) {
               console.log(event);
             }
             const newState = this.handleExecutionEvent(event);

--- a/core/new-gui/src/app/workspace/service/workflow-status/workflow-status.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-status/workflow-status.service.ts
@@ -1,10 +1,11 @@
 import { Injectable } from '@angular/core';
 import { Observable, Subject } from 'rxjs';
 import { environment } from '../../../../environments/environment';
-import { ExecutionState, OperatorState, OperatorStatistics, ResultObject } from '../../types/execute-workflow.interface';
+import { ExecutionState, OperatorState, OperatorStatistics, IncrementalOutputResult, ResultObject } from '../../types/execute-workflow.interface';
 import { ExecuteWorkflowService } from '../execute-workflow/execute-workflow.service';
 import { WorkflowActionService } from '../workflow-graph/model/workflow-action.service';
 import { WorkflowWebsocketService } from '../workflow-websocket/workflow-websocket.service';
+import { assertNever } from 'src/app/common/util/assert';
 
 @Injectable({
   providedIn: 'root'
@@ -14,8 +15,15 @@ export class WorkflowStatusService {
   private statusSubject = new Subject<Record<string, OperatorStatistics>>();
   private currentStatus: Record<string, OperatorStatistics> = {};
 
-  private resultSubject = new Subject<Record<string, ResultObject>>();
-  private currentResult: Record<string, ResultObject> = {};
+  private resultUpdateStream = new Subject<Record<string, IncrementalOutputResult>>();
+
+  // current incremental result
+  // for SET_SNAPSHOT output mode:  latested output snapshot
+  // for SET_DELTA    output mode:  accumulated delta
+  //                                delta no retraction   - same as snapshot
+  //                                delta with retraction - accumulated delta is not compacted
+  // When resultUpdateStream emits a new update event, the update is already applied on the result set
+  private currentIncrementalResult: Record<string, ResultObject> = {};
 
   constructor(
     private workflowActionService: WorkflowActionService,
@@ -26,7 +34,6 @@ export class WorkflowStatusService {
       return;
     }
     this.getStatusUpdateStream().subscribe(event => this.currentStatus = event);
-    this.getResultUpdateStream().subscribe(event => this.currentResult = event);
 
     this.workflowWebsocketService.websocketEvent().subscribe(event => {
       if (event.type !== 'WebWorkflowStatusUpdateEvent') {
@@ -36,24 +43,36 @@ export class WorkflowStatusService {
     });
 
     this.workflowWebsocketService.websocketEvent().subscribe(event => {
-      let resultArray: readonly ResultObject[] | undefined;
-      if (event.type === 'WebWorkflowStatusUpdateEvent') {
-        resultArray = Object.values(event.operatorStatistics).map(o => o.aggregatedOutputResults).filter((o): o is ResultObject => !!o);
-      } else if (event.type === 'WorkflowCompletedEvent') {
-        resultArray = event.result;
-      }
-
-      if (! resultArray) {
+      if (event.type !== 'WebWorkflowResultUpdateEvent') {
         return;
       }
 
-      const resultMap: Record<string, ResultObject> = {};
-      resultArray.forEach(r => {
-        resultMap[r.operatorID] = r;
+      // apply the update on the result set based on SET_SNAPSHOT and SET_DELTA semantics
+      Object.entries(event.operatorResults).forEach(e => {
+        const opID = e[0];
+        const resultUpdate = e[1];
+
+        if (resultUpdate.outputMode === 'SET_SNAPSHOT') {
+          this.currentIncrementalResult[opID] = resultUpdate.result;
+        } else if (resultUpdate.outputMode === 'SET_DELTA') {
+          const combinedResult = [];
+          combinedResult.push(this.currentIncrementalResult[opID]?.table ?? []);
+          combinedResult.push(resultUpdate.result.table);
+          let rowCount = 0;
+          rowCount += this.currentIncrementalResult[opID]?.totalRowCount ?? 0;
+          rowCount += resultUpdate.result.totalRowCount;
+          this.currentIncrementalResult[opID] = {
+            operatorID: resultUpdate.result.operatorID,
+            chartType: resultUpdate.result.chartType,
+            table: combinedResult,
+            totalRowCount: rowCount,
+          };
+        } else {
+          const _exhaustiveCheck: never = resultUpdate.outputMode;
+        }
       });
-      if (Object.keys(resultMap).length !== 0) {
-        this.resultSubject.next(resultMap);
-      }
+
+      this.resultUpdateStream.next(event.operatorResults);
     });
 
     this.executeWorkflowService.getExecutionStateStream().subscribe(event => {
@@ -64,7 +83,6 @@ export class WorkflowStatusService {
             operatorState: OperatorState.Initializing,
             aggregatedInputRowCount: 0,
             aggregatedOutputRowCount: 0,
-            aggregatedOutputResults: undefined
           };
         });
         this.statusSubject.next(initialStatistics);
@@ -80,12 +98,12 @@ export class WorkflowStatusService {
     return this.currentStatus;
   }
 
-  public getResultUpdateStream(): Observable<Record<string, ResultObject>> {
-    return this.resultSubject.asObservable();
+  public getResultUpdateStream(): Observable<Record<string, IncrementalOutputResult>> {
+    return this.resultUpdateStream.asObservable();
   }
 
-  public getCurrentResult(): Record<string, ResultObject> {
-    return this.currentResult;
+  public getCurrentIncrementalResult(): Record<string, IncrementalOutputResult> {
+    return this.currentIncrementalResult;
   }
 
 }

--- a/core/new-gui/src/app/workspace/service/workflow-status/workflow-status.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-status/workflow-status.service.ts
@@ -59,9 +59,10 @@ export class WorkflowStatusService {
         if (resultUpdate.outputMode === 'SET_SNAPSHOT') {
           this.currentIncrementalResult[opID] = resultUpdate;
         } else if (resultUpdate.outputMode === 'SET_DELTA') {
-          const combinedResult = [];
-          combinedResult.push(this.currentIncrementalResult[opID]?.result.table ?? []);
-          combinedResult.push(resultUpdate.result.table);
+          const currentResult = this.currentIncrementalResult[opID]?.result.table ?? [];
+          const deltaResult = resultUpdate.result.table;
+          const combinedResult = currentResult.concat(deltaResult);
+
           let rowCount = 0;
           rowCount += this.currentIncrementalResult[opID]?.result.totalRowCount ?? 0;
           rowCount += resultUpdate.result.totalRowCount;

--- a/core/new-gui/src/app/workspace/service/workflow-status/workflow-status.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-status/workflow-status.service.ts
@@ -36,7 +36,6 @@ export class WorkflowStatusService {
     this.getResultUpdateStream().subscribe(event => {
       Object.entries(event).forEach(e => {
         console.log(`operator ${e[0]} result update -  mode: ${e[1].outputMode}, count: ${e[1].result.table.length}`);
-        console.log(e[1].result);
       });
     });
 
@@ -45,14 +44,6 @@ export class WorkflowStatusService {
         return;
       }
       this.statusSubject.next(event.operatorStatistics);
-    }, error => {
-
-    });
-
-    this.workflowWebsocketService.websocketEvent().subscribe(event => {
-      // success logic
-    }, error => {
-      // error logic
     });
 
     this.workflowWebsocketService.websocketEvent().subscribe(event => {

--- a/core/new-gui/src/app/workspace/types/execute-workflow.interface.ts
+++ b/core/new-gui/src/app/workspace/types/execute-workflow.interface.ts
@@ -88,15 +88,25 @@ export enum OperatorState {
   Recovering = 'Recovering',
 }
 
+export type IncrementalOutputMode = 'SET_SNAPSHOT' | 'SET_DELTA';
+
+export interface IncrementalOutputResult extends Readonly<{
+  outputMode: IncrementalOutputMode,
+  result: ResultObject
+}> { }
+
 export interface OperatorStatistics extends Readonly<{
   operatorState: OperatorState,
   aggregatedInputRowCount: number,
   aggregatedOutputRowCount: number,
-  aggregatedOutputResults: ResultObject | undefined | null // undefined/null if operator is not sink
 }> { }
 
 export interface WorkflowStatusUpdate extends Readonly<{
   operatorStatistics: Record<string, OperatorStatistics>
+}> { }
+
+export interface WorkflowResultUpdate extends Readonly<{
+  operatorResults: Record<string, IncrementalOutputResult>
 }> { }
 
 export enum ExecutionState {

--- a/core/new-gui/src/app/workspace/types/workflow-websocket.interface.ts
+++ b/core/new-gui/src/app/workspace/types/workflow-websocket.interface.ts
@@ -1,4 +1,4 @@
-import { LogicalPlan, WorkflowStatusUpdate, ResultObject, LogicalOperator, BreakpointInfo } from './execute-workflow.interface';
+import { LogicalPlan, WorkflowStatusUpdate, ResultObject, LogicalOperator, BreakpointInfo, WorkflowResultUpdate } from './execute-workflow.interface';
 import { BreakpointTriggerInfo, BreakpointFault, BreakpointFaultedTuple } from './workflow-common.interface';
 
 
@@ -83,6 +83,7 @@ export type TexeraWebsocketEventTypeMap = {
   'WorkflowStartedEvent': {},
   'WorkflowCompletedEvent': {result: ReadonlyArray<ResultObject>},
   'WebWorkflowStatusUpdateEvent': WorkflowStatusUpdate,
+  'WebWorkflowResultUpdateEvent': WorkflowResultUpdate,
   'WorkflowPausedEvent': {},
   'WorkflowResumedEvent': {},
   'RecoveryStartedEvent': {},


### PR DESCRIPTION
The controller periodically queries the sink operator workers to fetch the result update. Previously, each result update is the full result set snapshot. 
This design is optimized for aggregation operators before the sink, such as word cloud. Aggregation operators produce a contant number of results and its delta output has many retractions. Therefore, using snapshot output helps the frontend to not handle retractions and it has an acceptable overhead.

For non-aggregation visualization operators such as scatter plot, this design brings a high overhead because in insertion-only delta workflows, the result set snapshot gets larger and larger for each update. In this case, it would be better to only send the incremental delta results. 

In this PR, we added the support of sending results in either full snapshot mode or in incremental delta mode. The following major changes are made:
- Introduce `IncrementalOutputMode`, with 2 options: `SET_SNAPSHOT` (for full snapshot output mode) and `SET_DELTA` (for incremental delta output mode).
- Add `getOutputMode` method to `VisualizationOperator`, the visualization operator can specify its desired output mode. This output mode will be used in the sink after the visualization operator. 
-  In each result update from the worker to the engine, and from the engine to the frontend, `IncrementalOutputMode` is also attached to specify the semantics of this update.

Moreover, the following changes are made in the engine-level to better support this feature:
Separate `QueryResults` from `QueryStatistics`. Originally `QueryStatistics` also queries the sink worker result. Now they are two separate control messages. This separation is necessary for the following reasons:
- `QueryStatistics` is idempotent. `QueryResults` with `SET_SNAPSHOT` output mode is also idempotent. However, the new `QueryResult` with `SET_DELTA` output mode is NOT idempotent. We must ensure that each delta update is consumed ONLY ONCE in the entire pipeline.
-  Operator statistics are saved in the controller. In the old implementation, latest snapshot output is also saved in the controller. However, the new delta output result cannot be saved in the controller because it comes with a risk of being read twice.
- This separation also enables us to set two different query intervals.