### PR TITLE
Fix WebSocket Connection Status Indicator with Safari

### DIFF
--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.scss
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.scss
@@ -183,7 +183,6 @@
     }
 
     .animate-to-reveal-stop-button {
-      translate: 40px;
       transition: translate 0.3s ease-out;
       transition-delay: 0.1s;
     }
@@ -191,7 +190,6 @@
 
   .reveal-stop-button {
     .animate-to-reveal-stop-button {
-      translate: 0px;
     }
   }
 }


### PR DESCRIPTION
This PR fixes an issue that does not show the WebSocket connection indicator correctly on Safari. 

Before:
<img width="360" alt="Screen Shot 2021-05-04 at 00 44 19" src="https://user-images.githubusercontent.com/17627829/116973766-ddf47700-ac71-11eb-8846-1740fce5be23.png">

After:
<img width="349" alt="Screen Shot 2021-05-04 at 00 46 20" src="https://user-images.githubusercontent.com/17627829/116973953-2875f380-ac72-11eb-842c-c968bac2bc2b.png">

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>