### PR TITLE
Fix Twitter Search Hanging

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/TwitterSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/TwitterSourceOpExec.scala
@@ -7,8 +7,11 @@ abstract class TwitterSourceOpExec(
     apiKey: String,
     apiSecretKey: String
 ) extends SourceOperatorExecutor {
-  // batch size for each API request, 500 is the maximum tweets for each request defined by Twitter
-  val TWITTER_API_BATCH_SIZE = 500
+  // batch size for each API request defined by Twitter
+  //    500 is the maximum tweets for each request
+  //    10 is the minimal tweets for each request
+  val TWITTER_API_BATCH_SIZE_MAX = 500
+  val TWITTER_API_BATCH_SIZE_MIN = 10
 
   var twitterClient: TwitterClient = _
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpExec.scala
@@ -39,7 +39,7 @@ class TwitterFullArchiveSearchSourceOpExec(
             searchQuery,
             LocalDateTime.parse(fromDateTime, DateTimeFormatter.ISO_DATE_TIME),
             LocalDateTime.parse(toDateTime, DateTimeFormatter.ISO_DATE_TIME),
-            curLimit.min(TWITTER_API_BATCH_SIZE)
+            curLimit.min(TWITTER_API_BATCH_SIZE_MAX)
           )
         }
 
@@ -105,16 +105,21 @@ class TwitterFullArchiveSearchSourceOpExec(
     // it returns the nextToken as null. The solution is not ideal but should do job in
     // the most cases.
     // TODO: replace with newer version library twittered when the bug is fixed.
-    var retry = 5
+    var retry = 2
     do {
       response = twitterClient.searchForTweetsFullArchive(
         query,
         startDateTime,
         endDateTime,
-        maxResults.max(10), // a request needs at least 10 results
+        maxResults.max(TWITTER_API_BATCH_SIZE_MIN),
         nextToken
       )
       retry -= 1
+
+      // Twitter limit 1 request per second for V2 FullArchiveSearch
+      // If request too frequently, twitter will force the client wait for 5 minutes.
+      // Here we send at most 1 request per second to avoid hitting rate limit.
+      Thread.sleep(1000)
     } while (response.getNextToken == null && retry > 0)
 
     nextToken = response.getNextToken


### PR DESCRIPTION
This PR fixes #1177.

Twitter has some rate limits on how frequently a client can request data. In this case, the V2 FullArchiveSearch API has a limit of 1 request per second, 500 max tweets per request.

Once the rate limit is hit, the client is forced to wait for 5 minutes before continuing, which would cause a hanging workflow (a hanging data message).

We will control our request frequency to avoid hitting twitter's rate limit.

<sup> Created from JetBrains using [CodeStream](https://codestream.com/?utm_source=cs&utm_medium=pr&utm_campaign=github*com)</sup>