### PR TITLE
Fix word cloud operator output schema

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpDesc.java
@@ -64,7 +64,7 @@ public class WordCloudOpDesc extends VisualizationOperator {
     public Schema getOutputSchema(Schema[] schemas) {
         return Schema.newBuilder().add(
                 new Attribute("word", AttributeType.STRING),
-                new Attribute("size", AttributeType.INTEGER)
+                new Attribute("count", AttributeType.INTEGER)
         ).build();
     }
 }


### PR DESCRIPTION
fix word cloud operator's wrong output schema. The actual schema is "word" and "count" instead of "word" and "size".