### PR TITLE
Use StubUserService in tests

### DIFF
--- a/core/new-gui/src/app/common/service/user/stub-user.service.ts
+++ b/core/new-gui/src/app/common/service/user/stub-user.service.ts
@@ -1,69 +1,78 @@
-// import { Injectable } from '@angular/core';
-// import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Injectable } from '@angular/core';
 
-// import { Observable } from 'rxjs/Observable';
-// import { environment } from '../../../../environments/environment';
-// import { EventEmitter } from '@angular/core';
-// import { observable, Subject } from 'rxjs';
-// import { User } from '../../type/user';
-// import { UserWebResponse } from '../../type/user';
-// import { UserService } from './user.service';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs';
+import { User } from '../../type/user';
+import { UserService } from './user.service';
 
-// export const MOCK_USER_ID = 1;
-// export const MOCK_USER_NAME = 'testUser';
-// export const MOCK_USER = {
-//   userName: MOCK_USER_NAME,
-//   userID: MOCK_USER_ID
-// };
+export const MOCK_USER_ID = 1;
+export const MOCK_USER_NAME = 'testUser';
+export const MOCK_USER = {
+  name: MOCK_USER_NAME,
+  uid: MOCK_USER_ID
+};
 
-// type PublicInterfaceOf<Class> = {
-//   [Member in keyof Class]: Class[Member];
-// };
+type PublicInterfaceOf<Class> = {
+  [Member in keyof Class]: Class[Member];
+};
 
-// /**
-//  * This StubUserService is to test other service's functionality that depends on UserService
-//  * The login/register will succeed when receive the user name {@link stubUserName} and fail otherwise.
-//  * It will correctly emit UserChangedEvent as the normal UserService do.
-//  */
-// @Injectable()
-// export class StubUserService implements PublicInterfaceOf<UserService> {
-//   public userChangedEvent: Subject<User | undefined> = new Subject();
-//   public user: User | undefined;
+/**
+ * This StubUserService is to test other service's functionality that depends on UserService
+ * The login/register will succeed when receive the user name {@link stubUserName} and fail otherwise.
+ * It will correctly emit UserChangedEvent as the normal UserService do.
+ */
+@Injectable()
+export class StubUserService implements PublicInterfaceOf<UserService> {
+  public userChangeSubject: Subject<User | undefined> = new Subject();
+  public user: User | undefined;
 
-//   constructor() {
-//     this.user = MOCK_USER;
-//     this.userChangedEvent.next(this.user);
-//   }
+  constructor() {
+    this.user = MOCK_USER;
+    this.userChangeSubject.next(this.user);
+  }
 
-//   public getUser(): User | undefined {
-//     return this.user;
-//   }
+  public getGoogleAuthInstance(): Observable<gapi.auth2.GoogleAuth> {
+    throw new Error('Method not implemented.');
+  }
 
-//   public register(userName: string): Observable<UserWebResponse> {
-//     throw new Error('unimplemented');
-//   }
+  public googleLogin(authCode: string): Observable<User> {
+    throw new Error('Method not implemented.');
+  }
 
-//   public login(userName: string): Observable<UserWebResponse> {
-//     if (this.user) {
-//       throw new Error('user is already logged in');
-//     }
-//     throw new Error('unimplemented');
-//   }
+  public validateUsername(userName: string): { result: boolean; message: string; } {
+    throw new Error('Method not implemented.');
+  }
 
-//   public logOut(): void {
-//     throw new Error('unimplemented');
-//   }
+  public userChanged(): Observable<User | undefined> {
 
-//   public isLogin(): boolean {
-//     return this.user !== undefined;
-//   }
+    return this.userChangeSubject.asObservable();
+  }
 
-//   public getUserChangedEvent(): Observable<User | undefined> {
-//     return this.userChangedEvent.asObservable();
-//   }
+  public getUser(): User | undefined {
+    return this.user;
+  }
 
-//   private changeUser(user: User | undefined): void {
-//     this.user = user;
-//   }
+  public register(userName: string): Observable<Response> {
+    throw new Error('unimplemented');
+  }
 
-// }
+  public login(userName: string): Observable<Response> {
+    if (this.user) {
+      throw new Error('user is already logged in');
+    }
+    throw new Error('unimplemented');
+  }
+
+  public logOut(): void {
+    throw new Error('unimplemented');
+  }
+
+  public isLogin(): boolean {
+    return this.user !== undefined;
+  }
+
+  public changeUser(user: User | undefined): void {
+    this.user = user;
+  }
+
+}

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-add/ngbd-modal-resource-add.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-add/ngbd-modal-resource-add.component.spec.ts
@@ -11,8 +11,7 @@ import { FileUploadModule } from 'ng2-file-upload';
 import { UserService } from '../../../../../common/service/user/user.service';
 import { UserDictionaryUploadService } from '../../../../../common/service/user/user-dictionary/user-dictionary-upload.service';
 import { UserDictionaryService } from '../../../../../common/service/user/user-dictionary/user-dictionary.service';
-import { GoogleApiModule, GoogleApiService, GoogleAuthService, NG_GAPI_CONFIG } from 'ng-gapi';
-import { environment } from '../../../../../../environments/environment';
+import { StubUserService } from '../../../../../common/service/user/stub-user.service';
 
 describe('NgbdModalResourceAddComponent', () => {
   let component: NgbdModalResourceAddComponent;
@@ -26,15 +25,9 @@ describe('NgbdModalResourceAddComponent', () => {
       declarations: [NgbdModalResourceAddComponent],
       providers: [
         NgbActiveModal,
-        UserService,
+        {provide: UserService, useClass: StubUserService},
         UserDictionaryService,
-        UserDictionaryUploadService,
-        GoogleApiService,
-        GoogleAuthService,
-        {
-          provide: NG_GAPI_CONFIG,
-          useValue: { client_id: environment.google.clientID }
-        }
+        UserDictionaryUploadService
       ],
       imports: [
         CustomNgMaterialModule,

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-view/ngbd-modal-resource-view.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-view/ngbd-modal-resource-view.component.spec.ts
@@ -8,8 +8,7 @@ import { CustomNgMaterialModule } from '../../../../../common/custom-ng-material
 import { UserService } from '../../../../../common/service/user/user.service';
 import { UserDictionaryService } from '../../../../../common/service/user/user-dictionary/user-dictionary.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { GoogleApiService, GoogleAuthService, NG_GAPI_CONFIG } from 'ng-gapi';
-import { environment } from '../../../../../../environments/environment';
+import { StubUserService } from '../../../../../common/service/user/stub-user.service';
 
 describe('NgbdModalResourceViewComponent', () => {
   let component: NgbdModalResourceViewComponent;
@@ -20,14 +19,8 @@ describe('NgbdModalResourceViewComponent', () => {
       declarations: [NgbdModalResourceViewComponent],
       providers: [
         NgbActiveModal,
-        UserService,
-        UserDictionaryService,
-        GoogleApiService,
-        GoogleAuthService,
-        {
-          provide: NG_GAPI_CONFIG,
-          useValue: { client_id: environment.google.clientID }
-        }
+        {provide: UserService, useClass: StubUserService},
+        UserDictionaryService
       ],
       imports: [
         CustomNgMaterialModule,

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/ngbd-modal-file-add/ngbd-modal-file-add.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/ngbd-modal-file-add/ngbd-modal-file-add.component.spec.ts
@@ -10,8 +10,7 @@ import { UserFileService } from '../../../../../common/service/user/user-file/us
 import { NgbdModalFileAddComponent } from './ngbd-modal-file-add.component';
 import { UserService } from '../../../../../common/service/user/user.service';
 import { UserFileUploadService } from '../../../../../common/service/user/user-file/user-file-upload.service';
-import { GoogleApiModule, GoogleApiService, GoogleAuthService, NG_GAPI_CONFIG } from 'ng-gapi';
-import { environment } from '../../../../../../environments/environment';
+import { StubUserService } from '../../../../../common/service/user/stub-user.service';
 
 describe('NgbdModalFileAddComponent', () => {
   let component: NgbdModalFileAddComponent;
@@ -21,16 +20,10 @@ describe('NgbdModalFileAddComponent', () => {
     TestBed.configureTestingModule({
       declarations: [NgbdModalFileAddComponent],
       providers: [
-        UserService,
+        {provide: UserService, useClass: StubUserService},
         UserFileService,
         UserFileUploadService,
-        NgbActiveModal,
-        GoogleApiService,
-        GoogleAuthService,
-        {
-          provide: NG_GAPI_CONFIG,
-          useValue: { client_id: environment.google.clientID }
-        }
+        NgbActiveModal
       ],
       imports: [
         CustomNgMaterialModule,

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.spec.ts
@@ -9,8 +9,7 @@ import { UserFileSectionComponent } from './user-file-section.component';
 import { UserFileService } from '../../../../common/service/user/user-file/user-file.service';
 import { UserService } from '../../../../common/service/user/user.service';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { GoogleApiService, GoogleAuthService, NG_GAPI_CONFIG } from 'ng-gapi';
-import { environment } from '../../../../../environments/environment';
+import { StubUserService } from '../../../../common/service/user/stub-user.service';
 
 describe('UserFileSectionComponent', () => {
   let component: UserFileSectionComponent;
@@ -21,14 +20,8 @@ describe('UserFileSectionComponent', () => {
       declarations: [UserFileSectionComponent],
       providers: [
         NgbModal,
-        UserFileService,
-        UserService,
-        GoogleApiService,
-        GoogleAuthService,
-        {
-          provide: NG_GAPI_CONFIG,
-          useValue: { client_id: environment.google.clientID }
-        }
+        {provide: UserService, useClass: StubUserService},
+        UserFileService
       ],
       imports: [
         CustomNgMaterialModule,

--- a/core/new-gui/src/app/dashboard/component/top-bar/top-bar.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/top-bar/top-bar.component.spec.ts
@@ -1,4 +1,4 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { async, TestBed } from '@angular/core/testing';
 
 import { TopBarComponent } from './top-bar.component';
 import { UserIconComponent } from './user-icon/user-icon.component';
@@ -8,8 +8,7 @@ import { CustomNgMaterialModule } from '../../../common/custom-ng-material.modul
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { UserService } from '../../../common/service/user/user.service';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { GoogleApiModule, GoogleApiService, GoogleAuthService, NG_GAPI_CONFIG } from 'ng-gapi';
-import { environment } from '../../../../environments/environment';
+import { StubUserService } from '../../../common/service/user/stub-user.service';
 
 describe('TopBarComponent', () => {
   let component: TopBarComponent;
@@ -19,13 +18,7 @@ describe('TopBarComponent', () => {
       declarations: [TopBarComponent, UserIconComponent],
       providers: [
         NgbModal,
-        UserService,
-        GoogleApiService,
-        GoogleAuthService,
-        {
-          provide: NG_GAPI_CONFIG,
-          useValue: { client_id: environment.google.clientID }
-        }
+        {provide: UserService, useClass: StubUserService}
       ],
       imports: [
         HttpClientTestingModule,

--- a/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-icon.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-icon.component.spec.ts
@@ -4,8 +4,7 @@ import { UserIconComponent } from './user-icon.component';
 import { UserService } from '../../../../common/service/user/user.service';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { GoogleApiService, GoogleAuthService, NG_GAPI_CONFIG } from 'ng-gapi';
-import { environment } from '../../../../../environments/environment';
+import { StubUserService } from '../../../../common/service/user/stub-user.service';
 
 describe('UserIconComponent', () => {
   let component: UserIconComponent;
@@ -16,13 +15,7 @@ describe('UserIconComponent', () => {
       declarations: [UserIconComponent],
       providers: [
         NgbModal,
-        UserService,
-        GoogleApiService,
-        GoogleAuthService,
-        {
-          provide: NG_GAPI_CONFIG,
-          useValue: { client_id: environment.google.clientID }
-        }
+        {provide: UserService, useClass: StubUserService}
       ],
       imports: [
         HttpClientTestingModule

--- a/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-login/ngbdmodal-user-login.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-login/ngbdmodal-user-login.component.spec.ts
@@ -10,8 +10,7 @@ import { MatTabsModule } from '@angular/material/tabs';
 import { FormBuilder, FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { GoogleApiModule, GoogleApiService, GoogleAuthService, NG_GAPI_CONFIG } from 'ng-gapi';
-import { environment } from '../../../../../../environments/environment';
+import { StubUserService } from '../../../../../common/service/user/stub-user.service';
 
 describe('UserLoginComponent', () => {
   let component: NgbdModalUserLoginComponent;
@@ -22,14 +21,8 @@ describe('UserLoginComponent', () => {
       declarations: [NgbdModalUserLoginComponent],
       providers: [
         NgbActiveModal,
-        UserService,
-        FormBuilder,
-        GoogleApiService,
-        GoogleAuthService,
-        {
-          provide: NG_GAPI_CONFIG,
-          useValue: { client_id: environment.google.clientID }
-        }
+        {provide: UserService, useClass: StubUserService},
+        FormBuilder
       ],
       imports: [
         BrowserAnimationsModule,


### PR DESCRIPTION
This PR uses a StubUserService to replace the actual UserService in many tests depending on a UserService. The objective is to hide real UserService's internal implementation from the dependents. 

With this approach, the random issue introduced by initiating GoogleAuthService will be solved because it does not need to be injected into so many Services that are depending on UserService. Fixes #1170 

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>