### PR TITLE
Kill the workflow when error in preparing workflow

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
@@ -7,11 +7,17 @@ import com.softwaremill.macwire.wire
 import com.twitter.util.Future
 import edu.uci.ics.amber.clustering.ClusterListener.GetAvailableNodeAddresses
 import edu.uci.ics.amber.engine.architecture.common.WorkflowActor
-import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{ErrorOccurred, WorkflowStatusUpdate}
+import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.{
+  ErrorOccurred,
+  WorkflowStatusUpdate
+}
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.KillWorkflowHandler.KillWorkflow
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.LinkWorkersHandler.LinkWorkers
 import edu.uci.ics.amber.engine.architecture.linksemantics.LinkStrategy
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor.{NetworkMessage, RegisterActorRef}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor.{
+  NetworkMessage,
+  RegisterActorRef
+}
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkInputPort
 import edu.uci.ics.amber.engine.architecture.pythonworker.promisehandlers.SendPythonUdfHandler.SendPythonUdf
 import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState.READY


### PR DESCRIPTION
This PR fixes #1289, it might not be complete, though.

One of the possible reasons for none terminated python worker is due to errored during the workflow preparation phase. During which the python code is sent through a control message to be loaded dynamically. When python code load failed (mostly due to syntax/compilation error), the error is propagated to the frontend, and the workers are detached without being terminated. This fix terminates the entire workflow upon this failure.