### PR TITLE
Remove label on link of limit operator

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/limit/LimitOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/limit/LimitOpDesc.scala
@@ -31,7 +31,7 @@ class LimitOpDesc extends OperatorDescriptor {
       "Limit",
       "Limit the number of output rows",
       OperatorGroupConstants.UTILITY_GROUP,
-      inputPorts = List(InputPort("testPortName")),
+      inputPorts = List(InputPort("")),
       outputPorts = List(OutputPort())
     )
 


### PR DESCRIPTION
Remove the label on the link of the limit operator to fix  #1077 

<img width="348" alt="Screen Shot 2021-05-07 at 1 21 26 PM" src="https://user-images.githubusercontent.com/9158114/117506504-8b011500-af3a-11eb-99dc-23159c37000a.png"> <img width="346" alt="Screen Shot 2021-05-07 at 1 22 35 PM" src="https://user-images.githubusercontent.com/9158114/117506502-8a687e80-af3a-11eb-8c32-8f2450a0a616.png">
