### PR TITLE
TwitterFullArchiveSearch with User information and fix ID type

### DIFF
--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -146,8 +146,8 @@ libraryDependencies += "com.konghq" % "unirest-java" % "3.11.11"
 // https://mvnrepository.com/artifact/com.github.marianobarrios/lbmq
 libraryDependencies += "com.github.marianobarrios" % "lbmq" % "0.5.0"
 
-// https://mvnrepository.com/artifact/com.github.redouane59.twitter/twittered
-libraryDependencies += "com.github.redouane59.twitter" % "twittered" % "1.23"
+// https://mvnrepository.com/artifact/io.github.redouane59.twitter/twittered
+libraryDependencies += "io.github.redouane59.twitter" % "twittered" % "2.5"
 
 // https://mvnrepository.com/artifact/org.jooq/jooq
 libraryDependencies += "org.jooq" % "jooq" % "3.14.4"

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/TwitterSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/TwitterSourceOpExec.scala
@@ -1,17 +1,25 @@
 package edu.uci.ics.texera.workflow.operators.source.apis.twitter
-import com.github.redouane59.twitter.TwitterClient
-import com.github.redouane59.twitter.signature.TwitterCredentials
 import edu.uci.ics.texera.workflow.common.operators.source.SourceOperatorExecutor
+import io.github.redouane59.twitter.TwitterClient
+import io.github.redouane59.twitter.signature.TwitterCredentials
 
 abstract class TwitterSourceOpExec(
     apiKey: String,
     apiSecretKey: String
 ) extends SourceOperatorExecutor {
   // batch size for each API request defined by Twitter
-  //    500 is the maximum tweets for each request
-  //    10 is the minimal tweets for each request
+  //  500 is the maximum tweets for each request
+
   val TWITTER_API_BATCH_SIZE_MAX = 500
-  val TWITTER_API_BATCH_SIZE_MIN = 10
+
+  //  10 is the minimal tweets for each request
+  // val TWITTER_API_BATCH_SIZE_MIN = 10
+
+  //  however, when using batch size < 100, could cause using different
+  //  twitter endpoints which has different rate limit.
+  //  (related to redouane59/twitteredV2.5)
+  //  thus, in practice, we use 100 as the min batch size.
+  val TWITTER_API_BATCH_SIZE_MIN = 100
 
   var twitterClient: TwitterClient = _
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/TwitterSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/TwitterSourceOpExec.scala
@@ -9,7 +9,6 @@ abstract class TwitterSourceOpExec(
 ) extends SourceOperatorExecutor {
   // batch size for each API request defined by Twitter
   //  500 is the maximum tweets for each request
-
   val TWITTER_API_BATCH_SIZE_MAX = 500
 
   //  10 is the minimal tweets for each request

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpDesc.scala
@@ -38,7 +38,7 @@ class TwitterFullArchiveSearchSourceOpDesc extends TwitterSourceOpDesc {
   @JsonSchemaDescription("ISO 8601 format")
   var toDateTime: String = _
 
-  @JsonProperty(required = true, defaultValue = "10")
+  @JsonProperty(required = true, defaultValue = "100")
   @JsonSchemaTitle("Limit")
   @JsonSchemaDescription("Maximum number of tweets to retrieve")
   var limit: Int = _
@@ -47,16 +47,7 @@ class TwitterFullArchiveSearchSourceOpDesc extends TwitterSourceOpDesc {
     // TODO: use multiple workers
     new ManyToOneOpExecConfig(
       operatorIdentifier,
-      _ =>
-        new TwitterFullArchiveSearchSourceOpExec(
-          sourceSchema(),
-          apiKey,
-          apiSecretKey,
-          searchQuery,
-          fromDateTime,
-          toDateTime,
-          limit
-        )
+      _ => new TwitterFullArchiveSearchSourceOpExec(this, operatorSchemaInfo)
     )
 
   override def sourceSchema(): Schema = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpDesc.scala
@@ -74,13 +74,15 @@ class TwitterFullArchiveSearchSourceOpDesc extends TwitterSourceOpDesc {
         new Attribute("user_id", AttributeType.STRING),
         new Attribute("user_created_at", AttributeType.TIMESTAMP),
         new Attribute("user_name", AttributeType.STRING),
-        new Attribute("user_display_name", AttributeType.STRING),
-        new Attribute("user_lang", AttributeType.STRING),
-        new Attribute("user_description", AttributeType.STRING),
-        new Attribute("user_followers_count", AttributeType.LONG),
-        new Attribute("user_following_count", AttributeType.LONG),
-        new Attribute("user_tweet_count", AttributeType.LONG),
-        new Attribute("user_location", AttributeType.STRING)
+        new Attribute("user_display_name", AttributeType.STRING)
+        // The following works but currently all get null returned. Will need to wait for
+        // redouane59/twittered to update
+        // new Attribute("user_lang", AttributeType.STRING),
+        // new Attribute("user_description", AttributeType.STRING),
+        // new Attribute("user_followers_count", AttributeType.LONG),
+        // new Attribute("user_following_count", AttributeType.LONG),
+        // new Attribute("user_tweet_count", AttributeType.LONG),
+        // new Attribute("user_location", AttributeType.STRING)
       )
       .build()
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpDesc.scala
@@ -12,8 +12,8 @@ import edu.uci.ics.texera.workflow.common.operators.ManyToOneOpExecConfig
 import edu.uci.ics.texera.workflow.common.tuple.schema.{
   Attribute,
   AttributeType,
-  Schema,
-  OperatorSchemaInfo
+  OperatorSchemaInfo,
+  Schema
 }
 import edu.uci.ics.texera.workflow.operators.source.apis.twitter.TwitterSourceOpDesc
 
@@ -67,20 +67,29 @@ class TwitterFullArchiveSearchSourceOpDesc extends TwitterSourceOpDesc {
     Schema
       .newBuilder()
       .add(
-        new Attribute("id", AttributeType.LONG),
+        new Attribute("id", AttributeType.STRING),
         new Attribute("text", AttributeType.STRING),
         new Attribute("created_at", AttributeType.TIMESTAMP),
-        new Attribute("author_id", AttributeType.LONG),
         new Attribute("lang", AttributeType.STRING),
         new Attribute("tweet_type", AttributeType.STRING),
         new Attribute("place_id", AttributeType.STRING),
         new Attribute("place_coordinate", AttributeType.STRING),
-        new Attribute("in_reply_to_status_id", AttributeType.LONG),
-        new Attribute("in_reply_to_user_id", AttributeType.LONG),
+        new Attribute("in_reply_to_status_id", AttributeType.STRING),
+        new Attribute("in_reply_to_user_id", AttributeType.STRING),
         new Attribute("like_count", AttributeType.LONG),
         new Attribute("quote_count", AttributeType.LONG),
         new Attribute("reply_count", AttributeType.LONG),
-        new Attribute("retweet_count", AttributeType.LONG)
+        new Attribute("retweet_count", AttributeType.LONG),
+        new Attribute("user_id", AttributeType.STRING),
+        new Attribute("user_created_at", AttributeType.TIMESTAMP),
+        new Attribute("user_name", AttributeType.STRING),
+        new Attribute("user_display_name", AttributeType.STRING),
+        new Attribute("user_lang", AttributeType.STRING),
+        new Attribute("user_description", AttributeType.STRING),
+        new Attribute("user_followers_count", AttributeType.LONG),
+        new Attribute("user_following_count", AttributeType.LONG),
+        new Attribute("user_tweet_count", AttributeType.LONG),
+        new Attribute("user_location", AttributeType.STRING)
       )
       .build()
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpExec.scala
@@ -22,10 +22,10 @@ class TwitterFullArchiveSearchSourceOpExec(
     desc: TwitterFullArchiveSearchSourceOpDesc,
     operatorSchemaInfo: OperatorSchemaInfo
 ) extends TwitterSourceOpExec(desc.apiKey, desc.apiSecretKey) {
-  var curLimit: Int = desc.limit
   val outputSchemaAttributes: Array[AttributeType] = operatorSchemaInfo.outputSchema.getAttributes
     .map((attribute: Attribute) => { attribute.getType })
     .toArray
+  var curLimit: Int = desc.limit
   // nextToken is used to retrieve next page of results, if exists.
   var nextToken: String = _
   // contains tweets from the previous request.
@@ -90,19 +90,21 @@ class TwitterFullArchiveSearchSourceOpExec(
             user.get.getId,
             user.get.getCreatedAt,
             user.get.getName,
-            user.get.getDisplayedName,
-            user.get.getLang,
-            user.get.getDescription,
-            Option(user.get.getPublicMetrics)
-              .map(u => java.lang.Long.valueOf(u.getFollowersCount))
-              .orNull,
-            Option(user.get.getPublicMetrics)
-              .map(u => java.lang.Long.valueOf(u.getFollowingCount))
-              .orNull,
-            Option(user.get.getPublicMetrics)
-              .map(u => java.lang.Long.valueOf(u.getTweetCount))
-              .orNull,
-            user.get.getLocation
+            user.get.getDisplayedName
+            // The following works but currently all get null returned. Will need to wait for
+            // redouane59/twittered to update
+            // user.get.getLang,
+            // user.get.getDescription,
+            // Option(user.get.getPublicMetrics)
+            //   .map(u => java.lang.Long.valueOf(u.getFollowersCount))
+            //   .orNull,
+            // Option(user.get.getPublicMetrics)
+            //   .map(u => java.lang.Long.valueOf(u.getFollowingCount))
+            //   .orNull,
+            // Option(user.get.getPublicMetrics)
+            //   .map(u => java.lang.Long.valueOf(u.getTweetCount))
+            //   .orNull,
+            // user.get.getLocation
           ),
           outputSchemaAttributes
         )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpExec.scala
@@ -20,7 +20,7 @@ import scala.collection.{Iterator, mutable}
 import scala.jdk.CollectionConverters.asScalaBufferConverter
 class TwitterFullArchiveSearchSourceOpExec(
     desc: TwitterFullArchiveSearchSourceOpDesc,
-    operatorSchemaInfo: OperatorSchemaInfo,
+    operatorSchemaInfo: OperatorSchemaInfo
 ) extends TwitterSourceOpExec(desc.apiKey, desc.apiSecretKey) {
   var curLimit: Int = desc.limit
   val outputSchemaAttributes: Array[AttributeType] = operatorSchemaInfo.outputSchema.getAttributes

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpExec.scala
@@ -1,14 +1,17 @@
 package edu.uci.ics.texera.workflow.operators.source.apis.twitter.v2
 
-import com.github.redouane59.twitter.dto.tweet.{Tweet, TweetSearchResponse}
-import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeTypeUtils, Schema}
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
+import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeTypeUtils, Schema}
 import edu.uci.ics.texera.workflow.operators.source.apis.twitter.TwitterSourceOpExec
+import io.github.redouane59.twitter.dto.endpoints.AdditionalParameters
+import io.github.redouane59.twitter.dto.tweet.TweetList
+import io.github.redouane59.twitter.dto.tweet.TweetV2.TweetData
+import io.github.redouane59.twitter.dto.user.UserV2.UserData
 
-import java.time.{LocalDateTime, ZoneId, ZoneOffset}
 import java.time.format.DateTimeFormatter
-import scala.collection.{mutable, Iterator}
+import java.time.{LocalDateTime, ZoneId, ZoneOffset}
 import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
+import scala.collection.{Iterator, mutable}
 import scala.jdk.CollectionConverters.asScalaBufferConverter
 class TwitterFullArchiveSearchSourceOpExec(
     schema: Schema,
@@ -24,9 +27,11 @@ class TwitterFullArchiveSearchSourceOpExec(
   var nextToken: String = _
 
   // contains tweets from the previous request.
-  var tweetCache: mutable.Buffer[Tweet] = mutable.Buffer()
+  var tweetCache: mutable.Buffer[TweetData] = mutable.Buffer()
+  var userCache: Map[String, UserData] = _
 
   var hasNextRequest: Boolean = curLimit > 0
+  var lastQueryTime: Long = 0
 
   override def produceTexeraTuple(): Iterator[Tuple] =
     new Iterator[Tuple]() {
@@ -47,7 +52,7 @@ class TwitterFullArchiveSearchSourceOpExec(
         if (tweetCache.isEmpty) {
           return null
         }
-        val tweet: Tweet = tweetCache.remove(0)
+        val tweet: TweetData = tweetCache.remove(0)
 
         curLimit -= 1
 
@@ -55,6 +60,8 @@ class TwitterFullArchiveSearchSourceOpExec(
         if (curLimit == 0) {
           hasNextRequest = false
         }
+
+        val user = userCache.get(tweet.getAuthorId)
 
         val fields = AttributeTypeUtils.parseFields(
           Array[Object](
@@ -68,9 +75,6 @@ class TwitterFullArchiveSearchSourceOpExec(
               .toLocalDateTime
               .atOffset(ZoneOffset.UTC)
               .format(DateTimeFormatter.ISO_DATE_TIME),
-            tweet.getAuthorId,
-            // tweet.getUser, // currently unsupported by the redouane59/twittered library
-            // TODO: add user information
             tweet.getLang,
             tweet.getTweetType.toString,
             // TODO: add actual geo related information
@@ -78,10 +82,26 @@ class TwitterFullArchiveSearchSourceOpExec(
             Option(tweet.getGeo).map(_.getCoordinates).orNull,
             tweet.getInReplyToStatusId,
             tweet.getInReplyToUserId,
-            Integer.valueOf(tweet.getLikeCount),
-            Integer.valueOf(tweet.getQuoteCount),
-            Integer.valueOf(tweet.getReplyCount),
-            Integer.valueOf(tweet.getRetweetCount)
+            java.lang.Long.valueOf(tweet.getLikeCount),
+            java.lang.Long.valueOf(tweet.getQuoteCount),
+            java.lang.Long.valueOf(tweet.getReplyCount),
+            java.lang.Long.valueOf(tweet.getRetweetCount),
+            user.get.getId,
+            user.get.getCreatedAt,
+            user.get.getName,
+            user.get.getDisplayedName,
+            user.get.getLang,
+            user.get.getDescription,
+            Option(user.get.getPublicMetrics)
+              .map(u => java.lang.Long.valueOf(u.getFollowersCount))
+              .orNull,
+            Option(user.get.getPublicMetrics)
+              .map(u => java.lang.Long.valueOf(u.getFollowingCount))
+              .orNull,
+            Option(user.get.getPublicMetrics)
+              .map(u => java.lang.Long.valueOf(u.getTweetCount))
+              .orNull,
+            user.get.getLocation
           ),
           schema.getAttributes.map((attribute: Attribute) => { attribute.getType }).toArray
         )
@@ -95,8 +115,27 @@ class TwitterFullArchiveSearchSourceOpExec(
       endDateTime: LocalDateTime,
       maxResults: Int
   ): Unit = {
+    def enforceRateLimit(): Unit = {
+      // Twitter limit 1 request per second and 300 calls in 15 minutes for V2 FullArchiveSearch
+      // If request too frequently, twitter will force the client wait for 5 minutes.
+      // Here we send at most 1 request per second to avoid hitting rate limit.
+      val currentTime = System.currentTimeMillis()
 
-    var response: TweetSearchResponse = null
+      // using 1100 to avoid some edge cases
+      if (currentTime - lastQueryTime < 1100) {
+        Thread.sleep(currentTime - lastQueryTime)
+      }
+      lastQueryTime = System.currentTimeMillis()
+    }
+
+    val params = AdditionalParameters
+      .builder()
+      .startTime(startDateTime)
+      .endTime(endDateTime)
+      .maxResults(maxResults.max(TWITTER_API_BATCH_SIZE_MIN))
+      .recursiveCall(false)
+      .nextToken(nextToken)
+      .build()
 
     // There is bug in the library twittered that it returns null although there exists
     // more pages.
@@ -105,28 +144,23 @@ class TwitterFullArchiveSearchSourceOpExec(
     // it returns the nextToken as null. The solution is not ideal but should do job in
     // the most cases.
     // TODO: replace with newer version library twittered when the bug is fixed.
+    var response: TweetList = null
     var retry = 2
     do {
-      response = twitterClient.searchForTweetsFullArchive(
-        query,
-        startDateTime,
-        endDateTime,
-        maxResults.max(TWITTER_API_BATCH_SIZE_MIN),
-        nextToken
-      )
+      enforceRateLimit()
+      response = twitterClient.searchAllTweets(query, params)
       retry -= 1
+    } while (response.getMeta.getNextToken == null && retry > 0)
 
-      // Twitter limit 1 request per second for V2 FullArchiveSearch
-      // If request too frequently, twitter will force the client wait for 5 minutes.
-      // Here we send at most 1 request per second to avoid hitting rate limit.
-      Thread.sleep(1000)
-    } while (response.getNextToken == null && retry > 0)
-
-    nextToken = response.getNextToken
+    nextToken = response.getMeta.getNextToken
 
     // when there is no more pages left, no need to request any more
     hasNextRequest = nextToken != null
 
-    tweetCache = response.getTweets.asScala
+    tweetCache = response.getData.asScala
+    userCache =
+      response.getIncludes.getUsers.map((userData: UserData) => userData.getId -> userData).toMap
+
   }
+
 }


### PR DESCRIPTION
In this PR:
1. Updated from `"com.github.redouane59.twitter" % "twittered" % "1.23"` to `"io.github.redouane59.twitter" % "twittered" % "2.5"` in order to use User information.
2. Changed types of ID (tweet_id, user_id, etc) to be type AttributeType.STRING instead of AttributeType.LONG, since the tweet ids are longer than Long types. Fixes #1229.
3. Changed the logic of enforcing the Twitter rate limit. It is still a limited version. Also fixes #1226 to still use 500 as the maximum tweet count per request.