### PR TITLE
Fix worker pause issue

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -211,7 +211,7 @@ class DataProcessor( // dependencies:
   }
 
   private[this] def processControlCommandsDuringExecution(): Unit = {
-    while (!isControlQueueEmpty) {
+    while (!isControlQueueEmpty || pauseManager.isPaused) {
       takeOneControlCommandAndProcess()
     }
   }

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/PauseSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/PauseSpec.scala
@@ -58,11 +58,13 @@ class PauseSpec
     parent.expectMsg(ControllerState.Running)
     controller ! ControlInvocation(AsyncRPCClient.IgnoreReply, PauseWorkflow())
     parent.expectMsg(ControllerState.Paused)
+    Thread.sleep(4000)
     controller ! ControlInvocation(AsyncRPCClient.IgnoreReply, ResumeWorkflow())
     parent.expectMsg(ControllerState.Running)
     Thread.sleep(400)
     controller ! ControlInvocation(AsyncRPCClient.IgnoreReply, PauseWorkflow())
     parent.expectMsg(ControllerState.Paused)
+    Thread.sleep(4000)
     controller ! ControlInvocation(AsyncRPCClient.IgnoreReply, ResumeWorkflow())
     parent.expectMsg(ControllerState.Running)
     parent.expectMsg(1.minute, ControllerState.Completed)
@@ -99,4 +101,5 @@ class PauseSpec
       )
     )
   }
+
 }


### PR DESCRIPTION
This PR:
1. Added pause check so that workers can be paused immediately after calling `pauseManager.pause()`.
2. Modified pause tests so that they will fail if workers are not immediately paused after they report "paused".