### PR TITLE
Log warnings when queue size exceeds certain limit

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
@@ -37,6 +37,7 @@ abstract class WorkflowActor(
   })
 
   val networkCommunicationActor: NetworkSenderActorRef = NetworkSenderActorRef(
+    // create a network communication actor on the same machine as the WorkflowActor itself
     context.actorOf(NetworkCommunicationActor.props(parentNetworkCommunicationActorRef, logger))
   )
   lazy val controlOutputPort: ControlOutputPort = wire[ControlOutputPort]

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
@@ -37,7 +37,7 @@ abstract class WorkflowActor(
   })
 
   val networkCommunicationActor: NetworkSenderActorRef = NetworkSenderActorRef(
-    context.actorOf(NetworkCommunicationActor.props(parentNetworkCommunicationActorRef))
+    context.actorOf(NetworkCommunicationActor.props(parentNetworkCommunicationActorRef, logger))
   )
   lazy val controlOutputPort: ControlOutputPort = wire[ControlOutputPort]
   lazy val asyncRPCClient: AsyncRPCClient = wire[AsyncRPCClient]

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
@@ -86,7 +86,7 @@ class CongestionControl {
     inTransit.values
   }
 
-  def getStatusReport:String = {
+  def getStatusReport: String = {
     s"current window size = ${windowSize} \t in transit = ${inTransit.size} \t waiting = ${toBeSent.size}"
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
@@ -86,4 +86,8 @@ class CongestionControl {
     inTransit.values
   }
 
+  def getStatusReport:String = {
+    s"current window size = ${windowSize} \t in transit = ${inTransit.size} \t waiting = ${toBeSent.size}"
+  }
+
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkCommunicationActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkCommunicationActor.scala
@@ -56,8 +56,8 @@ object NetworkCommunicationActor {
 
   final case class MessageBecomesDeadLetter(message: NetworkMessage)
 
-  def props(parentSender: ActorRef): Props =
-    Props(new NetworkCommunicationActor(parentSender))
+  def props(parentSender: ActorRef, workerLogger: WorkflowLogger): Props =
+    Props(new NetworkCommunicationActor(parentSender, workerLogger))
 }
 
 /** This actor handles the transformation from identifier to actorRef

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkCommunicationActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkCommunicationActor.scala
@@ -2,7 +2,15 @@ package edu.uci.ics.amber.engine.architecture.messaginglayer
 
 import akka.actor.{Actor, ActorRef, Cancellable, Props}
 import com.typesafe.scalalogging.LazyLogging
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor.{GetActorRef, MessageBecomesDeadLetter, NetworkAck, NetworkMessage, RegisterActorRef, ResendMessages, SendRequest}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor.{
+  GetActorRef,
+  MessageBecomesDeadLetter,
+  NetworkAck,
+  NetworkMessage,
+  RegisterActorRef,
+  ResendMessages,
+  SendRequest
+}
 import edu.uci.ics.amber.engine.common.WorkflowLogger
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.ambermessage.WorkflowMessage
@@ -56,7 +64,7 @@ object NetworkCommunicationActor {
   * and also sends message to other actors. This is the most outer part of
   * the messaging layer.
   */
-class NetworkCommunicationActor(parentRef: ActorRef, workerLogger:WorkflowLogger) extends Actor{
+class NetworkCommunicationActor(parentRef: ActorRef, workerLogger: WorkflowLogger) extends Actor {
 
   val idToActorRefs = new mutable.HashMap[ActorVirtualIdentity, ActorRef]()
   val idToCongestionControls = new mutable.HashMap[ActorVirtualIdentity, CongestionControl]()
@@ -101,7 +109,8 @@ class NetworkCommunicationActor(parentRef: ActorRef, workerLogger:WorkflowLogger
             s"unknown identifier: $actorID",
             actorID.toString,
             Map.empty
-          ))
+          )
+        )
       }
     case RegisterActorRef(actorID, ref) =>
       registerActorRef(actorID, ref)
@@ -162,7 +171,7 @@ class NetworkCommunicationActor(parentRef: ActorRef, workerLogger:WorkflowLogger
       idToCongestionControls.foreach {
         case (actorID, ctrl) =>
           val msgsNeedResend = ctrl.getTimedOutInTransitMessages
-          if(msgsNeedResend.nonEmpty){
+          if (msgsNeedResend.nonEmpty) {
             workerLogger.logInfo(s"output channel for $actorID: ${ctrl.getStatusReport}")
           }
           msgsNeedResend.foreach { msg =>

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkCommunicationActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkCommunicationActor.scala
@@ -2,15 +2,8 @@ package edu.uci.ics.amber.engine.architecture.messaginglayer
 
 import akka.actor.{Actor, ActorRef, Cancellable, Props}
 import com.typesafe.scalalogging.LazyLogging
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor.{
-  GetActorRef,
-  MessageBecomesDeadLetter,
-  NetworkAck,
-  NetworkMessage,
-  RegisterActorRef,
-  ResendMessages,
-  SendRequest
-}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor.{GetActorRef, MessageBecomesDeadLetter, NetworkAck, NetworkMessage, RegisterActorRef, ResendMessages, SendRequest}
+import edu.uci.ics.amber.engine.common.WorkflowLogger
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.ambermessage.WorkflowMessage
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
@@ -63,7 +56,7 @@ object NetworkCommunicationActor {
   * and also sends message to other actors. This is the most outer part of
   * the messaging layer.
   */
-class NetworkCommunicationActor(parentRef: ActorRef) extends Actor with LazyLogging {
+class NetworkCommunicationActor(parentRef: ActorRef, workerLogger:WorkflowLogger) extends Actor{
 
   val idToActorRefs = new mutable.HashMap[ActorVirtualIdentity, ActorRef]()
   val idToCongestionControls = new mutable.HashMap[ActorVirtualIdentity, CongestionControl]()
@@ -103,13 +96,12 @@ class NetworkCommunicationActor(parentRef: ActorRef) extends Actor with LazyLogg
       } else if (parentRef != null) {
         parentRef ! GetActorRef(actorID, replyTo + self)
       } else {
-        throw new WorkflowRuntimeException(
+        workerLogger.logError(
           WorkflowRuntimeError(
             s"unknown identifier: $actorID",
             actorID.toString,
             Map.empty
-          )
-        )
+          ))
       }
     case RegisterActorRef(actorID, ref) =>
       registerActorRef(actorID, ref)
@@ -169,7 +161,11 @@ class NetworkCommunicationActor(parentRef: ActorRef) extends Actor with LazyLogg
       queriedActorVirtualIdentities.clear()
       idToCongestionControls.foreach {
         case (actorID, ctrl) =>
-          ctrl.getTimedOutInTransitMessages.foreach { msg =>
+          val msgsNeedResend = ctrl.getTimedOutInTransitMessages
+          if(msgsNeedResend.nonEmpty){
+            workerLogger.logInfo(s"output channel for $actorID: ${ctrl.getStatusReport}")
+          }
+          msgsNeedResend.foreach { msg =>
             sendOrGetActorRef(actorID, msg)
           }
       }
@@ -177,7 +173,7 @@ class NetworkCommunicationActor(parentRef: ActorRef) extends Actor with LazyLogg
       // only remove the mapping from id to actorRef
       // to trigger discover mechanism
       val actorID = messageIDToIdentity(msg.messageID)
-      logger.warn(s"actor for $actorID might have crashed or failed")
+      workerLogger.logWarning(s"actor for $actorID might have crashed or failed")
       idToActorRefs.remove(actorID)
       if (parentRef != null) {
         getActorRefMappingFromParent(actorID)
@@ -211,6 +207,6 @@ class NetworkCommunicationActor(parentRef: ActorRef) extends Actor with LazyLogg
 
   override def postStop(): Unit = {
     resendHandle.cancel()
-    logger.info(s"network communication actor for ${context.parent} stopped!")
+    workerLogger.logInfo(s"network communication actor stopped!")
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerAsyncRPCHandlerInitializer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerAsyncRPCHandlerInitializer.scala
@@ -43,4 +43,5 @@ class WorkerAsyncRPCHandlerInitializer(
     with UpdateInputLinkingHandler
     with ShutdownDPThreadHandler {
   val logger: WorkflowLogger = WorkflowLogger("WorkerControlHandler")
+  var lastReportTime = 0L
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerInternalQueue.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerInternalQueue.scala
@@ -62,6 +62,10 @@ trait WorkerInternalQueue {
 
   def enableDataQueue(): Unit = dataQueue.enable(true)
 
+  def getDataQueueLength: Int = dataQueue.size()
+
+  def getControlQueueLength: Int = controlQueue.size()
+
   def isControlQueueEmpty: Boolean = controlQueue.isEmpty
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
@@ -1,6 +1,9 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
-import edu.uci.ics.amber.engine.architecture.worker.{WorkerAsyncRPCHandlerInitializer, WorkerStatistics}
+import edu.uci.ics.amber.engine.architecture.worker.{
+  WorkerAsyncRPCHandlerInitializer,
+  WorkerStatistics
+}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
 import edu.uci.ics.amber.engine.common.{Constants, ITupleSinkOperatorExecutor}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
@@ -16,6 +16,13 @@ trait QueryStatisticsHandler {
   this: WorkerAsyncRPCHandlerInitializer =>
 
   registerHandler { (msg: QueryStatistics, sender) =>
+    // report internal queue length if the gap > 30s
+    val now = System.currentTimeMillis()
+    if(now - lastReportTime > 30000){
+      logger.logInfo(s"Data Queue Length = ${dataProcessor.getDataQueueLength} Control Queue Length = ${dataProcessor.getControlQueueLength}")
+      lastReportTime = now
+    }
+
     // collect input and output row count
     val (in, out) = dataProcessor.collectStatistics()
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
@@ -18,8 +18,10 @@ trait QueryStatisticsHandler {
   registerHandler { (msg: QueryStatistics, sender) =>
     // report internal queue length if the gap > 30s
     val now = System.currentTimeMillis()
-    if(now - lastReportTime > 30000){
-      logger.logInfo(s"Data Queue Length = ${dataProcessor.getDataQueueLength} Control Queue Length = ${dataProcessor.getControlQueueLength}")
+    if (now - lastReportTime > 30000) {
+      logger.logInfo(
+        s"Data Queue Length = ${dataProcessor.getDataQueueLength} Control Queue Length = ${dataProcessor.getControlQueueLength}"
+      )
       lastReportTime = now
     }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
@@ -1,11 +1,8 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
-import edu.uci.ics.amber.engine.architecture.worker.{
-  WorkerAsyncRPCHandlerInitializer,
-  WorkerStatistics
-}
+import edu.uci.ics.amber.engine.architecture.worker.{WorkerAsyncRPCHandlerInitializer, WorkerStatistics}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
-import edu.uci.ics.amber.engine.common.ITupleSinkOperatorExecutor
+import edu.uci.ics.amber.engine.common.{Constants, ITupleSinkOperatorExecutor}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
 
 object QueryStatisticsHandler {
@@ -18,7 +15,7 @@ trait QueryStatisticsHandler {
   registerHandler { (msg: QueryStatistics, sender) =>
     // report internal queue length if the gap > 30s
     val now = System.currentTimeMillis()
-    if (now - lastReportTime > 30000) {
+    if (now - lastReportTime > Constants.loggingQueueSizeInterval) {
       logger.logInfo(
         s"Data Queue Length = ${dataProcessor.getDataQueueLength}, Control Queue Length = ${dataProcessor.getControlQueueLength}"
       )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
@@ -20,7 +20,7 @@ trait QueryStatisticsHandler {
     val now = System.currentTimeMillis()
     if (now - lastReportTime > 30000) {
       logger.logInfo(
-        s"Data Queue Length = ${dataProcessor.getDataQueueLength} Control Queue Length = ${dataProcessor.getControlQueueLength}"
+        s"Data Queue Length = ${dataProcessor.getDataQueueLength}, Control Queue Length = ${dataProcessor.getControlQueueLength}"
       )
       lastReportTime = now
     }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/Constants.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/Constants.scala
@@ -13,4 +13,7 @@ object Constants {
   var numWorkerPerNode = 2
   var dataVolumePerNode = 10
   var defaultTau: FiniteDuration = 10.milliseconds
+
+  // time interval for logging queue sizes - 30s
+  val loggingQueueSizeInterval = 30000
 }


### PR DESCRIPTION
This PR adds a defensive logging mechanism to amber. Through this feature, developers can get more insight into what is happening inside the engine and where they should pay attention. 
1. Every worker will log their internal data/control queue size every 30s when it receives a `CheckStatistics` message.
2. Every worker will log their congestion control queue size if there is any message to be resent. Also, resending of the messages will be checked for every 30s.
3. To be consistent, `NetworkCommunicationActor` now uses the worker's logger