### PR TITLE
Progressive Result Display 

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
@@ -9,6 +9,7 @@ object WebOperatorStatistics {
   def apply(
       operatorID: String,
       operatorStatistics: OperatorStatistics,
+      dirtyPageIndices: Map[String, List[Int]],
       workflowCompiler: WorkflowCompiler
   ): WebOperatorStatistics = {
     val chartType = OperatorResult.getChartType(operatorID, workflowCompiler)
@@ -16,13 +17,19 @@ object WebOperatorStatistics {
       // if chartType is null (normal sink), don't send results as well
       .flatMap(r => chartType.map(_ => r))
       // convert tuple format
-      .map(r => OperatorResult.fromTuple(operatorID, r, chartType, r.size))
+      .map(r =>
+        chartType match {
+          case Some(_) => OperatorResult.fromTuple(operatorID, r, chartType, r.size)
+          case None    => OperatorResult.fromTuple(operatorID, List.empty, chartType, r.size)
+        }
+      )
 
     WebOperatorStatistics(
       operatorStatistics.operatorState,
       operatorStatistics.aggregatedInputRowCount,
       operatorStatistics.aggregatedOutputRowCount,
-      results
+      results,
+      dirtyPageIndices.get(operatorID)
     )
   }
 
@@ -32,17 +39,19 @@ case class WebOperatorStatistics(
     operatorState: OperatorState,
     aggregatedInputRowCount: Long,
     aggregatedOutputRowCount: Long,
-    aggregatedOutputResults: Option[OperatorResult] // in case of a sink operator
+    aggregatedOutputResults: Option[OperatorResult], // in case of a sink operator
+    aggregatedOutputResultDirtyPageIndices: Option[List[Int]]
 )
 
 object WebWorkflowStatusUpdateEvent {
   def apply(
       update: WorkflowStatusUpdate,
+      sinkOpDirtyPageIndices: Map[String, List[Int]],
       workflowCompiler: WorkflowCompiler
   ): WebWorkflowStatusUpdateEvent = {
     WebWorkflowStatusUpdateEvent(
       update.operatorStatistics.map(e =>
-        (e._1, WebOperatorStatistics.apply(e._1, e._2, workflowCompiler))
+        (e._1, WebOperatorStatistics.apply(e._1, e._2, sinkOpDirtyPageIndices, workflowCompiler))
       )
     )
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
@@ -14,9 +14,9 @@ object WebOperatorStatistics {
   ): WebOperatorStatistics = {
     val chartType = OperatorResult.getChartType(operatorID, workflowCompiler)
     val results = operatorStatistics.aggregatedOutputResults
-      // if chartType is null (normal sink), don't send results as well
-      .flatMap(r => chartType.map(_ => r))
-      // convert tuple format
+      // if chartType is present, then send all results
+      // else (normal view result table), then send empty list
+      //   (pagination will take care of sending actual result)
       .map(r =>
         chartType match {
           case Some(_) => OperatorResult.fromTuple(operatorID, r, chartType, r.size)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -44,7 +44,6 @@ object WorkflowWebsocketResource {
   // Map[sessionId, Map[operatorId, List[ITuple]]]
   val sessionResults = new mutable.HashMap[String, Map[String, List[ITuple]]]
 
-
   // Map[sessionId, Map[downloadType, googleSheetLink]
   val sessionDownloadCache = new mutable.HashMap[String, mutable.HashMap[String, String]]
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -13,15 +13,16 @@ import edu.uci.ics.texera.web.{ServletAwareConfigurator, TexeraWebApplication}
 import edu.uci.ics.texera.web.model.event._
 import edu.uci.ics.texera.web.model.request._
 import edu.uci.ics.texera.web.resource.WorkflowWebsocketResource.{
+  getDirtyPageIndices,
   sessionDownloadCache,
   sessionJobs,
   sessionMap,
   sessionResults
 }
 import edu.uci.ics.texera.web.resource.auth.UserResource
-import edu.uci.ics.texera.workflow.common.{Utils, WorkflowContext}
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.workflow.{WorkflowCompiler, WorkflowInfo}
+import edu.uci.ics.texera.workflow.common.{Utils, WorkflowContext}
 
 import java.util.concurrent.atomic.AtomicInteger
 import javax.servlet.http.HttpSession
@@ -43,8 +44,36 @@ object WorkflowWebsocketResource {
   // Map[sessionId, Map[operatorId, List[ITuple]]]
   val sessionResults = new mutable.HashMap[String, Map[String, List[ITuple]]]
 
+
   // Map[sessionId, Map[downloadType, googleSheetLink]
   val sessionDownloadCache = new mutable.HashMap[String, mutable.HashMap[String, String]]
+
+  /**
+    * Calculate which page in frontend need to be re-fetched
+    * @param beforeList data before status update event (i.e. unmodified sessionResults)
+    * @param afterList data after status update event
+    * @return list of indices of modified pages starting from 1
+    */
+  def getDirtyPageIndices(beforeList: List[ITuple], afterList: List[ITuple]): List[Int] = {
+    val pageSize = 10
+
+    var currentIndex = 1
+    var currentIndexPageCount = 0
+    val dirtyPageIndices = new mutable.HashSet[Int]()
+    for ((before, after) <- beforeList.zipAll(afterList, null, null)) {
+      if (before == null || after == null || !before.equals(after)) {
+        dirtyPageIndices.add(currentIndex)
+      }
+      currentIndexPageCount += 1
+      if (currentIndexPageCount == pageSize) {
+        currentIndexPageCount = 0
+        currentIndex += 1
+      }
+    }
+
+    dirtyPageIndices.toList
+  }
+
 }
 
 @ServerEndpoint(
@@ -214,7 +243,30 @@ class WorkflowWebsocketResource {
         WorkflowWebsocketResource.sessionJobs.remove(session.getId)
       },
       workflowStatusUpdateListener = statusUpdate => {
-        send(session, WebWorkflowStatusUpdateEvent.apply(statusUpdate, texeraWorkflowCompiler))
+        val sinkOpDirtyPageIndices = statusUpdate.operatorStatistics
+          .filter(e => e._2.aggregatedOutputResults.isDefined)
+          .map(e => {
+            val beforeList =
+              sessionResults.getOrElse(session.getId, Map.empty).getOrElse(e._1, List.empty)
+            val afterList = e._2.aggregatedOutputResults.get
+            val dirtyPageIndices = getDirtyPageIndices(beforeList, afterList)
+            (e._1, dirtyPageIndices)
+          })
+
+        sessionResults.update(
+          session.getId,
+          statusUpdate.operatorStatistics
+            .filter(e => e._2.aggregatedOutputResults.isDefined)
+            .map(e => (e._1, e._2.aggregatedOutputResults.get))
+        )
+        send(
+          session,
+          WebWorkflowStatusUpdateEvent.apply(
+            statusUpdate,
+            sinkOpDirtyPageIndices,
+            texeraWorkflowCompiler
+          )
+        )
       },
       modifyLogicCompletedListener = _ => {
         send(session, ModifyLogicCompletedEvent())

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.html
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.html
@@ -18,9 +18,17 @@
       Skip Records
     </button>
     <div class="result-table" [hidden]="!currentColumns">
-      <nz-table #basicTable (nzQueryParams)="onTableQueryParamsChange($event)" [nzData]="currentResult"
-        [nzFrontPagination]="isFrontPagination" [nzLoading]="isLoadingResult" [nzPageIndex]="currentPageIndex"
-        [nzPageSize]="currentPageSize" [nzTotal]="total" nzBordered="true">
+      <nz-table
+        #basicTable
+        [nzData]="currentResult"
+        nzBordered="true"
+        [nzFrontPagination]="isFrontPagination"
+        [nzLoading]="isLoadingResult"
+        [nzTotal]="total"
+        [nzPageIndex]="currentPageIndex"
+        [nzPageSize]="10"
+        (nzQueryParams)="onTableQueryParamsChange($event)"
+      >
         <thead>
           <tr>
             <th *ngFor="let column of currentColumns">

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -13,6 +13,7 @@ import { WorkflowWebsocketService } from '../../service/workflow-websocket/workf
 import { ExecutionState } from '../../types/execute-workflow.interface';
 import { IndexableObject, PAGINATION_INFO_STORAGE_KEY, ResultPaginationInfo, TableColumn } from '../../types/result-table.interface';
 import { BreakpointTriggerInfo } from '../../types/workflow-common.interface';
+import { WorkflowStatusService } from '../../service/workflow-status/workflow-status.service';
 
 /**
  * ResultPanelComponent is the bottom level area that displays the
@@ -34,6 +35,8 @@ import { BreakpointTriggerInfo } from '../../types/workflow-common.interface';
   styleUrls: ['./result-panel.component.scss']
 })
 export class ResultPanelComponent {
+  public static readonly DEFAULT_PAGE_SIZE: number = 10;
+
   private static readonly PRETTY_JSON_TEXT_LIMIT: number = 50000;
   private static readonly TABLE_COLUMN_TEXT_LIMIT: number = 1000;
 
@@ -65,18 +68,17 @@ export class ResultPanelComponent {
   //   for more details
   public isFrontPagination: boolean = true;
   public isLoadingResult: boolean = false;
-  public currentPageSize: number = 10;
   // this starts from **ONE**, not zero
   public currentPageIndex: number = 1;
   public total: number = 0;
-  private operatorID: string = '';
 
   constructor(
     private executeWorkflowService: ExecuteWorkflowService,
     private modalService: NzModalService,
     private resultPanelToggleService: ResultPanelToggleService,
     private workflowActionService: WorkflowActionService,
-    private workflowWebsocketService: WorkflowWebsocketService
+    private workflowWebsocketService: WorkflowWebsocketService,
+    private workflowStatusService: WorkflowStatusService
   ) {
     const activeStates: ExecutionState[] = [ExecutionState.Completed, ExecutionState.Failed, ExecutionState.BreakpointTriggered];
     Observable.merge(
@@ -87,8 +89,6 @@ export class ResultPanelComponent {
     ).subscribe(trigger => this.displayResultPanel());
 
     this.executeWorkflowService.getExecutionStateStream().subscribe(event => {
-      console.log(event.current.state);
-      console.log(event.current);
       if (event.current.state === ExecutionState.BreakpointTriggered) {
         const breakpointOperator = this.executeWorkflowService.getBreakpointTriggerInfo()?.operatorID;
         if (breakpointOperator) {
@@ -100,6 +100,11 @@ export class ResultPanelComponent {
         this.resultPanelToggleService.openResultPanel();
       }
       if (event.current.state === ExecutionState.Completed || event.current.state === ExecutionState.Running) {
+        if (event.current.state === ExecutionState.Completed) {
+          // remove previously stored partial result
+          sessionRemoveObject(PAGINATION_INFO_STORAGE_KEY);
+        }
+
         const sinkOperators = this.workflowActionService.getTexeraGraph().getAllOperators()
           .filter(op => op.operatorType.toLowerCase().includes('sink'));
         if (sinkOperators.length > 0) {
@@ -120,8 +125,79 @@ export class ResultPanelComponent {
         if (result.operatorID === highlightedOperators[0]) {
           this.total = result.totalRowCount;
           this.currentResult = result.table.slice();
-          this.isLoadingResult = false;
+
+          // When there is a result data from the backend,
+          //  1. Get all the column names except '_id', using the first instance of
+          //      result data.
+          //  2. Use those names to generate a list of display columns, which would
+          //      be used for displaying on angular mateiral table.
+          //  3. Pass the result data as array to generate a new angular material
+          //      data table.
+          //  4. Set the newly created data table to our own paginator.
+
+          let columns: {columnKey: any, columnText: string}[];
+
+          const columnKeys = Object.keys(this.currentResult[0]).filter(x => x !== '_id');
+          this.currentDisplayColumns = columnKeys;
+          columns = columnKeys.map(v => ({columnKey: v, columnText: v}));
+
+          // generate columnDef from first row, column definition is in order
+          this.currentColumns = ResultPanelComponent.generateColumns(columns);
+
+          // save result
+          const resultPaginationInfo = {
+            newWorkflowExecuted: false,
+            currentResult: this.currentResult,
+            currentPageIndex: this.currentPageIndex,
+            total: this.total,
+            columnKeys: columnKeys,
+            operatorID: this.resultPanelOperatorID
+          };
+          sessionSetObject(PAGINATION_INFO_STORAGE_KEY, resultPaginationInfo);
           return;
+        }
+      }
+    });
+
+    this.workflowStatusService.getResultUpdateStream().subscribe(_ => {
+      if (!this.resultPanelOperatorID) {
+        return;
+      }
+
+      const result = this.workflowStatusService.getCurrentResult()[this.resultPanelOperatorID];
+      const currentSinkStats = this.workflowStatusService.getCurrentStatus()[this.resultPanelOperatorID];
+
+      // Don't update if the state is already in Completed
+      //  because our result may conflict with the more recent result from WorkflowCompletedEvent
+      if (result && this.executeWorkflowService.getExecutionState().state !== ExecutionState.Completed) {
+        this.chartType = result.chartType;
+        this.isFrontPagination = false;
+
+        const previousTotal = this.total;
+        this.total = result.totalRowCount;
+
+        // if there are new results and we need them
+        if ((currentSinkStats.aggregatedOutputResultDirtyPageIndices ?? []).includes(this.currentPageIndex) ||
+        (previousTotal !== this.total && this.currentResult.length < ResultPanelComponent.DEFAULT_PAGE_SIZE)) {
+
+          if (this.total < previousTotal &&  // less row count
+            this.currentPageIndex === Math.ceil(previousTotal / ResultPanelComponent.DEFAULT_PAGE_SIZE) && // on the last page
+            Math.ceil(this.total / ResultPanelComponent.DEFAULT_PAGE_SIZE) < this.currentPageIndex) {  // less page
+              this.currentPageIndex = Math.ceil(this.total / ResultPanelComponent.DEFAULT_PAGE_SIZE);  // decrease page index
+          }
+
+          this.workflowWebsocketService.send('ResultPaginationRequest',
+            { pageSize: ResultPanelComponent.DEFAULT_PAGE_SIZE, pageIndex: this.currentPageIndex });
+        } else {
+          const resultPaginationInfo = {
+            newWorkflowExecuted: false,
+            currentResult: this.currentResult,
+            currentPageIndex: this.currentPageIndex,
+            total: this.total,
+            columnKeys: this.currentColumns,
+            operatorID: this.resultPanelOperatorID
+          };
+          sessionSetObject(PAGINATION_INFO_STORAGE_KEY, resultPaginationInfo);
         }
       }
     });
@@ -194,17 +270,16 @@ export class ResultPanelComponent {
     // store result into session storage so that they could be restored
     //   when user click the "view result" operator again
     const resultPaginationInfo = sessionGetObject<ResultPaginationInfo>(PAGINATION_INFO_STORAGE_KEY);
-    if (resultPaginationInfo && !resultPaginationInfo.newWorkflowExecuted && this.currentResult.length > 0) {
+    if (resultPaginationInfo && !resultPaginationInfo.newWorkflowExecuted && this.currentResult.length > 0 && this.resultPanelOperatorID) {
       sessionSetObject(PAGINATION_INFO_STORAGE_KEY, {
         ...resultPaginationInfo,
         // We have to turn it into array first because JSON.stringfy(someMap) will produce an empty object
-        viewResultOperatorInfoMap: Array.from((new Map(resultPaginationInfo.viewResultOperatorInfoMap).set(this.operatorID, {
+        viewResultOperatorInfoMap: Array.from((new Map(resultPaginationInfo.viewResultOperatorInfoMap).set(this.resultPanelOperatorID, {
           currentResult: this.currentResult,
           currentPageIndex: this.currentPageIndex,
-          currentPageSize: this.currentPageSize,
           total: this.total,
           columnKeys: this.currentDisplayColumns ?? [],
-          operatorID: this.operatorID
+          operatorID: this.resultPanelOperatorID
         })).entries())
       });
     }
@@ -221,8 +296,11 @@ export class ResultPanelComponent {
     this.breakpointAction = false;
 
     this.isFrontPagination = true;
-    this.currentPageIndex = 1;
-    this.currentPageSize = 10;
+
+    if (sessionGetObject<ResultPaginationInfo>(PAGINATION_INFO_STORAGE_KEY) !== null) {
+      this.currentPageIndex = 1;
+    }
+
     this.total = 0;
     this.isLoadingResult = false;
   }
@@ -293,16 +371,15 @@ export class ResultPanelComponent {
    * @param params new parameters
    */
   public onTableQueryParamsChange(params: NzTableQueryParams) {
-    const {pageSize: newPageSize, pageIndex: newPageIndex} = params;
-    this.currentPageSize = newPageSize;
-    this.currentPageIndex = newPageIndex;
+    const { pageSize: newPageSize, pageIndex: newPageIndex } = params;
 
     if (this.isFrontPagination) {
       return;
     }
 
-    this.isLoadingResult = true;
-    this.workflowWebsocketService.send('ResultPaginationRequest', {pageSize: newPageSize, pageIndex: newPageIndex});
+    this.currentPageIndex = newPageIndex;
+
+    this.workflowWebsocketService.send('ResultPaginationRequest', { pageSize: newPageSize, pageIndex: newPageIndex });
   }
 
   /**
@@ -314,7 +391,7 @@ export class ResultPanelComponent {
    * @param operatorID id of the operator providing data
    */
   private setupResultTable(resultData: ReadonlyArray<object>, totalRowCount: number, operatorID: string) {
-    this.operatorID = operatorID;
+    this.resultPanelOperatorID = operatorID;
 
     if (resultData.length < 1) {
       return;
@@ -323,26 +400,26 @@ export class ResultPanelComponent {
     // if there is no new result
     //   then restore the previous paginated result data from session storage
     let resultPaginationInfo = sessionGetObject<ResultPaginationInfo>(PAGINATION_INFO_STORAGE_KEY);
-    let viewResultOperatorInfoMap;
-    if (resultPaginationInfo && !resultPaginationInfo.newWorkflowExecuted &&
-      (viewResultOperatorInfoMap = new Map(resultPaginationInfo.viewResultOperatorInfoMap)).has(this.operatorID)) {
-      const viewResultOperatorInfo = viewResultOperatorInfoMap.get(this.operatorID)!;
-      this.isFrontPagination = false;
-      this.currentResult = viewResultOperatorInfo.currentResult;
-      this.currentPageIndex = viewResultOperatorInfo.currentPageIndex;
-      this.currentPageSize = viewResultOperatorInfo.currentPageSize;
-      this.total = viewResultOperatorInfo.total;
-      this.currentDisplayColumns = viewResultOperatorInfo.columnKeys;
-      // generate columnDef from first row, column definition is in order
-      this.currentColumns = ResultPanelComponent.generateColumns(
-        this.currentDisplayColumns.map(v => ({columnKey: v, columnText: v}))
-      );
-      return;
+
+    if (resultPaginationInfo && !resultPaginationInfo.newWorkflowExecuted) {
+      const viewResultOperatorInfoMap = new Map(resultPaginationInfo.viewResultOperatorInfoMap);
+      const viewResultOperatorInfo = viewResultOperatorInfoMap.get(this.resultPanelOperatorID);
+      if (viewResultOperatorInfo) {
+        this.isFrontPagination = false;
+        this.currentResult = viewResultOperatorInfo.currentResult;
+        this.currentPageIndex = viewResultOperatorInfo.currentPageIndex;
+        this.total = viewResultOperatorInfo.total;
+        this.currentDisplayColumns = viewResultOperatorInfo.columnKeys;
+
+        this.currentColumns = ResultPanelComponent.generateColumns(
+          this.currentDisplayColumns.map(v => ({columnKey: v, columnText: v}))
+        );
+        return;
+      }
     }
+
     // creates a shallow copy of the readonly response.result,
     //  this copy will be has type object[] because MatTableDataSource's input needs to be object[]
-
-    // save a copy of current result
     this.currentResult = resultData.slice();
 
     // When there is a result data from the backend,
@@ -362,11 +439,10 @@ export class ResultPanelComponent {
 
     // generate columnDef from first row, column definition is in order
     this.currentColumns = ResultPanelComponent.generateColumns(columns);
-    this.total = totalRowCount ?? resultData.length;
+    this.total = totalRowCount;
 
-    // get the current page size, if the result length is less than `this.currentPageSize`,
-    //  then the maximum number of items each page will be the length of the result, otherwise `this.currentPageSize`.
-    this.currentPageSize = Math.min(this.total, this.currentPageSize);
+    this.workflowWebsocketService.send('ResultPaginationRequest',
+    { pageSize: ResultPanelComponent.DEFAULT_PAGE_SIZE, pageIndex: this.currentPageIndex });
 
     // save paginated result into session storage
     resultPaginationInfo = {
@@ -376,17 +452,15 @@ export class ResultPanelComponent {
       viewResultOperatorInfoMap: resultPaginationInfo ? (new Map(resultPaginationInfo.viewResultOperatorInfoMap)).set(operatorID, {
         currentResult: this.currentResult,
         currentPageIndex: this.currentPageIndex,
-        currentPageSize: this.currentPageSize,
         total: this.total,
         columnKeys: columnKeys,
-        operatorID: this.operatorID
+        operatorID: this.resultPanelOperatorID
       }) : new Map([[operatorID, {
         currentResult: this.currentResult,
         currentPageIndex: this.currentPageIndex,
-        currentPageSize: this.currentPageSize,
         total: this.total,
         columnKeys: columnKeys,
-        operatorID: this.operatorID
+        operatorID: this.resultPanelOperatorID
       }]])
     };
     sessionSetObject(PAGINATION_INFO_STORAGE_KEY, {

--- a/core/new-gui/src/app/workspace/types/execute-workflow.interface.ts
+++ b/core/new-gui/src/app/workspace/types/execute-workflow.interface.ts
@@ -93,7 +93,8 @@ export interface OperatorStatistics extends Readonly<{
   aggregatedInputRowCount: number,
   aggregatedOutputRowCount: number,
   aggregatedOutputResults: ResultObject | undefined | null // undefined/null if operator is not sink
-}> { }
+  aggregatedOutputResultDirtyPageIndices?: Array<number>
+}> {}
 
 export interface WorkflowStatusUpdate extends Readonly<{
   operatorStatistics: Record<string, OperatorStatistics>

--- a/core/new-gui/src/app/workspace/types/result-table.interface.ts
+++ b/core/new-gui/src/app/workspace/types/result-table.interface.ts
@@ -39,7 +39,6 @@ export const PAGINATION_INFO_STORAGE_KEY = 'result-panel-pagination-info';
 export interface ViewResultOperatorInfo extends Readonly<{
   currentResult: object[];
   currentPageIndex: number;
-  currentPageSize: number;
   total: number;
   columnKeys: string[];
   operatorID: string


### PR DESCRIPTION
This task is done by @WANGJIEKE . Link to original PR: #1007. Pull request reopened because the branch is rebased on master.
Zuozhi reviewed this PR and approved it.


## Description

The server will send status updates (with the newest 10 rows of output) to the client.

The client will update the result panel once per second based on the received status update.

## Demo

![Screen Recording 2021-01-31 at 11 10 33 PM](https://user-images.githubusercontent.com/21030118/106427020-78e37800-641b-11eb-9350-88dbbcba3cf0.gif)


It can also display not only appended result, but also modified and deleted in real time.

https://user-images.githubusercontent.com/21030118/119858066-b332d100-bf46-11eb-98da-c53cad58a6c8.mp4

