### PR TITLE
Remove QueryResult from QueryStatistics (#1100 Part 1)

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerLayer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerLayer.scala
@@ -75,7 +75,7 @@ class WorkerLayer(
       workerID -> WorkerInfo(
         workerID,
         Uninitialized,
-        WorkerStatistics(Uninitialized, 0, 0, Option.empty)
+        WorkerStatistics(Uninitialized, 0, 0)
       )
     }.toMap
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/principal/OperatorStatistics.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/principal/OperatorStatistics.scala
@@ -3,5 +3,5 @@ package edu.uci.ics.amber.engine.architecture.principal
 case class OperatorStatistics(
     operatorState: OperatorState,
     aggregatedInputRowCount: Long,
-    aggregatedOutputRowCount: Long,
+    aggregatedOutputRowCount: Long
 )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/principal/OperatorStatistics.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/principal/OperatorStatistics.scala
@@ -1,10 +1,7 @@
 package edu.uci.ics.amber.engine.architecture.principal
 
-import edu.uci.ics.amber.engine.common.tuple.ITuple
-
 case class OperatorStatistics(
     operatorState: OperatorState,
     aggregatedInputRowCount: Long,
     aggregatedOutputRowCount: Long,
-    aggregatedOutputResults: Option[List[ITuple]] // in case of a sink operator
 )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerStatistics.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerStatistics.scala
@@ -7,5 +7,4 @@ case class WorkerStatistics(
     workerState: WorkerState,
     inputRowCount: Long,
     outputRowCount: Long,
-    outputResults: Option[List[ITuple]] // in case of a sink operator
 )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerStatistics.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerStatistics.scala
@@ -6,5 +6,5 @@ import edu.uci.ics.amber.engine.common.tuple.ITuple
 case class WorkerStatistics(
     workerState: WorkerState,
     inputRowCount: Long,
-    outputRowCount: Long,
+    outputRowCount: Long
 )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
@@ -38,14 +38,8 @@ trait QueryStatisticsHandler {
     }
 
     val state = stateManager.getCurrentState
-    val result = operator match {
-      case sink: ITupleSinkOperatorExecutor =>
-        Option(sink.getResultTuples())
-      case _ =>
-        Option.empty
-    }
 
-    WorkerStatistics(state, in, displayOut, result)
+    WorkerStatistics(state, in, displayOut)
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/operators/OpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/operators/OpExecConfig.scala
@@ -79,17 +79,8 @@ abstract class OpExecConfig(val id: OperatorIdentity) extends Serializable {
 
   def getOutputRowCount: Long = topology.layers.last.statistics.map(_.outputRowCount).sum
 
-  def getOutputResults: Option[List[ITuple]] = {
-    val allEmpty = topology.layers.last.statistics.forall(e => e.outputResults.isEmpty)
-    if (allEmpty) {
-      Option.empty
-    } else {
-      Option(topology.layers.last.statistics.flatMap(e => e.outputResults).flatten.toList)
-    }
-  }
-
   def getOperatorStatistics: OperatorStatistics =
-    OperatorStatistics(getState, getInputRowCount, getOutputRowCount, getOutputResults)
+    OperatorStatistics(getState, getInputRowCount, getOutputRowCount)
 
   def checkStartDependencies(workflow: Workflow): Unit = {
     //do nothing by default

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
@@ -2,6 +2,7 @@ package edu.uci.ics.texera.web.model.event
 
 import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.WorkflowStatusUpdate
 import edu.uci.ics.amber.engine.architecture.principal.{OperatorState, OperatorStatistics}
+import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.texera.workflow.common.workflow.WorkflowCompiler
 
 object WebOperatorStatistics {
@@ -13,7 +14,8 @@ object WebOperatorStatistics {
       workflowCompiler: WorkflowCompiler
   ): WebOperatorStatistics = {
     val chartType = OperatorResult.getChartType(operatorID, workflowCompiler)
-    val results = operatorStatistics.aggregatedOutputResults
+    // TODO: temporary fix to make it compile, this will be reverted soon in a subsequent PR
+    val results = Option.empty[List[ITuple]]
       // if chartType is present, then send all results
       // else (normal view result table), then send empty list
       //   (pagination will take care of sending actual result)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStatusUpdateEvent.scala
@@ -15,7 +15,8 @@ object WebOperatorStatistics {
   ): WebOperatorStatistics = {
     val chartType = OperatorResult.getChartType(operatorID, workflowCompiler)
     // TODO: temporary fix to make it compile, this will be reverted soon in a subsequent PR
-    val results = Option.empty[List[ITuple]]
+    val results = Option
+      .empty[List[ITuple]]
       // if chartType is present, then send all results
       // else (normal view result table), then send empty list
       //   (pagination will take care of sending actual result)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -242,30 +242,31 @@ class WorkflowWebsocketResource {
         WorkflowWebsocketResource.sessionJobs.remove(session.getId)
       },
       workflowStatusUpdateListener = statusUpdate => {
-        val sinkOpDirtyPageIndices = statusUpdate.operatorStatistics
-          .filter(e => e._2.aggregatedOutputResults.isDefined)
-          .map(e => {
-            val beforeList =
-              sessionResults.getOrElse(session.getId, Map.empty).getOrElse(e._1, List.empty)
-            val afterList = e._2.aggregatedOutputResults.get
-            val dirtyPageIndices = getDirtyPageIndices(beforeList, afterList)
-            (e._1, dirtyPageIndices)
-          })
-
-        sessionResults.update(
-          session.getId,
-          statusUpdate.operatorStatistics
-            .filter(e => e._2.aggregatedOutputResults.isDefined)
-            .map(e => (e._1, e._2.aggregatedOutputResults.get))
-        )
-        send(
-          session,
-          WebWorkflowStatusUpdateEvent.apply(
-            statusUpdate,
-            sinkOpDirtyPageIndices,
-            texeraWorkflowCompiler
-          )
-        )
+        // TODO: temporarily disable progressive result update until a further PR
+//        val sinkOpDirtyPageIndices = statusUpdate.operatorStatistics
+//          .filter(e => e._2.aggregatedOutputResults.isDefined)
+//          .map(e => {
+//            val beforeList =
+//              sessionResults.getOrElse(session.getId, Map.empty).getOrElse(e._1, List.empty)
+//            val afterList = e._2.aggregatedOutputResults.get
+//            val dirtyPageIndices = getDirtyPageIndices(beforeList, afterList)
+//            (e._1, dirtyPageIndices)
+//          })
+//
+//        sessionResults.update(
+//          session.getId,
+//          statusUpdate.operatorStatistics
+//            .filter(e => e._2.aggregatedOutputResults.isDefined)
+//            .map(e => (e._1, e._2.aggregatedOutputResults.get))
+//        )
+//        send(
+//          session,
+//          WebWorkflowStatusUpdateEvent.apply(
+//            statusUpdate,
+//            sinkOpDirtyPageIndices,
+//            texeraWorkflowCompiler
+//          )
+//        )
       },
       modifyLogicCompletedListener = _ => {
         send(session, ModifyLogicCompletedEvent())


### PR DESCRIPTION
This is Part 1 of the PRs to break down the big PR #1100, which aims to provide incremental result update in delta mode.

Currently the engine queries the operator statistics and result using the same control message. This will cause issues for supporting output in delta mode. The reaons for the change is stated in the end.. 

In this PR, we first delete the result tuple from `QueryStatistics` result. We'll add a new control message `QueryResults` in subsequent PRs.


Detailed reasons for separating `QueryResults` from `QueryStatistics`.
- `QueryStatistics` is idempotent. `QueryResults` with `SET_SNAPSHOT` output mode is also idempotent. However, the new `QueryResult` with `SET_DELTA` output mode is NOT idempotent. We must ensure that each delta update is consumed ONLY ONCE in the entire pipeline.
-  Operator statistics are saved in the controller. In the old implementation, latest snapshot output is also saved in the controller. However, the new delta output result cannot be saved in the controller because it comes with a risk of being read twice.
- This separation also enables us to set two different query intervals.