### PR TITLE
Fix hiding unrelated html elements

### DIFF
--- a/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.html
+++ b/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.html
@@ -15,6 +15,6 @@
 <div id="texera-result-chart-content">
 </div>
 <!-- this id should be identical to VisualizationPanelContentComponent.MAP_CONTAINER -->
-<div [hidden]="hideMap" id="texera-result-map-container">
+<div [hidden]="displayMap" id="texera-result-map-container">
 </div>
 <iframe *ngIf="displayHTML" id="texera-result-html-content-container" [srcdoc]="htmlData"></iframe>

--- a/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.html
+++ b/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.html
@@ -1,7 +1,7 @@
 <meta charset="utf-8">
 
 
-<div id="texera-word-cloud-control">
+<div *ngIf="displayWordCloud" id="texera-word-cloud-control">
   <nz-space>
     <nz-form-label>Normalization Scale</nz-form-label>
     <nz-select [ngModel]="wordCloudControls.scale" (ngModelChange)="updateWordCloudScale($event)"
@@ -15,6 +15,6 @@
 <div id="texera-result-chart-content">
 </div>
 <!-- this id should be identical to VisualizationPanelContentComponent.MAP_CONTAINER -->
-<div id="texera-result-map-container">
+<div [hidden]="hideMap" id="texera-result-map-container">
 </div>
 <iframe *ngIf="displayHTML" id="texera-result-html-content-container" [srcdoc]="htmlData"></iframe>

--- a/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.ts
+++ b/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.ts
@@ -70,7 +70,8 @@ export class VisualizationPanelContentComponent implements AfterContentInit, OnD
   @Input()
   operatorID: string | undefined;
   displayHTML: boolean = false; // variable to decide whether to display the container to display the HTML container(iFrame)
-
+  displayWordCloud: boolean = false; // variable to decide whether to display the container for worldcloud visualization
+  hideMap: boolean = true; // variable to decide whether to hide/unhide the map
   data: object[] | undefined;
   chartType: ChartType | undefined;
   columns: string[] = [];
@@ -136,9 +137,12 @@ export class VisualizationPanelContentComponent implements AfterContentInit, OnD
       return;
     }
     this.displayHTML = false;
+    this.displayWordCloud = false;
+    this.hideMap = true;
     switch (this.chartType) {
       // correspond to WordCloudSink.java
       case ChartType.WORD_CLOUD:
+        this.displayWordCloud = true;
         this.generateWordCloud();
         break;
       // correspond to TexeraBarChart.java
@@ -153,6 +157,7 @@ export class VisualizationPanelContentComponent implements AfterContentInit, OnD
         this.generateChart();
         break;
       case ChartType.SPATIAL_SCATTERPLOT:
+        this.hideMap = false;
         this.generateSpatialScatterplot();
         break;
       case ChartType.SIMPLE_SCATTERPLOT:

--- a/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.ts
+++ b/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-panel-content.component.ts
@@ -71,7 +71,7 @@ export class VisualizationPanelContentComponent implements AfterContentInit, OnD
   operatorID: string | undefined;
   displayHTML: boolean = false; // variable to decide whether to display the container to display the HTML container(iFrame)
   displayWordCloud: boolean = false; // variable to decide whether to display the container for worldcloud visualization
-  hideMap: boolean = true; // variable to decide whether to hide/unhide the map
+  displayMap: boolean = true; // variable to decide whether to hide/unhide the map
   data: object[] | undefined;
   chartType: ChartType | undefined;
   columns: string[] = [];
@@ -138,7 +138,7 @@ export class VisualizationPanelContentComponent implements AfterContentInit, OnD
     }
     this.displayHTML = false;
     this.displayWordCloud = false;
-    this.hideMap = true;
+    this.displayMap = true;
     switch (this.chartType) {
       // correspond to WordCloudSink.java
       case ChartType.WORD_CLOUD:
@@ -157,7 +157,7 @@ export class VisualizationPanelContentComponent implements AfterContentInit, OnD
         this.generateChart();
         break;
       case ChartType.SPATIAL_SCATTERPLOT:
-        this.hideMap = false;
+        this.displayMap = false;
         this.generateSpatialScatterplot();
         break;
       case ChartType.SIMPLE_SCATTERPLOT:


### PR DESCRIPTION
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/9158114/121467826-b11d3900-c96e-11eb-9d41-6bcdaa0a8515.gif)

Right now, the wordcloud scaling options from #1096 appears for all other viz types as seen in the attached workflow.

This PR fixes these two issues making the display for each viz type invisible to other viz types

1. Make the wordcloud scaling option unavailable for all other viz types by using `*ngIf`
2. Make the spatial scatterplot map container hidden if the viz type is not spatial scatterplot by using `[hidden]` instead of `*ngIf` because of making changes in between content generations. 
The map container has a fixed length because the default length by Mapbox if not defined, is very small, so this is why it has to be hidden if not used because the length is larger than other viz types

![ezgif com-gif-maker (2)](https://user-images.githubusercontent.com/9158114/121467984-f0e42080-c96e-11eb-8ef8-df549e3b1663.gif)
