### PR TITLE
Fix BIT type as AttributeType.BOOLEAN

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeTypeUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeTypeUtils.scala
@@ -265,6 +265,7 @@ object AttributeTypeUtils extends Serializable {
         ).getOrElse(throw parseError)
 
       case long: java.lang.Long => new Timestamp(long)
+
       case timestamp: Timestamp => timestamp
       // Integer, Double and Boolean are considered to be illegal here.
       case _ =>

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeTypeUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeTypeUtils.scala
@@ -265,6 +265,7 @@ object AttributeTypeUtils extends Serializable {
         ).getOrElse(throw parseError)
 
       case long: java.lang.Long => new Timestamp(long)
+      case timestamp: Timestamp => timestamp
       // Integer, Double and Boolean are considered to be illegal here.
       case _ =>
         throw parseError

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/SQLSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/SQLSourceOpDesc.scala
@@ -133,8 +133,7 @@ abstract class SQLSourceOpDesc extends SourceOperatorDescriptor {
         val columnName = columns.getString("COLUMN_NAME")
         val datatype = columns.getInt("DATA_TYPE")
         datatype match {
-          case Types.BIT | // -7 Types.BIT
-              Types.TINYINT | // -6 Types.TINYINT
+          case Types.TINYINT | // -6 Types.TINYINT
               Types.SMALLINT | // 5 Types.SMALLINT
               Types.INTEGER => // 4 Types.INTEGER
             schemaBuilder.add(new Attribute(columnName, AttributeType.INTEGER))
@@ -143,7 +142,8 @@ abstract class SQLSourceOpDesc extends SourceOperatorDescriptor {
               Types.DOUBLE | // 8 Types.DOUBLE
               Types.NUMERIC => // 3 Types.NUMERIC
             schemaBuilder.add(new Attribute(columnName, AttributeType.DOUBLE))
-          case Types.BOOLEAN => // 16 Types.BOOLEAN
+          case Types.BIT | // -7 Types.BIT
+              Types.BOOLEAN => // 16 Types.BOOLEAN
             schemaBuilder.add(new Attribute(columnName, AttributeType.BOOLEAN))
           case Types.BINARY | //-2 Types.BINARY
               Types.DATE | //91 Types.DATE

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/SQLSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/SQLSourceOpExec.scala
@@ -186,7 +186,7 @@ abstract class SQLSourceOpExec(
       breakable {
         val columnName = attr.getName
         val columnType = attr.getType
-        val value = curResultSet.get.getString(columnName)
+        val value = curResultSet.get.getObject(columnName)
 
         if (value == null) {
           // add the field as null


### PR DESCRIPTION
This PR fixes an issue where the BIT types from sql was treated as `AttributeType.INTEGER`, instead of `AttributeType.BOOLEAN`. 

In postgresql, boolean type is stored as BIT, since it can only have three values: `true`, `false` and `null`. We will treat it as BOOLEAN in texera.

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>