### PR TITLE
Properly update ConsoleFrame when state changes

### DIFF
--- a/core/new-gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.html
+++ b/core/new-gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.html
@@ -1,15 +1,17 @@
-<div class="texera-panel-message">
-  <div *ngIf="errorMessages">
-    <div *ngFor="let item of errorMessages | keyvalue">
-      {{item.key}}:{{item.value}}
-    </div>
-  </div>
-  <div *ngFor="let message of consoleMessages">
-    <div class="console-message">{{message}}</div>
+<div *ngIf="errorMessages">
+  <div *ngFor="let item of errorMessages | keyvalue">
+    <div class="error-message">{{item.key}}:{{item.value}}</div>
   </div>
 </div>
+<!-- hide this button to temporarily disable this feature         -->
 <button (click)="onClickSkipTuples()" *ngIf="breakpointTriggerInfo !== undefined"
         nz-button
+        [hidden]="true"
         [disabled]="!breakpointAction">
   Skip Records
 </button>
+<div *ngFor="let message of consoleMessages">
+  <div class="console-message">{{message}}</div>
+</div>
+
+

--- a/core/new-gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.html
+++ b/core/new-gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.html
@@ -1,14 +1,15 @@
 <div class="texera-panel-message">
-  <div *ngFor="let message of consoleMessages">
-    <div class="console-message">{{message}}</div>
-  </div>
   <div *ngIf="errorMessages">
     <div *ngFor="let item of errorMessages | keyvalue">
       {{item.key}}:{{item.value}}
     </div>
   </div>
+  <div *ngFor="let message of consoleMessages">
+    <div class="console-message">{{message}}</div>
+  </div>
 </div>
-<button class="btn btn-secondary" *ngIf="breakpointTriggerInfo !== undefined" (click)="onClickSkipTuples()"
+<button (click)="onClickSkipTuples()" *ngIf="breakpointTriggerInfo !== undefined"
+        nz-button
         [disabled]="!breakpointAction">
   Skip Records
 </button>

--- a/core/new-gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.scss
+++ b/core/new-gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.scss
@@ -1,3 +1,13 @@
+.error-message {
+  font-family: monaco, serif;
+  font-size: 11px;
+  font-style: normal;
+  font-variant: normal;
+  font-weight: 200;
+  line-height: 14px;
+  color: red;
+}
+
 .console-message {
   font-family: monaco, serif;
   font-size: 11px;

--- a/core/new-gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.ts
@@ -82,8 +82,7 @@ export class ConsoleFrameComponent implements OnInit, OnDestroy {
     const breakpointTriggerInfo = this.executeWorkflowService.getBreakpointTriggerInfo();
 
     if (resultPanelOperatorID) {
-      this.displayConsoleMessages(resultPanelOperatorID);
-
+      // first display error messages if applicable
       if (resultPanelOperatorID === breakpointTriggerInfo?.operatorID) {
         // if we hit a breakpoint
         this.displayBreakpoint(breakpointTriggerInfo);
@@ -91,6 +90,9 @@ export class ConsoleFrameComponent implements OnInit, OnDestroy {
         // otherwise we assume it's a fault
         this.displayFault();
       }
+
+      // always display console messages
+      this.displayConsoleMessages(resultPanelOperatorID);
     }
   }
 


### PR DESCRIPTION
This PR solves the inconsistent error message display issue on the `ConsoleFrame`, fixes #1305. Now the logic is as following:

1. Error messages could be displayed with console messages together.
2. Error messages could be coming from two types: 
    a. Faulted, that the workflow is failed and terminated.
    b. Breakpoint hit, that the workflow hits a breakpoint and paused.
3. Error messages and console messages are left unchanged when terminating a workflow.
4. Error messages and console messages are cleared when a new workflow execution is started.

Screenshot:
<img width="1740" alt="Screen Shot 2021-08-20 at 23 23 23" src="https://user-images.githubusercontent.com/17627829/130312710-8e05bfa6-f61e-4f0d-9454-0125d9d9225b.png">
