### PR TITLE
[Operator Caching Step 2] Frontend changes to implement operator caching

### DIFF
--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -157,6 +157,24 @@
         >
           <i nz-icon nzTheme="twotone" nzType="stop"></i>
         </button>
+        <button
+          *ngIf="isCacheOperator || ! isCacheOperatorClickable"
+          [disabled]="! isCacheOperatorClickable"
+          (click)="onClickCacheOperators()"
+          nz-button
+          title="cache operators"
+        >
+          <i nz-icon nzType="database" nzTheme="outline"></i>
+        </button>
+        <button
+          *ngIf="! isCacheOperator && isCacheOperatorClickable"
+          [disabled]="! isCacheOperatorClickable"
+          (click)="onClickCacheOperators()"
+          nz-button
+          title="operators cached, click to remove cache"
+        >
+          <i nz-icon nzType="database" nzTheme="twotone"></i>
+        </button>
       </nz-button-group>
     </div>
 

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -158,7 +158,7 @@
           <i nz-icon nzTheme="twotone" nzType="stop"></i>
         </button>
         <button
-          *ngIf="isCacheOperator || ! isCacheOperatorClickable"
+          *ngIf="operatorCacheEnabled && (isCacheOperator || ! isCacheOperatorClickable)"
           [disabled]="! isCacheOperatorClickable"
           (click)="onClickCacheOperators()"
           nz-button
@@ -167,7 +167,7 @@
           <i nz-icon nzType="database" nzTheme="outline"></i>
         </button>
         <button
-          *ngIf="! isCacheOperator && isCacheOperatorClickable"
+          *ngIf="operatorCacheEnabled && (! isCacheOperator && isCacheOperatorClickable)"
           [disabled]="! isCacheOperatorClickable"
           (click)="onClickCacheOperators()"
           nz-button

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -62,6 +62,9 @@ export class NavigationComponent {
   public isDisableOperatorClickable: boolean = false;
   public isDisableOperator: boolean = true;
 
+  public isCacheOperatorClickable: boolean = false;
+  public isCacheOperator: boolean = true;
+
   constructor(
     public executeWorkflowService: ExecuteWorkflowService,
     public tourService: TourService,
@@ -113,6 +116,7 @@ export class NavigationComponent {
     this.registerWorkflowMetadataDisplayRefresh();
 
     this.handleDisableOperatorStatusChange();
+    this.handleCacheOperatorStatusChange();
   }
 
   // apply a behavior to the run button via bound variables
@@ -377,6 +381,18 @@ export class NavigationComponent {
     }
   }
 
+  public onClickCacheOperators(): void {
+    if (this.isCacheOperator) {
+      this.effectivelyHighlightedOperators().forEach((op) => {
+        this.workflowActionService.getTexeraGraph().cacheOperator(op);
+      });
+    } else {
+      this.effectivelyHighlightedOperators().forEach((op) => {
+        this.workflowActionService.getTexeraGraph().unCacheOperator(op);
+      });
+    }
+  }
+
   /**
    * Returns true if currently highlighted elements are all groups.
    */
@@ -479,6 +495,38 @@ export class NavigationComponent {
 
         this.isDisableOperator = !allDisabled;
         this.isDisableOperatorClickable =
+          effectiveHighlightedOperators.length !== 0;
+      });
+  }
+
+  handleCacheOperatorStatusChange() {
+    merge(
+      this.workflowActionService
+        .getJointGraphWrapper()
+        .getJointOperatorHighlightStream(),
+      this.workflowActionService
+        .getJointGraphWrapper()
+        .getJointOperatorUnhighlightStream(),
+      this.workflowActionService
+        .getJointGraphWrapper()
+        .getJointGroupHighlightStream(),
+      this.workflowActionService
+        .getJointGraphWrapper()
+        .getJointGroupUnhighlightStream(),
+      this.workflowActionService
+        .getTexeraGraph()
+        .getCachedOperatorsChangedStream()
+    )
+      .pipe(untilDestroyed(this))
+      .subscribe((event) => {
+        const effectiveHighlightedOperators =
+          this.effectivelyHighlightedOperators();
+        const allCached = this.effectivelyHighlightedOperators().every((op) =>
+          this.workflowActionService.getTexeraGraph().isOperatorCached(op)
+        );
+
+        this.isCacheOperator = !allCached;
+        this.isCacheOperatorClickable =
           effectiveHighlightedOperators.length !== 0;
       });
   }

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -62,6 +62,7 @@ export class NavigationComponent {
   public isDisableOperatorClickable: boolean = false;
   public isDisableOperator: boolean = true;
 
+  public operatorCacheEnabled: boolean = environment.operatorCacheEnabled;
   public isCacheOperatorClickable: boolean = false;
   public isCacheOperator: boolean = true;
 

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -141,8 +141,6 @@ export class ResultPanelComponent implements OnInit {
       return;
     }
 
-    // break this into another detect cycle, so that the dynamic component can be reloaded
-
     const executionState = this.executeWorkflowService.getExecutionState();
     if (
       executionState.state in
@@ -154,31 +152,23 @@ export class ResultPanelComponent implements OnInit {
       });
     } else {
       if (this.currentOperatorId) {
-        if (
-          this.workflowActionService
-            .getTexeraGraph()
-            .getOperator(this.currentOperatorId)
-            .operatorType.toLowerCase()
-            .includes("sink")
-        ) {
-          const resultService = this.workflowResultService.getResultService(
+        const resultService = this.workflowResultService.getResultService(
+          this.currentOperatorId
+        );
+        const paginatedResultService =
+          this.workflowResultService.getPaginatedResultService(
             this.currentOperatorId
           );
-          const paginatedResultService =
-            this.workflowResultService.getPaginatedResultService(
-              this.currentOperatorId
-            );
-          if (paginatedResultService) {
-            this.switchFrameComponent({
-              component: ResultTableFrameComponent,
-              componentInputs: { operatorId: this.currentOperatorId }
-            });
-          } else if (resultService && resultService.getChartType()) {
-            this.switchFrameComponent({
-              component: VisualizationFrameComponent,
-              componentInputs: { operatorId: this.currentOperatorId }
-            });
-          }
+        if (paginatedResultService) {
+          this.switchFrameComponent({
+            component: ResultTableFrameComponent,
+            componentInputs: { operatorId: this.currentOperatorId }
+          });
+        } else if (resultService && resultService.getChartType()) {
+          this.switchFrameComponent({
+            component: VisualizationFrameComponent,
+            componentInputs: { operatorId: this.currentOperatorId }
+          });
         } else {
           this.switchFrameComponent({
             component: ConsoleFrameComponent,

--- a/core/new-gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.ts
@@ -95,6 +95,13 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
         }
         const opUpdate = update[this.operatorId];
         if (!opUpdate || !isWebPaginationUpdate(opUpdate)) {
+          // clear result panel if currently display results
+          if (this.totalNumTuples > 0) {
+            this.totalNumTuples = 0;
+            this.currentPageIndex = 1;
+            this.currentColumns = undefined;
+            this.currentResult = [];
+          }
           return;
         }
         this.isFrontPagination = false;

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -35,7 +35,6 @@ import {
   Point
 } from "../../types/workflow-common.interface";
 import { auditTime, filter, map } from "rxjs/operators";
-import { WorkflowWebsocketService } from "../../service/workflow-websocket/workflow-websocket.service";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 
 // argument type of callback event on a JointJS Paper
@@ -131,7 +130,6 @@ export class WorkflowEditorComponent implements AfterViewInit {
     private jointUIService: JointUIService,
     private workflowStatusService: WorkflowStatusService,
     private workflowUtilService: WorkflowUtilService,
-    private workflowWebsocketService: WorkflowWebsocketService,
     private executeWorkflowService: ExecuteWorkflowService
   ) {}
 
@@ -151,7 +149,6 @@ export class WorkflowEditorComponent implements AfterViewInit {
     this.handlePaperZoom();
     this.handleWindowResize();
     this.handleViewDeleteOperator();
-    this.handleOperatorCache();
     this.handleCellHighlight();
     this.handleDisableOperator();
     this.handleViewDeleteLink();
@@ -598,39 +595,6 @@ export class WorkflowEditorComponent implements AfterViewInit {
           this.jointUIService.changeOperatorDisableStatus(
             this.getJointPaper(),
             op
-          );
-        });
-      });
-  }
-
-  private handleOperatorCache(): void {
-    this.workflowActionService
-      .getTexeraGraph()
-      .getCachedOperatorsChangedStream()
-      .pipe(untilDestroyed(this))
-      .subscribe((event) => {
-        event.newCached.concat(event.newUnCached).forEach((opID) => {
-          const op = this.workflowActionService
-            .getTexeraGraph()
-            .getOperator(opID);
-          this.jointUIService.changeOperatorCacheStatus(
-            this.getJointPaper(),
-            op
-          );
-        });
-      });
-    this.workflowWebsocketService
-      .subscribeToEvent("CacheStatusUpdateEvent")
-      .pipe(untilDestroyed(this))
-      .subscribe((event) => {
-        Object.entries(event.cacheStatusMap).forEach(([opID, cacheStatus]) => {
-          const op = this.workflowActionService
-            .getTexeraGraph()
-            .getOperator(opID);
-          this.jointUIService.changeOperatorCacheStatus(
-            this.getJointPaper(),
-            op,
-            cacheStatus
           );
         });
       });

--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -18,6 +18,7 @@ import { NzMessageService } from "ng-zorro-antd/message";
 import { WorkflowConsoleService } from "../service/workflow-console/workflow-console.service";
 import { debounceTime, filter } from "rxjs/operators";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { OperatorCacheStatusService } from "../service/workflow-status/operator-cache-status.service";
 
 @UntilDestroy()
 @Component({
@@ -41,6 +42,7 @@ export class WorkspaceComponent implements AfterViewInit {
     private schemaPropagationService: SchemaPropagationService,
     private undoRedoService: UndoRedoService,
     private userService: UserService,
+    private operatorCacheStatus: OperatorCacheStatusService,
     private workflowCacheService: WorkflowCacheService,
     private workflowPersistService: WorkflowPersistService,
     private workflowWebsocketService: WorkflowWebsocketService,

--- a/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.ts
@@ -11,7 +11,6 @@ import { ExecuteWorkflowService } from "../../execute-workflow/execute-workflow.
 import { WorkflowActionService } from "../../workflow-graph/model/workflow-action.service";
 import { DynamicSchemaService } from "../dynamic-schema.service";
 import { catchError, debounceTime, filter, mergeMap } from "rxjs/operators";
-import { WorkflowWebsocketService } from "../../workflow-websocket/workflow-websocket.service";
 
 // endpoint for schema propagation
 export const SCHEMA_PROPAGATION_ENDPOINT = "queryplan/autocomplete";
@@ -40,8 +39,7 @@ export class SchemaPropagationService {
     private httpClient: HttpClient,
     private workflowActionService: WorkflowActionService,
     private dynamicSchemaService: DynamicSchemaService,
-    private logger: NGXLogger,
-    private workflowWebsocketService: WorkflowWebsocketService
+    private logger: NGXLogger
   ) {
     // do nothing if schema propagation is not enabled
     if (!environment.schemaPropagationEnabled) {
@@ -69,23 +67,6 @@ export class SchemaPropagationService {
         this.operatorInputSchemaMap = response.result;
         this._applySchemaPropagationResult(this.operatorInputSchemaMap);
       });
-
-    merge(
-      this.workflowActionService.getTexeraGraph().getLinkAddStream(),
-      this.workflowActionService.getTexeraGraph().getLinkDeleteStream(),
-      this.workflowActionService
-        .getTexeraGraph()
-        .getOperatorPropertyChangeStream()
-        .pipe(debounceTime(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS)),
-      this.workflowActionService
-        .getTexeraGraph()
-        .getDisabledOperatorsChangedStream(),
-      this.workflowActionService
-        .getTexeraGraph()
-        .getCachedOperatorsChangedStream()
-    ).subscribe(() => {
-      this.invokeCacheStatusUpdate();
-    });
   }
 
   public getOperatorInputSchema(
@@ -169,13 +150,6 @@ export class SchemaPropagationService {
           return EMPTY;
         })
       );
-  }
-
-  private invokeCacheStatusUpdate(): void {
-    const workflow = ExecuteWorkflowService.getLogicalPlanRequest(
-      this.workflowActionService.getTexeraGraph()
-    );
-    this.workflowWebsocketService.send("CacheStatusUpdateRequest", workflow);
   }
 
   /**

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -85,12 +85,6 @@ export class ExecuteWorkflowService {
         if (newState !== undefined) {
           this.updateExecutionState(newState);
         }
-        if (
-          event.type !== "HeartBeatResponse" &&
-          event.type !== "WebWorkflowStatusUpdateEvent"
-        ) {
-          console.log(event);
-        }
       });
     }
   }

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -85,6 +85,12 @@ export class ExecuteWorkflowService {
         if (newState !== undefined) {
           this.updateExecutionState(newState);
         }
+        if (
+          event.type !== "HeartBeatResponse" &&
+          event.type !== "WebWorkflowStatusUpdateEvent"
+        ) {
+          console.log(event);
+        }
       });
     }
   }
@@ -482,7 +488,11 @@ export class ExecuteWorkflowService {
       ExecuteWorkflowService.transformBreakpoint(workflowGraph, e[0], e[1])
     );
 
-    return { operators, links, breakpoints };
+    const cachedOperatorIDs: string[] = Array.from(
+      workflowGraph.getCachedOperators()
+    ).filter((op) => !workflowGraph.isOperatorDisabled(op));
+
+    return { operators, links, breakpoints, cachedOperatorIDs };
   }
 
   public static transformBreakpoint(

--- a/core/new-gui/src/app/workspace/service/execute-workflow/mock-workflow-plan.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/mock-workflow-plan.ts
@@ -36,7 +36,8 @@ export const mockLogicalPlan_scan_result: LogicalPlan = {
       }
     }
   ],
-  breakpoints: []
+  breakpoints: [],
+  cachedOperatorIDs: []
 };
 
 export const mockWorkflowPlan_scan_sentiment_result: WorkflowGraph =
@@ -79,5 +80,6 @@ export const mockLogicalPlan_scan_sentiment_result: LogicalPlan = {
       }
     }
   ],
-  breakpoints: []
+  breakpoints: [],
+  cachedOperatorIDs: []
 };

--- a/core/new-gui/src/app/workspace/service/joint-ui/joint-ui.service.ts
+++ b/core/new-gui/src/app/workspace/service/joint-ui/joint-ui.service.ts
@@ -16,7 +16,7 @@ import {
   OperatorState,
   OperatorStatistics
 } from "../../types/execute-workflow.interface";
-import { CacheStatus } from "../../types/workflow-websocket.interface";
+import { OperatorResultCacheStatus } from "../../types/workflow-websocket.interface";
 
 /**
  * Defines the SVG element for the breakpoint button
@@ -414,7 +414,7 @@ export class JointUIService {
   public changeOperatorCacheStatus(
     jointPaper: joint.dia.Paper,
     operator: OperatorPredicate,
-    cacheStatus?: CacheStatus
+    cacheStatus?: OperatorResultCacheStatus
   ): void {
     jointPaper
       .getModelById(operator.operatorID)
@@ -703,7 +703,7 @@ export class JointUIService {
 
   public static getOperatorCacheDisplayText(
     operator: OperatorPredicate,
-    cacheStatus?: CacheStatus
+    cacheStatus?: OperatorResultCacheStatus
   ): string {
     if (cacheStatus && cacheStatus !== "cache not enabled") {
       return cacheStatus;

--- a/core/new-gui/src/app/workspace/service/joint-ui/joint-ui.service.ts
+++ b/core/new-gui/src/app/workspace/service/joint-ui/joint-ui.service.ts
@@ -16,6 +16,7 @@ import {
   OperatorState,
   OperatorStatistics
 } from "../../types/execute-workflow.interface";
+import { CacheStatus } from "../../types/workflow-websocket.interface";
 
 /**
  * Defines the SVG element for the breakpoint button
@@ -83,6 +84,7 @@ export const sourceOperatorHandle = "M 0 0 L 0 8 L 8 8 L 8 0 z";
  */
 export const targetOperatorHandle = "M 12 0 L 0 6 L 12 12 z";
 
+export const operatorCacheClass = "texera-operator-cache";
 export const operatorStateClass = "texera-operator-state";
 
 export const operatorProcessedCountClass = "texera-operator-processed-count";
@@ -106,6 +108,7 @@ class TexeraCustomJointElement extends joint.shapes.devs.Model {
       <text class="${operatorProcessedCountClass}"></text>
       <text class="${operatorOutputCountClass}"></text>
       <text class="${operatorStateClass}"></text>
+      <text class="${operatorCacheClass}"></text>
     </g>`;
 }
 
@@ -408,6 +411,19 @@ export class JointUIService {
       .attr("rect/fill", JointUIService.getOperatorFillColor(operator));
   }
 
+  public changeOperatorCacheStatus(
+    jointPaper: joint.dia.Paper,
+    operator: OperatorPredicate,
+    cacheStatus?: CacheStatus
+  ): void {
+    jointPaper
+      .getModelById(operator.operatorID)
+      .attr(
+        ".texera-operator-cache/text",
+        JointUIService.getOperatorCacheDisplayText(operator, cacheStatus)
+      );
+  }
+
   public getBreakpointButton(): new () => joint.linkTools.Button {
     return joint.linkTools.Button.extend({
       name: "info-button",
@@ -683,6 +699,17 @@ export class JointUIService {
   public static getOperatorFillColor(operator: OperatorPredicate): string {
     const isDisabled = operator.isDisabled ?? false;
     return isDisabled ? "#E0E0E0" : "#FFFFFF";
+  }
+
+  public static getOperatorCacheDisplayText(
+    operator: OperatorPredicate,
+    cacheStatus?: CacheStatus
+  ): string {
+    if (cacheStatus && cacheStatus !== "cache not enabled") {
+      return cacheStatus;
+    }
+    const isCached = operator.isCached ?? false;
+    return isCached ? "will be cached" : "";
   }
 
   /**

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
@@ -1127,7 +1127,8 @@ export class WorkflowActionService {
       this.getTexeraGraph().getOperatorPropertyChangeStream(),
       this.getTexeraGraph().getBreakpointChangeStream(),
       this.getJointGraphWrapper().getElementPositionChangeEvent(),
-      this.getTexeraGraph().getDisabledOperatorsChangedStream()
+      this.getTexeraGraph().getDisabledOperatorsChangedStream(),
+      this.getTexeraGraph().getCachedOperatorsChangedStream()
     );
   }
 

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
@@ -39,6 +39,7 @@ export class WorkflowGraph {
   private readonly linkBreakpointMap = new Map<string, Breakpoint>();
 
   private readonly operatorAddSubject = new Subject<OperatorPredicate>();
+
   private readonly operatorDeleteSubject = new Subject<{
     deletedOperator: OperatorPredicate;
   }>();
@@ -46,6 +47,11 @@ export class WorkflowGraph {
     newDisabled: string[];
     newEnabled: string[];
   }>();
+  private readonly cachedOperatorChangedSubject = new Subject<{
+    newCached: string[];
+    newUnCached: string[];
+  }>();
+
   private readonly linkAddSubject = new Subject<OperatorLink>();
   private readonly linkDeleteSubject = new Subject<{
     deletedLink: OperatorLink;
@@ -138,6 +144,52 @@ export class WorkflowGraph {
     return new Set(
       Array.from(this.operatorIDMap.keys()).filter((op) =>
         this.isOperatorDisabled(op)
+      )
+    );
+  }
+
+  public cacheOperator(operatorID: string): void {
+    const operator = this.getOperator(operatorID);
+    if (!operator) {
+      throw new Error(`operator with ID ${operatorID} doesn't exist`);
+    }
+    if (this.isOperatorCached(operatorID)) {
+      return;
+    }
+    this.operatorIDMap.set(operatorID, { ...operator, isCached: true });
+    this.cachedOperatorChangedSubject.next({
+      newCached: [operatorID],
+      newUnCached: []
+    });
+  }
+
+  public unCacheOperator(operatorID: string): void {
+    const operator = this.getOperator(operatorID);
+    if (!operator) {
+      throw new Error(`operator with ID ${operatorID} doesn't exist`);
+    }
+    if (!this.isOperatorCached(operatorID)) {
+      return;
+    }
+    this.operatorIDMap.set(operatorID, { ...operator, isCached: false });
+    this.cachedOperatorChangedSubject.next({
+      newCached: [],
+      newUnCached: [operatorID]
+    });
+  }
+
+  public isOperatorCached(operatorID: string): boolean {
+    const operator = this.getOperator(operatorID);
+    if (!operator) {
+      throw new Error(`operator with ID ${operatorID} doesn't exist`);
+    }
+    return operator.isCached ?? false;
+  }
+
+  public getCachedOperators(): ReadonlySet<string> {
+    return new Set(
+      Array.from(this.operatorIDMap.keys()).filter((op) =>
+        this.isOperatorCached(op)
       )
     );
   }
@@ -415,6 +467,13 @@ export class WorkflowGraph {
     newEnabled: ReadonlyArray<string>;
   }> {
     return this.disabledOperatorChangedSubject.asObservable();
+  }
+
+  public getCachedOperatorsChangedStream(): Observable<{
+    newCached: ReadonlyArray<string>;
+    newUnCached: ReadonlyArray<string>;
+  }> {
+    return this.cachedOperatorChangedSubject.asObservable();
   }
 
   /**

--- a/core/new-gui/src/app/workspace/service/workflow-result/workflow-result.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-result/workflow-result.service.ts
@@ -8,7 +8,10 @@ import {
   WorkflowResultUpdate
 } from "../../types/execute-workflow.interface";
 import { WorkflowWebsocketService } from "../workflow-websocket/workflow-websocket.service";
-import { PaginatedResultEvent } from "../../types/workflow-websocket.interface";
+import {
+  PaginatedResultEvent,
+  WorkflowAvailableResultEvent
+} from "../../types/workflow-websocket.interface";
 import { Observable, of, Subject } from "rxjs";
 import * as uuid from "uuid";
 import { ChartType } from "../../types/visualization.interface";
@@ -28,21 +31,28 @@ export class WorkflowResultService {
   >();
   private operatorResultServices = new Map<string, OperatorResultService>();
 
-  private resultUpdateStream = new Subject<Record<string, WebResultUpdate>>();
+  private resultUpdateStream = new Subject<
+    Record<string, WebResultUpdate | undefined>
+  >();
   private resultInitiateStream = new Subject<string>();
 
   constructor(private wsService: WorkflowWebsocketService) {
     this.wsService
       .subscribeToEvent("WebResultUpdateEvent")
       .subscribe((event) => this.handleResultUpdate(event.updates));
+    this.wsService
+      .subscribeToEvent("WorkflowAvailableResultEvent")
+      .subscribe((event) => this.handleCleanResultCache(event));
+  }
+
+  public getResultUpdateStream(): Observable<
+    Record<string, WebResultUpdate | undefined>
+  > {
+    return this.resultUpdateStream;
   }
 
   public getResultInitiateStream(): Observable<string> {
     return this.resultInitiateStream.asObservable();
-  }
-
-  public getResultUpdateStream(): Observable<Record<string, WebResultUpdate>> {
-    return this.resultUpdateStream.asObservable();
   }
 
   public getPaginatedResultService(
@@ -55,6 +65,51 @@ export class WorkflowResultService {
     operatorID: string
   ): OperatorResultService | undefined {
     return this.operatorResultServices.get(operatorID);
+  }
+
+  private handleCleanResultCache(event: WorkflowAvailableResultEvent): void {
+    const removedOrInvalidatedOperators = new Set<string>();
+    // remove operators that no longer have results
+    this.operatorResultServices.forEach((_, op) => {
+      if (!(op in event.availableOperators)) {
+        this.operatorResultServices.delete(op);
+        removedOrInvalidatedOperators.add(op);
+      }
+    });
+    this.paginatedResultServices.forEach((_, op) => {
+      if (!(op in event.availableOperators)) {
+        this.paginatedResultServices.delete(op);
+        removedOrInvalidatedOperators.add(op);
+      }
+    });
+    // for each operator that has results:
+    Object.entries(event.availableOperators).forEach((e) => {
+      const op = e[0];
+      const cacheValid = e[1].cacheValid;
+      const outputMode = e[1].outputMode;
+
+      // make sure to init or reuse result service for each operator
+      const resultService = (() => {
+        if (outputMode.type === "PaginationMode") {
+          return this.getOrInitPaginatedResultService(op);
+        } else {
+          return this.getOrInitResultService(op);
+        }
+      })();
+
+      // invalidate frontend cache if needed
+      if (!cacheValid) {
+        resultService.reset();
+        removedOrInvalidatedOperators.add(op);
+      }
+    });
+    console.log(removedOrInvalidatedOperators);
+
+    const invalidatedOperatorsUpdate: Record<string, undefined> = {};
+    removedOrInvalidatedOperators.forEach(
+      (op) => (invalidatedOperatorsUpdate[op] = undefined)
+    );
+    this.resultUpdateStream.next(invalidatedOperatorsUpdate);
   }
 
   private handleResultUpdate(event: WorkflowResultUpdate): void {
@@ -113,6 +168,11 @@ export class OperatorResultService {
 
   public getChartType(): ChartType | undefined {
     return this.chartType;
+  }
+
+  public reset(): void {
+    this.chartType = undefined;
+    this.resultSnapshot = undefined;
   }
 
   public handleResultUpdate(update: WebDataUpdate): void {
@@ -184,6 +244,13 @@ class OperatorPaginationResultService {
       this.pendingRequests.set(requestID, pendingRequestSubject);
       return pendingRequestSubject;
     }
+  }
+
+  public reset(): void {
+    this.pendingRequests.clear();
+    this.resultCache.clear();
+    this.currentPageIndex = 1;
+    this.currentTotalNumTuples = 0;
   }
 
   public handleResultUpdate(update: WebPaginationUpdate): void {

--- a/core/new-gui/src/app/workspace/service/workflow-result/workflow-result.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-result/workflow-result.service.ts
@@ -31,6 +31,7 @@ export class WorkflowResultService {
   >();
   private operatorResultServices = new Map<string, OperatorResultService>();
 
+  // event stream of operator result update, undefined indicates the operator result is cleared
   private resultUpdateStream = new Subject<
     Record<string, WebResultUpdate | undefined>
   >();
@@ -83,10 +84,10 @@ export class WorkflowResultService {
       }
     });
     // for each operator that has results:
-    Object.entries(event.availableOperators).forEach((e) => {
-      const op = e[0];
-      const cacheValid = e[1].cacheValid;
-      const outputMode = e[1].outputMode;
+    Object.entries(event.availableOperators).forEach((availabeOp) => {
+      const op = availabeOp[0];
+      const cacheValid = availabeOp[1].cacheValid;
+      const outputMode = availabeOp[1].outputMode;
 
       // make sure to init or reuse result service for each operator
       const resultService = (() => {
@@ -103,7 +104,6 @@ export class WorkflowResultService {
         removedOrInvalidatedOperators.add(op);
       }
     });
-    console.log(removedOrInvalidatedOperators);
 
     const invalidatedOperatorsUpdate: Record<string, undefined> = {};
     removedOrInvalidatedOperators.forEach(

--- a/core/new-gui/src/app/workspace/service/workflow-status/operator-cache-status.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-status/operator-cache-status.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from "@angular/core/testing";
+
+import { OperatorCacheStatusService } from "./operator-cache-status.service";
+
+describe("OperatorCacheStatusService", () => {
+  let service: OperatorCacheStatusService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(OperatorCacheStatusService);
+  });
+
+  it("should be created", () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/core/new-gui/src/app/workspace/service/workflow-status/operator-cache-status.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-status/operator-cache-status.service.spec.ts
@@ -1,12 +1,18 @@
 import { TestBed } from "@angular/core/testing";
+import { OperatorMetadataService } from "../operator-metadata/operator-metadata.service";
+import { StubOperatorMetadataService } from "../operator-metadata/stub-operator-metadata.service";
 
 import { OperatorCacheStatusService } from "./operator-cache-status.service";
 
-describe("OperatorCacheStatusService", () => {
+xdescribe("OperatorCacheStatusService", () => {
   let service: OperatorCacheStatusService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
+      ]
+    });
     service = TestBed.inject(OperatorCacheStatusService);
   });
 

--- a/core/new-gui/src/app/workspace/service/workflow-status/operator-cache-status.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-status/operator-cache-status.service.ts
@@ -24,6 +24,10 @@ export class OperatorCacheStatusService {
     this.registerHandleCacheStatusUpdate();
   }
 
+  /**
+   * Requests cache status (invalid/valid/toBeCached) when workflow is changed from the engine
+   * for example, when operator is updated, the cache status might be invalidated
+   */
   private registerRequestCacheStatusUpdate() {
     merge(
       this.workflowActionService.getTexeraGraph().getLinkAddStream(),
@@ -46,6 +50,9 @@ export class OperatorCacheStatusService {
     });
   }
 
+  /**
+   * Registers handler for cache status update from the backend.
+   */
   private registerHandleCacheStatusUpdate() {
     this.workflowActionService
       .getTexeraGraph()

--- a/core/new-gui/src/app/workspace/service/workflow-status/operator-cache-status.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-status/operator-cache-status.service.ts
@@ -1,0 +1,90 @@
+import { Injectable } from "@angular/core";
+import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
+import { WorkflowWebsocketService } from "../workflow-websocket/workflow-websocket.service";
+import { SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS } from "../dynamic-schema/schema-propagation/schema-propagation.service";
+import { debounceTime } from "rxjs/operators";
+import { ExecuteWorkflowService } from "../execute-workflow/execute-workflow.service";
+import { merge } from "rxjs";
+import { JointUIService } from "../joint-ui/joint-ui.service";
+import { environment } from "src/environments/environment";
+
+@Injectable({
+  providedIn: "root"
+})
+export class OperatorCacheStatusService {
+  constructor(
+    private jointUIService: JointUIService,
+    private workflowActionService: WorkflowActionService,
+    private workflowWebsocketService: WorkflowWebsocketService
+  ) {
+    if (!environment.operatorCacheEnabled) {
+      return;
+    }
+    this.registerRequestCacheStatusUpdate();
+    this.registerHandleCacheStatusUpdate();
+  }
+
+  private registerRequestCacheStatusUpdate() {
+    merge(
+      this.workflowActionService.getTexeraGraph().getLinkAddStream(),
+      this.workflowActionService.getTexeraGraph().getLinkDeleteStream(),
+      this.workflowActionService
+        .getTexeraGraph()
+        .getOperatorPropertyChangeStream()
+        .pipe(debounceTime(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS)),
+      this.workflowActionService
+        .getTexeraGraph()
+        .getDisabledOperatorsChangedStream(),
+      this.workflowActionService
+        .getTexeraGraph()
+        .getCachedOperatorsChangedStream()
+    ).subscribe(() => {
+      const workflow = ExecuteWorkflowService.getLogicalPlanRequest(
+        this.workflowActionService.getTexeraGraph()
+      );
+      this.workflowWebsocketService.send("CacheStatusUpdateRequest", workflow);
+    });
+  }
+
+  private registerHandleCacheStatusUpdate() {
+    this.workflowActionService
+      .getTexeraGraph()
+      .getCachedOperatorsChangedStream()
+      .subscribe((event) => {
+        const mainJointPaper = this.workflowActionService
+          .getJointGraphWrapper()
+          .getMainJointPaper();
+        if (!mainJointPaper) {
+          return;
+        }
+
+        event.newCached.concat(event.newUnCached).forEach((opID) => {
+          const op = this.workflowActionService
+            .getTexeraGraph()
+            .getOperator(opID);
+
+          this.jointUIService.changeOperatorCacheStatus(mainJointPaper, op);
+        });
+      });
+    this.workflowWebsocketService
+      .subscribeToEvent("CacheStatusUpdateEvent")
+      .subscribe((event) => {
+        const mainJointPaper = this.workflowActionService
+          .getJointGraphWrapper()
+          .getMainJointPaper();
+        if (!mainJointPaper) {
+          return;
+        }
+        Object.entries(event.cacheStatusMap).forEach(([opID, cacheStatus]) => {
+          const op = this.workflowActionService
+            .getTexeraGraph()
+            .getOperator(opID);
+          this.jointUIService.changeOperatorCacheStatus(
+            mainJointPaper,
+            op,
+            cacheStatus
+          );
+        });
+      });
+  }
+}

--- a/core/new-gui/src/app/workspace/types/execute-workflow.interface.ts
+++ b/core/new-gui/src/app/workspace/types/execute-workflow.interface.ts
@@ -46,6 +46,7 @@ export interface LogicalPlan
     operators: LogicalOperator[];
     links: LogicalLink[];
     breakpoints: BreakpointInfo[];
+    cachedOperatorIDs: string[];
   }> {}
 
 /**

--- a/core/new-gui/src/app/workspace/types/workflow-common.interface.ts
+++ b/core/new-gui/src/app/workspace/types/workflow-common.interface.ts
@@ -26,6 +26,7 @@ export interface OperatorPredicate
     outputPorts: { portID: string; displayName?: string }[];
     showAdvanced: boolean;
     isDisabled?: boolean;
+    isCached?: boolean;
   }> {}
 
 export interface OperatorLink

--- a/core/new-gui/src/app/workspace/types/workflow-websocket.interface.ts
+++ b/core/new-gui/src/app/workspace/types/workflow-websocket.interface.ts
@@ -100,10 +100,10 @@ export type WorkflowAvailableResultEvent = Readonly<{
   availableOperators: ReadonlyArray<OperatorAvailableResult>;
 }>;
 
-export type CacheStatus = "cache invalid" | "cache valid" | "cache not enabled";
+export type OperatorResultCacheStatus = "cache invalid" | "cache valid" | "cache not enabled";
 export interface CacheStatusUpdateEvent
   extends Readonly<{
-    cacheStatusMap: Record<string, CacheStatus>;
+    cacheStatusMap: Record<string, OperatorResultCacheStatus>;
   }> {}
 
 export type TexeraWebsocketRequestTypeMap = {

--- a/core/new-gui/src/app/workspace/types/workflow-websocket.interface.ts
+++ b/core/new-gui/src/app/workspace/types/workflow-websocket.interface.ts
@@ -2,6 +2,7 @@ import {
   BreakpointInfo,
   LogicalOperator,
   LogicalPlan,
+  WebOutputMode,
   WorkflowResultUpdateEvent,
   WorkflowStatusUpdate
 } from "./execute-workflow.interface";
@@ -82,10 +83,28 @@ export type ResultExportRequest = Readonly<{
   operatorId: string;
 }>;
 
+export type CacheStatusUpdateRequest = LogicalPlan;
+
 export type ResultExportResponse = Readonly<{
   status: "success" | "error";
   message: string;
 }>;
+
+export type OperatorAvailableResult = Readonly<{
+  operatorID: string;
+  cacheValid: boolean;
+  outputMode: WebOutputMode;
+}>;
+
+export type WorkflowAvailableResultEvent = Readonly<{
+  availableOperators: ReadonlyArray<OperatorAvailableResult>;
+}>;
+
+export type CacheStatus = "cache invalid" | "cache valid" | "cache not enabled";
+export interface CacheStatusUpdateEvent
+  extends Readonly<{
+    cacheStatusMap: Record<string, CacheStatus>;
+  }> {}
 
 export type TexeraWebsocketRequestTypeMap = {
   HelloWorldRequest: WebSocketHelloWorld;
@@ -99,6 +118,7 @@ export type TexeraWebsocketRequestTypeMap = {
   AddBreakpointRequest: BreakpointInfo;
   ResultPaginationRequest: PaginationRequest;
   ResultExportRequest: ResultExportRequest;
+  CacheStatusUpdateRequest: CacheStatusUpdateRequest;
 };
 
 export type TexeraWebsocketEventTypeMap = {
@@ -119,6 +139,8 @@ export type TexeraWebsocketEventTypeMap = {
   PaginatedResultEvent: PaginatedResultEvent;
   WorkflowExecutionErrorEvent: WorkflowExecutionError;
   ResultExportResponse: ResultExportResponse;
+  WorkflowAvailableResultEvent: WorkflowAvailableResultEvent;
+  CacheStatusUpdateEvent: CacheStatusUpdateEvent;
 };
 
 // helper type definitions to generate the request and event types

--- a/core/new-gui/src/app/workspace/types/workflow-websocket.interface.ts
+++ b/core/new-gui/src/app/workspace/types/workflow-websocket.interface.ts
@@ -100,7 +100,10 @@ export type WorkflowAvailableResultEvent = Readonly<{
   availableOperators: ReadonlyArray<OperatorAvailableResult>;
 }>;
 
-export type OperatorResultCacheStatus = "cache invalid" | "cache valid" | "cache not enabled";
+export type OperatorResultCacheStatus =
+  | "cache invalid"
+  | "cache valid"
+  | "cache not enabled";
 export interface CacheStatusUpdateEvent
   extends Readonly<{
     cacheStatusMap: Record<string, OperatorResultCacheStatus>;

--- a/core/new-gui/src/environments/environment.default.ts
+++ b/core/new-gui/src/environments/environment.default.ts
@@ -46,6 +46,11 @@ export const defaultEnvironment = {
   linkBreakpointEnabled: true,
 
   /**
+   * whether operator caching is enabled
+   */
+  operatorCacheEnabled: false,
+
+  /**
    * the access code for mapbox
    */
   mapbox: {


### PR DESCRIPTION
This is the second PR to add operator caching. This PR only includes frontend changes that enables users to specify a cached operator, and display cache status.