### PR TITLE
Replace CommandCompleted with Unit

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/AssignBreakpointHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/AssignBreakpointHandler.scala
@@ -5,14 +5,14 @@ import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.GlobalB
 import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.AssignBreakpointHandler.AssignGlobalBreakpoint
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.AssignLocalBreakpointHandler.AssignLocalBreakpoint
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.OperatorIdentity
 
 object AssignBreakpointHandler {
   final case class AssignGlobalBreakpoint[T](
       breakpoint: GlobalBreakpoint[T],
       operatorID: OperatorIdentity
-  ) extends ControlCommand[CommandCompleted]
+  ) extends ControlCommand[Unit]
 }
 
 /** Assign a breakpoint to a specific operator
@@ -41,9 +41,7 @@ trait AssignBreakpointHandler {
             }
             .toSeq
         )
-        .map { ret =>
-          CommandCompleted()
-        }
+        .map { _ => }
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/FatalErrorHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/FatalErrorHandler.scala
@@ -3,13 +3,12 @@ package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.FatalErrorHandler.FatalError
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.KillWorkflowHandler.KillWorkflow
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
-import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.util.CONTROLLER
 import edu.uci.ics.amber.error.WorkflowRuntimeError
 
 object FatalErrorHandler {
-  final case class FatalError(e: WorkflowRuntimeError) extends ControlCommand[CommandCompleted]
+  final case class FatalError(e: WorkflowRuntimeError) extends ControlCommand[Unit]
 }
 
 /** Indicate a fatal error has occurred in the workflow

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/KillWorkflowHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/KillWorkflowHandler.scala
@@ -1,13 +1,12 @@
 package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 
 import akka.actor.PoisonPill
-import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.KillWorkflowHandler.KillWorkflow
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 
 object KillWorkflowHandler {
-  final case class KillWorkflow() extends ControlCommand[CommandCompleted]
+  final case class KillWorkflow() extends ControlCommand[Unit]
 }
 
 /** Kill the workflow and release all resources
@@ -25,7 +24,6 @@ trait KillWorkflowHandler {
       // the workers and network communication actors will also be killed
       // the dp thread will be shut down when the workers kill themselves
       actorContext.self ! PoisonPill
-      CommandCompleted()
     }
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LinkCompletedHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LinkCompletedHandler.scala
@@ -4,11 +4,11 @@ import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.LinkCompletedHandler.LinkCompleted
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.StartHandler.StartWorker
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 
 object LinkCompletedHandler {
-  final case class LinkCompleted(linkID: LinkIdentity) extends ControlCommand[CommandCompleted]
+  final case class LinkCompleted(linkID: LinkIdentity) extends ControlCommand[Unit]
 }
 
 /** Notify the completion of a particular link
@@ -45,10 +45,10 @@ trait LinkCompletedHandler {
               .map(send(StartWorker(), _))
               .toSeq
           )
-          .map(ret => CommandCompleted())
+          .map(ret => {})
       } else {
         // if the link is not completed yet, do nothing
-        Future { CommandCompleted() }
+        Future {}
       }
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LinkWorkersHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LinkWorkersHandler.scala
@@ -6,10 +6,10 @@ import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.LinkWork
 import edu.uci.ics.amber.engine.architecture.linksemantics.LinkStrategy
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.AddPartitioningHandler.AddPartitioning
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.UpdateInputLinkingHandler.UpdateInputLinking
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 
 object LinkWorkersHandler {
-  final case class LinkWorkers(link: LinkStrategy) extends ControlCommand[CommandCompleted]
+  final case class LinkWorkers(link: LinkStrategy) extends ControlCommand[Unit]
 }
 
 /** add a data transfer partitioning to the sender workers and update input linking
@@ -32,7 +32,7 @@ trait LinkWorkersHandler {
       }
       Future.collect(futures.toSeq).map { _ =>
         // returns when all has completed
-        CommandCompleted()
+
       }
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LocalBreakpointTriggeredHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LocalBreakpointTriggeredHandler.scala
@@ -9,15 +9,14 @@ import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.PauseHan
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.PauseHandler.PauseWorker
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryAndRemoveBreakpointsHandler.QueryAndRemoveBreakpoints
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.ResumeHandler.ResumeWorker
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
-import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.util.CONTROLLER
 
 import scala.collection.mutable
 
 object LocalBreakpointTriggeredHandler {
   final case class LocalBreakpointTriggered(localBreakpoints: Array[(String, Long)])
-      extends ControlCommand[CommandCompleted]
+      extends ControlCommand[Unit]
 }
 
 /** indicate one/multiple local breakpoints have triggered on a worker
@@ -46,9 +45,7 @@ trait LocalBreakpointTriggeredHandler {
 
       if (unResolved.isEmpty) {
         // no breakpoint needs to resolve, return directly
-        Future {
-          CommandCompleted()
-        }
+        Future {}
       } else {
         // we need to resolve global breakpoints
         // before query workers, increase the version number
@@ -96,9 +93,7 @@ trait LocalBreakpointTriggeredHandler {
                     .collect(targetOp.getAllWorkers.map { worker =>
                       send(ResumeWorker(), worker)
                     }.toSeq)
-                    .map { ret =>
-                      CommandCompleted()
-                    }
+                    .map { _ => {} }
                 } else {
                   // other wise, report to frontend and pause entire workflow
                   if (eventListener.breakpointTriggeredListener != null) {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LocalOperatorExceptionHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LocalOperatorExceptionHandler.scala
@@ -5,7 +5,7 @@ import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandle
 import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.BreakpointTriggered
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.LocalOperatorExceptionHandler.LocalOperatorException
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.PauseHandler.PauseWorkflow
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.util.CONTROLLER
 
@@ -13,7 +13,7 @@ import scala.collection.mutable
 
 object LocalOperatorExceptionHandler {
   final case class LocalOperatorException(triggeredTuple: ITuple, e: Throwable)
-      extends ControlCommand[CommandCompleted]
+      extends ControlCommand[Unit]
 }
 
 /** indicate an exception thrown from the operator logic on a worker

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/PauseHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/PauseHandler.scala
@@ -13,7 +13,7 @@ import edu.uci.ics.amber.engine.architecture.controller.{
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.PauseHandler.PauseWorker
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryCurrentInputTupleHandler.QueryCurrentInputTuple
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 
@@ -21,7 +21,7 @@ import scala.collection.mutable
 
 object PauseHandler {
 
-  final case class PauseWorkflow() extends ControlCommand[CommandCompleted]
+  final case class PauseWorkflow() extends ControlCommand[Unit]
 }
 
 /** pause the entire workflow
@@ -75,7 +75,7 @@ trait PauseHandler {
           }
           disableStatusUpdate() // to be enabled in resume
           actorContext.parent ! ControllerState.Paused // for testing
-          CommandCompleted()
+
         }
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/ResumeHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/ResumeHandler.scala
@@ -7,10 +7,10 @@ import edu.uci.ics.amber.engine.architecture.controller.{
   ControllerState
 }
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.ResumeHandler.ResumeWorker
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 
 object ResumeHandler {
-  final case class ResumeWorkflow() extends ControlCommand[CommandCompleted]
+  final case class ResumeWorkflow() extends ControlCommand[Unit]
 }
 
 /** resume the entire workflow
@@ -31,12 +31,12 @@ trait ResumeHandler {
             workflow.getWorkerInfo(worker).state = ret
           }
         }.toSeq)
-        .map { ret =>
+        .map { _ =>
           // update frontend status
           updateFrontendWorkflowStatus()
           enableStatusUpdate() //re-enabled it since it is disabled in pause
           actorContext.parent ! ControllerState.Running //for testing
-          CommandCompleted()
+
         }
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/StartWorkflowHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/StartWorkflowHandler.scala
@@ -1,21 +1,19 @@
 package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 
 import com.twitter.util.Future
-import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.QueryWorkerStatisticsHandler.ControllerInitiateQueryStatistics
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.StartWorkflowHandler.StartWorkflow
 import edu.uci.ics.amber.engine.architecture.controller.{
   ControllerAsyncRPCHandlerInitializer,
   ControllerState
 }
-import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.StartWorkflowHandler.StartWorkflow
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.WorkerLayer
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.StartHandler.StartWorker
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 
 import scala.collection.mutable
 
 object StartWorkflowHandler {
-  final case class StartWorkflow() extends ControlCommand[CommandCompleted]
+  final case class StartWorkflow() extends ControlCommand[Unit]
 }
 
 /** start the workflow by starting the source workers
@@ -32,7 +30,7 @@ trait StartWorkflowHandler {
       Future
         .collect(
           workflow.getSourceLayers
-            // get all startable layers
+            // get all start-able layers
             .filter(layer => layer.canStart)
             .flatMap { layer =>
               startedLayers.add(layer)
@@ -45,10 +43,10 @@ trait StartWorkflowHandler {
             }
             .toSeq
         )
-        .map { ret =>
+        .map { _ =>
           actorContext.parent ! ControllerState.Running // for testing
           enableStatusUpdate()
-          CommandCompleted()
+
         }
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/WorkerExecutionStartedHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/WorkerExecutionStartedHandler.scala
@@ -2,11 +2,11 @@ package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 
 import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.WorkerExecutionStartedHandler.WorkerStateUpdated
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.worker.WorkerState
 
 object WorkerExecutionStartedHandler {
-  final case class WorkerStateUpdated(state: WorkerState) extends ControlCommand[CommandCompleted]
+  final case class WorkerStateUpdated(state: WorkerState) extends ControlCommand[Unit]
 }
 
 /** indicate the state change of a worker
@@ -21,7 +21,7 @@ trait WorkerExecutionStartedHandler {
       // set the state
       workflow.getOperator(sender).getWorker(sender).state = msg.state
       updateFrontendWorkflowStatus()
-      CommandCompleted()
+
     }
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/AddPartitioningHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/AddPartitioningHandler.scala
@@ -3,13 +3,13 @@ package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 import edu.uci.ics.amber.engine.architecture.sendsemantics.partitionings.Partitioning
 import edu.uci.ics.amber.engine.architecture.worker.WorkerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.AddPartitioningHandler.AddPartitioning
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.amber.engine.common.worker.WorkerState.Ready
 
 object AddPartitioningHandler {
   final case class AddPartitioning(tag: LinkIdentity, partitioning: Partitioning)
-      extends ControlCommand[CommandCompleted]
+      extends ControlCommand[Unit]
 }
 
 trait AddPartitioningHandler {
@@ -18,7 +18,7 @@ trait AddPartitioningHandler {
   registerHandler { (msg: AddPartitioning, sender) =>
     stateManager.assertState(Ready)
     tupleToBatchConverter.addPartitionerWithPartitioning(msg.tag, msg.partitioning)
-    CommandCompleted()
+
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/AssignLocalBreakpointHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/AssignLocalBreakpointHandler.scala
@@ -3,11 +3,10 @@ package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 import edu.uci.ics.amber.engine.architecture.breakpoint.localbreakpoint.LocalBreakpoint
 import edu.uci.ics.amber.engine.architecture.worker.WorkerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.AssignLocalBreakpointHandler.AssignLocalBreakpoint
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 
 object AssignLocalBreakpointHandler {
-  final case class AssignLocalBreakpoint(bp: LocalBreakpoint)
-      extends ControlCommand[CommandCompleted]
+  final case class AssignLocalBreakpoint(bp: LocalBreakpoint) extends ControlCommand[Unit]
 }
 
 trait AssignLocalBreakpointHandler {
@@ -15,6 +14,6 @@ trait AssignLocalBreakpointHandler {
 
   registerHandler { (msg: AssignLocalBreakpoint, sender) =>
     breakpointManager.registerOrReplaceBreakpoint(msg.bp)
-    CommandCompleted()
+
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ShutdownDPThreadHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ShutdownDPThreadHandler.scala
@@ -1,13 +1,13 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
-import java.util.concurrent.CompletableFuture
-
 import edu.uci.ics.amber.engine.architecture.worker.WorkerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.ShutdownDPThreadHandler.ShutdownDPThread
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
+
+import java.util.concurrent.CompletableFuture
 
 object ShutdownDPThreadHandler {
-  final case class ShutdownDPThread() extends ControlCommand[CommandCompleted]
+  final case class ShutdownDPThread() extends ControlCommand[Unit]
 }
 
 trait ShutdownDPThreadHandler {
@@ -17,7 +17,7 @@ trait ShutdownDPThreadHandler {
     {
       dataProcessor.shutdown()
       new CompletableFuture[Void]().get // wait here to be interrupted
-      CommandCompleted() // this will actually never be called
+      () // return unit. this will actually never be called
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/UpdateInputLinkingHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/UpdateInputLinkingHandler.scala
@@ -2,14 +2,14 @@ package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
 import edu.uci.ics.amber.engine.architecture.worker.WorkerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.UpdateInputLinkingHandler.UpdateInputLinking
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LinkIdentity}
 import edu.uci.ics.amber.engine.common.worker.WorkerState.Ready
 
 object UpdateInputLinkingHandler {
 
   final case class UpdateInputLinking(identifier: ActorVirtualIdentity, inputLink: LinkIdentity)
-      extends ControlCommand[CommandCompleted]
+      extends ControlCommand[Unit]
 }
 
 trait UpdateInputLinkingHandler {
@@ -18,7 +18,6 @@ trait UpdateInputLinkingHandler {
   registerHandler { (msg: UpdateInputLinking, sender) =>
     stateManager.assertState(Ready)
     batchToTupleConverter.registerInput(msg.identifier, msg.inputLink)
-    CommandCompleted()
   }
 
 }

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -14,10 +14,9 @@ import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatist
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.ResumeHandler.ResumeWorker
 import edu.uci.ics.amber.engine.common.ambermessage.ControlPayload
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.{CommandCompleted, ControlCommand}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.rpc.{AsyncRPCClient, AsyncRPCServer}
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager
-import edu.uci.ics.amber.engine.common.worker.WorkerState.{Completed, Running}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.util.CONTROLLER
 import edu.uci.ics.amber.engine.common.virtualidentity.{
@@ -25,6 +24,7 @@ import edu.uci.ics.amber.engine.common.virtualidentity.{
   LayerIdentity,
   LinkIdentity
 }
+import edu.uci.ics.amber.engine.common.worker.WorkerState.{Completed, Running}
 import edu.uci.ics.amber.engine.common.{InputExhausted, WorkflowLogger}
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import org.scalamock.scalatest.MockFactory
@@ -96,7 +96,7 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     assert(dp.isControlQueueEmpty)
   }
 
-  case class DummyControl() extends ControlCommand[CommandCompleted]
+  case class DummyControl() extends ControlCommand[Unit]
 
   "data processor" should "process data messages" in {
     val asyncRPCClient: AsyncRPCClient = mock[AsyncRPCClient]
@@ -105,7 +105,7 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     val workerStateManager: WorkerStateManager = new WorkerStateManager(Running)
     inAnyOrder {
       (batchProducer.emitEndOfUpstream _).expects().anyNumberOfTimes()
-      (asyncRPCClient.send[CommandCompleted] _).expects(*, *).anyNumberOfTimes()
+      (asyncRPCClient.send[Unit] _).expects(*, *).anyNumberOfTimes()
       inSequence {
         (operator.open _).expects().once()
         tuples.foreach { x =>
@@ -130,7 +130,7 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     val asyncRPCServer: AsyncRPCServer = mock[AsyncRPCServer]
     inAnyOrder {
       (asyncRPCServer.logControlInvocation _).expects(*, *).anyNumberOfTimes()
-      (asyncRPCClient.send[CommandCompleted] _).expects(*, *).anyNumberOfTimes()
+      (asyncRPCClient.send[Unit] _).expects(*, *).anyNumberOfTimes()
       inSequence {
         (operator.open _).expects().once()
         inAnyOrder {
@@ -167,7 +167,7 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     inAnyOrder {
       (operator.open _).expects().once()
       (asyncRPCServer.logControlInvocation _).expects(*, *).anyNumberOfTimes()
-      (asyncRPCClient.send[CommandCompleted] _).expects(*, *).anyNumberOfTimes()
+      (asyncRPCClient.send[Unit] _).expects(*, *).anyNumberOfTimes()
       (asyncRPCServer.receive _).expects(*, *).repeat(3)
       (operator.close _).expects().once()
     }


### PR DESCRIPTION
This PR replaces the `CommandCompleted` completely with just `Unit`, as the return type, upon a successful RPC call.

With Protobuf, such return type will be represented as `google.protobuf.Empty`.
With Python, such return type will be represented as `None`.

Both `google.protobuf.Empty` and Python's `None` have the exact same semantic as the `Unit` in Scala.