### PR TITLE
Remove toggle to display the spatial map in popup

### DIFF
--- a/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.html
+++ b/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.html
@@ -4,6 +4,6 @@
   <div id="texera-result-chart-content">
   </div>
   <!-- this id should be identical to VisualizationPanelContentComponent.MAP_CONTAINER -->
-  <div *ngIf="displayMap" id="texera-result-map-container">
+  <div id="texera-result-map-container">
   </div>
   <iframe *ngIf="displayHTML" id="texera-result-html-content-container" [srcdoc]="htmlData"></iframe>

--- a/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.ts
+++ b/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.ts
@@ -55,7 +55,6 @@ export class VisualizationPanelContentComponent implements AfterContentInit, OnD
   @Input()
   operatorID: string | undefined;
   displayHTML: boolean = false; // variable to decide whether to display the container to display the HTML container(iFrame)
-  displayMap: boolean = false; // variable to decide whether to display the container to display the map
 
   data: object[] | undefined;
   chartType: ChartType | undefined;
@@ -119,7 +118,6 @@ export class VisualizationPanelContentComponent implements AfterContentInit, OnD
       return;
     }
     this.displayHTML = false;
-    this.displayMap = false;
     switch (this.chartType) {
       // correspond to WordCloudSink.java
       case ChartType.WORD_CLOUD:
@@ -137,7 +135,6 @@ export class VisualizationPanelContentComponent implements AfterContentInit, OnD
         this.generateChart();
         break;
       case ChartType.SPATIAL_SCATTERPLOT:
-        this.displayMap = true;
         this.generateSpatialScatterplot();
         break;
       case ChartType.SIMPLE_SCATTERPLOT:


### PR DESCRIPTION
I have made the map container to be displayed only if the viz type is spatial scatterplot (because it has a fixed height), I have added this part in the HTML_viz operator PR #1142 and it was tested. 
However, because it was tested using a udf operator, the entire workflow was not progressive, I realized this has issues if the visualization is progressive.
For now, I am reverting the change, and will work on fixing it later