### PR TITLE
Disable dependent tests with AsterixDB

### DIFF
--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
@@ -334,18 +334,19 @@ class DataProcessingSpec
     executeWorkflow(id, workflow)
   }
 
-  "Engine" should "execute asterixdb->sink workflow normally" in {
-
-    val asterixDBOp = TestOperators.asterixDBSourceOpDesc()
-    val sink = TestOperators.sinkOpDesc()
-    val (id, workflow) = buildWorkflow(
-      mutable.MutableList[OperatorDescriptor](asterixDBOp, sink),
-      mutable.MutableList[OperatorLink](
-        OperatorLink(OperatorPort(asterixDBOp.operatorID, 0), OperatorPort(sink.operatorID, 0))
-      )
-    )
-    executeWorkflow(id, workflow)
-  }
+  // TODO: use mock data to perform the test, remove dependency on the real AsterixDB
+//  "Engine" should "execute asterixdb->sink workflow normally" in {
+//
+//    val asterixDBOp = TestOperators.asterixDBSourceOpDesc()
+//    val sink = TestOperators.sinkOpDesc()
+//    val (id, workflow) = buildWorkflow(
+//      mutable.MutableList[OperatorDescriptor](asterixDBOp, sink),
+//      mutable.MutableList[OperatorLink](
+//        OperatorLink(OperatorPort(asterixDBOp.operatorID, 0), OperatorPort(sink.operatorID, 0))
+//      )
+//    )
+//    executeWorkflow(id, workflow)
+//  }
 
   "Engine" should "execute mysql->sink workflow normally" in {
     val (host, port, database, table, username, password) = initializeInMemoryMySQLInstance()

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/TestOperators.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/TestOperators.scala
@@ -106,6 +106,7 @@ object TestOperators {
     inMemoryMySQLSourceOpDesc
   }
 
+  // TODO: use mock data to perform the test, remove dependency on the real AsterixDB
   def asterixDBSourceOpDesc(): AsterixDBSourceOpDesc = {
     val asterixDBOp = new AsterixDBSourceOpDesc()
     asterixDBOp.host = "ipubmed4.ics.uci.edu" // AsterixDB at version 0.9.5


### PR DESCRIPTION
The current way of doing the AsterixDB test has a dependency on the real AsterixDB instance. We should move to mock data instead. This PR disables such tests temporarily. 


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>