### PR TITLE
Add HashBasedShufflePartitioner in Python UDF V2

### DIFF
--- a/core/amber/src/main/python/core/architecture/packaging/tuple_to_batch_converter.py
+++ b/core/amber/src/main/python/core/architecture/packaging/tuple_to_batch_converter.py
@@ -3,13 +3,15 @@ from collections import OrderedDict
 from itertools import chain
 from typing import Iterable, Iterator
 
+from core.architecture.sendsemantics.hash_based_shuffle_partitioner import HashBasedShufflePartitioner
 from core.architecture.sendsemantics.one_to_one_partitioner import OneToOnePartitioner
 from core.architecture.sendsemantics.partitioner import Partitioner
 from core.architecture.sendsemantics.round_robin_partitioner import RoundRobinPartitioner
 from core.models import Tuple
 from core.models.payload import DataFrame, DataPayload
 from core.util import get_one_of
-from proto.edu.uci.ics.amber.engine.architecture.sendsemantics import OneToOnePartitioning, Partitioning, \
+from proto.edu.uci.ics.amber.engine.architecture.sendsemantics import HashBasedShufflePartitioning, \
+    OneToOnePartitioning, Partitioning, \
     RoundRobinPartitioning
 from proto.edu.uci.ics.amber.engine.common import ActorVirtualIdentity, LinkIdentity
 
@@ -19,8 +21,9 @@ class TupleToBatchConverter:
     def __init__(self, ):
         self._partitioners: OrderedDict[LinkIdentity, Partitioning] = OrderedDict()
         self._partitioning_to_partitioner: dict[type(Partitioning), type(Partitioner)] = {
-            OneToOnePartitioning:   OneToOnePartitioner,
-            RoundRobinPartitioning: RoundRobinPartitioner
+            OneToOnePartitioning:         OneToOnePartitioner,
+            RoundRobinPartitioning:       RoundRobinPartitioner,
+            HashBasedShufflePartitioning: HashBasedShufflePartitioner
         }
 
     def add_partitioning(self, tag: LinkIdentity, partitioning: Partitioning) -> None:


### PR DESCRIPTION
This PR adds an implementation of `HashBasedShufflePartitioner` in the Python end. So Python UDF V2's output can be shuffled and pipelined into the operators that require `HashBashedShufflePartitioning`, such as `HashJoin`.
