### PR TITLE
Disable WorkflowCache when UserSystem is enabled

### DIFF
--- a/core/new-gui/src/app/app.module.ts
+++ b/core/new-gui/src/app/app.module.ts
@@ -88,6 +88,7 @@ import { NzCardModule } from 'ng-zorro-antd/card';
 import { NzStatisticModule } from 'ng-zorro-antd/statistic';
 import { NzTagModule } from 'ng-zorro-antd/tag';
 import { NzAvatarModule } from 'ng-zorro-antd/avatar';
+import { NzMessageModule } from "ng-zorro-antd/message";
 
 registerLocaleData(en);
 
@@ -172,6 +173,7 @@ registerLocaleData(en);
     NzListModule,
     NzInputModule,
     NzMenuModule,
+    NzMessageModule,
     NzCollapseModule,
     NzToolTipModule,
     NzTableModule,

--- a/core/new-gui/src/app/common/service/user/user.service.ts
+++ b/core/new-gui/src/app/common/service/user/user.service.ts
@@ -45,10 +45,7 @@ export class UserService {
       throw new Error('Already logged in when register.');
     }
 
-    return this.http.post<Response>(`${AppSettings.getApiEndpoint()}/${UserService.REGISTER_ENDPOINT}`, {
-      userName,
-      password
-    });
+    return this.http.post<Response>(`${AppSettings.getApiEndpoint()}/${UserService.REGISTER_ENDPOINT}`, {userName, password});
 
   }
 
@@ -83,10 +80,7 @@ export class UserService {
     if (this.currentUser) {
       throw new Error('Already logged in when login in.');
     }
-    return this.http.post<Response>(`${AppSettings.getApiEndpoint()}/${UserService.LOGIN_ENDPOINT}`, {
-      userName,
-      password
-    });
+    return this.http.post<Response>(`${AppSettings.getApiEndpoint()}/${UserService.LOGIN_ENDPOINT}`, {userName, password});
   }
 
   /**

--- a/core/new-gui/src/app/common/service/user/user.service.ts
+++ b/core/new-gui/src/app/common/service/user/user.service.ts
@@ -6,6 +6,7 @@ import { environment } from '../../../../environments/environment';
 import { AppSettings } from '../../app-setting';
 import { User } from '../../type/user';
 import { GoogleAuthService } from 'ng-gapi';
+
 /**
  * User Service contains the function of registering and logging the user.
  * It will save the user account inside for future use.
@@ -44,7 +45,10 @@ export class UserService {
       throw new Error('Already logged in when register.');
     }
 
-    return this.http.post<Response>(`${AppSettings.getApiEndpoint()}/${UserService.REGISTER_ENDPOINT}`, {userName, password});
+    return this.http.post<Response>(`${AppSettings.getApiEndpoint()}/${UserService.REGISTER_ENDPOINT}`, {
+      userName,
+      password
+    });
 
   }
 
@@ -52,7 +56,7 @@ export class UserService {
    * this method returns a Google OAuth Instance
    */
   public getGoogleAuthInstance(): Observable<gapi.auth2.GoogleAuth> {
-      return this.googleAuth.getAuth();
+    return this.googleAuth.getAuth();
   }
 
 
@@ -66,7 +70,7 @@ export class UserService {
       throw new Error('Already logged in when login in.');
     }
     return this.http.post<User>(`${AppSettings.getApiEndpoint()}/${UserService.GOOGLE_LOGIN_ENDPOINT}`, {authCode})
-          .filter((user: User) => user != null);
+      .filter((user: User) => user != null);
   }
 
   /**
@@ -79,7 +83,10 @@ export class UserService {
     if (this.currentUser) {
       throw new Error('Already logged in when login in.');
     }
-    return this.http.post<Response>(`${AppSettings.getApiEndpoint()}/${UserService.LOGIN_ENDPOINT}`, {userName, password});
+    return this.http.post<Response>(`${AppSettings.getApiEndpoint()}/${UserService.LOGIN_ENDPOINT}`, {
+      userName,
+      password
+    });
   }
 
   /**
@@ -103,10 +110,8 @@ export class UserService {
    * @param user
    */
   public changeUser(user: User | undefined): void {
-    if (this.currentUser !== user) {
-      this.currentUser = user;
-      this.userChangeSubject.next(this.currentUser);
-    }
+    this.currentUser = user;
+    this.userChangeSubject.next(this.currentUser);
   }
 
   /**
@@ -127,8 +132,7 @@ export class UserService {
 
   private loginFromSession(): void {
     this.http.get<User>(`${AppSettings.getApiEndpoint()}/${UserService.AUTH_STATUS_ENDPOINT}`)
-      .filter(user => user != null)
-      .subscribe(user => this.changeUser(user));
+      .subscribe(user => this.changeUser(user != null ? user : undefined));
   }
 
 }

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
@@ -10,7 +10,7 @@ import { DashboardWorkflowEntry } from '../../../type/dashboard-workflow-entry';
 import { UserService } from '../../../../common/service/user/user.service';
 
 export const ROUTER_WORKFLOW_BASE_URL = `/workflow`;
-export const ROUTER_WORKFLOW_CREATE_NEW_URL = `${ROUTER_WORKFLOW_BASE_URL}/new`;
+export const ROUTER_WORKFLOW_CREATE_NEW_URL = `/`;
 
 @Component({
   selector: 'texera-saved-workflow-section',

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.ts
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.ts
@@ -1,11 +1,9 @@
-import { DragDropService } from './../../../service/drag-drop/drag-drop.service';
-import { WorkflowActionService } from '../../../service/workflow-graph/model/workflow-action.service' ;
-import { Component, Input, AfterViewInit, OnInit, ElementRef, OnDestroy } from '@angular/core';
-import { Observable, of, Subject, Subscription, zip } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
+import { DragDropService } from '../../../service/drag-drop/drag-drop.service';
+import { WorkflowActionService } from '../../../service/workflow-graph/model/workflow-action.service';
+import { AfterViewInit, Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { Subscription } from 'rxjs';
 
 import { OperatorSchema } from '../../../types/operator-schema.interface';
-import { assertType } from 'src/app/common/util/assert';
 
 /**
  * OperatorLabelComponent is one operator box in the operator panel.
@@ -47,7 +45,7 @@ export class OperatorLabelComponent implements OnInit, AfterViewInit, OnDestroy 
   }
 
   ngOnInit() {
-    if (! this.operator) {
+    if (!this.operator) {
       throw new Error('operator label component: operator is not specified');
     }
     if (this.fromSearchBox) {
@@ -58,7 +56,7 @@ export class OperatorLabelComponent implements OnInit, AfterViewInit, OnDestroy 
   }
 
   ngAfterViewInit() {
-    if (! this.operatorLabelID || ! this.operator) {
+    if (!this.operatorLabelID || !this.operator) {
       throw new Error('operator label component: operator is not specified');
     }
     this.dragDropService.registerOperatorLabelDrag(this.operatorLabelID, this.operator.operatorType);
@@ -96,8 +94,8 @@ export class OperatorLabelComponent implements OnInit, AfterViewInit, OnDestroy 
   }
 
   private handleWorkFlowModificationEnabled(): Subscription {
-    return this.workflowActionService.getWorkflowModificationEnabledStream().subscribe( enabled => {
-      this.draggable = enabled;
+    return this.workflowActionService.getWorkflowModificationEnabledStream().subscribe(canModify => {
+      this.draggable = canModify;
     });
   }
 

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.ts
@@ -7,9 +7,9 @@ import { map } from 'rxjs/operators';
 import { OperatorMetadataService } from '../../service/operator-metadata/operator-metadata.service';
 
 import { GroupInfo, OperatorMetadata, OperatorSchema } from '../../types/operator-schema.interface';
-import { DragDropService } from './../../service/drag-drop/drag-drop.service';
-import { WorkflowActionService } from './../../service/workflow-graph/model/workflow-action.service';
-import { WorkflowUtilService } from './../../service/workflow-graph/util/workflow-util.service';
+import { DragDropService } from '../../service/drag-drop/drag-drop.service';
+import { WorkflowActionService } from '../../service/workflow-graph/model/workflow-action.service';
+import { WorkflowUtilService } from '../../service/workflow-graph/util/workflow-util.service';
 import { OperatorLabelComponent } from './operator-label/operator-label.component';
 
 /**
@@ -127,7 +127,7 @@ export class OperatorPanelComponent implements OnInit {
 }
 
 // generates a list of group names sorted by the order
-// slice() will make a copy of the list, because we don't want to sort the orignal list
+// slice() will make a copy of the list, because we don't want to sort the original list
 export function getGroupNamesSorted(groupInfoList: ReadonlyArray<GroupInfo>): string[] {
   return groupInfoList.slice()
     .sort((a, b) => (a.groupOrder - b.groupOrder))

--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -83,13 +83,16 @@ export class WorkspaceComponent implements OnDestroy, AfterViewInit {
     this.operatorMetadataService.getOperatorMetadata()
       .filter(metadata => metadata.operators.length !== 0).subscribe(() => {
       if (environment.userSystemEnabled) {
-
         // load workflow with wid if presented in the URL
         if (this.route.snapshot.params.id) {
           const wid = this.route.snapshot.params.id;
           // if wid is present in the url, load it from the backend
           this.subscriptions.add(this.userService.userChanged().subscribe(() => this.loadWorkflowWithId(wid)));
+        } else {
+          // no workflow to load, pending to create a new workflow
         }
+        // responsible for persisting the workflow to the backend
+        this.registerAutoPersistWorkflow();
       } else {
         // load the cached workflow
         this.workflowActionService.reloadWorkflow(this.workflowCacheService.getCachedWorkflow());
@@ -139,8 +142,6 @@ export class WorkspaceComponent implements OnDestroy, AfterViewInit {
         // clear stack
         this.undoRedoService.clearUndoStack();
         this.undoRedoService.clearRedoStack();
-        // responsible for persisting the workflow to the backend
-        this.registerAutoPersistWorkflow();
       },
       () => { this.message.error('You don\'t have access to this workflow, please log in with an appropriate account'); }
     );

--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -87,9 +87,9 @@ export class WorkspaceComponent implements OnDestroy, AfterViewInit {
         this.workflowActionService.disableWorkflowModification();
         // load workflow with wid if presented in the URL
         if (this.route.snapshot.params.id) {
-          const id = this.route.snapshot.params.id;
+          const wid = this.route.snapshot.params.id;
           // if wid is present in the url, load it from the backend
-          this.subscriptions.add(this.userService.userChanged().subscribe(() => this.loadWorkflowWithId(id)));
+          this.subscriptions.add(this.userService.userChanged().subscribe(() => this.loadWorkflowWithId(wid)));
         }
       } else {
         // load the cached workflow

--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -77,14 +77,13 @@ export class WorkspaceComponent implements OnDestroy, AfterViewInit {
      * WorkflowActionService is the single source of the workflow representation. Both WorkflowCacheService and WorkflowPersistService are
      * reflecting changes from WorkflowActionService.
      */
+    // clear the current workspace, reset as `WorkflowActionService.DEFAULT_WORKFLOW`
+    this.workflowActionService.resetAsNewWorkflow();
 
     this.operatorMetadataService.getOperatorMetadata()
       .filter(metadata => metadata.operators.length !== 0).subscribe(() => {
       if (environment.userSystemEnabled) {
-        // clear the current workspace, reset as `WorkflowActionService.DEFAULT_WORKFLOW`
-        this.workflowActionService.resetAsNewWorkflow();
-        // disable the workspace until the workflow is fetched from the backend
-        this.workflowActionService.disableWorkflowModification();
+
         // load workflow with wid if presented in the URL
         if (this.route.snapshot.params.id) {
           const wid = this.route.snapshot.params.id;
@@ -129,6 +128,8 @@ export class WorkspaceComponent implements OnDestroy, AfterViewInit {
   }
 
   private loadWorkflowWithId(wid: number): void {
+    // disable the workspace until the workflow is fetched from the backend
+    this.workflowActionService.disableWorkflowModification();
     this.workflowPersistService.retrieveWorkflow(wid).subscribe(
       (workflow: Workflow) => {
         // enable workspace for modification
@@ -144,4 +145,5 @@ export class WorkspaceComponent implements OnDestroy, AfterViewInit {
       () => { this.message.error('You don\'t have access to this workflow, please log in with an appropriate account'); }
     );
   }
+
 }

--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -15,6 +15,7 @@ import { UndoRedoService } from '../service/undo-redo/undo-redo.service';
 import { WorkflowCacheService } from '../service/workflow-cache/workflow-cache.service';
 import { WorkflowActionService } from '../service/workflow-graph/model/workflow-action.service';
 import { WorkflowWebsocketService } from '../service/workflow-websocket/workflow-websocket.service';
+import { NzMessageService } from 'ng-zorro-antd/message';
 
 @Component({
   selector: 'texera-workspace',
@@ -46,7 +47,8 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     private workflowActionService: WorkflowActionService,
     private location: Location,
     private route: ActivatedRoute,
-    private operatorMetadataService: OperatorMetadataService
+    private operatorMetadataService: OperatorMetadataService,
+    private message: NzMessageService
   ) {
     this.subscriptions.add(this.resultPanelToggleService.getToggleChangeStream().subscribe(
       value => this.showResultPanel = value
@@ -56,58 +58,56 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
 
     /**
-     * On initialization of the workspace, there could be four cases:
-     * 1. Accessed by URL `/`, no workflow is cached or in the URL (Cold Start):
-     *    - This won't be able to find a workflow on the backend to link with. It starts with the WorkflowActionService.DEFAULT_WORKFLOW,
-     *    which is an empty workflow with undefined id. This new empty workflow will be cached in localStorage upon initialization.
-     *    - After an Auto-persist being triggered by a workspace event, it will create a new workflow in the database
-     *    and update the cached workflow with its new ID from database.
-     * 2. Accessed by URL `/`, with a workflow cached (refresh manually, or create new workflow button from workspace):
-     *    - This will trigger the WorkflowCacheService to load the workflow from cache. It can be linked to the database if the cached
-     *    workflow has ID.
-     *    - After an Auto-persist being triggered by a workspace event, if not having an ID, it will create a new workflow in the database
-     *    and update the cached workflow with its new ID from database.
-     * 3. Accessed by URL `/workflow/:id` (refresh manually, or redirected from dashboard workflow list):
-     *    - No matter if there exists a cached workflow, it will retrieves the workflow from database with the given ID. the cached workflow
-     *    will be overwritten. Because it has an ID, it will be linked to the database
+     * On initialization of the workspace, there could be three cases:
+     *
+     * - with userSystem enabled, usually during prod mode:
+     * 1. Accessed by URL `/`, no workflow is in the URL (Cold Start):
+     -    - A new `WorkflowActionService.DEFAULT_WORKFLOW` is created, which is an empty workflow with undefined id.
+     *    - After an Auto-persist being triggered by a WorkflowAction event, it will create a new workflow in the database
+     *    and update the URL with its new ID from database.
+     * 2. Accessed by URL `/workflow/:id` (refresh manually, or redirected from dashboard workflow list):
+     *    - It will retrieve the workflow from database with the given ID. Because it has an ID, it will be linked to the database
      *    - Auto-persist will be triggered upon all workspace events.
-     * 4. Accessed by URL `/workflow/new` (create new workflow button from dashboard):
-     *    - A new empty workflow is created.
-     *    - After an Auto-persist being triggered by a workspace event, if not having an ID, it will create a new workflow in the database
-     *    and update the cached workflow with its new ID from database.
+     *
+     * - with userSystem disabled, during dev mode:
+     * 1. Accessed by URL `/`, with a workflow cached (refresh manually):
+     *    - This will trigger the WorkflowCacheService to load the workflow from cache.
+     *    - Auto-cache will be triggered upon all workspace events.
      *
      * WorkflowActionService is the single source of the workflow representation. Both WorkflowCacheService and WorkflowPersistService are
      * reflecting changes from WorkflowActionService.
      */
 
-    // responsible for saving the existing workflow.
-    this.registerAutoCacheWorkFlow();
-
-    // responsible for reloading workflow back to the JointJS paper when the browser refreshes.
-    this.registerAutoReloadWorkflow();
 
     if (environment.userSystemEnabled) {
+      // clear the current workspace, reset as `WorkflowActionService.DEFAULT_WORKFLOW`
+      this.workflowActionService.resetAsNewWorkflow();
+
+      // responsible for persisting the workflow to the backend.
+      this.registerAutoPersistWorkflow();
+
+      // load workflow with wid if presented in the URL
       if (this.route.snapshot.params.id) {
         const id = this.route.snapshot.params.id;
-        if (id === 'new') {
-          // if new is present in the url, create a new workflow
-          this.workflowCacheService.resetCachedWorkflow();
-          this.workflowActionService.resetAsNewWorkflow();
-          this.location.go('/');
-        } else {
-          // if wid is present in the url, load it from backend
-          this.subscriptions.add(this.userService.userChanged().combineLatest(this.operatorMetadataService.getOperatorMetadata()
-            .filter(metadata => metadata.operators.length !== 0))
-            .subscribe(() => this.loadWorkflowWithID(id)));
-        }
-      } else {
-        // load wid from cache
-        const workflow = this.workflowCacheService.getCachedWorkflow();
-        const id = workflow?.wid;
-        if (id !== undefined) { this.location.go(`/workflow/${id}`); }
+        // if wid is present in the url, load it from backend
+        this.subscriptions.add(this.userService.userChanged().combineLatest(this.operatorMetadataService.getOperatorMetadata()
+          .filter(metadata => metadata.operators.length !== 0))
+          .subscribe(() => this.loadWorkflowWithID(id)));
       }
 
-      this.registerAutoPersistWorkflow();
+    } else {
+
+      // load wid from cache
+      const workflow = this.workflowCacheService.getCachedWorkflow();
+      const id = workflow?.wid;
+      if (id !== undefined) { this.location.go(`/workflow/${id}`); }
+
+      // responsible for saving the existing workflow in cache.
+      this.registerAutoCacheWorkFlow();
+
+      // responsible for reloading workflow back to the JointJS paper when the browser refreshes.
+      this.registerAutoReloadWorkflowFromCache();
+
     }
 
   }
@@ -116,7 +116,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
     this.subscriptions.unsubscribe();
   }
 
-  private registerAutoReloadWorkflow(): void {
+  private registerAutoReloadWorkflowFromCache(): void {
     this.subscriptions.add(this.operatorMetadataService.getOperatorMetadata()
       .filter(metadata => metadata.operators.length !== 0)
       .subscribe(() => { this.workflowActionService.reloadWorkflow(this.workflowCacheService.getCachedWorkflow()); }));
@@ -135,7 +135,6 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
         this.workflowPersistService.persistWorkflow(this.workflowActionService.getWorkflow())
           .subscribe((updatedWorkflow: Workflow) => {
             this.workflowActionService.setWorkflowMetadata(updatedWorkflow);
-            this.workflowCacheService.setCacheWorkflow(this.workflowActionService.getWorkflow());
             this.location.go(`/workflow/${updatedWorkflow.wid}`);
           });
         // to sync up with the updated information, such as workflow.wid
@@ -149,19 +148,8 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
         this.workflowActionService.reloadWorkflow(workflow);
         this.undoRedoService.clearUndoStack();
         this.undoRedoService.clearRedoStack();
-        this.workflowCacheService.setCacheWorkflow(this.workflowActionService.getWorkflow());
       },
-      () => { this.noAccessToWorkflow(); }
+      () => { this.message.error('You don\'t have access to this workflow, please log in with another account'); }
     ));
-  }
-
-  private noAccessToWorkflow(): void {
-    this.undoRedoService.clearUndoStack();
-    this.undoRedoService.clearRedoStack();
-    this.workflowCacheService.resetCachedWorkflow();
-    this.workflowActionService.reloadWorkflow(this.workflowCacheService.getCachedWorkflow());
-    this.location.go(`/`);
-    // TODO: replace with a proper error message with the framework
-    alert('You don\'t have access to this workflow, please log in with another account');
   }
 }

--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -149,7 +149,7 @@ export class WorkspaceComponent implements OnInit, OnDestroy {
         this.undoRedoService.clearUndoStack();
         this.undoRedoService.clearRedoStack();
       },
-      () => { this.message.error('You don\'t have access to this workflow, please log in with another account'); }
+      () => { this.message.error('You don\'t have access to this workflow, please log in with an appropriate account'); }
     ));
   }
 }

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -367,14 +367,8 @@ export class ExecuteWorkflowService {
     const links: LogicalLink[] = workflowGraph
       .getAllEnabledLinks()
       .map(link => ({
-        origin: {
-          operatorID: link.source.operatorID,
-          portOrdinal: getOutputPortOrdinal(link.source.operatorID, link.source.portID)
-        },
-        destination: {
-          operatorID: link.target.operatorID,
-          portOrdinal: getInputPortOrdinal(link.target.operatorID, link.target.portID)
-        }
+        origin: {operatorID: link.source.operatorID, portOrdinal: getOutputPortOrdinal(link.source.operatorID, link.source.portID)},
+        destination: {operatorID: link.target.operatorID, portOrdinal: getInputPortOrdinal(link.target.operatorID, link.target.portID)}
       }));
 
     const breakpoints: BreakpointInfo[] = Array.from(workflowGraph.getAllEnabledLinkBreakpoints().entries())

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 
 import { Subject } from 'rxjs/Subject';
 import { Observable } from 'rxjs/Observable';
@@ -16,8 +16,8 @@ import {
 } from '../../types/execute-workflow.interface';
 import { environment } from '../../../../environments/environment';
 import { WorkflowWebsocketService } from '../workflow-websocket/workflow-websocket.service';
-import { BreakpointTriggerInfo, BreakpointRequest, Breakpoint } from '../../types/workflow-common.interface';
-import { TexeraWebsocketEvent, OperatorCurrentTuples, ResultDownloadResponse } from '../../types/workflow-websocket.interface';
+import { Breakpoint, BreakpointRequest, BreakpointTriggerInfo } from '../../types/workflow-common.interface';
+import { OperatorCurrentTuples, ResultDownloadResponse, TexeraWebsocketEvent } from '../../types/workflow-websocket.interface';
 import { isEqual } from 'lodash';
 import { PAGINATION_INFO_STORAGE_KEY, ResultPaginationInfo } from '../../types/result-table.interface';
 import { sessionGetObject, sessionSetObject } from '../../../common/util/storage';
@@ -68,25 +68,20 @@ export class ExecuteWorkflowService {
     private http: HttpClient
   ) {
     if (environment.amberEngineEnabled) {
+      workflowWebsocketService.subscribeToEvent('ResultDownloadResponse')
+        .subscribe((event) => this.resultDownloadStream.next(event));
+
       workflowWebsocketService.websocketEvent().subscribe(event => {
-        switch (event.type) {
-          case 'ResultDownloadResponse': {
-            this.resultDownloadStream.next(event);
-            break;
-          } default: {
-            // workflow status related event
-            if (event.type !== 'WebWorkflowStatusUpdateEvent') {
-              console.log(event);
-            }
-            const newState = this.handleExecutionEvent(event);
-            this.updateExecutionState(newState);
-          }
+        // workflow status related event
+        const newState = this.handleExecutionEvent(event);
+        if (newState !== undefined) {
+          this.updateExecutionState(newState);
         }
       });
     }
   }
 
-  public handleExecutionEvent(event: TexeraWebsocketEvent): ExecutionStateInfo {
+  public handleExecutionEvent(event: TexeraWebsocketEvent): ExecutionStateInfo | undefined {
     switch (event.type) {
       case 'WorkflowStartedEvent':
         return {state: ExecutionState.Running};
@@ -139,7 +134,7 @@ export class ExecuteWorkflowService {
         });
         return {state: ExecutionState.Failed, errorMessages: backendErrorMessages};
       default:
-        return this.currentState;
+        return undefined;
     }
   }
 
@@ -195,7 +190,7 @@ export class ExecuteWorkflowService {
       return;
     }
     if (this.currentState === undefined || this.currentState.state !== ExecutionState.Running) {
-      throw new Error('cannot pause workflow, current execution state is ' + this.currentState.state);
+      throw new Error('cannot pause workflow, current execution state is ' + this.currentState?.state);
     }
     this.workflowWebsocketService.send('PauseWorkflowRequest', {});
     this.updateExecutionState({state: ExecutionState.Pausing});
@@ -303,13 +298,10 @@ export class ExecuteWorkflowService {
   }
 
   private updateExecutionState(stateInfo: ExecutionStateInfo): void {
-    this.updateWorkflowActionLock(stateInfo);
     if (isEqual(this.currentState, stateInfo)) {
       return;
     }
-    console.log('stateInfo', stateInfo);
-    console.log(this.clearTimeoutState);
-    console.log(this.clearTimeoutState?.includes(stateInfo.state));
+    this.updateWorkflowActionLock(stateInfo);
     if (this.clearTimeoutState?.includes(stateInfo.state)) {
       this.clearExecutionTimeout();
     }
@@ -375,8 +367,14 @@ export class ExecuteWorkflowService {
     const links: LogicalLink[] = workflowGraph
       .getAllEnabledLinks()
       .map(link => ({
-        origin: {operatorID: link.source.operatorID, portOrdinal: getOutputPortOrdinal(link.source.operatorID, link.source.portID)},
-        destination: {operatorID: link.target.operatorID, portOrdinal: getInputPortOrdinal(link.target.operatorID, link.target.portID)}
+        origin: {
+          operatorID: link.source.operatorID,
+          portOrdinal: getOutputPortOrdinal(link.source.operatorID, link.source.portID)
+        },
+        destination: {
+          operatorID: link.target.operatorID,
+          portOrdinal: getInputPortOrdinal(link.target.operatorID, link.target.portID)
+        }
       }));
 
     const breakpoints: BreakpointInfo[] = Array.from(workflowGraph.getAllEnabledLinkBreakpoints().entries())

--- a/core/new-gui/src/app/workspace/service/workflow-cache/workflow-cache.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-cache/workflow-cache.service.ts
@@ -1,6 +1,4 @@
 import { Injectable } from '@angular/core';
-import { UserService } from '../../../common/service/user/user.service';
-import { User } from '../../../common/type/user';
 import { Workflow } from '../../../common/type/workflow';
 import { localGetObject, localRemoveObject, localSetObject } from '../../../common/util/storage';
 
@@ -10,12 +8,6 @@ import { localGetObject, localRemoveObject, localSetObject } from '../../../comm
 export class WorkflowCacheService {
   private static readonly WORKFLOW_KEY: string = 'workflow';
 
-  constructor(
-    private userService: UserService
-  ) {
-    // reset the cache upon change of user
-    this.registerUserChangeClearCache();
-  }
 
   public getCachedWorkflow(): Workflow | undefined {
     return localGetObject<Workflow>(WorkflowCacheService.WORKFLOW_KEY);
@@ -29,11 +21,11 @@ export class WorkflowCacheService {
     localSetObject(WorkflowCacheService.WORKFLOW_KEY, workflow);
   }
 
-  private registerUserChangeClearCache(): void {
-    this.userService.userChanged().subscribe((user: User | undefined) => {
-      if (user === undefined) {
-        this.resetCachedWorkflow();
-      }
-    });
-  }
+  // private registerUserChangeClearCache(): void {
+  //   this.userService.userChanged().subscribe((user: User | undefined) => {
+  //     if (user === undefined) {
+  //       this.resetCachedWorkflow();
+  //     }
+  //   });
+  // }
 }

--- a/core/new-gui/src/app/workspace/service/workflow-cache/workflow-cache.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-cache/workflow-cache.service.ts
@@ -20,12 +20,4 @@ export class WorkflowCacheService {
   public setCacheWorkflow(workflow: Workflow | undefined): void {
     localSetObject(WorkflowCacheService.WORKFLOW_KEY, workflow);
   }
-
-  // private registerUserChangeClearCache(): void {
-  //   this.userService.userChanged().subscribe((user: User | undefined) => {
-  //     if (user === undefined) {
-  //       this.resetCachedWorkflow();
-  //     }
-  //   });
-  // }
 }


### PR DESCRIPTION
The previous implementation has `WorkflowCache` and `WorkflowPersist` services enabled in parallel. This creates unsynced issues when the network is slow and persisted workflow is not synced in the cache. 

This PR removes this parallelism: 
- when `UserSystem` is enabled, normally in production mode, the `WorkflowPersistService` will be enabled.
- when `UserSystem` is disabled, normally in development mode, the `WorkflowCacheService` will be enabled.

The `WorkflowPersistService` and the `WorkflowCacheService` become supplementary to each other and will never interact with each other.

There are some more changes in this PR:
- Simplifies the logic of creating a new workflow, combining `/workflow/new` onto `/` to indicate creating of a new workflow.
- Disables the workspace while loading a workflow.