### PR TITLE
Fix frontend validation error of optional fields when the field is filled then deleted

### DIFF
--- a/core/amber/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
+++ b/core/amber/src/main/scala/com/kjetland/jackson/jsonSchema/JsonSchemaGenerator.scala
@@ -30,6 +30,8 @@ object JsonSchemaConfig {
     defaultArrayFormat = None,
     useOneOfForOption = false,
     useOneOfForNullables = false,
+    useNullableForOption = false,
+    useNullableForNullables = false,
     usePropertyOrdering = false,
     hidePolymorphismTypeProperty = false,
     disableWarnings = false,
@@ -53,6 +55,8 @@ object JsonSchemaConfig {
     defaultArrayFormat = Some("table"),
     useOneOfForOption = true,
     useOneOfForNullables = false,
+    useNullableForOption = false,
+    useNullableForNullables = false,
     usePropertyOrdering = true,
     hidePolymorphismTypeProperty = true,
     disableWarnings = false,
@@ -91,6 +95,8 @@ object JsonSchemaConfig {
     defaultArrayFormat = None,
     useOneOfForOption = true,
     useOneOfForNullables = true,
+    useNullableForOption = false,
+    useNullableForNullables = false,
     usePropertyOrdering = false,
     hidePolymorphismTypeProperty = false,
     disableWarnings = false,
@@ -109,6 +115,8 @@ object JsonSchemaConfig {
               defaultArrayFormat:Optional[String],
               useOneOfForOption:Boolean,
               useOneOfForNullables:Boolean,
+              useNullableForOption:Boolean,
+              useNullableForNullables:Boolean,
               usePropertyOrdering:Boolean,
               hidePolymorphismTypeProperty:Boolean,
               disableWarnings:Boolean,
@@ -131,6 +139,8 @@ object JsonSchemaConfig {
       Option(defaultArrayFormat.orElse(null)),
       useOneOfForOption,
       useOneOfForNullables,
+      useNullableForOption,
+      useNullableForNullables,
       usePropertyOrdering,
       hidePolymorphismTypeProperty,
       disableWarnings,
@@ -232,6 +242,8 @@ case class JsonSchemaConfig
   defaultArrayFormat:Option[String],
   useOneOfForOption:Boolean,
   useOneOfForNullables:Boolean,
+  useNullableForOption:Boolean,
+  useNullableForNullables:Boolean,
   usePropertyOrdering:Boolean,
   hidePolymorphismTypeProperty:Boolean,
   disableWarnings:Boolean,
@@ -1164,6 +1176,12 @@ class JsonSchemaGenerator
 
                       // Return oneOfReal which, from now on, will be used as the node representing this property
                       PropertyNode(oneOfReal, thisPropertyNode)
+                    } else if (!requiredProperty && ((config.useNullableForOption && optionalType) ||
+                      (config.useNullableForNullables && !optionalType))) {
+                      // add {nullable: true} in the json schema following OpenAPI and AJV specification
+                      // see https://ajv.js.org/json-schema.html#openapi-support
+                      thisPropertyNode.put("nullable", true)
+                      PropertyNode(thisPropertyNode, thisPropertyNode)
                     } else {
                       // Our type must not be null: primitives, @NotNull annotations, @JsonProperty annotations marked required etc.
                       PropertyNode(thisPropertyNode, thisPropertyNode)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/OperatorMetadataGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/OperatorMetadataGenerator.scala
@@ -55,6 +55,9 @@ object OperatorMetadataGenerator {
 
   val texeraSchemaGeneratorConfig: JsonSchemaConfig = html5EnabledSchema.copy(
     useOneOfForOption = false,
+    useOneOfForNullables = false,
+    useNullableForOption = true,
+    useNullableForNullables = true,
     defaultArrayFormat = None,
     jsonSchemaDraft = JsonSchemaDraft.DRAFT_07
   )

--- a/core/new-gui/src/app/workspace/service/validation/validation-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/validation/validation-workflow.service.ts
@@ -38,7 +38,7 @@ export class ValidationWorkflowService {
   private readonly operatorValidationStream = new Subject<{ operatorID: string, validation: Validation }>();
   // stream of global validation error status is updated, only errors will be reported
   private readonly workflowValidationErrorStream = new BehaviorSubject<{ errors: Record<string, ValidationError> }>( {errors: {}});
-  private ajv = new Ajv({ schemaId: 'auto', allErrors: true });
+  private ajv = new Ajv({ schemaId: 'auto', allErrors: true, nullable: true });
 
   // this map record --> <operatorID, error string>
   private workflowErrors: Record<string, ValidationError> = {};


### PR DESCRIPTION
Our frontend operator validation has a bug, where if a user fills in an optional field, then clears it, the frontend validation will show an error. 
![bug](https://user-images.githubusercontent.com/12578068/127733746-302649bb-df8d-4ed6-a1d1-6955a6054e09.gif)


This is because the form library `ngx-formly` we use will emit the value `{limit: null}` after the `limit` field is deleted.
The frontend validator library `ajv` doesn't allow `null` values because the type of the `limit` field is `int`, which is not nullable. Although `limit` field is not required, `ajv` only accepts `undefined` or `not present`. 


There are a couple of possible workarounds:
1. change the `ngx-formly` library to not emit `null` value, however, the library doesn't give this option
2. change the `ajv` library to accept `null` when the field is optional, however, the library doesn't give this option
3. change the json schema to mark the field as `nullable`, since we control the json schema generation process, this is the only workaround we can implement

The following shows the fixed frontend validation:
![fixed](https://user-images.githubusercontent.com/12578068/127733961-2156aaa9-e44c-41e1-89f5-ba898f8e7458.gif)

