### PR TITLE
Fix union operator doesn't allow multiple inputs in frontend

### DIFF
--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -895,7 +895,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
     if (this.workflowActionService.getTexeraGraph().hasOperator(targetCellID)) {
       const portIndex = this.workflowActionService.getTexeraGraph().getOperator(targetCellID)
         .inputPorts.findIndex(p => p.portID === targetPortID);
-      if (portIndex > 0) {
+      if (portIndex >= 0) {
         const portInfo = this.dynamicSchemaService.getDynamicSchema(targetCellID).additionalMetadata.inputPorts[portIndex];
         allowMultiInput = portInfo.allowMultiInputs ?? false;
       }


### PR DESCRIPTION
This PR fixes #1104 a frontend bug that doesn't allow multiple inputs to be connected to the union operator.