### PR TITLE
Fix Intersect operator after new interface change

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpDesc.scala
@@ -2,7 +2,12 @@ package edu.uci.ics.texera.workflow.operators.intersect
 
 import com.google.common.base.Preconditions
 import edu.uci.ics.amber.engine.operators.OpExecConfig
-import edu.uci.ics.texera.workflow.common.metadata.{InputPort, OperatorGroupConstants, OperatorInfo, OutputPort}
+import edu.uci.ics.texera.workflow.common.metadata.{
+  InputPort,
+  OperatorGroupConstants,
+  OperatorInfo,
+  OutputPort
+}
 import edu.uci.ics.texera.workflow.common.operators.{HashOpExecConfig, OperatorDescriptor}
 import edu.uci.ics.texera.workflow.common.tuple.schema.{OperatorSchemaInfo, Schema}
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpDesc.scala
@@ -2,18 +2,13 @@ package edu.uci.ics.texera.workflow.operators.intersect
 
 import com.google.common.base.Preconditions
 import edu.uci.ics.amber.engine.operators.OpExecConfig
-import edu.uci.ics.texera.workflow.common.metadata.{
-  InputPort,
-  OperatorGroupConstants,
-  OperatorInfo,
-  OutputPort
-}
+import edu.uci.ics.texera.workflow.common.metadata.{InputPort, OperatorGroupConstants, OperatorInfo, OutputPort}
 import edu.uci.ics.texera.workflow.common.operators.{HashOpExecConfig, OperatorDescriptor}
-import edu.uci.ics.texera.workflow.common.tuple.schema.Schema
+import edu.uci.ics.texera.workflow.common.tuple.schema.{OperatorSchemaInfo, Schema}
 
 class IntersectOpDesc extends OperatorDescriptor {
 
-  override def operatorExecutor: OpExecConfig = {
+  override def operatorExecutor(operatorSchemaInfo: OperatorSchemaInfo): OpExecConfig = {
     new HashOpExecConfig(operatorIdentifier, _ => new IntersectOpExec())
   }
 


### PR DESCRIPTION
When #1146 was merged, somehow the CI didn't consider the fact that a new operator had been added. A minor error in code, but it's a compilation error.