### PR TITLE
Python UDF debug logging optimize with loguru

### DIFF
--- a/core/amber/src/main/resources/python_udf/demo_non_map_udf.py
+++ b/core/amber/src/main/resources/python_udf/demo_non_map_udf.py
@@ -1,26 +1,26 @@
-from operators.texera_udf_operator_base import TexeraUDFOperator, log_exception
+from operators.texera_udf_operator_base import TexeraUDFOperator, exception
 
 
 class DemoOperator(TexeraUDFOperator):
-    @log_exception
+    @exception
     def __init__(self):
         super().__init__()
         self._result_tuples = []
 
-    @log_exception
+    @exception
     def accept(self, row, nth_child=0):
         self._result_tuples.append(row)  # must take args
         self._result_tuples.append(row)
 
-    @log_exception
+    @exception
     def has_next(self):
         return len(self._result_tuples) != 0
 
-    @log_exception
+    @exception
     def next(self):
         return self._result_tuples.pop()
 
-    @log_exception
+    @exception
     def close(self):
         pass
 

--- a/core/amber/src/main/resources/python_udf/demo_non_map_udf.py
+++ b/core/amber/src/main/resources/python_udf/demo_non_map_udf.py
@@ -1,26 +1,22 @@
-from operators.texera_udf_operator_base import TexeraUDFOperator, exception
+from operators.texera_udf_operator_base import TexeraUDFOperator
 
 
 class DemoOperator(TexeraUDFOperator):
-    @exception
+
     def __init__(self):
         super().__init__()
         self._result_tuples = []
 
-    @exception
     def accept(self, row, nth_child=0):
         self._result_tuples.append(row)  # must take args
         self._result_tuples.append(row)
 
-    @exception
     def has_next(self):
         return len(self._result_tuples) != 0
 
-    @exception
     def next(self):
         return self._result_tuples.pop()
 
-    @exception
     def close(self):
         pass
 

--- a/core/amber/src/main/resources/python_udf/nltk_sentiment_classify.py
+++ b/core/amber/src/main/resources/python_udf/nltk_sentiment_classify.py
@@ -3,24 +3,24 @@ import pickle
 import pandas
 
 from operators.texera_map_operator import TexeraMapOperator
-from operators.texera_udf_operator_base import log_exception
+from operators.texera_udf_operator_base import exception
 
 
 class NLTKSentimentOperator(TexeraMapOperator):
-    @log_exception
+    @exception
     def __init__(self):
         super(NLTKSentimentOperator, self).__init__(self.predict)
         self._model_file = None
         self._sentiment_model = None
 
-    @log_exception
+    @exception
     def open(self, *args):
         super(NLTKSentimentOperator, self).open(*args)
         model_file_path = args[2]
         self._model_file = open(model_file_path, 'rb')
         self._sentiment_model = pickle.load(self._model_file)
 
-    @log_exception
+    @exception
     def close(self):
         self._model_file.close()
 

--- a/core/amber/src/main/resources/python_udf/nltk_sentiment_classify.py
+++ b/core/amber/src/main/resources/python_udf/nltk_sentiment_classify.py
@@ -3,24 +3,20 @@ import pickle
 import pandas
 
 from operators.texera_map_operator import TexeraMapOperator
-from operators.texera_udf_operator_base import exception
 
 
 class NLTKSentimentOperator(TexeraMapOperator):
-    @exception
     def __init__(self):
         super(NLTKSentimentOperator, self).__init__(self.predict)
         self._model_file = None
         self._sentiment_model = None
 
-    @exception
     def open(self, *args):
         super(NLTKSentimentOperator, self).open(*args)
         model_file_path = args[2]
         self._model_file = open(model_file_path, 'rb')
         self._sentiment_model = pickle.load(self._model_file)
 
-    @exception
     def close(self):
         self._model_file.close()
 

--- a/core/amber/src/main/resources/python_udf/operators/texera_blocking_supervised_trainer_operator.py
+++ b/core/amber/src/main/resources/python_udf/operators/texera_blocking_supervised_trainer_operator.py
@@ -1,17 +1,13 @@
-import logging
 import pickle
 
 import pandas
 from sklearn.model_selection import train_test_split
 
-from operators.texera_udf_operator_base import TexeraUDFOperator, log_exception
-
-logger = logging.getLogger(__name__)
+from operators.texera_udf_operator_base import TexeraUDFOperator
 
 
 class TexeraBlockingSupervisedTrainerOperator(TexeraUDFOperator):
 
-    @log_exception
     def __init__(self):
         super().__init__()
         self._x = []
@@ -20,7 +16,6 @@ class TexeraBlockingSupervisedTrainerOperator(TexeraUDFOperator):
         self._train_args = dict()
         self._model_file_path = None
 
-    @log_exception
     def input_exhausted(self, *args, **kwargs):
         x_train, x_test, y_train, y_test = train_test_split(self._x, self._y, test_size=self._test_ratio, random_state=1)
         model = self.train(x_train, y_train, **self._train_args)
@@ -31,22 +26,18 @@ class TexeraBlockingSupervisedTrainerOperator(TexeraUDFOperator):
             y_pred = self.test(model, x_test, y_test)
             self.report(y_test, y_pred)
 
-    @log_exception
     def accept(self, row: pandas.Series, nth_child: int = 0) -> None:
         self._x.append(row[0])
         self._y.append(row[1])
 
     @staticmethod
-    @log_exception
     def train(x_train, y_train, *args, **kwargs):
         raise NotImplementedError
 
     @staticmethod
-    @log_exception
     def test(model, x_test, y_test, *args, **kwargs):
         pass
 
-    @log_exception
     def report(self, y_test, y_pred, *args, **kwargs):
         from sklearn.metrics import classification_report
         matrix = pandas.DataFrame(classification_report(y_test, y_pred, output_dict=True)).transpose()

--- a/core/amber/src/main/resources/python_udf/operators/texera_blocking_unsupervised_trainer_operator.py
+++ b/core/amber/src/main/resources/python_udf/operators/texera_blocking_unsupervised_trainer_operator.py
@@ -1,38 +1,28 @@
-import logging
-
 import pandas
 
-from operators.texera_udf_operator_base import TexeraUDFOperator, log_exception
-
-logger = logging.getLogger(__name__)
+from operators.texera_udf_operator_base import TexeraUDFOperator
 
 
 class TexeraBlockingUnsupervisedTrainerOperator(TexeraUDFOperator):
 
-    @log_exception
     def __init__(self):
         super().__init__()
         self._data = []
         self._train_args = dict()
 
-    @log_exception
     def accept(self, row: pandas.Series, nth_child: int = 0) -> None:
         self._data.append(row[0])
 
-    @log_exception
     def close(self) -> None:
         pass
 
     @staticmethod
-    @log_exception
     def train(data, *args, **kwargs):
         raise NotImplementedError
 
-    @log_exception
     def report(self, model) -> None:
         pass
 
-    @log_exception
     def input_exhausted(self, *args):
         model = self.train(self._data, **self._train_args)
         self.report(model)

--- a/core/amber/src/main/resources/python_udf/operators/texera_filter_operator.py
+++ b/core/amber/src/main/resources/python_udf/operators/texera_filter_operator.py
@@ -1,11 +1,8 @@
-import logging
 from typing import Callable
 
 import pandas
 
-from operators.texera_udf_operator_base import TexeraUDFOperator, log_exception
-
-logger = logging.getLogger(__name__)
+from operators.texera_udf_operator_base import TexeraUDFOperator
 
 
 class TexeraFilterOperator(TexeraUDFOperator):
@@ -17,14 +14,12 @@ class TexeraFilterOperator(TexeraUDFOperator):
     inherited class; If only use filter function, simply define a `filter_function` in the script.
     """
 
-    @log_exception
     def __init__(self, filter_function: Callable):
         super().__init__()
         if filter_function is None:
             raise NotImplementedError
         self._filter_function: Callable = filter_function
 
-    @log_exception
     def accept(self, row: pandas.Series, nth_child: int = 0) -> None:
         if self._filter_function(row, *self._args):
             self._result_tuples.append(row)

--- a/core/amber/src/main/resources/python_udf/operators/texera_map_operator.py
+++ b/core/amber/src/main/resources/python_udf/operators/texera_map_operator.py
@@ -1,11 +1,8 @@
-import logging
 from typing import Callable
 
 import pandas
 
-from operators.texera_udf_operator_base import TexeraUDFOperator, log_exception
-
-logger = logging.getLogger(__name__)
+from operators.texera_udf_operator_base import TexeraUDFOperator
 
 
 class TexeraMapOperator(TexeraUDFOperator):
@@ -17,13 +14,11 @@ class TexeraMapOperator(TexeraUDFOperator):
     `map_function` in the script.
     """
 
-    @log_exception
     def __init__(self, map_function: Callable):
         super().__init__()
         if map_function is None:
             raise NotImplementedError
         self._map_function: Callable = map_function
 
-    @log_exception
     def accept(self, row: pandas.Series, nth_child: int = 0) -> None:
         self._result_tuples.append(self._map_function(row, *self._args))  # must take args

--- a/core/amber/src/main/resources/python_udf/operators/texera_udf_operator_base.py
+++ b/core/amber/src/main/resources/python_udf/operators/texera_udf_operator_base.py
@@ -1,44 +1,10 @@
-import functools
 import logging
 from typing import Dict, Optional, Tuple, List
 
 import pandas
 
 
-class log_exception:
-    """
-    a decorator to log the exception and re-raise the exception.
-
-    """
-
-    def __init__(self, fn):
-        functools.update_wrapper(self, fn)
-        self.fn = fn
-
-    def __set_name__(self, owner, name):
-        """
-        to set class name to the given method
-        :param owner:
-        :param name:
-        :return:
-        """
-        # bind class name to the method
-        self.fn.__class_name = owner.__name__
-
-        # then overwrite the original method
-        setattr(owner, name, self.fn)
-
-    def __call__(self, *args, **kwargs):
-        try:
-            return self.fn(*args, **kwargs)
-        except Exception:
-            err = "exception in " + self.fn.__name__ + "\n"
-            err += "-------------------------------------------------------------------------\n"
-            self.fn.__class_name.__logger.exception(err)
-            raise
-
-
-class ClassLoggerMetal(type):
+class ClassLoggerMeta(type):
     def __init__(cls, *args):
         super().__init__(*args)
 
@@ -48,20 +14,18 @@ class ClassLoggerMetal(type):
         setattr(cls, logger_attribute_name, logging.getLogger(cls.__name__))
 
 
-class TexeraUDFOperator(metaclass=ClassLoggerMetal):
+class TexeraUDFOperator(metaclass=ClassLoggerMeta):
     """
     Base class for row-oriented one-table input, one-table output user-defined operators. This must be implemented
     before using.
     """
     __logger = None
 
-    @log_exception
     def __init__(self):
         self._args: Tuple = tuple()
         self._kwargs: Optional[Dict] = None
         self._result_tuples: List = []
 
-    @log_exception
     def open(self, *args) -> None:
         """
         Specify here what the UDF should do before executing on tuples. For example, you may want to open a model file
@@ -73,7 +37,6 @@ class TexeraUDFOperator(metaclass=ClassLoggerMetal):
         """
         self._args = args
 
-    @log_exception
     def accept(self, row: pandas.Series, nth_child: int = 0) -> None:
         """
         This is what the UDF operator should do for every row. Do not return anything here, just accept it. The result
@@ -84,28 +47,24 @@ class TexeraUDFOperator(metaclass=ClassLoggerMetal):
         """
         pass
 
-    @log_exception
     def has_next(self) -> bool:
         """
         Return a boolean value that indicates whether there will be a next result.
         """
         return bool(self._result_tuples)
 
-    @log_exception
     def next(self) -> pandas.Series:
         """
         Get the next result row. This will be called after accept(), so result should be prepared.
         """
         return self._result_tuples.pop(0)
 
-    @log_exception
     def close(self) -> None:
         """
         Close this operator, releasing any resources. For example, you might want to close a model file.
         """
         pass
 
-    @log_exception
     def input_exhausted(self, *args, **kwargs):
         """
         Executes when the input is exhausted, useful for some blocking execution like training.

--- a/core/amber/src/main/resources/python_udf/operators/texera_udf_operator_base.py
+++ b/core/amber/src/main/resources/python_udf/operators/texera_udf_operator_base.py
@@ -1,25 +1,14 @@
-import logging
+from abc import ABC
 from typing import Dict, Optional, Tuple, List
 
 import pandas
 
 
-class ClassLoggerMeta(type):
-    def __init__(cls, *args):
-        super().__init__(*args)
-
-        # Explicit name mangling
-        logger_attribute_name = '_' + cls.__name__ + '__logger'
-
-        setattr(cls, logger_attribute_name, logging.getLogger(cls.__name__))
-
-
-class TexeraUDFOperator(metaclass=ClassLoggerMeta):
+class TexeraUDFOperator(ABC):
     """
     Base class for row-oriented one-table input, one-table output user-defined operators. This must be implemented
     before using.
     """
-    __logger = None
 
     def __init__(self):
         self._args: Tuple = tuple()

--- a/core/amber/src/main/resources/python_udf/server/udf_server.py
+++ b/core/amber/src/main/resources/python_udf/server/udf_server.py
@@ -98,7 +98,7 @@ class UDFServer(FlightServerBase):
         """
         logger.debug(f"Flight Server on Action {action.type}")
         if action.type == "health_check":
-            # do nothing, do a heart beat
+            # do nothing but a heart beat
             pass
         elif action.type == "open":
             self._udf_open()

--- a/core/amber/src/main/resources/python_udf/server/udf_server.py
+++ b/core/amber/src/main/resources/python_udf/server/udf_server.py
@@ -1,16 +1,12 @@
 import ast
 import json
-import os
 import threading
-from datetime import datetime
 from typing import Dict
 
 import pandas
 import pyarrow
 from loguru import logger
 from pyarrow.flight import FlightDescriptor, Action, FlightServerBase, Result, FlightInfo, Location, FlightEndpoint, RecordBatchStream
-
-logger.add(f"texera-python_udf-{datetime.utcnow().isoformat()}-{os.getpid()}.log", rotation="500 MB")
 
 
 class UDFServer(FlightServerBase):
@@ -180,7 +176,7 @@ class UDFServer(FlightServerBase):
         # TODO: add server related configurations here
         pass
 
-    @logger.catch(reraise=False, default=json.dumps({'status': 'Fail'}))
+    @logger.catch(default=json.dumps({'status': 'Fail'}))
     def compute(self):
 
         # execute UDF

--- a/core/amber/src/main/resources/python_udf/server/udf_server.py
+++ b/core/amber/src/main/resources/python_udf/server/udf_server.py
@@ -123,7 +123,15 @@ class UDFServer(FlightServerBase):
         yield self._response('success')
 
     def _delayed_shutdown(self):
-        """Shut down after a delay."""
+        """
+        Shut down after a delay.
+
+        This is used to allow client to send a terminate command to server. The server would
+        start a shutdown thread, with a short delay, during which allows the client to close the connection.
+
+        The short delay is set to be 100 ms, though it does not matter since it is on another thread.
+
+        """
         sleep(0.1)
         logger.debug("Bye bye!")
         self.shutdown()

--- a/core/amber/src/main/resources/python_udf/server/udf_server.py
+++ b/core/amber/src/main/resources/python_udf/server/udf_server.py
@@ -124,8 +124,8 @@ class UDFServer(FlightServerBase):
 
     def _delayed_shutdown(self):
         """Shut down after a delay."""
-        logger.debug("Bye bye!")
         sleep(0.1)
+        logger.debug("Bye bye!")
         self.shutdown()
         self.wait()
 

--- a/core/amber/src/main/resources/python_udf/server/udf_server.py
+++ b/core/amber/src/main/resources/python_udf/server/udf_server.py
@@ -1,5 +1,6 @@
 import ast
 import threading
+from time import sleep
 from typing import Dict
 
 import pandas
@@ -124,6 +125,7 @@ class UDFServer(FlightServerBase):
     def _delayed_shutdown(self):
         """Shut down after a delay."""
         logger.debug("Bye bye!")
+        sleep(0.1)
         self.shutdown()
         self.wait()
 

--- a/core/amber/src/main/resources/python_udf/svm_classifier.py
+++ b/core/amber/src/main/resources/python_udf/svm_classifier.py
@@ -4,19 +4,16 @@ import pandas
 
 from mock_data import df_from_mysql
 from operators.texera_map_operator import TexeraMapOperator
-from operators.texera_udf_operator_base import exception
 
 
 class SVMClassifier(TexeraMapOperator):
 
-    @exception
     def __init__(self):
         super(SVMClassifier, self).__init__(self.predict)
         self._model_file_path = None
         self._vc = None
         self._clf = None
 
-    @exception
     def open(self, *args):
         super(SVMClassifier, self).open(*args)
         self._model_file_path = args[-1]

--- a/core/amber/src/main/resources/python_udf/svm_classifier.py
+++ b/core/amber/src/main/resources/python_udf/svm_classifier.py
@@ -4,19 +4,19 @@ import pandas
 
 from mock_data import df_from_mysql
 from operators.texera_map_operator import TexeraMapOperator
-from operators.texera_udf_operator_base import log_exception
+from operators.texera_udf_operator_base import exception
 
 
 class SVMClassifier(TexeraMapOperator):
 
-    @log_exception
+    @exception
     def __init__(self):
         super(SVMClassifier, self).__init__(self.predict)
         self._model_file_path = None
         self._vc = None
         self._clf = None
 
-    @log_exception
+    @exception
     def open(self, *args):
         super(SVMClassifier, self).open(*args)
         self._model_file_path = args[-1]

--- a/core/amber/src/main/resources/python_udf/svm_trainer.py
+++ b/core/amber/src/main/resources/python_udf/svm_trainer.py
@@ -5,11 +5,10 @@ from sklearn.svm import SVC
 
 from mock_data import df_from_mysql
 from operators.texera_blocking_supervised_trainer_operator import TexeraBlockingSupervisedTrainerOperator
-from operators.texera_udf_operator_base import exception
 
 
 class SVMTrainer(TexeraBlockingSupervisedTrainerOperator):
-    @exception
+
     def open(self, *args):
         super(SVMTrainer, self).open(*args)
         self._test_ratio = float(args[2])
@@ -19,7 +18,6 @@ class SVMTrainer(TexeraBlockingSupervisedTrainerOperator):
         self._model_file_path = args[-1]
 
     @staticmethod
-    @exception
     def train(x_train, y_train, *args, **kwargs):
         vectorizer = CountVectorizer()
 
@@ -40,7 +38,6 @@ class SVMTrainer(TexeraBlockingSupervisedTrainerOperator):
         return vectorizer, clf
 
     @staticmethod
-    @exception
     def test(model, x_test, y_test, *args, **kwargs):
         vc, clf = model
         return clf.predict(vc.transform(x_test))

--- a/core/amber/src/main/resources/python_udf/svm_trainer.py
+++ b/core/amber/src/main/resources/python_udf/svm_trainer.py
@@ -5,11 +5,11 @@ from sklearn.svm import SVC
 
 from mock_data import df_from_mysql
 from operators.texera_blocking_supervised_trainer_operator import TexeraBlockingSupervisedTrainerOperator
-from operators.texera_udf_operator_base import log_exception
+from operators.texera_udf_operator_base import exception
 
 
 class SVMTrainer(TexeraBlockingSupervisedTrainerOperator):
-    @log_exception
+    @exception
     def open(self, *args):
         super(SVMTrainer, self).open(*args)
         self._test_ratio = float(args[2])
@@ -19,7 +19,7 @@ class SVMTrainer(TexeraBlockingSupervisedTrainerOperator):
         self._model_file_path = args[-1]
 
     @staticmethod
-    @log_exception
+    @exception
     def train(x_train, y_train, *args, **kwargs):
         vectorizer = CountVectorizer()
 
@@ -40,7 +40,7 @@ class SVMTrainer(TexeraBlockingSupervisedTrainerOperator):
         return vectorizer, clf
 
     @staticmethod
-    @log_exception
+    @exception
     def test(model, x_test, y_test, *args, **kwargs):
         vc, clf = model
         return clf.predict(vc.transform(x_test))

--- a/core/amber/src/main/resources/python_udf/texera_udf_main.py
+++ b/core/amber/src/main/resources/python_udf/texera_udf_main.py
@@ -105,6 +105,6 @@ if __name__ == '__main__':
 
     location = "grpc+tcp://localhost:" + port
 
-    # rediect user's print into logger
+    # redirect user's print into logger
     with contextlib.redirect_stdout(StreamToLogger()):
         UDFServer(final_UDF, "localhost", location).serve()

--- a/core/amber/src/main/resources/python_udf/texera_udf_main.py
+++ b/core/amber/src/main/resources/python_udf/texera_udf_main.py
@@ -5,6 +5,8 @@ import sys
 from datetime import datetime
 from pathlib import Path
 
+from loguru import logger
+
 from operators.texera_filter_operator import TexeraFilterOperator
 from operators.texera_map_operator import TexeraMapOperator
 from server.udf_server import UDFServer
@@ -26,14 +28,11 @@ def init_root_logger(log_input_level: str,
     :return:
     """
 
-    logger = logging.getLogger()
-    logger.setLevel(log_input_level)
-
     # set up stream handler, which outputs to stdout and stderr
     stream_handler = logging.StreamHandler()
     stream_handler.setLevel(stream_log_level)
-    stream_handler.setFormatter(logging.Formatter(stream_log_fmt, datefmt=stream_datefmt))
-    logger.addHandler(stream_handler)
+    # stream_handler.setFormatter(logging.Formatter(stream_log_fmt, datefmt=stream_datefmt))
+    logger.add(stream_handler)
 
     # set up file handler, which outputs log file
     file_name = f"texera-python_udf-{datetime.utcnow().isoformat()}-{os.getpid()}.log"
@@ -41,9 +40,9 @@ def init_root_logger(log_input_level: str,
     file_handler = logging.FileHandler(file_path)
 
     file_handler.setLevel(file_log_level)
-    file_handler.setFormatter(logging.Formatter(file_log_fmt, datefmt=file_datefmt))
+    # file_handler.setFormatter(logging.Formatter(file_log_fmt, datefmt=file_datefmt))
     logger.info(f"Attaching a FileHandler to logger, file path: {file_path}")
-    logger.addHandler(file_handler)
+    logger.add(file_handler)
     logger.info(f"Logger FileHandler is now attached, previous logs are in StreamHandler only.")
 
 

--- a/core/amber/src/main/resources/python_udf/texera_udf_main.py
+++ b/core/amber/src/main/resources/python_udf/texera_udf_main.py
@@ -45,6 +45,24 @@ def init_root_logger(log_input_level: str,
     logger.add(file_handler)
     logger.info(f"Logger FileHandler is now attached, previous logs are in StreamHandler only.")
 
+    class InterceptHandler(logging.Handler):
+        def emit(self, record):
+            # Get corresponding Loguru level if it exists
+            try:
+                level = logger.level(record.levelname).name
+            except ValueError:
+                level = record.levelno
+
+            # Find caller from where originated the logged message
+            frame, depth = logging.currentframe(), 2
+            while frame.f_code.co_filename == logging.__file__:
+                frame = frame.f_back
+                depth += 1
+
+            logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
+
+    logging.basicConfig(handlers=[InterceptHandler()], level=0)
+
 
 if __name__ == '__main__':
 

--- a/core/amber/src/main/resources/python_udf/texera_udf_main.py
+++ b/core/amber/src/main/resources/python_udf/texera_udf_main.py
@@ -105,5 +105,6 @@ if __name__ == '__main__':
 
     location = "grpc+tcp://localhost:" + port
 
+    # rediect user's print into logger
     with contextlib.redirect_stdout(StreamToLogger()):
         UDFServer(final_UDF, "localhost", location).serve()

--- a/core/amber/src/main/resources/python_udf/tobacco_relevancy_classify.py
+++ b/core/amber/src/main/resources/python_udf/tobacco_relevancy_classify.py
@@ -6,7 +6,7 @@ from nltk.corpus import stopwords
 from nltk.tokenize import word_tokenize
 
 from operators.texera_map_operator import TexeraMapOperator
-from operators.texera_udf_operator_base import log_exception
+from operators.texera_udf_operator_base import exception
 
 
 def lower_case(text):
@@ -55,14 +55,14 @@ class TobaccoClassifier(object):
 class TobaccoRelevancyOperator(TexeraMapOperator):
     logger = logging.getLogger("PythonUDF.TobaccoRelevancyOperator")
 
-    @log_exception
+    @exception
     def __init__(self):
         super(TobaccoRelevancyOperator, self).__init__(self.predict)
         self._cv_model_path = None
         self._classifier_model_path = None
         self._classifier = None
 
-    @log_exception
+    @exception
     def open(self, *args):
         super(TobaccoRelevancyOperator, self).open(*args)
         self._cv_model_path = args[2]

--- a/core/amber/src/main/resources/python_udf/tobacco_relevancy_classify.py
+++ b/core/amber/src/main/resources/python_udf/tobacco_relevancy_classify.py
@@ -1,4 +1,3 @@
-import logging
 import pickle
 
 import pandas
@@ -6,7 +5,6 @@ from nltk.corpus import stopwords
 from nltk.tokenize import word_tokenize
 
 from operators.texera_map_operator import TexeraMapOperator
-from operators.texera_udf_operator_base import exception
 
 
 def lower_case(text):
@@ -53,16 +51,13 @@ class TobaccoClassifier(object):
 
 
 class TobaccoRelevancyOperator(TexeraMapOperator):
-    logger = logging.getLogger("PythonUDF.TobaccoRelevancyOperator")
 
-    @exception
     def __init__(self):
         super(TobaccoRelevancyOperator, self).__init__(self.predict)
         self._cv_model_path = None
         self._classifier_model_path = None
         self._classifier = None
 
-    @exception
     def open(self, *args):
         super(TobaccoRelevancyOperator, self).open(*args)
         self._cv_model_path = args[2]

--- a/core/amber/src/main/resources/python_udf/topic_modeling_mallet_trainer.py
+++ b/core/amber/src/main/resources/python_udf/topic_modeling_mallet_trainer.py
@@ -1,21 +1,20 @@
 import logging
+import os
 
 # Use gensim 3.8.3
 import gensim
 import gensim.corpora as corpora
 import pandas
-import os
+from loguru import logger
 
 from operators.texera_blocking_unsupervised_trainer_operator import TexeraBlockingUnsupervisedTrainerOperator
-from operators.texera_udf_operator_base import log_exception
 
 # to change library's logger setting
 logging.getLogger("gensim").setLevel(logging.ERROR)
 
-class TopicModeling(TexeraBlockingUnsupervisedTrainerOperator):
-    logger = logging.getLogger("PythonUDF.TopicModelingMalletTrainer")
 
-    @log_exception
+class TopicModeling(TexeraBlockingUnsupervisedTrainerOperator):
+
     def open(self, *args):
         super(TopicModeling, self).open(*args)
 
@@ -26,26 +25,24 @@ class TopicModeling(TexeraBlockingUnsupervisedTrainerOperator):
         else:
             raise RuntimeError("Not enough arguments in topic modeling mallet operator")
 
-        MALLET_PATH = os.path.join(MALLET_HOME,"bin","mallet")
+        MALLET_PATH = os.path.join(MALLET_HOME, "bin", "mallet")
         # We need to fix a seed value so that the output of LDA is deterministic i.e. same output every time.
         # The below value is just an arbitrarily chosen value.
         RANDOM_SEED = 41
         os.environ['MALLET_HOME'] = MALLET_HOME
 
-        self._train_args = {"mallet_path":MALLET_PATH, "random_seed":RANDOM_SEED, "num_topics":NUM_TOPICS}
+        self._train_args = {"mallet_path": MALLET_PATH, "random_seed": RANDOM_SEED, "num_topics": NUM_TOPICS}
 
-        self.logger.debug(f"getting args {args}")
-        self.logger.debug(f"parsed training args {self._train_args}")
+        logger.debug(f"getting args {args}")
+        logger.debug(f"parsed training args {self._train_args}")
 
-    @log_exception
     def accept(self, row: pandas.Series, nth_child: int = 0) -> None:
         # override accept to accept rows as lists
         self._data.append(row[0].strip().split())
 
     @staticmethod
-    @log_exception
     def train(data, mallet_path: str, random_seed: int, num_topics: int, *args, **kwargs):
-        TopicModeling.logger.debug(f"start training, args:{args}, kwargs:{kwargs}")
+        logger.debug(f"start training, args:{args}, kwargs:{kwargs}")
 
         # Create Dictionary
         id2word = corpora.Dictionary(data)
@@ -56,18 +53,22 @@ class TopicModeling(TexeraBlockingUnsupervisedTrainerOperator):
         # Term Document Frequency
         corpus = [id2word.doc2bow(text1) for text1 in texts]
 
-        lda_mallet_model = gensim.models.wrappers.LdaMallet(mallet_path, corpus=corpus, num_topics=num_topics, id2word=id2word, random_seed = random_seed)
+        lda_mallet_model = gensim.models.wrappers.LdaMallet(mallet_path,
+                                                            corpus=corpus,
+                                                            num_topics=num_topics,
+                                                            id2word=id2word,
+                                                            random_seed=random_seed)
 
         return lda_mallet_model
 
-    @log_exception
     def report(self, model):
-        self.logger.debug(f"reporting trained results")
+        logger.debug(f"reporting trained results")
         for id, topic in model.print_topics(num_topics=self._train_args["num_topics"]):
             self._result_tuples.append(pandas.Series({"output": topic}))
 
 
 operator_instance = TopicModeling()
+
 if __name__ == '__main__':
     """
     The following lines can be put in the file and name it tokenized.txt:

--- a/core/amber/src/main/resources/python_udf/topic_modeling_trainer.py
+++ b/core/amber/src/main/resources/python_udf/topic_modeling_trainer.py
@@ -3,9 +3,11 @@ import logging
 import gensim
 import gensim.corpora as corpora
 import pandas
+from loguru import logger
 
 from operators.texera_blocking_unsupervised_trainer_operator import TexeraBlockingUnsupervisedTrainerOperator
 
+# to change library's logger setting
 logging.getLogger("gensim").setLevel(logging.ERROR)
 
 
@@ -20,8 +22,8 @@ class TopicModelingTrainer(TexeraBlockingUnsupervisedTrainerOperator):
         else:
             raise RuntimeError("Not enough arguments in topic modeling operator.")
 
-        self.__logger.debug(f"getting args {args}")
-        self.__logger.debug(f"parsed training args {self._train_args}")
+        logger.debug(f"getting args {args}")
+        logger.debug(f"parsed training args {self._train_args}")
 
     def accept(self, row: pandas.Series, nth_child: int = 0) -> None:
         # override accept to accept rows as lists
@@ -29,7 +31,7 @@ class TopicModelingTrainer(TexeraBlockingUnsupervisedTrainerOperator):
 
     @staticmethod
     def train(data, *args, **kwargs):
-        TopicModelingTrainer.__logger.debug(f"start training, args:{args}, kwargs:{kwargs}")
+        logger.debug(f"start training, args:{args}, kwargs:{kwargs}")
 
         # Create Dictionary
         id2word = corpora.Dictionary(data)
@@ -53,7 +55,7 @@ class TopicModelingTrainer(TexeraBlockingUnsupervisedTrainerOperator):
         return lda_model
 
     def report(self, model):
-        self.__logger.debug(f"reporting trained results")
+        logger.debug(f"reporting trained results")
         for id, topic in model.print_topics(num_topics=self._train_args["num_topics"]):
             self._result_tuples.append(pandas.Series({"output": topic}))
 

--- a/core/amber/src/main/resources/python_udf/topic_modeling_trainer.py
+++ b/core/amber/src/main/resources/python_udf/topic_modeling_trainer.py
@@ -1,14 +1,16 @@
+import logging
+
 import gensim
 import gensim.corpora as corpora
 import pandas
 
 from operators.texera_blocking_unsupervised_trainer_operator import TexeraBlockingUnsupervisedTrainerOperator
-from operators.texera_udf_operator_base import log_exception
+
+logging.getLogger("gensim").setLevel(logging.ERROR)
 
 
 class TopicModelingTrainer(TexeraBlockingUnsupervisedTrainerOperator):
 
-    @log_exception
     def open(self, *args):
         super(TopicModelingTrainer, self).open(*args)
 
@@ -21,13 +23,11 @@ class TopicModelingTrainer(TexeraBlockingUnsupervisedTrainerOperator):
         self.__logger.debug(f"getting args {args}")
         self.__logger.debug(f"parsed training args {self._train_args}")
 
-    @log_exception
     def accept(self, row: pandas.Series, nth_child: int = 0) -> None:
         # override accept to accept rows as lists
         self._data.append(row[0].strip().split())
 
     @staticmethod
-    @log_exception
     def train(data, *args, **kwargs):
         TopicModelingTrainer.__logger.debug(f"start training, args:{args}, kwargs:{kwargs}")
 
@@ -52,7 +52,6 @@ class TopicModelingTrainer(TexeraBlockingUnsupervisedTrainerOperator):
 
         return lda_model
 
-    @log_exception
     def report(self, model):
         self.__logger.debug(f"reporting trained results")
         for id, topic in model.print_topics(num_topics=self._train_args["num_topics"]):

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpDesc.java
@@ -97,8 +97,8 @@ public class PythonUDFOpDesc extends OperatorDescriptor {
 
         // check if inputColumns are presented in inputSchema.
         if (inputColumns != null) {
-            for (String s : inputColumns) {
-                if (!inputSchema.containsAttribute(s)) throw new RuntimeException("No such column:" + s + ".");
+            for (String column : inputColumns) {
+                if (!inputSchema.containsAttribute(column)) throw new RuntimeException("No such column:" + column + ".");
             }
         }
 
@@ -118,8 +118,8 @@ public class PythonUDFOpDesc extends OperatorDescriptor {
 
         // for any pythonUDFType, it can add custom output columns (attributes).
         if (outputColumns != null) {
-            for (Attribute a : outputColumns) {
-                if (inputSchema.containsAttribute(a.getName())) throw new RuntimeException("Column name " + a.getName()
+            for (Attribute column : outputColumns) {
+                if (inputSchema.containsAttribute(column.getName())) throw new RuntimeException("Column name " + column.getName()
                         + " already exists!");
             }
             outputSchemaBuilder.add(outputColumns).build();

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
@@ -400,7 +400,7 @@ public class PythonUDFOpExec implements OperatorExecutor {
 
             try {
                 flightClient = FlightClient.builder(memoryAllocator, flightServerURI).build();
-                connected = new String(communicate(flightClient, MSG.HEALTH_CHECK), StandardCharsets.UTF_8).equals("Flight Server is up and running!");
+                connected = new String(communicate(flightClient, MSG.HEALTH_CHECK), StandardCharsets.UTF_8).equals("success");
                 if (!connected) Thread.sleep(WAIT_TIME_MS);
             } catch (FlightRuntimeException e) {
                 System.out.println("Flight Client:\tNot connected to the server in this try.");

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
@@ -579,35 +579,28 @@ public class PythonUDFOpExec implements OperatorExecutor {
 
         Config config = WebUtils.config();
         String pythonPath = config.getString("python.path").trim();
-        String logInputLevel = config.getString("python.log.level").trim();
 
         String logStreamHandlerLevel = config.getString("python.log.streamHandler.level").trim();
         String logStreamHandlerFormat = config.getString("python.log.streamHandler.format").trim();
-        String logStreamHandlerDateFormat = config.getString("python.log.streamHandler.datefmt").trim();
 
         String logFileHandlerDir = config.getString("python.log.fileHandler.dir").trim();
         String logFileHandlerLevel = config.getString("python.log.fileHandler.level").trim();
         String logFileHandlerFormat = config.getString("python.log.fileHandler.format").trim();
-        String logFileHandlerDateFormat = config.getString("python.log.fileHandler.datefmt").trim();
 
         pythonServerProcess =
                 new ProcessBuilder(pythonPath.isEmpty() ? "python3" : pythonPath, // add fall back in case of empty
                         "-u",
                         udfMainScriptPath,
                         Integer.toString(portNumber),
-                        logInputLevel.isEmpty() ? "INFO" : logInputLevel,
 
                         logStreamHandlerLevel.isEmpty() ? "INFO" : logStreamHandlerLevel,
-                        logStreamHandlerFormat.isEmpty() ? "[%(asctime)s.%(msecs)03d] %(processName)s %(threadName)s " +
-                                "%(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s" : logStreamHandlerFormat,
-                        logStreamHandlerDateFormat.isEmpty() ? "%m-%d-%Y %H:%M:%S" : logStreamHandlerDateFormat,
+                        logStreamHandlerFormat.isEmpty() ? "{time} {level} {message}" : logStreamHandlerFormat,
 
                         logFileHandlerDir.isEmpty() ? "/tmp/" : logFileHandlerDir,
                         logFileHandlerLevel.isEmpty() ? "INFO" : logFileHandlerLevel,
-                        logFileHandlerFormat.isEmpty() ? "[%(asctime)s.%(msecs)03d] %(processName)s %(threadName)s " +
-                                "%(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s" : logFileHandlerFormat,
-                        logFileHandlerDateFormat.isEmpty() ? "%m-%d-%Y %H:%M:%S" : logFileHandlerDateFormat,
+                        logFileHandlerFormat.isEmpty() ? "{time} {level} {message}" : logFileHandlerFormat,
                         pythonScriptPath)
+                        .inheritIO()
                         .start();
         return location;
     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
@@ -131,10 +131,10 @@ public class PythonUDFOpExec implements OperatorExecutor {
         try {
             FlightResponseMap result = PythonUDFOpExec.objectMapper.readValue(communicate(client, MSG.COMPUTE),
                     FlightResponseMap.class);
-            if (result.get("status").equals("Fail")) {
-                String errorMessage = result.get("errorMessage");
-                throw new Exception(errorMessage);
-            }
+//            if (result.get("status").equals("Fail")) {
+//                String errorMessage = result.get("errorMessage");
+//                throw new Exception(errorMessage);
+//            }
         } catch (Exception e) {
             closeAndThrow(client, e);
         }
@@ -329,6 +329,7 @@ public class PythonUDFOpExec implements OperatorExecutor {
                 root.clear();
             }
         } catch (RuntimeException e) {
+            System.out.println("NO SUCH FLIGHT!!");
             closeAndThrow(client, e);
         }
     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/pythonUDF/PythonUDFOpExec.java
@@ -594,11 +594,15 @@ public class PythonUDFOpExec implements OperatorExecutor {
                         Integer.toString(portNumber),
 
                         logStreamHandlerLevel.isEmpty() ? "INFO" : logStreamHandlerLevel,
-                        logStreamHandlerFormat.isEmpty() ? "{time} {level} {message}" : logStreamHandlerFormat,
+                        logStreamHandlerFormat.isEmpty() ? "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | " +
+                                "<level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - " +
+                                "<level>{message}</level>" : logStreamHandlerFormat,
 
                         logFileHandlerDir.isEmpty() ? "/tmp/" : logFileHandlerDir,
                         logFileHandlerLevel.isEmpty() ? "INFO" : logFileHandlerLevel,
-                        logFileHandlerFormat.isEmpty() ? "{time} {level} {message}" : logFileHandlerFormat,
+                        logFileHandlerFormat.isEmpty() ? "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | " +
+                                "<level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - " +
+                                "<level>{message}</level>" : logFileHandlerFormat,
                         pythonScriptPath)
                         .inheritIO()
                         .start();

--- a/core/conf/web.conf
+++ b/core/conf/web.conf
@@ -13,27 +13,20 @@
 	    "path": ""
 
 	    "log": {
-	        # logger input level
-	        "level": "DEBUG",
-
 	        "streamHandler": {
 	            # handler output level
-                "level": "ERROR",
+                "level": "DEBUG",
 	            # handler log format
-                "format": "[%(asctime)s.%(msecs)03d] %(processName)s %(threadName)s %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
-                # date format
-                "datefmt": "%m-%d-%Y %H:%M:%S"
+                "format": "{time} {level} {message}"
 	        },
 
 	        "fileHandler": {
 	            # log diretory
                 "dir": "/tmp/",
                 # handler output level
-                "level": "INFO",
+                "level": "DEBUG",
                 # handler log format
-                "format": "[%(asctime)s.%(msecs)03d] %(processName)s %(threadName)s %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s",
-                # date format
-                "datefmt": "%m-%d-%Y %H:%M:%S"
+                "format": "{time} {level} {message}"
 	        }
 	    }
 	}

--- a/core/conf/web.conf
+++ b/core/conf/web.conf
@@ -17,7 +17,7 @@
 	            # handler output level
                 "level": "DEBUG",
 	            # handler log format
-                "format": "{time} {level} {message}"
+                "format": "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>"
 	        },
 
 	        "fileHandler": {
@@ -26,7 +26,7 @@
                 # handler output level
                 "level": "DEBUG",
                 # handler log format
-                "format": "{time} {level} {message}"
+                "format": "<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | <level>{level: <8}</level> | <cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> - <level>{message}</level>"
 	        }
 	    }
 	}


### PR DESCRIPTION
The previous implementation has some limitation due to design choices:
1. udf APIs are assumed to be implemented correctly.
2. pyarrow does not report the correct error to the java client.
3. io (stderr/stdout) is being inherited by java's io, thus not possible to be injected.
4. custom logger on different levels does not work on all python versions (due to standard logging updates).

In this PR, the following changes are being applied:
1. use a singleton logger by [loguru](https://github.com/Delgan/loguru) library, instead of using different loggers on different levels. This is to support all different python versions from 3.6 above.
2. replaced `@log_exception` with loguru's `@logger.catch` to all UDF APIs, now handles errors during open, input_exhausted, accept, close. 
3. errors are being logged on the python end and re-raised to be handled by the `pyarrow` server. It will report exceptions to the java client and we can report it to the frontend.
4. injected python standard logging with loguru as well. so users can use custom loggers in their code.
5. `print()` function is redirected from stdout to logger as INFO level.


<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>