### PR TITLE
Update Frontend Formatter

### DIFF
--- a/core/new-gui/.prettierrc.json
+++ b/core/new-gui/.prettierrc.json
@@ -1,14 +1,13 @@
 {
-  "printWidth": 80,
+  "printWidth": 120,
   "tabWidth": 2,
   "useTabs": false,
   "semi": true,
   "singleQuote": false,
   "quoteProps": "as-needed",
-  "trailingComma": "none",
+  "trailingComma": "es5",
   "bracketSpacing": true,
-  "arrowParens": "always",
-  "jsxBracketSameLine": true,
+  "arrowParens": "avoid",
   "overrides": [
     {
       "files": "*.component.html",

--- a/core/new-gui/angular.json
+++ b/core/new-gui/angular.json
@@ -38,9 +38,7 @@
               "node_modules/bootstrap/dist/css/bootstrap.min.css",
               "src/styles.scss"
             ],
-            "scripts": [
-              "./node_modules/ngx-monaco-editor/assets/monaco/vs/loader.js"
-            ]
+            "scripts": ["./node_modules/ngx-monaco-editor/assets/monaco/vs/loader.js"]
           },
           "configurations": {
             "production": {
@@ -112,18 +110,12 @@
         "e2e": {
           "builder": "multi-target:multi-target",
           "options": {
-            "targets": [
-              "texera-gui:build:production",
-              "texera-gui:cypress-headless-with-fullstack"
-            ],
+            "targets": ["texera-gui:build:production", "texera-gui:cypress-headless-with-fullstack"],
             "sequential": true
           },
           "configurations": {
             "watch": {
-              "targets": [
-                "texera-gui:build:production",
-                "texera-gui:cypress-watch-with-fullstack"
-              ],
+              "targets": ["texera-gui:build:production", "texera-gui:cypress-watch-with-fullstack"],
               "sequential": true
             }
           }
@@ -171,22 +163,14 @@
         "cypress-headless-with-fullstack": {
           "builder": "multi-target:multi-target",
           "options": {
-            "targets": [
-              "texera-gui:fullstack",
-              "texera-gui:cypress-headless",
-              "texera-gui:kill-fullstack"
-            ],
+            "targets": ["texera-gui:fullstack", "texera-gui:cypress-headless", "texera-gui:kill-fullstack"],
             "sequential": true
           }
         },
         "cypress-watch-with-fullstack": {
           "builder": "multi-target:multi-target",
           "options": {
-            "targets": [
-              "texera-gui:fullstack",
-              "texera-gui:cypress-watch",
-              "texera-gui:kill-fullstack"
-            ],
+            "targets": ["texera-gui:fullstack", "texera-gui:cypress-watch", "texera-gui:kill-fullstack"],
             "sequential": true
           }
         }

--- a/core/new-gui/decorate-angular-cli.js
+++ b/core/new-gui/decorate-angular-cli.js
@@ -48,9 +48,8 @@ function symlinkNgCLItoNxCLI() {
        * This is the most reliable way to create symlink-like behavior on Windows.
        * Such that it works in all shells and works with npx.
        */
-      ["", ".cmd", ".ps1"].forEach((ext) => {
-        if (fs.existsSync(nxPath + ext))
-          fs.writeFileSync(ngPath + ext, fs.readFileSync(nxPath + ext));
+      ["", ".cmd", ".ps1"].forEach(ext => {
+        if (fs.existsSync(nxPath + ext)) fs.writeFileSync(ngPath + ext, fs.readFileSync(nxPath + ext));
       });
     } else {
       // If unix-based, symlink
@@ -58,9 +57,7 @@ function symlinkNgCLItoNxCLI() {
     }
   } catch (e) {
     output.error({
-      title:
-        "Unable to create a symlink from the Angular CLI to the Nx CLI:" +
-        e.message
+      title: "Unable to create a symlink from the Angular CLI to the Nx CLI:" + e.message,
     });
     throw e;
   }
@@ -70,10 +67,10 @@ try {
   symlinkNgCLItoNxCLI();
   require("@nrwl/cli/lib/decorate-cli").decorateCli();
   output.log({
-    title: "Angular CLI has been decorated to enable computation caching."
+    title: "Angular CLI has been decorated to enable computation caching.",
   });
 } catch (e) {
   output.error({
-    title: "Decoration of the Angular CLI did not complete successfully"
+    title: "Decoration of the Angular CLI did not complete successfully",
   });
 }

--- a/core/new-gui/git-version.js
+++ b/core/new-gui/git-version.js
@@ -5,7 +5,7 @@ const { writeFileSync, existsSync, mkdirSync } = require("fs-extra");
 
 const gitInfo = gitDescribeSync({
   dirtyMark: false,
-  dirtySemver: false
+  dirtySemver: false,
 });
 
 gitInfo.version = version;
@@ -24,9 +24,4 @@ export const Version = ${JSON.stringify(gitInfo, null, 4)};
   { encoding: "utf-8" }
 );
 
-console.log(
-  `Wrote version info ${gitInfo.raw} to ${relative(
-    resolve(__dirname, ".."),
-    file
-  )}`
-);
+console.log(`Wrote version info ${gitInfo.raw} to ${relative(resolve(__dirname, ".."), file)}`);

--- a/core/new-gui/karma.conf.js
+++ b/core/new-gui/karma.conf.js
@@ -10,15 +10,15 @@ module.exports = function (config) {
       require("karma-chrome-launcher"),
       require("karma-jasmine-html-reporter"),
       require("karma-coverage-istanbul-reporter"),
-      require("@angular-devkit/build-angular/plugins/karma")
+      require("@angular-devkit/build-angular/plugins/karma"),
     ],
     client: {
-      clearContext: false // leave Jasmine Spec Runner output visible in browser
+      clearContext: false, // leave Jasmine Spec Runner output visible in browser
     },
     coverageIstanbulReporter: {
       dir: require("path").join(__dirname, "coverage"),
       reports: ["html", "lcovonly"],
-      fixWebpackSourcePaths: true
+      fixWebpackSourcePaths: true,
     },
 
     reporters: ["progress", "kjhtml"],
@@ -28,6 +28,6 @@ module.exports = function (config) {
     autoWatch: true,
     browsers: ["Chrome"],
     singleRun: false,
-    browserNoActivityTimeout: 20000
+    browserNoActivityTimeout: 20000,
   });
 };

--- a/core/new-gui/multi-target/src/multi-target.ts
+++ b/core/new-gui/multi-target/src/multi-target.ts
@@ -6,7 +6,7 @@ import {
   ScheduleOptions,
   Target,
   targetStringFromTarget,
-  targetFromTargetString
+  targetFromTargetString,
 } from "@angular-devkit/architect";
 import { JsonObject, logging } from "@angular-devkit/core";
 
@@ -44,11 +44,7 @@ class TargetData {
   private failSubscribers: ((targetFails: number) => void)[] = [];
   private successSubscribers: ((targetSuccesses: number) => void)[] = [];
 
-  constructor(
-    totalTargets: number,
-    targetFails: number,
-    targetSuccesses: number
-  ) {
+  constructor(totalTargets: number, targetFails: number, targetSuccesses: number) {
     this.totalTargets = totalTargets;
     this.targetFails = targetFails;
     this.targetSuccesses = targetSuccesses;
@@ -62,7 +58,7 @@ class TargetData {
    */
   incrementTargetFails() {
     this.targetFails += 1;
-    this.failSubscribers.forEach((fn) => fn(this.targetFails));
+    this.failSubscribers.forEach(fn => fn(this.targetFails));
   }
 
   /**
@@ -71,7 +67,7 @@ class TargetData {
    */
   incrementTargetSuccesses() {
     this.targetSuccesses += 1;
-    this.successSubscribers.forEach((fn) => fn(this.targetSuccesses));
+    this.successSubscribers.forEach(fn => fn(this.targetSuccesses));
   }
 
   getTargetFails(): number {
@@ -107,10 +103,7 @@ export default createBuilder(multiBuilder);
  * @param context BuilderContext
  * @returns promise of builderOutput, resolves if build successful, rejects if not. Always produces a BuilderOutput either way.
  */
-function multiBuilder(
-  options: Options,
-  context: BuilderContext
-): Promise<BuilderOutput> {
+function multiBuilder(options: Options, context: BuilderContext): Promise<BuilderOutput> {
   // For help understanding builders/Architect, visit https://angular.io/guide/cli-builder.
 
   // multiBuilder takes a list of build targets (options.targets) and runs them.
@@ -123,9 +116,7 @@ function multiBuilder(
 
   // const used to label/prefix logs
   const multiTargetStr: string =
-    context.target === undefined
-      ? "Anonymous Multi-Target Builder"
-      : targetStringFromTarget(context.target);
+    context.target === undefined ? "Anonymous Multi-Target Builder" : targetStringFromTarget(context.target);
 
   return new Promise<BuilderOutput>(async (resolve, reject) => {
     if (options.sequential && options.race) {
@@ -134,7 +125,7 @@ function multiBuilder(
       reject({
         success: false,
         target: context.target as Target,
-        error: errorMsg
+        error: errorMsg,
       });
     }
 
@@ -147,15 +138,13 @@ function multiBuilder(
     // Subscribing to changes in targetData.targetFails lets us determine when to reject (this builder has failed)
     targetData.subscribeToFails((targetFails: number) => {
       if (!options.race) {
-        const subTargetStr = targetStringFromTarget(
-          targetData.failedTargets[targetData.failedTargets.length - 1]
-        );
+        const subTargetStr = targetStringFromTarget(targetData.failedTargets[targetData.failedTargets.length - 1]);
         const errorMsg = `(${multiTargetStr})-->(${subTargetStr}) failed!`;
         context.logger.fatal(errorMsg);
         reject({
           success: false,
           target: context.target as Target,
-          error: errorMsg
+          error: errorMsg,
         });
       } else if (options.race && targetFails === targetData.totalTargets) {
         const errorMsg = `(${multiTargetStr}) failed: all sub-targets failed! (race: true).`;
@@ -163,12 +152,10 @@ function multiBuilder(
         reject({
           success: false,
           target: context.target as Target,
-          error: errorMsg
+          error: errorMsg,
         });
       } else if (options.race && targetFails < targetData.totalTargets) {
-        const subTargetStr = targetStringFromTarget(
-          targetData.failedTargets[targetData.failedTargets.length - 1]
-        );
+        const subTargetStr = targetStringFromTarget(targetData.failedTargets[targetData.failedTargets.length - 1]);
         const errorMsg = `(${multiTargetStr})-->(${subTargetStr}) failed. Ignoring due to config (race: true) `;
         context.logger.warn(errorMsg);
       }
@@ -222,10 +209,7 @@ function multiBuilder(
  * Each **BuilderRun** represents a builder successfully scheduled and running.
  * Each **BuilderRun.result** is the **Promise<BuilderOutput>** of that builder (resolves if builder runs successfully).
  */
-function scheduleTarget(
-  target: Target,
-  context: BuilderContext
-): Promise<BuilderRun> {
+function scheduleTarget(target: Target, context: BuilderContext): Promise<BuilderRun> {
   // @ts-ignore logger is actually Logger but was interfaced (as part of BuilderContext) into a LoggerApi.
   const opt: ScheduleOptions = { logger: <logging.Logger>context.logger };
   const overrides: JsonObject | undefined = undefined;

--- a/core/new-gui/protractor.conf.js
+++ b/core/new-gui/protractor.conf.js
@@ -7,7 +7,7 @@ exports.config = {
   allScriptsTimeout: 11000,
   specs: ["./e2e/**/*.e2e-spec.ts"],
   capabilities: {
-    browserName: "chrome"
+    browserName: "chrome",
   },
   directConnect: true,
   baseUrl: "http://localhost:4200/",
@@ -15,14 +15,12 @@ exports.config = {
   jasmineNodeOpts: {
     showColors: true,
     defaultTimeoutInterval: 30000,
-    print: function () {}
+    print: function () {},
   },
   onPrepare() {
     require("ts-node").register({
-      project: "e2e/tsconfig.e2e.json"
+      project: "e2e/tsconfig.e2e.json",
     });
-    jasmine
-      .getEnv()
-      .addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
-  }
+    jasmine.getEnv().addReporter(new SpecReporter({ spec: { displayStacktrace: true } }));
+  },
 };

--- a/core/new-gui/src/app/app-routing.module.ts
+++ b/core/new-gui/src/app/app-routing.module.ts
@@ -16,12 +16,12 @@ import { WorkspaceComponent } from "./workspace/component/workspace.component";
 const routes: Routes = [
   {
     path: "",
-    component: WorkspaceComponent
+    component: WorkspaceComponent,
   },
   {
     path: "workflow/:id",
-    component: WorkspaceComponent
-  }
+    component: WorkspaceComponent,
+  },
 ];
 
 if (environment.userSystemEnabled) {
@@ -38,28 +38,28 @@ if (environment.userSystemEnabled) {
     children: [
       {
         path: "workflow",
-        component: SavedWorkflowSectionComponent
+        component: SavedWorkflowSectionComponent,
       },
       {
         path: "user-dictionary",
-        component: UserDictionarySectionComponent
+        component: UserDictionarySectionComponent,
       },
       {
         path: "user-file",
-        component: UserFileSectionComponent
-      }
-    ]
+        component: UserFileSectionComponent,
+      },
+    ],
   });
 }
 
 // redirect all other paths to index.
 routes.push({
   path: "**",
-  redirectTo: ""
+  redirectTo: "",
 });
 
 @NgModule({
   imports: [RouterModule.forRoot(routes, { relativeLinkResolution: "legacy" })],
-  exports: [RouterModule]
+  exports: [RouterModule],
 })
 export class AppRoutingModule {}

--- a/core/new-gui/src/app/app.component.ts
+++ b/core/new-gui/src/app/app.component.ts
@@ -3,6 +3,6 @@ import { Component } from "@angular/core";
 @Component({
   selector: "texera-root",
   templateUrl: "./app.component.html",
-  styleUrls: ["./app.component.scss"]
+  styleUrls: ["./app.component.scss"],
 })
 export class AppComponent {}

--- a/core/new-gui/src/app/app.module.ts
+++ b/core/new-gui/src/app/app.module.ts
@@ -146,7 +146,7 @@ registerLocaleData(en);
     ResultTableFrameComponent,
     OperatorPropertyEditFrameComponent,
     BreakpointPropertyEditFrameComponent,
-    NotificationComponent
+    NotificationComponent,
   ],
   imports: [
     BrowserModule,
@@ -163,10 +163,8 @@ registerLocaleData(en);
     FormsModule,
     ReactiveFormsModule,
     LoggerModule.forRoot({
-      level: environment.production
-        ? NgxLoggerLevel.ERROR
-        : NgxLoggerLevel.DEBUG,
-      serverLogLevel: NgxLoggerLevel.OFF
+      level: environment.production ? NgxLoggerLevel.ERROR : NgxLoggerLevel.DEBUG,
+      serverLogLevel: NgxLoggerLevel.OFF,
     }),
     FormlyModule.forRoot(TEXERA_FORMLY_CONFIG),
     FormlyMaterialModule,
@@ -174,8 +172,8 @@ registerLocaleData(en);
     GoogleApiModule.forRoot({
       provide: NG_GAPI_CONFIG,
       useValue: {
-        client_id: environment.google.clientID
-      }
+        client_id: environment.google.clientID,
+      },
     }),
     NzDatePickerModule,
     NzDropDownModule,
@@ -201,7 +199,7 @@ registerLocaleData(en);
     NzTagModule,
     NzAvatarModule,
     DynamicModule,
-    MonacoEditorModule.forRoot()
+    MonacoEditorModule.forRoot(),
   ],
   entryComponents: [
     NgbdModalAddWorkflowComponent,
@@ -212,7 +210,7 @@ registerLocaleData(en);
     NgbdModalUserLoginComponent,
     RowModalComponent,
     NgbdModalFileAddComponent,
-    NgbdModalWorkflowShareAccessComponent
+    NgbdModalWorkflowShareAccessComponent,
   ],
   providers: [
     UserService,
@@ -224,10 +222,10 @@ registerLocaleData(en);
     {
       provide: HTTP_INTERCEPTORS,
       useClass: BlobErrorHttpInterceptor,
-      multi: true
-    }
+      multi: true,
+    },
   ],
-  bootstrap: [AppComponent]
+  bootstrap: [AppComponent],
   // dynamically created component must be placed in the entryComponents attribute
 })
 export class AppModule {}

--- a/core/new-gui/src/app/common/component/notification/notification/notification.component.spec.ts
+++ b/core/new-gui/src/app/common/component/notification/notification/notification.component.spec.ts
@@ -11,7 +11,7 @@ describe("NotificationComponent", () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [NotificationComponent],
-        imports: [NzMessageModule]
+        imports: [NzMessageModule],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/common/component/notification/notification/notification.component.ts
+++ b/core/new-gui/src/app/common/component/notification/notification/notification.component.ts
@@ -1,22 +1,16 @@
 import { Component, OnInit } from "@angular/core";
 import { NzMessageService } from "ng-zorro-antd/message";
-import {
-  Notification,
-  NotificationService
-} from "../../../service/notification/notification.service";
+import { Notification, NotificationService } from "../../../service/notification/notification.service";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 
 @UntilDestroy()
 @Component({
   selector: "texera-notification",
   templateUrl: "./notification.component.html",
-  styleUrls: ["./notification.component.scss"]
+  styleUrls: ["./notification.component.scss"],
 })
 export class NotificationComponent implements OnInit {
-  constructor(
-    private message: NzMessageService,
-    private notificationService: NotificationService
-  ) {}
+  constructor(private message: NzMessageService, private notificationService: NotificationService) {}
 
   ngOnInit(): void {
     this.notificationService

--- a/core/new-gui/src/app/common/custom-ng-material.module.ts
+++ b/core/new-gui/src/app/common/custom-ng-material.module.ts
@@ -89,7 +89,7 @@ import { MatTooltipModule } from "@angular/material/tooltip";
     MatToolbarModule,
     MatTooltipModule,
     MatNativeDateModule,
-    MatPaginatorModule
-  ]
+    MatPaginatorModule,
+  ],
 })
 export class CustomNgMaterialModule {}

--- a/core/new-gui/src/app/common/formly/array.type.ts
+++ b/core/new-gui/src/app/common/formly/array.type.ts
@@ -7,27 +7,21 @@ import { FieldArrayType } from "@ngx-formly/core";
     <legend *ngIf="to.label">{{ to.label }}</legend>
     <p *ngIf="to.description">{{ to.description }}</p>
 
-    <div
-      class="alert alert-danger"
-      role="alert"
-      *ngIf="showError && formControl.errors"
-    >
+    <div class="alert alert-danger" role="alert" *ngIf="showError && formControl.errors">
       <formly-validation-message [field]="field"></formly-validation-message>
     </div>
 
     <div *ngFor="let field of field.fieldGroup; let i = index" class="row">
       <formly-field class="col-10" [field]="field"></formly-field>
       <div class="col-2 text-right">
-        <button class="btn btn-danger" type="button" (click)="remove(i)">
-          -
-        </button>
+        <button class="btn btn-danger" type="button" (click)="remove(i)">-</button>
       </div>
     </div>
 
     <div class="d-flex flex-row-reverse">
       <button class="btn btn-primary" type="button" (click)="add()">+</button>
     </div>
-  </div> `
+  </div> `,
 })
 export class ArrayTypeComponent extends FieldArrayType {}
 

--- a/core/new-gui/src/app/common/formly/formly-config.ts
+++ b/core/new-gui/src/app/common/formly/formly-config.ts
@@ -24,7 +24,7 @@ export const TEXERA_FORMLY_CONFIG = {
     { name: "minItems", message: minItemsValidationMessage },
     { name: "maxItems", message: maxItemsValidationMessage },
     { name: "uniqueItems", message: "should NOT have duplicate items" },
-    { name: "const", message: constValidationMessage }
+    { name: "const", message: constValidationMessage },
   ],
   types: [
     { name: "string", extends: "input" },
@@ -33,18 +33,18 @@ export const TEXERA_FORMLY_CONFIG = {
       extends: "input",
       defaultOptions: {
         templateOptions: {
-          type: "number"
-        }
-      }
+          type: "number",
+        },
+      },
     },
     {
       name: "integer",
       extends: "input",
       defaultOptions: {
         templateOptions: {
-          type: "number"
-        }
-      }
+          type: "number",
+        },
+      },
     },
     { name: "boolean", extends: "checkbox" },
     { name: "enum", extends: "select" },
@@ -52,8 +52,8 @@ export const TEXERA_FORMLY_CONFIG = {
     { name: "array", component: ArrayTypeComponent },
     { name: "object", component: ObjectTypeComponent },
     { name: "multischema", component: MultiSchemaTypeComponent },
-    { name: "codearea", component: CodeareaCustomTemplateComponent }
-  ]
+    { name: "codearea", component: CodeareaCustomTemplateComponent },
+  ],
 };
 
 export function minItemsValidationMessage(err: any, field: FormlyFieldConfig) {
@@ -80,24 +80,15 @@ export function maxValidationMessage(err: any, field: FormlyFieldConfig) {
   return `should be <= ${field.templateOptions?.max}`;
 }
 
-export function multipleOfValidationMessage(
-  err: any,
-  field: FormlyFieldConfig
-) {
+export function multipleOfValidationMessage(err: any, field: FormlyFieldConfig) {
   return `should be multiple of ${field.templateOptions?.step}`;
 }
 
-export function exclusiveMinimumValidationMessage(
-  err: any,
-  field: FormlyFieldConfig
-) {
+export function exclusiveMinimumValidationMessage(err: any, field: FormlyFieldConfig) {
   return `should be > ${field.templateOptions?.exclusiveMinimum}`;
 }
 
-export function exclusiveMaximumValidationMessage(
-  err: any,
-  field: FormlyFieldConfig
-) {
+export function exclusiveMaximumValidationMessage(err: any, field: FormlyFieldConfig) {
   return `should be < ${field.templateOptions?.exclusiveMaximum}`;
 }
 

--- a/core/new-gui/src/app/common/formly/formly-utils.ts
+++ b/core/new-gui/src/app/common/formly/formly-utils.ts
@@ -3,26 +3,14 @@ import { isDefined } from "../util/predicate";
 import { SchemaAttribute } from "../../workspace/service/dynamic-schema/schema-propagation/schema-propagation.service";
 import { Observable } from "rxjs";
 import { FORM_DEBOUNCE_TIME_MS } from "../../workspace/service/execute-workflow/execute-workflow.service";
-import {
-  debounceTime,
-  distinctUntilChanged,
-  filter,
-  share
-} from "rxjs/operators";
+import { debounceTime, distinctUntilChanged, filter, share } from "rxjs/operators";
 
-export function getFieldByName(
-  fieldName: string,
-  fields: FormlyFieldConfig[]
-): FormlyFieldConfig | undefined {
+export function getFieldByName(fieldName: string, fields: FormlyFieldConfig[]): FormlyFieldConfig | undefined {
   return fields.filter((field, _, __) => field.key === fieldName)[0];
 }
 
-export function setHideExpression(
-  toggleHidden: string[],
-  fields: FormlyFieldConfig[],
-  hiddenBy: string
-): void {
-  toggleHidden.forEach((hiddenFieldName) => {
+export function setHideExpression(toggleHidden: string[], fields: FormlyFieldConfig[], hiddenBy: string): void {
+  toggleHidden.forEach(hiddenFieldName => {
     const fieldToBeHidden = getFieldByName(hiddenFieldName, fields);
     if (isDefined(fieldToBeHidden)) {
       fieldToBeHidden.hideExpression = "!model." + hiddenBy;
@@ -38,10 +26,10 @@ export function setChildTypeDependency(
 ): void {
   const timestampFieldNames = attributes
     ?.flat()
-    .filter((attribute) => {
+    .filter(attribute => {
       return attribute?.attributeType === "timestamp";
     })
-    .map((attribute) => attribute?.attributeName);
+    .map(attribute => attribute?.attributeName);
 
   if (timestampFieldNames) {
     const childField = getFieldByName(childName, fields);
@@ -54,7 +42,7 @@ export function setChildTypeDependency(
           JSON.stringify(timestampFieldNames) +
           ".includes(model." +
           parentName +
-          ")? 'Input a datetime string' : 'Input a positive number'"
+          ")? 'Input a datetime string' : 'Input a positive number'",
       };
     }
   }
@@ -85,7 +73,7 @@ export function createOutputFormChangeEventStream(
         // .do(evt => console.log(evt))
         // don't emit the event if form data is same with current actual data
         // also check for other unlikely circumstances (see below)
-        filter((formData) => modelCheck(formData)),
+        filter(formData => modelCheck(formData)),
         // share() because the original observable is a hot observable
         share()
       )

--- a/core/new-gui/src/app/common/formly/multischema.type.ts
+++ b/core/new-gui/src/app/common/formly/multischema.type.ts
@@ -7,19 +7,12 @@ import { FieldType } from "@ngx-formly/core";
     <div class="card-body">
       <legend *ngIf="to.label">{{ to.label }}</legend>
       <p *ngIf="to.description">{{ to.description }}</p>
-      <div
-        class="alert alert-danger"
-        role="alert"
-        *ngIf="showError && formControl.errors"
-      >
+      <div class="alert alert-danger" role="alert" *ngIf="showError && formControl.errors">
         <formly-validation-message [field]="field"></formly-validation-message>
       </div>
-      <formly-field
-        *ngFor="let f of field.fieldGroup"
-        [field]="f"
-      ></formly-field>
+      <formly-field *ngFor="let f of field.fieldGroup" [field]="f"></formly-field>
     </div>
-  </div> `
+  </div> `,
 })
 export class MultiSchemaTypeComponent extends FieldType {}
 

--- a/core/new-gui/src/app/common/formly/null.type.ts
+++ b/core/new-gui/src/app/common/formly/null.type.ts
@@ -3,7 +3,7 @@ import { FieldType } from "@ngx-formly/core";
 
 @Component({
   // selector: 'formly-null-type',
-  template: ""
+  template: "",
 })
 export class NullTypeComponent extends FieldType {}
 

--- a/core/new-gui/src/app/common/formly/object.type.ts
+++ b/core/new-gui/src/app/common/formly/object.type.ts
@@ -6,19 +6,15 @@ import { FieldType } from "@ngx-formly/core";
   template: `<div class="mb-3">
     <legend *ngIf="to.label">{{ to.label }}</legend>
     <p *ngIf="to.description">{{ to.description }}</p>
-    <div
-      class="alert alert-danger"
-      role="alert"
-      *ngIf="showError && formControl.errors"
-    >
+    <div class="alert alert-danger" role="alert" *ngIf="showError && formControl.errors">
       <formly-validation-message [field]="field"></formly-validation-message>
     </div>
     <formly-field *ngFor="let f of field.fieldGroup" [field]="f"></formly-field>
-  </div> `
+  </div> `,
 })
 export class ObjectTypeComponent extends FieldType {
   defaultOptions = {
-    defaultValue: {}
+    defaultValue: {},
   };
 }
 

--- a/core/new-gui/src/app/common/service/blob-error-http-interceptor.service.ts
+++ b/core/new-gui/src/app/common/service/blob-error-http-interceptor.service.ts
@@ -1,27 +1,14 @@
 import { Injectable } from "@angular/core";
-import {
-  HttpErrorResponse,
-  HttpEvent,
-  HttpHandler,
-  HttpInterceptor,
-  HttpRequest
-} from "@angular/common/http";
+import { HttpErrorResponse, HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from "@angular/common/http";
 import { Observable, throwError } from "rxjs";
 import { catchError } from "rxjs/operators";
 
 @Injectable()
 export class BlobErrorHttpInterceptor implements HttpInterceptor {
-  public intercept(
-    req: HttpRequest<any>,
-    next: HttpHandler
-  ): Observable<HttpEvent<any>> {
+  public intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     return next.handle(req).pipe(
       catchError((err: unknown) => {
-        if (
-          err instanceof HttpErrorResponse &&
-          err.error instanceof Blob &&
-          err.error.type === "application/json"
-        ) {
+        if (err instanceof HttpErrorResponse && err.error instanceof Blob && err.error.type === "application/json") {
           // https://github.com/angular/angular/issues/19888
           // When request of type Blob, the error is also in Blob instead of object of the json data
           return new Promise<any>((resolve, reject) => {
@@ -35,14 +22,14 @@ export class BlobErrorHttpInterceptor implements HttpInterceptor {
                     headers: err.headers,
                     status: err.status,
                     statusText: err.statusText,
-                    url: err.url !== null ? err.url : undefined
+                    url: err.url !== null ? err.url : undefined,
                   })
                 );
               } catch (_) {
                 reject(err);
               }
             };
-            reader.onerror = (_) => {
+            reader.onerror = _ => {
               reject(err);
             };
             reader.readAsText(err.error);

--- a/core/new-gui/src/app/common/service/notification/notification.service.ts
+++ b/core/new-gui/src/app/common/service/notification/notification.service.ts
@@ -12,7 +12,7 @@ export interface Notification {
  * to show on NotificationComponent.
  */
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class NotificationService {
   private notificationStream = new Subject<Notification>();

--- a/core/new-gui/src/app/common/service/user/stub-user.service.ts
+++ b/core/new-gui/src/app/common/service/user/stub-user.service.ts
@@ -10,7 +10,7 @@ export const MOCK_USER_ID = 1;
 export const MOCK_USER_NAME = "testUser";
 export const MOCK_USER = {
   name: MOCK_USER_NAME,
-  uid: MOCK_USER_ID
+  uid: MOCK_USER_ID,
 };
 
 /**

--- a/core/new-gui/src/app/common/service/user/user.service.ts
+++ b/core/new-gui/src/app/common/service/user/user.service.ts
@@ -14,7 +14,7 @@ import { filter } from "rxjs/operators";
  * @author Adam
  */
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class UserService {
   public static readonly AUTH_STATUS_ENDPOINT = "users/auth/status";
@@ -24,8 +24,7 @@ export class UserService {
   public static readonly GOOGLE_LOGIN_ENDPOINT = "users/google-login";
 
   private currentUser: User | undefined = undefined;
-  private userChangeSubject: ReplaySubject<User | undefined> =
-    new ReplaySubject<User | undefined>(1);
+  private userChangeSubject: ReplaySubject<User | undefined> = new ReplaySubject<User | undefined>(1);
 
   constructor(private http: HttpClient, private googleAuth: GoogleAuthService) {
     if (environment.userSystemEnabled) {
@@ -45,10 +44,10 @@ export class UserService {
       throw new Error("Already logged in when register.");
     }
 
-    return this.http.post<Response>(
-      `${AppSettings.getApiEndpoint()}/${UserService.REGISTER_ENDPOINT}`,
-      { userName, password }
-    );
+    return this.http.post<Response>(`${AppSettings.getApiEndpoint()}/${UserService.REGISTER_ENDPOINT}`, {
+      userName,
+      password,
+    });
   }
 
   /**
@@ -68,10 +67,7 @@ export class UserService {
       throw new Error("Already logged in when login in.");
     }
     return this.http
-      .post<User>(
-        `${AppSettings.getApiEndpoint()}/${UserService.GOOGLE_LOGIN_ENDPOINT}`,
-        { authCode }
-      )
+      .post<User>(`${AppSettings.getApiEndpoint()}/${UserService.GOOGLE_LOGIN_ENDPOINT}`, { authCode })
       .pipe(filter((user: User) => user != null));
   }
 
@@ -85,10 +81,10 @@ export class UserService {
     if (this.currentUser) {
       throw new Error("Already logged in when login in.");
     }
-    return this.http.post<Response>(
-      `${AppSettings.getApiEndpoint()}/${UserService.LOGIN_ENDPOINT}`,
-      { userName, password }
-    );
+    return this.http.post<Response>(`${AppSettings.getApiEndpoint()}/${UserService.LOGIN_ENDPOINT}`, {
+      userName,
+      password,
+    });
   }
 
   /**
@@ -96,9 +92,7 @@ export class UserService {
    */
   public logOut(): void {
     this.http
-      .get<Response>(
-        `${AppSettings.getApiEndpoint()}/${UserService.LOG_OUT_ENDPOINT}`
-      )
+      .get<Response>(`${AppSettings.getApiEndpoint()}/${UserService.LOG_OUT_ENDPOINT}`)
       .subscribe(() => this.changeUser(undefined));
   }
 
@@ -139,9 +133,7 @@ export class UserService {
 
   private loginFromSession(): void {
     this.http
-      .get<User>(
-        `${AppSettings.getApiEndpoint()}/${UserService.AUTH_STATUS_ENDPOINT}`
-      )
-      .subscribe((user) => this.changeUser(user != null ? user : undefined));
+      .get<User>(`${AppSettings.getApiEndpoint()}/${UserService.AUTH_STATUS_ENDPOINT}`)
+      .subscribe(user => this.changeUser(user != null ? user : undefined));
   }
 }

--- a/core/new-gui/src/app/common/service/workflow-persist/workflow-persist.service.spec.ts
+++ b/core/new-gui/src/app/common/service/workflow-persist/workflow-persist.service.spec.ts
@@ -1,8 +1,5 @@
 import { TestBed } from "@angular/core/testing";
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from "@angular/common/http/testing";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
 import { WorkflowPersistService } from "./workflow-persist.service";
 import { jsonCast } from "../../util/storage";
 import { WorkflowContent } from "../../type/workflow";
@@ -33,7 +30,7 @@ describe("WorkflowPersistService", () => {
     "\"groups\":[],\"breakpoints\":{}}";
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule]
+      imports: [HttpClientTestingModule],
     });
     service = TestBed.inject(WorkflowPersistService);
     httpTestingController = TestBed.get(HttpTestingController);
@@ -47,21 +44,19 @@ describe("WorkflowPersistService", () => {
     service
       .createWorkflow(jsonCast<WorkflowContent>(testContent), "testname")
       .pipe(last())
-      .subscribe((value) => {
+      .subscribe(value => {
         expect(value).toBeTruthy();
       });
-    httpTestingController.expectOne((request) => request.method === "POST");
+    httpTestingController.expectOne(request => request.method === "POST");
   });
 
   it("should check if workflow content and name returned correctly", () => {
     service
       .createWorkflow(jsonCast<WorkflowContent>(testContent), "testname")
       .pipe(last())
-      .subscribe((value) => {
+      .subscribe(value => {
         expect(value.workflow.name).toEqual("testname_copy");
-        expect(value.workflow.content).toEqual(
-          jsonCast<WorkflowContent>(testContent)
-        );
+        expect(value.workflow.content).toEqual(jsonCast<WorkflowContent>(testContent));
       });
   });
 });

--- a/core/new-gui/src/app/common/service/workflow-persist/workflow-persist.service.ts
+++ b/core/new-gui/src/app/common/service/workflow-persist/workflow-persist.service.ts
@@ -14,7 +14,7 @@ export const WORKFLOW_CREATE_URL = WORKFLOW_BASE_URL + "/create";
 export const WORKFLOW_DUPLICATE_URL = WORKFLOW_BASE_URL + "/duplicate";
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class WorkflowPersistService {
   constructor(private http: HttpClient) {}
@@ -25,14 +25,11 @@ export class WorkflowPersistService {
    */
   public persistWorkflow(workflow: Workflow): Observable<Workflow> {
     return this.http
-      .post<Workflow>(
-        `${AppSettings.getApiEndpoint()}/${WORKFLOW_PERSIST_URL}`,
-        {
-          wid: workflow.wid,
-          name: workflow.name,
-          content: JSON.stringify(workflow.content)
-        }
-      )
+      .post<Workflow>(`${AppSettings.getApiEndpoint()}/${WORKFLOW_PERSIST_URL}`, {
+        wid: workflow.wid,
+        name: workflow.name,
+        content: JSON.stringify(workflow.content),
+      })
       .pipe(
         filter((updatedWorkflow: Workflow) => updatedWorkflow != null),
         map(WorkflowPersistService.parseWorkflowInfo)
@@ -49,37 +46,21 @@ export class WorkflowPersistService {
     newWorkflowName: string = "Untitled workflow"
   ): Observable<DashboardWorkflowEntry> {
     return this.http
-      .post<DashboardWorkflowEntry>(
-        `${AppSettings.getApiEndpoint()}/${WORKFLOW_CREATE_URL}`,
-        {
-          name: newWorkflowName,
-          content: JSON.stringify(newWorkflowContent)
-        }
-      )
-      .pipe(
-        filter(
-          (createdWorkflow: DashboardWorkflowEntry) => createdWorkflow != null
-        )
-      );
+      .post<DashboardWorkflowEntry>(`${AppSettings.getApiEndpoint()}/${WORKFLOW_CREATE_URL}`, {
+        name: newWorkflowName,
+        content: JSON.stringify(newWorkflowContent),
+      })
+      .pipe(filter((createdWorkflow: DashboardWorkflowEntry) => createdWorkflow != null));
   }
 
   /**
    * creates a workflow and insert it to backend database and return its information
    * @param targetWid
    */
-  public duplicateWorkflow(
-    targetWid: number
-  ): Observable<DashboardWorkflowEntry> {
+  public duplicateWorkflow(targetWid: number): Observable<DashboardWorkflowEntry> {
     return this.http
-      .post<DashboardWorkflowEntry>(
-        `${AppSettings.getApiEndpoint()}/${WORKFLOW_DUPLICATE_URL}`,
-        { wid: targetWid }
-      )
-      .pipe(
-        filter(
-          (createdWorkflow: DashboardWorkflowEntry) => createdWorkflow != null
-        )
-      );
+      .post<DashboardWorkflowEntry>(`${AppSettings.getApiEndpoint()}/${WORKFLOW_DUPLICATE_URL}`, { wid: targetWid })
+      .pipe(filter((createdWorkflow: DashboardWorkflowEntry) => createdWorkflow != null));
   }
 
   /**
@@ -87,50 +68,33 @@ export class WorkflowPersistService {
    * @param wid, the workflow id.
    */
   public retrieveWorkflow(wid: number): Observable<Workflow> {
-    return this.http
-      .get<Workflow>(
-        `${AppSettings.getApiEndpoint()}/${WORKFLOW_BASE_URL}/${wid}`
-      )
-      .pipe(
-        filter((workflow: Workflow) => workflow != null),
-        map(WorkflowPersistService.parseWorkflowInfo)
-      );
+    return this.http.get<Workflow>(`${AppSettings.getApiEndpoint()}/${WORKFLOW_BASE_URL}/${wid}`).pipe(
+      filter((workflow: Workflow) => workflow != null),
+      map(WorkflowPersistService.parseWorkflowInfo)
+    );
   }
 
   /**
    * retrieves a list of workflows from backend database that belongs to the user in the session.
    */
-  public retrieveWorkflowsBySessionUser(): Observable<
-    DashboardWorkflowEntry[]
-  > {
-    return this.http
-      .get<DashboardWorkflowEntry[]>(
-        `${AppSettings.getApiEndpoint()}/${WORKFLOW_LIST_URL}`
+  public retrieveWorkflowsBySessionUser(): Observable<DashboardWorkflowEntry[]> {
+    return this.http.get<DashboardWorkflowEntry[]>(`${AppSettings.getApiEndpoint()}/${WORKFLOW_LIST_URL}`).pipe(
+      map((dashboardWorkflowEntries: DashboardWorkflowEntry[]) =>
+        dashboardWorkflowEntries.map((workflowEntry: DashboardWorkflowEntry) => {
+          return {
+            ...workflowEntry,
+            dashboardWorkflowEntry: WorkflowPersistService.parseWorkflowInfo(workflowEntry.workflow),
+          };
+        })
       )
-      .pipe(
-        map((dashboardWorkflowEntries: DashboardWorkflowEntry[]) =>
-          dashboardWorkflowEntries.map(
-            (workflowEntry: DashboardWorkflowEntry) => {
-              return {
-                ...workflowEntry,
-                dashboardWorkflowEntry:
-                  WorkflowPersistService.parseWorkflowInfo(
-                    workflowEntry.workflow
-                  )
-              };
-            }
-          )
-        )
-      );
+    );
   }
 
   /**
    * deletes the given workflow, the user in the session must own the workflow.
    */
   public deleteWorkflow(wid: number): Observable<Response> {
-    return this.http.delete<Response>(
-      `${AppSettings.getApiEndpoint()}/${WORKFLOW_BASE_URL}/${wid}`
-    );
+    return this.http.delete<Response>(`${AppSettings.getApiEndpoint()}/${WORKFLOW_BASE_URL}/${wid}`);
   }
 
   /**

--- a/core/new-gui/src/app/common/type/generic-web-response.ts
+++ b/core/new-gui/src/app/common/type/generic-web-response.ts
@@ -4,7 +4,7 @@
  * Source: https://stackoverflow.com/questions/50365598/typescript-runtime-error-cannot-read-property-of-undefined-enum
  */
 export enum GenericWebResponseCode {
-  SUCCESS = 0
+  SUCCESS = 0,
 }
 
 export interface GenericWebResponse

--- a/core/new-gui/src/app/common/type/workflow.ts
+++ b/core/new-gui/src/app/common/type/workflow.ts
@@ -1,11 +1,6 @@
 import { WorkflowMetadata } from "../../dashboard/type/workflow-metadata.interface";
 import { PlainGroup } from "../../workspace/service/workflow-graph/model/operator-group";
-import {
-  Breakpoint,
-  OperatorLink,
-  OperatorPredicate,
-  Point
-} from "../../workspace/types/workflow-common.interface";
+import { Breakpoint, OperatorLink, OperatorPredicate, Point } from "../../workspace/types/workflow-common.interface";
 
 /**
  * WorkflowContent is used to store the information of the workflow

--- a/core/new-gui/src/app/common/util/json.ts
+++ b/core/new-gui/src/app/common/util/json.ts
@@ -10,11 +10,8 @@
 import { IndexableObject } from "../../workspace/types/result-table.interface";
 import deepMap from "deep-map";
 
-export function trimDisplayJsonData(
-  rowData: IndexableObject,
-  maxLen: number
-): Record<string, unknown> {
-  return deepMap<Record<string, unknown>>(rowData, (value) => {
+export function trimDisplayJsonData(rowData: IndexableObject, maxLen: number): Record<string, unknown> {
+  return deepMap<Record<string, unknown>>(rowData, value => {
     if (typeof value === "string" && value.length > maxLen) {
       return value.substring(0, maxLen) + "...";
     } else {

--- a/core/new-gui/src/app/dashboard/component/dashboard.component.html
+++ b/core/new-gui/src/app/dashboard/component/dashboard.component.html
@@ -1,8 +1,6 @@
 <div class="dashboard-grid-container grid-container">
   <texera-top-bar class="dashboard-top-bar grid-container"></texera-top-bar>
-  <texera-feature-bar
-    class="dashboard-feature-bar grid-container"
-  ></texera-feature-bar>
+  <texera-feature-bar class="dashboard-feature-bar grid-container"></texera-feature-bar>
   <div class="dashboard-feature-box grid-container">
     <texera-feature-container></texera-feature-container>
   </div>

--- a/core/new-gui/src/app/dashboard/component/dashboard.component.ts
+++ b/core/new-gui/src/app/dashboard/component/dashboard.component.ts
@@ -12,6 +12,6 @@ import { WorkflowPersistService } from "../../common/service/workflow-persist/wo
   selector: "texera-dashboard",
   templateUrl: "./dashboard.component.html",
   styleUrls: ["./dashboard.component.scss"],
-  providers: [WorkflowPersistService]
+  providers: [WorkflowPersistService],
 })
 export class DashboardComponent {}

--- a/core/new-gui/src/app/dashboard/component/feature-bar/feature-bar.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-bar/feature-bar.component.html
@@ -9,12 +9,7 @@
       nzTooltipPlacement="right"
       nzType="text"
     >
-      <i
-        class="feature-bar-btn-icon"
-        nz-icon
-        nzTheme="outline"
-        nzType="project"
-      ></i>
+      <i class="feature-bar-btn-icon" nz-icon nzTheme="outline" nzType="project"></i>
       Workflows
     </button>
   </nz-list-item>
@@ -27,12 +22,7 @@
       nzTooltipPlacement="right"
       nzType="text"
     >
-      <i
-        class="feature-bar-btn-icon"
-        nz-icon
-        nzTheme="outline"
-        nzType="folder-open"
-      ></i>
+      <i class="feature-bar-btn-icon" nz-icon nzTheme="outline" nzType="folder-open"></i>
       User Files
     </button>
   </nz-list-item>

--- a/core/new-gui/src/app/dashboard/component/feature-bar/feature-bar.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-bar/feature-bar.component.spec.ts
@@ -14,7 +14,7 @@ describe("FeatureBarComponent", () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [FeatureBarComponent],
-        imports: [RouterTestingModule, MatDividerModule, MatListModule]
+        imports: [RouterTestingModule, MatDividerModule, MatListModule],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/dashboard/component/feature-bar/feature-bar.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-bar/feature-bar.component.ts
@@ -13,6 +13,6 @@ import { Component } from "@angular/core";
 @Component({
   selector: "texera-feature-bar",
   templateUrl: "./feature-bar.component.html",
-  styleUrls: ["./feature-bar.component.scss"]
+  styleUrls: ["./feature-bar.component.scss"],
 })
 export class FeatureBarComponent {}

--- a/core/new-gui/src/app/dashboard/component/feature-container/feature-container.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/feature-container.component.spec.ts
@@ -11,7 +11,7 @@ describe("FeatureContainerComponent", () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [FeatureContainerComponent],
-        imports: [RouterTestingModule]
+        imports: [RouterTestingModule],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/dashboard/component/feature-container/feature-container.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/feature-container.component.ts
@@ -10,6 +10,6 @@ import { Component } from "@angular/core";
 @Component({
   selector: "texera-feature-container",
   templateUrl: "./feature-container.component.html",
-  styleUrls: ["./feature-container.component.scss"]
+  styleUrls: ["./feature-container.component.scss"],
 })
 export class FeatureContainerComponent {}

--- a/core/new-gui/src/app/dashboard/component/feature-container/resource-section/resource-section.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/resource-section/resource-section.component.spec.ts
@@ -9,7 +9,7 @@ describe("ResourceSectionComponent", () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [ResourceSectionComponent]
+        declarations: [ResourceSectionComponent],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/dashboard/component/feature-container/resource-section/resource-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/resource-section/resource-section.component.ts
@@ -3,6 +3,6 @@ import { Component } from "@angular/core";
 @Component({
   selector: "texera-resource-section",
   templateUrl: "./resource-section.component.html",
-  styleUrls: ["./resource-section.component.scss"]
+  styleUrls: ["./resource-section.component.scss"],
 })
 export class ResourceSectionComponent {}

--- a/core/new-gui/src/app/dashboard/component/feature-container/running-job-section/running-job-section.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/running-job-section/running-job-section.component.spec.ts
@@ -9,7 +9,7 @@ describe("RunningJobSectionComponent", () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [RunningJobSectionComponent]
+        declarations: [RunningJobSectionComponent],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/dashboard/component/feature-container/running-job-section/running-job-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/running-job-section/running-job-section.component.ts
@@ -3,6 +3,6 @@ import { Component } from "@angular/core";
 @Component({
   selector: "texera-running-job-section",
   templateUrl: "./running-job-section.component.html",
-  styleUrls: ["./running-job-section.component.scss"]
+  styleUrls: ["./running-job-section.component.scss"],
 })
 export class RunningJobSectionComponent {}

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-add-workflow/ngbd-modal-add-workflow.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-add-workflow/ngbd-modal-add-workflow.component.html
@@ -1,11 +1,6 @@
 <div class="modal-header">
   <h4 class="modal-title">Add New Project</h4>
-  <button
-    (click)="activeModal.close()"
-    aria-label="Close"
-    class="close"
-    type="button"
-  >
+  <button (click)="activeModal.close()" aria-label="Close" class="close" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
 </div>
@@ -16,18 +11,6 @@
   <div class="warning-note" id="warning"></div>
 </div>
 <div class="modal-footer">
-  <button
-    (click)="addWorkflow()"
-    class="btn btn-outline-dark add-button"
-    type="button"
-  >
-    Add
-  </button>
-  <button
-    (click)="activeModal.close()"
-    class="btn btn-outline-dark"
-    type="button"
-  >
-    Close
-  </button>
+  <button (click)="addWorkflow()" class="btn btn-outline-dark add-button" type="button">Add</button>
+  <button (click)="activeModal.close()" class="btn btn-outline-dark" type="button">Close</button>
 </div>

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-add-workflow/ngbd-modal-add-workflow.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-add-workflow/ngbd-modal-add-workflow.component.spec.ts
@@ -20,7 +20,7 @@ describe("NgbdModalAddProjectComponent", () => {
       TestBed.configureTestingModule({
         declarations: [NgbdModalAddWorkflowComponent],
         providers: [NgbActiveModal],
-        imports: [MatDialogModule, NgbModule, FormsModule, HttpClientModule]
+        imports: [MatDialogModule, NgbModule, FormsModule, HttpClientModule],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-add-workflow/ngbd-modal-add-workflow.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-add-workflow/ngbd-modal-add-workflow.component.ts
@@ -11,10 +11,7 @@ import { NgbActiveModal } from "@ng-bootstrap/ng-bootstrap";
 @Component({
   selector: "texera-add-workflow-section-modal",
   templateUrl: "ngbd-modal-add-workflow.component.html",
-  styleUrls: [
-    "../../../dashboard.component.scss",
-    "ngbd-modal-add-workflow.component.scss"
-  ]
+  styleUrls: ["../../../dashboard.component.scss", "ngbd-modal-add-workflow.component.scss"],
 })
 export class NgbdModalAddWorkflowComponent {
   public name: string = "";

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-delete-workflow/ngbd-modal-delete-workflow.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-delete-workflow/ngbd-modal-delete-workflow.component.html
@@ -1,11 +1,6 @@
 <div class="modal-header">
   <h4 class="modal-title">Delete the Project</h4>
-  <button
-    (click)="activeModal.close()"
-    aria-label="Close"
-    class="close"
-    type="button"
-  >
+  <button (click)="activeModal.close()" aria-label="Close" class="close" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
 </div>
@@ -17,18 +12,8 @@
 </div>
 
 <div class="modal-footer">
-  <button
-    (click)="deleteSavedWorkflow()"
-    class="btn btn-outline-dark delete-confirm-button"
-    type="button"
-  >
+  <button (click)="deleteSavedWorkflow()" class="btn btn-outline-dark delete-confirm-button" type="button">
     Confirm
   </button>
-  <button
-    (click)="activeModal.close()"
-    class="btn btn-outline-dark"
-    type="button"
-  >
-    Close
-  </button>
+  <button (click)="activeModal.close()" class="btn btn-outline-dark" type="button">Close</button>
 </div>

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-delete-workflow/ngbd-modal-delete-workflow.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-delete-workflow/ngbd-modal-delete-workflow.component.spec.ts
@@ -22,7 +22,7 @@ describe("NgbdModalDeleteProjectComponent", () => {
     wid: 4,
     content: jsonCast<WorkflowContent>("{}"),
     creationTime: 1,
-    lastModifiedTime: 2
+    lastModifiedTime: 2,
   };
 
   beforeEach(
@@ -30,7 +30,7 @@ describe("NgbdModalDeleteProjectComponent", () => {
       TestBed.configureTestingModule({
         declarations: [NgbdModalDeleteWorkflowComponent],
         providers: [NgbActiveModal],
-        imports: [MatDialogModule, NgbModule, FormsModule, HttpClientModule]
+        imports: [MatDialogModule, NgbModule, FormsModule, HttpClientModule],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-delete-workflow/ngbd-modal-delete-workflow.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-delete-workflow/ngbd-modal-delete-workflow.component.ts
@@ -11,10 +11,7 @@ import { Workflow } from "../../../../../common/type/workflow";
 @Component({
   selector: "texera-resource-section-delete-project-modal",
   templateUrl: "./ngbd-modal-delete-workflow.component.html",
-  styleUrls: [
-    "./ngbd-modal-delete-workflow.component.scss",
-    "../../../dashboard.component.scss"
-  ]
+  styleUrls: ["./ngbd-modal-delete-workflow.component.scss", "../../../dashboard.component.scss"],
 })
 export class NgbdModalDeleteWorkflowComponent {
   @Input() workflow!: Workflow;

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.html
@@ -1,13 +1,6 @@
 <div class="modal-header">
-  <h4 class="modal-title" id="modal-basic-title">
-    Share This Workflow With Someone
-  </h4>
-  <button
-    (click)="activeModal.dismiss('Cross click')"
-    aria-label="Close"
-    class="close"
-    type="button"
-  >
+  <h4 class="modal-title" id="modal-basic-title">Share This Workflow With Someone</h4>
+  <button (click)="activeModal.dismiss('Cross click')" aria-label="Close" class="close" type="button">
     <span aria-hidden="true"> × </span>
   </button>
 </div>
@@ -15,23 +8,14 @@
   <form (ngSubmit)="onClickShareWorkflow(workflow)" [formGroup]="shareForm">
     <div class="form-group">
       <label for="username"> Username of the target user to share </label>
-      <input
-        class="form-control"
-        formControlName="username"
-        id="username"
-        type="text"
-      />
+      <input class="form-control" formControlName="username" id="username" type="text" />
 
       <br />
       <label for="accessLevel"> Access Level </label>
       <div id="accessLevel">
         <select class="custom-select" formControlName="accessLevel">
           <option disabled value="">Choose Access Level To Be Shared</option>
-          <option
-            (change)="changeType($event)"
-            *ngFor="let accessLevel of accessLevels"
-            [ngValue]="accessLevel"
-          >
+          <option (change)="changeType($event)" *ngFor="let accessLevel of accessLevels" [ngValue]="accessLevel">
             {{ accessLevel }}
           </option>
         </select>
@@ -42,11 +26,7 @@
     </div>
   </form>
   <br />
-  <button
-    (click)="onClickGetAllSharedAccess(workflow)"
-    class="btn"
-    type="button"
-  >
+  <button (click)="onClickGetAllSharedAccess(workflow)" class="btn" type="button">
     <i class="fa fa-refresh"></i>
   </button>
   <label for="current-share">Access:</label>
@@ -54,14 +34,8 @@
     <li>{{ workflowOwner }} <span class="badge badge-primary">Owner</span></li>
     <li *ngFor="let userWorkflowAccess of allUserWorkflowAccess">
       {{ userWorkflowAccess.userName }}
-      <span class="badge badge-primary"
-        >{{ userWorkflowAccess.accessLevel }}</span
-      >
-      <button
-        (click)="onClickRemoveAccess(workflow, userWorkflowAccess.userName)"
-        class="btn"
-        type="button"
-      >
+      <span class="badge badge-primary">{{ userWorkflowAccess.accessLevel }}</span>
+      <button (click)="onClickRemoveAccess(workflow, userWorkflowAccess.userName)" class="btn" type="button">
         <i class="fa fa-trash"></i>
       </button>
     </li>

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.spec.ts
@@ -20,7 +20,7 @@ describe("NgbdModalShareAccessComponent", () => {
       " {\"operators\":[],\"operatorPositions\":{},\"links\":[],\"groups\":[],\"breakpoints\":{}}"
     ),
     creationTime: 1,
-    lastModifiedTime: 2
+    lastModifiedTime: 2,
   };
 
   beforeEach(
@@ -34,9 +34,9 @@ describe("NgbdModalShareAccessComponent", () => {
           HttpHandler,
           {
             provide: WorkflowAccessService,
-            useClass: StubWorkflowAccessService
-          }
-        ]
+            useClass: StubWorkflowAccessService,
+          },
+        ],
       });
     })
   );
@@ -57,10 +57,7 @@ describe("NgbdModalShareAccessComponent", () => {
   });
 
   it("can get all accesses", () => {
-    const mySpy = spyOn(
-      service,
-      "retrieveGrantedWorkflowAccessList"
-    ).and.callThrough();
+    const mySpy = spyOn(service, "retrieveGrantedWorkflowAccessList").and.callThrough();
     component.workflow = workflow;
     fixture.detectChanges();
     component.onClickGetAllSharedAccess(component.workflow);

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.ts
@@ -10,14 +10,14 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 @Component({
   selector: "texera-ngbd-modal-share-access",
   templateUrl: "./ngbd-modal-workflow-share-access.component.html",
-  styleUrls: ["./ngbd-modal-workflow-share-access.component.scss"]
+  styleUrls: ["./ngbd-modal-workflow-share-access.component.scss"],
 })
 export class NgbdModalWorkflowShareAccessComponent implements OnInit {
   @Input() workflow!: Workflow;
 
   public shareForm = this.formBuilder.group({
     username: ["", [Validators.required]],
-    accessLevel: ["", [Validators.required]]
+    accessLevel: ["", [Validators.required]],
   });
 
   public accessLevels: string[] = ["read", "write"];
@@ -49,8 +49,7 @@ export class NgbdModalWorkflowShareAccessComponent implements OnInit {
       .retrieveGrantedWorkflowAccessList(workflow)
       .pipe(untilDestroyed(this))
       .subscribe(
-        (userWorkflowAccess: ReadonlyArray<AccessEntry>) =>
-          (this.allUserWorkflowAccess = userWorkflowAccess),
+        (userWorkflowAccess: ReadonlyArray<AccessEntry>) => (this.allUserWorkflowAccess = userWorkflowAccess),
         // @ts-ignore // TODO: fix this with notification component
         (err: unknown) => console.log(err.error)
       );
@@ -68,11 +67,7 @@ export class NgbdModalWorkflowShareAccessComponent implements OnInit {
    * @param userToShareWith the target user
    * @param accessLevel the type of access to be given
    */
-  public grantWorkflowAccess(
-    workflow: Workflow,
-    userToShareWith: string,
-    accessLevel: string
-  ): void {
+  public grantWorkflowAccess(workflow: Workflow, userToShareWith: string, accessLevel: string): void {
     this.workflowGrantAccessService
       .grantUserWorkflowAccess(workflow, userToShareWith, accessLevel)
       .pipe(untilDestroyed(this))

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.html
@@ -10,24 +10,16 @@
       <nz-dropdown-menu #sortOptions="nzDropdownMenu">
         <ul nz-menu>
           <li nz-menu-item>
-            <button (click)="lastSort()" class="sorting_func" nz-button>
-              By Edit Time
-            </button>
+            <button (click)="lastSort()" class="sorting_func" nz-button>By Edit Time</button>
           </li>
           <li nz-menu-item>
-            <button (click)="dateSort()" class="sorting_func" nz-button>
-              By Create Time
-            </button>
+            <button (click)="dateSort()" class="sorting_func" nz-button>By Create Time</button>
           </li>
           <li nz-menu-item>
-            <button (click)="ascSort()" class="sorting_func" nz-button>
-              A -> Z
-            </button>
+            <button (click)="ascSort()" class="sorting_func" nz-button>A -> Z</button>
           </li>
           <li nz-menu-item>
-            <button (click)="dscSort()" class="sorting_func" nz-button>
-              Z -> A
-            </button>
+            <button (click)="dscSort()" class="sorting_func" nz-button>Z -> A</button>
           </li>
         </ul>
       </nz-dropdown-menu>
@@ -45,10 +37,7 @@
 
   <nz-card class="workflow-list-container subsection-grid-container">
     <nz-list>
-      <nz-list-item
-        *ngFor="let dashboardWorkflowEntry of dashboardWorkflowEntries"
-        class="workflow-list-item"
-      >
+      <nz-list-item *ngFor="let dashboardWorkflowEntry of dashboardWorkflowEntries" class="workflow-list-item">
         <nz-list-item-meta>
           <nz-list-item-meta-avatar>
             <nz-avatar
@@ -61,9 +50,7 @@
           </nz-list-item-meta-avatar>
           <nz-list-item-meta-title>
             <span class="workflow-dashboard-entry">
-              <label
-                (click)="jumpToWorkflow(dashboardWorkflowEntry)"
-                class="workflow-name"
+              <label (click)="jumpToWorkflow(dashboardWorkflowEntry)" class="workflow-name"
                 >{{ dashboardWorkflowEntry.workflow.name }}</label
               >
               <i
@@ -86,11 +73,9 @@
           </nz-list-item-meta-title>
           <nz-list-item-meta-description>
             <p class="workflow-time">
-              Last Access: {{ dashboardWorkflowEntry.workflow.lastModifiedTime |
-              date: "yyyy-MM-dd HH:mm" }}
+              Last Access: {{ dashboardWorkflowEntry.workflow.lastModifiedTime | date: "yyyy-MM-dd HH:mm" }}
               <span class="time-space"></span>
-              Created: {{ dashboardWorkflowEntry.workflow.creationTime | date:
-              "yyyy-MM-dd HH:mm" }}
+              Created: {{ dashboardWorkflowEntry.workflow.creationTime | date: "yyyy-MM-dd HH:mm" }}
             </p>
           </nz-list-item-meta-description>
         </nz-list-item-meta>

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.spec.ts
@@ -1,9 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { RouterTestingModule } from "@angular/router/testing";
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from "@angular/common/http/testing";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { SavedWorkflowSectionComponent } from "./saved-workflow-section.component";
 import { WorkflowPersistService } from "../../../../common/service/workflow-persist/workflow-persist.service";
@@ -11,12 +8,7 @@ import { MatDividerModule } from "@angular/material/divider";
 import { MatListModule } from "@angular/material/list";
 import { MatCardModule } from "@angular/material/card";
 import { MatDialogModule } from "@angular/material/dialog";
-import {
-  NgbActiveModal,
-  NgbModal,
-  NgbModalRef,
-  NgbModule
-} from "@ng-bootstrap/ng-bootstrap";
+import { NgbActiveModal, NgbModal, NgbModalRef, NgbModule } from "@ng-bootstrap/ng-bootstrap";
 import { NgbdModalWorkflowShareAccessComponent } from "./ngbd-modal-share-access/ngbd-modal-workflow-share-access.component";
 import { Workflow, WorkflowContent } from "../../../../common/type/workflow";
 import { jsonCast } from "../../../../common/util/storage";
@@ -41,83 +33,80 @@ describe("SavedWorkflowSectionComponent", () => {
     name: "workflow 1",
     content: jsonCast<WorkflowContent>("{}"),
     creationTime: 1,
-    lastModifiedTime: 2
+    lastModifiedTime: 2,
   };
   const testWorkflow2: Workflow = {
     wid: 2,
     name: "workflow 2",
     content: jsonCast<WorkflowContent>("{}"),
     creationTime: 3,
-    lastModifiedTime: 4
+    lastModifiedTime: 4,
   };
   const testWorkflow3: Workflow = {
     wid: 3,
     name: "workflow 3",
     content: jsonCast<WorkflowContent>("{}"),
     creationTime: 3,
-    lastModifiedTime: 3
+    lastModifiedTime: 3,
   };
   const testWorkflow4: Workflow = {
     wid: 4,
     name: "workflow 4",
     content: jsonCast<WorkflowContent>("{}"),
     creationTime: 4,
-    lastModifiedTime: 6
+    lastModifiedTime: 6,
   };
   const testWorkflow5: Workflow = {
     wid: 5,
     name: "workflow 5",
     content: jsonCast<WorkflowContent>("{}"),
     creationTime: 3,
-    lastModifiedTime: 8
+    lastModifiedTime: 8,
   };
   const testWorkflowEntries: DashboardWorkflowEntry[] = [
     {
       workflow: testWorkflow1,
       isOwner: true,
       ownerName: "Texera",
-      accessLevel: "Write"
+      accessLevel: "Write",
     },
     {
       workflow: testWorkflow2,
       isOwner: true,
       ownerName: "Texera",
-      accessLevel: "Write"
+      accessLevel: "Write",
     },
     {
       workflow: testWorkflow3,
       isOwner: true,
       ownerName: "Texera",
-      accessLevel: "Write"
+      accessLevel: "Write",
     },
     {
       workflow: testWorkflow4,
       isOwner: true,
       ownerName: "Texera",
-      accessLevel: "Write"
+      accessLevel: "Write",
     },
     {
       workflow: testWorkflow5,
       isOwner: true,
       ownerName: "Texera",
-      accessLevel: "Write"
-    }
+      accessLevel: "Write",
+    },
   ];
 
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        declarations: [
-          SavedWorkflowSectionComponent,
-          NgbdModalWorkflowShareAccessComponent
-        ],
+        declarations: [SavedWorkflowSectionComponent, NgbdModalWorkflowShareAccessComponent],
         providers: [
           WorkflowPersistService,
           NgbActiveModal,
           HttpClient,
           NgbActiveModal,
           WorkflowAccessService,
-          { provide: UserService, useClass: StubUserService }
+          { provide: UserService, useClass: StubUserService },
         ],
         imports: [
           MatDividerModule,
@@ -129,8 +118,8 @@ describe("SavedWorkflowSectionComponent", () => {
           RouterTestingModule,
           HttpClientTestingModule,
           ReactiveFormsModule,
-          NzDropDownModule
-        ]
+          NzDropDownModule,
+        ],
       }).compileComponents();
     })
   );
@@ -153,42 +142,22 @@ describe("SavedWorkflowSectionComponent", () => {
 
   it("alphaSortTest increaseOrder", () => {
     component.dashboardWorkflowEntries = [];
-    component.dashboardWorkflowEntries =
-      component.dashboardWorkflowEntries.concat(testWorkflowEntries);
+    component.dashboardWorkflowEntries = component.dashboardWorkflowEntries.concat(testWorkflowEntries);
     component.ascSort();
-    const SortedCase = component.dashboardWorkflowEntries.map(
-      (item) => item.workflow.name
-    );
-    expect(SortedCase).toEqual([
-      "workflow 1",
-      "workflow 2",
-      "workflow 3",
-      "workflow 4",
-      "workflow 5"
-    ]);
+    const SortedCase = component.dashboardWorkflowEntries.map(item => item.workflow.name);
+    expect(SortedCase).toEqual(["workflow 1", "workflow 2", "workflow 3", "workflow 4", "workflow 5"]);
   });
 
   it("alphaSortTest decreaseOrder", () => {
     component.dashboardWorkflowEntries = [];
-    component.dashboardWorkflowEntries =
-      component.dashboardWorkflowEntries.concat(testWorkflowEntries);
+    component.dashboardWorkflowEntries = component.dashboardWorkflowEntries.concat(testWorkflowEntries);
     component.dscSort();
-    const SortedCase = component.dashboardWorkflowEntries.map(
-      (item) => item.workflow.name
-    );
-    expect(SortedCase).toEqual([
-      "workflow 5",
-      "workflow 4",
-      "workflow 3",
-      "workflow 2",
-      "workflow 1"
-    ]);
+    const SortedCase = component.dashboardWorkflowEntries.map(item => item.workflow.name);
+    expect(SortedCase).toEqual(["workflow 5", "workflow 4", "workflow 3", "workflow 2", "workflow 1"]);
   });
 
   it("Modal Opened, then Closed", () => {
-    const modalRef: NgbModalRef = modalService.open(
-      NgbdModalWorkflowShareAccessComponent
-    );
+    const modalRef: NgbModalRef = modalService.open(NgbdModalWorkflowShareAccessComponent);
     spyOn(modalService, "open").and.returnValue(modalRef);
     component.onClickOpenShareAccess(testWorkflowEntries[0]);
     expect(modalService.open).toHaveBeenCalled();
@@ -198,23 +167,17 @@ describe("SavedWorkflowSectionComponent", () => {
 
   it("createDateSortTest", () => {
     component.dashboardWorkflowEntries = [];
-    component.dashboardWorkflowEntries =
-      component.dashboardWorkflowEntries.concat(testWorkflowEntries);
+    component.dashboardWorkflowEntries = component.dashboardWorkflowEntries.concat(testWorkflowEntries);
     component.dateSort();
-    const SortedCase = component.dashboardWorkflowEntries.map(
-      (item) => item.workflow.creationTime
-    );
+    const SortedCase = component.dashboardWorkflowEntries.map(item => item.workflow.creationTime);
     expect(SortedCase).toEqual([1, 3, 3, 3, 4]);
   });
 
   it("lastEditSortTest", () => {
     component.dashboardWorkflowEntries = [];
-    component.dashboardWorkflowEntries =
-      component.dashboardWorkflowEntries.concat(testWorkflowEntries);
+    component.dashboardWorkflowEntries = component.dashboardWorkflowEntries.concat(testWorkflowEntries);
     component.lastSort();
-    const SortedCase = component.dashboardWorkflowEntries.map(
-      (item) => item.workflow.lastModifiedTime
-    );
+    const SortedCase = component.dashboardWorkflowEntries.map(item => item.workflow.lastModifiedTime);
     expect(SortedCase).toEqual([2, 3, 4, 6, 8]);
   });
 });

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
@@ -17,10 +17,7 @@ export const ROUTER_WORKFLOW_CREATE_NEW_URL = "/";
 @Component({
   selector: "texera-saved-workflow-section",
   templateUrl: "./saved-workflow-section.component.html",
-  styleUrls: [
-    "./saved-workflow-section.component.scss",
-    "../../dashboard.component.scss"
-  ]
+  styleUrls: ["./saved-workflow-section.component.scss", "../../dashboard.component.scss"],
 })
 export class SavedWorkflowSectionComponent implements OnInit {
   public dashboardWorkflowEntries: DashboardWorkflowEntry[] = [];
@@ -40,9 +37,7 @@ export class SavedWorkflowSectionComponent implements OnInit {
    * open the Modal based on the workflow clicked on
    */
   public onClickOpenShareAccess({ workflow }: DashboardWorkflowEntry): void {
-    const modalRef = this.modalService.open(
-      NgbdModalWorkflowShareAccessComponent
-    );
+    const modalRef = this.modalService.open(NgbdModalWorkflowShareAccessComponent);
     modalRef.componentInstance.workflow = workflow;
   }
 
@@ -51,9 +46,7 @@ export class SavedWorkflowSectionComponent implements OnInit {
    */
   public ascSort(): void {
     this.dashboardWorkflowEntries.sort((t1, t2) =>
-      t1.workflow.name
-        .toLowerCase()
-        .localeCompare(t2.workflow.name.toLowerCase())
+      t1.workflow.name.toLowerCase().localeCompare(t2.workflow.name.toLowerCase())
     );
   }
 
@@ -62,9 +55,7 @@ export class SavedWorkflowSectionComponent implements OnInit {
    */
   public dscSort(): void {
     this.dashboardWorkflowEntries.sort((t1, t2) =>
-      t2.workflow.name
-        .toLowerCase()
-        .localeCompare(t1.workflow.name.toLowerCase())
+      t2.workflow.name.toLowerCase().localeCompare(t1.workflow.name.toLowerCase())
     );
   }
 
@@ -72,12 +63,10 @@ export class SavedWorkflowSectionComponent implements OnInit {
    * sort the project by creating time
    */
   public dateSort(): void {
-    this.dashboardWorkflowEntries.sort(
-      (left: DashboardWorkflowEntry, right: DashboardWorkflowEntry) =>
-        left.workflow.creationTime !== undefined &&
-        right.workflow.creationTime !== undefined
-          ? left.workflow.creationTime - right.workflow.creationTime
-          : 0
+    this.dashboardWorkflowEntries.sort((left: DashboardWorkflowEntry, right: DashboardWorkflowEntry) =>
+      left.workflow.creationTime !== undefined && right.workflow.creationTime !== undefined
+        ? left.workflow.creationTime - right.workflow.creationTime
+        : 0
     );
   }
 
@@ -85,12 +74,10 @@ export class SavedWorkflowSectionComponent implements OnInit {
    * sort the project by last modified time
    */
   public lastSort(): void {
-    this.dashboardWorkflowEntries.sort(
-      (left: DashboardWorkflowEntry, right: DashboardWorkflowEntry) =>
-        left.workflow.lastModifiedTime !== undefined &&
-        right.workflow.lastModifiedTime !== undefined
-          ? left.workflow.lastModifiedTime - right.workflow.lastModifiedTime
-          : 0
+    this.dashboardWorkflowEntries.sort((left: DashboardWorkflowEntry, right: DashboardWorkflowEntry) =>
+      left.workflow.lastModifiedTime !== undefined && right.workflow.lastModifiedTime !== undefined
+        ? left.workflow.lastModifiedTime - right.workflow.lastModifiedTime
+        : 0
     );
   }
 
@@ -105,9 +92,7 @@ export class SavedWorkflowSectionComponent implements OnInit {
    * duplicate the current workflow. A new record will appear in frontend
    * workflow list and backend database.
    */
-  public onClickDuplicateWorkflow({
-    workflow: { wid }
-  }: DashboardWorkflowEntry): void {
+  public onClickDuplicateWorkflow({ workflow: { wid } }: DashboardWorkflowEntry): void {
     if (wid) {
       this.workflowPersistService
         .duplicateWorkflow(wid)
@@ -128,9 +113,7 @@ export class SavedWorkflowSectionComponent implements OnInit {
    * message to frontend and delete the workflow on frontend. It
    * calls the deleteProject method in service which implements backend API.
    */
-  public openNgbdModalDeleteWorkflowComponent({
-    workflow
-  }: DashboardWorkflowEntry): void {
+  public openNgbdModalDeleteWorkflowComponent({ workflow }: DashboardWorkflowEntry): void {
     const modalRef = this.modalService.open(NgbdModalDeleteWorkflowComponent);
     modalRef.componentInstance.workflow = cloneDeep(workflow);
 
@@ -143,11 +126,10 @@ export class SavedWorkflowSectionComponent implements OnInit {
             .deleteWorkflow(wid)
             .pipe(untilDestroyed(this))
             .subscribe(
-              (_) => {
-                this.dashboardWorkflowEntries =
-                  this.dashboardWorkflowEntries.filter(
-                    (workflowEntry) => workflowEntry.workflow.wid !== wid
-                  );
+              _ => {
+                this.dashboardWorkflowEntries = this.dashboardWorkflowEntries.filter(
+                  workflowEntry => workflowEntry.workflow.wid !== wid
+                );
               },
               // @ts-ignore // TODO: fix this with notification component
               (err: unknown) => alert(err.error)
@@ -180,10 +162,7 @@ export class SavedWorkflowSectionComponent implements OnInit {
     this.workflowPersistService
       .retrieveWorkflowsBySessionUser()
       .pipe(untilDestroyed(this))
-      .subscribe(
-        (dashboardWorkflowEntries) =>
-          (this.dashboardWorkflowEntries = dashboardWorkflowEntries)
-      );
+      .subscribe(dashboardWorkflowEntries => (this.dashboardWorkflowEntries = dashboardWorkflowEntries));
   }
 
   private clearDashboardWorkflowEntries(): void {

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-add/ngbd-modal-resource-add.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-add/ngbd-modal-resource-add.component.html
@@ -1,19 +1,11 @@
 <div class="modal-header">
   <h4 class="modal-title">Add Dictionary</h4>
-  <button
-    (click)="activeModal.dismiss('close')"
-    aria-label="Close"
-    class="close"
-    type="button"
-  >
+  <button (click)="activeModal.dismiss('close')" aria-label="Close" class="close" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
 </div>
 <div class="modal-body">
-  <mat-tab-group
-    (selectedTabChange)="onTabChangeEvent($event)"
-    mat-stretch-tabs
-  >
+  <mat-tab-group (selectedTabChange)="onTabChangeEvent($event)" mat-stretch-tabs>
     <!-- upload files tab -->
     <mat-tab label="Upload">
       <div
@@ -27,35 +19,21 @@
       >
         Drop Files Here
         <div id="hide">
-          <input
-            #clickUpload
-            (change)="handleClickUploadFile($event)"
-            accept=".txt"
-            multiple
-            type="file"
-          />
+          <input #clickUpload (change)="handleClickUploadFile($event)" accept=".txt" multiple type="file" />
         </div>
       </div>
       <div *ngIf="getDictionaryArrayLength()">
         <li *ngFor="let item of getDictionaryArray()" class="file-queue-item">
           <span>
             <label>{{ item.name }}</label>
-            <label *ngIf="!isItemValid(item)" class="invalid-file"
-              >*Invalid</label
-            >
+            <label *ngIf="!isItemValid(item)" class="invalid-file">*Invalid</label>
           </span>
-          <button
-            (click)="deleteDictionary(item)"
-            [disabled]="item.isUploadingFlag"
-            class="queue-delete-button"
-          >
+          <button (click)="deleteDictionary(item)" [disabled]="item.isUploadingFlag" class="queue-delete-button">
             <i aria-hidden="true" class="fa fa-trash"></i>
           </button>
         </li>
         <div *ngIf="!validateAllDictionaryUploadItems()">
-          <label class="invalid-file-warning">
-            *You can not upload non text files or files with duplicate name
-          </label>
+          <label class="invalid-file-warning"> *You can not upload non text files or files with duplicate name </label>
         </div>
       </div>
     </mat-tab>
@@ -73,9 +51,7 @@
               placeholder="Name of Dictionary"
               required
             />
-            <mat-error *ngIf="nameValidator.invalid"
-              >*Name is <strong>required</strong></mat-error
-            >
+            <mat-error *ngIf="nameValidator.invalid">*Name is <strong>required</strong></mat-error>
           </mat-form-field>
           <mat-form-field>
             <textarea
@@ -90,9 +66,7 @@
               style="resize: none"
             >
             </textarea>
-            <mat-error *ngIf="contentValidator.invalid"
-              >*Content is <strong>required</strong></mat-error
-            >
+            <mat-error *ngIf="contentValidator.invalid">*Content is <strong>required</strong></mat-error>
           </mat-form-field>
           <mat-form-field>
             <input
@@ -102,11 +76,7 @@
             />
           </mat-form-field>
           <mat-form-field class="description-area">
-            <input
-              [(ngModel)]="getManualDictionary().description"
-              matInput
-              placeholder="Dictionary Description"
-            />
+            <input [(ngModel)]="getManualDictionary().description" matInput placeholder="Dictionary Description" />
           </mat-form-field>
         </mat-dialog-content>
       </div>
@@ -136,10 +106,5 @@
       <span *ngIf="false" class="fa fa-spinner fa-spin"></span>
     </button>
   </div>
-  <button
-    (click)="activeModal.dismiss('close')"
-    class="btn btn-outline-dark bottom-size"
-  >
-    Close
-  </button>
+  <button (click)="activeModal.dismiss('close')" class="btn btn-outline-dark bottom-size">Close</button>
 </div>

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-add/ngbd-modal-resource-add.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-add/ngbd-modal-resource-add.component.spec.ts
@@ -1,10 +1,7 @@
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { NgbActiveModal, NgbModule } from "@ng-bootstrap/ng-bootstrap";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from "@angular/common/http/testing";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
 
 import { HttpClient } from "@angular/common/http";
 import { NgbdModalResourceAddComponent } from "./ngbd-modal-resource-add.component";
@@ -31,7 +28,7 @@ describe("NgbdModalResourceAddComponent", () => {
           NgbActiveModal,
           { provide: UserService, useClass: StubUserService },
           UserDictionaryService,
-          UserDictionaryUploadService
+          UserDictionaryUploadService,
         ],
         imports: [
           CustomNgMaterialModule,
@@ -39,8 +36,8 @@ describe("NgbdModalResourceAddComponent", () => {
           FormsModule,
           FileUploadModule,
           ReactiveFormsModule,
-          HttpClientTestingModule
-        ]
+          HttpClientTestingModule,
+        ],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-add/ngbd-modal-resource-add.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-add/ngbd-modal-resource-add.component.ts
@@ -1,27 +1,16 @@
 import { Component } from "@angular/core";
 import { NgbActiveModal } from "@ng-bootstrap/ng-bootstrap";
-import {
-  DictionaryUploadItem,
-  ManualDictionaryUploadItem
-} from "../../../../../common/type/user-dictionary";
+import { DictionaryUploadItem, ManualDictionaryUploadItem } from "../../../../../common/type/user-dictionary";
 import { UserDictionaryUploadService } from "../../../../service/user-dictionary/user-dictionary-upload.service";
 
 import { FileUploader } from "ng2-file-upload";
 import { MatTabChangeEvent } from "@angular/material/tabs";
 
 import { ErrorStateMatcher } from "@angular/material/core";
-import {
-  FormControl,
-  FormGroupDirective,
-  NgForm,
-  Validators
-} from "@angular/forms";
+import { FormControl, FormGroupDirective, NgForm, Validators } from "@angular/forms";
 
 class DictionaryErrorStateMatcher implements ErrorStateMatcher {
-  isErrorState(
-    control: FormControl | null,
-    form: FormGroupDirective | NgForm | null
-  ): boolean {
+  isErrorState(control: FormControl | null, form: FormGroupDirective | NgForm | null): boolean {
     return !!(control && control.invalid && (control.dirty || control.touched));
   }
 }
@@ -39,10 +28,7 @@ class DictionaryErrorStateMatcher implements ErrorStateMatcher {
 @Component({
   selector: "texera-resource-section-add-dict-modal",
   templateUrl: "ngbd-modal-resource-add.component.html",
-  styleUrls: [
-    "./ngbd-modal-resource-add.component.scss",
-    "../../../dashboard.component.scss"
-  ]
+  styleUrls: ["./ngbd-modal-resource-add.component.scss", "../../../dashboard.component.scss"],
 })
 export class NgbdModalResourceAddComponent {
   // This checks whether the user has hover a file over the file upload area
@@ -56,20 +42,11 @@ export class NgbdModalResourceAddComponent {
 
   // These are used to create custom form control validators.
   public matcher = new DictionaryErrorStateMatcher();
-  public nameValidator: FormControl = new FormControl("", [
-    Validators.required
-  ]);
-  public contentValidator: FormControl = new FormControl("", [
-    Validators.required
-  ]);
-  public descriptionValidator: FormControl = new FormControl("", [
-    Validators.required
-  ]);
+  public nameValidator: FormControl = new FormControl("", [Validators.required]);
+  public contentValidator: FormControl = new FormControl("", [Validators.required]);
+  public descriptionValidator: FormControl = new FormControl("", [Validators.required]);
 
-  constructor(
-    public activeModal: NgbActiveModal,
-    public userDictionaryUploadService: UserDictionaryUploadService
-  ) {}
+  constructor(public activeModal: NgbActiveModal, public userDictionaryUploadService: UserDictionaryUploadService) {}
 
   /**
    * Handles the tab change event in the modal popup
@@ -85,14 +62,11 @@ export class NgbdModalResourceAddComponent {
   }
 
   public getDictionaryArrayLength(): number {
-    return this.userDictionaryUploadService.getDictionariesToBeUploaded()
-      .length;
+    return this.userDictionaryUploadService.getDictionariesToBeUploaded().length;
   }
 
   public deleteDictionary(dictionaryUploadItem: DictionaryUploadItem): void {
-    this.userDictionaryUploadService.removeFileFromUploadArray(
-      dictionaryUploadItem
-    );
+    this.userDictionaryUploadService.removeFileFromUploadArray(dictionaryUploadItem);
   }
 
   /**
@@ -110,9 +84,7 @@ export class NgbdModalResourceAddComponent {
   }
 
   public isItemValid(dictionaryUploadItem: DictionaryUploadItem): boolean {
-    return this.userDictionaryUploadService.validateDictionaryUploadItem(
-      dictionaryUploadItem
-    );
+    return this.userDictionaryUploadService.validateDictionaryUploadItem(dictionaryUploadItem);
   }
 
   public validateAllDictionaryUploadItems(): boolean {
@@ -122,15 +94,13 @@ export class NgbdModalResourceAddComponent {
   public isAllItemsUploading(): boolean {
     return this.userDictionaryUploadService
       .getDictionariesToBeUploaded()
-      .every((dictionaryUploadItem) => dictionaryUploadItem.isUploadingFlag);
+      .every(dictionaryUploadItem => dictionaryUploadItem.isUploadingFlag);
   }
   /**
    * this method handles the event when user click on the file dropping area.
    * @param clickUploadEvent
    */
-  public handleClickUploadFile(clickUploadEvent: {
-    target: HTMLInputElement;
-  }): void {
+  public handleClickUploadFile(clickUploadEvent: { target: HTMLInputElement }): void {
     const fileList: FileList | null = clickUploadEvent.target.files;
     if (fileList === null) {
       throw new Error("browser upload does not work as intended");

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-delete/ngbd-modal-resource-delete.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-delete/ngbd-modal-resource-delete.component.html
@@ -1,36 +1,17 @@
 <div class="modal-header">
   <h4 class="modal-title">Delete the Dictionary</h4>
-  <button
-    (click)="activeModal.close()"
-    aria-label="Close"
-    class="close"
-    type="button"
-  >
+  <button (click)="activeModal.close()" aria-label="Close" class="close" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
 </div>
 
 <div class="modal-body">
   <mat-dialog-actions>
-    <p class="modal-title">
-      Confirm to Delete the Dictionary {{ dictionary.name }}
-    </p>
+    <p class="modal-title">Confirm to Delete the Dictionary {{ dictionary.name }}</p>
   </mat-dialog-actions>
 </div>
 
 <div class="modal-footer">
-  <button
-    (click)="deleteDictionary()"
-    class="btn btn-outline-dark delete-confirm-button"
-    type="button"
-  >
-    Confirm
-  </button>
-  <button
-    (click)="activeModal.close()"
-    class="btn btn-outline-dark"
-    type="button"
-  >
-    Close
-  </button>
+  <button (click)="deleteDictionary()" class="btn btn-outline-dark delete-confirm-button" type="button">Confirm</button>
+  <button (click)="activeModal.close()" class="btn btn-outline-dark" type="button">Close</button>
 </div>

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-delete/ngbd-modal-resource-delete.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-delete/ngbd-modal-resource-delete.component.spec.ts
@@ -20,12 +20,7 @@ describe("NgbdModalResourceDeleteComponent", () => {
       TestBed.configureTestingModule({
         declarations: [NgbdModalResourceDeleteComponent],
         providers: [NgbActiveModal],
-        imports: [
-          CustomNgMaterialModule,
-          NgbModule,
-          FormsModule,
-          HttpClientModule
-        ]
+        imports: [CustomNgMaterialModule, NgbModule, FormsModule, HttpClientModule],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-delete/ngbd-modal-resource-delete.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-delete/ngbd-modal-resource-delete.component.ts
@@ -13,17 +13,14 @@ import { UserDictionary } from "../../../../../common/type/user-dictionary";
 @Component({
   selector: "texera-resource-section-delete-dict-modal",
   templateUrl: "./ngbd-modal-resource-delete.component.html",
-  styleUrls: [
-    "./ngbd-modal-resource-delete.component.scss",
-    "../../../dashboard.component.scss"
-  ]
+  styleUrls: ["./ngbd-modal-resource-delete.component.scss", "../../../dashboard.component.scss"],
 })
 export class NgbdModalResourceDeleteComponent {
   public dictionary: UserDictionary = {
     name: "",
     id: -1,
     items: [],
-    description: ""
+    description: "",
   };
 
   constructor(public activeModal: NgbActiveModal) {}

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-view/ngbd-modal-resource-view.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-view/ngbd-modal-resource-view.component.html
@@ -1,11 +1,6 @@
 <div class="modal-header">
   <h4 class="modal-title">{{ dictionary.name }}</h4>
-  <button
-    (click)="activeModal.close()"
-    aria-label="Close"
-    class="close"
-    type="button"
-  >
+  <button (click)="activeModal.close()" aria-label="Close" class="close" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
 </div>
@@ -29,28 +24,11 @@
   <br />
 
   <mat-dialog-actions>
-    <input
-      *ngIf="ifAdd"
-      [(ngModel)]="name"
-      matInput
-      placeholder="Add into dictionary"
-    />
-    <button
-      (click)="addDictionaryItem()"
-      class="btn btn-outline-dark add-button"
-      type="button"
-    >
-      Add
-    </button>
+    <input *ngIf="ifAdd" [(ngModel)]="name" matInput placeholder="Add into dictionary" />
+    <button (click)="addDictionaryItem()" class="btn btn-outline-dark add-button" type="button">Add</button>
   </mat-dialog-actions>
 </div>
 
 <div class="modal-footer">
-  <button
-    (click)="activeModal.close()"
-    class="btn btn-outline-dark"
-    type="button"
-  >
-    Close
-  </button>
+  <button (click)="activeModal.close()" class="btn btn-outline-dark" type="button">Close</button>
 </div>

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-view/ngbd-modal-resource-view.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-view/ngbd-modal-resource-view.component.spec.ts
@@ -18,17 +18,8 @@ describe("NgbdModalResourceViewComponent", () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [NgbdModalResourceViewComponent],
-        providers: [
-          NgbActiveModal,
-          { provide: UserService, useClass: StubUserService },
-          UserDictionaryService
-        ],
-        imports: [
-          CustomNgMaterialModule,
-          NgbModule,
-          FormsModule,
-          HttpClientTestingModule
-        ]
+        providers: [NgbActiveModal, { provide: UserService, useClass: StubUserService }, UserDictionaryService],
+        imports: [CustomNgMaterialModule, NgbModule, FormsModule, HttpClientTestingModule],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-view/ngbd-modal-resource-view.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/ngbd-modal-resource-view/ngbd-modal-resource-view.component.ts
@@ -16,18 +16,15 @@ const DICTIONARY_ITEM_PREVIEW_SIZE = 20;
 @Component({
   selector: "texera-resource-section-modal",
   templateUrl: "./ngbd-modal-resource-view.component.html",
-  styleUrls: [
-    "./ngbd-modal-resource-view.component.scss",
-    "../../../dashboard.component.scss"
-  ],
-  providers: [UserDictionaryService]
+  styleUrls: ["./ngbd-modal-resource-view.component.scss", "../../../dashboard.component.scss"],
+  providers: [UserDictionaryService],
 })
 export class NgbdModalResourceViewComponent {
   public dictionary: UserDictionary = {
     name: "",
     id: -1,
     items: [],
-    description: ""
+    description: "",
   };
 
   public name: string = "";
@@ -36,10 +33,7 @@ export class NgbdModalResourceViewComponent {
   public visible = true;
   public selectable = true;
 
-  constructor(
-    public activeModal: NgbActiveModal,
-    private userDictionaryService: UserDictionaryService
-  ) {}
+  constructor(public activeModal: NgbActiveModal, private userDictionaryService: UserDictionaryService) {}
 
   /**
    * addDictionaryItem gets the item added by user and sends it back to the main component.
@@ -62,15 +56,11 @@ export class NgbdModalResourceViewComponent {
    * @param item: name of the dictionary item
    */
   public remove(item: string): void {
-    this.dictionary.items = this.dictionary.items.filter(
-      (dictItems) => dictItems !== item
-    );
+    this.dictionary.items = this.dictionary.items.filter(dictItems => dictItems !== item);
     this.userDictionaryService.updateDictionary(this.dictionary);
   }
 
   public limitPreviewItemSize(item: string): string {
-    return item.length <= DICTIONARY_ITEM_PREVIEW_SIZE
-      ? item
-      : item.substr(0, DICTIONARY_ITEM_PREVIEW_SIZE) + "...";
+    return item.length <= DICTIONARY_ITEM_PREVIEW_SIZE ? item : item.substr(0, DICTIONARY_ITEM_PREVIEW_SIZE) + "...";
   }
 }

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/user-dictionary-section.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/user-dictionary-section.component.html
@@ -1,26 +1,14 @@
 <div class="user-dictionary-container subsection-grid-container">
   <mat-card class="button-area subsection-grid-container">
     <div class="d-inline-block" ngbDropdown>
-      <button
-        class="btn btn-outline-primary"
-        id="sortDropdown"
-        ngbDropdownToggle
-      >
-        Sort
-      </button>
+      <button class="btn btn-outline-primary" id="sortDropdown" ngbDropdownToggle>Sort</button>
       <div aria-labelledby="dropdownBasic1" ngbDropdownMenu>
         <mat-list>
-          <button (click)="ascSort()" class="sorting_func" mat-button>
-            A -> Z
-          </button>
+          <button (click)="ascSort()" class="sorting_func" mat-button>A -> Z</button>
           <mat-divider></mat-divider>
-          <button (click)="dscSort()" class="sorting_func" mat-button>
-            Z -> A
-          </button>
+          <button (click)="dscSort()" class="sorting_func" mat-button>Z -> A</button>
           <mat-divider></mat-divider>
-          <button (click)="sizeSort()" class="sorting_func" mat-button>
-            By Dictionary Size
-          </button>
+          <button (click)="sizeSort()" class="sorting_func" mat-button>By Dictionary Size</button>
           <mat-divider></mat-divider>
         </mat-list>
       </div>
@@ -41,28 +29,15 @@
         <h2 class="page-title">Dictionaries</h2>
         <br />
         <div class="scroll">
-          <mat-list-item
-            *ngFor="let dictionary of getDictArray()"
-            class="user-dictionary-list-item"
-          >
-            <ng-template #tipContent
-              >Description: {{ dictionary.description }}</ng-template
-            >
-            <div
-              [ngbTooltip]="tipContent"
-              class="section-for-tip"
-              placement="bottom"
-            >
+          <mat-list-item *ngFor="let dictionary of getDictArray()" class="user-dictionary-list-item">
+            <ng-template #tipContent>Description: {{ dictionary.description }}</ng-template>
+            <div [ngbTooltip]="tipContent" class="section-for-tip" placement="bottom">
               <p font-size="10px">
                 <span class="dict-name"> {{ dictionary.name }}</span>
               </p>
               <p>
                 Item Preview:
-                <mat-chip
-                  *ngFor="let item of dictionary.items.slice(0, 6)"
-                  [selectable]="true"
-                  class="preview-item"
-                >
+                <mat-chip *ngFor="let item of dictionary.items.slice(0, 6)" [selectable]="true" class="preview-item">
                   {{ limitPreviewItemSize(item) }}
                 </mat-chip>
               </p>

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/user-dictionary-section.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/user-dictionary-section.component.spec.ts
@@ -19,12 +19,7 @@ describe("UserDictionarySectionComponent", () => {
       TestBed.configureTestingModule({
         declarations: [UserDictionarySectionComponent],
         providers: [UserDictionaryService, NgbActiveModal],
-        imports: [
-          CustomNgMaterialModule,
-          NgbModule,
-          FormsModule,
-          HttpClientTestingModule
-        ]
+        imports: [CustomNgMaterialModule, NgbModule, FormsModule, HttpClientTestingModule],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/user-dictionary-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-dictionary-section/user-dictionary-section.component.ts
@@ -25,10 +25,7 @@ const DICTIONARY_ITEM_PREVIEW_SIZE = 20;
 @Component({
   selector: "texera-user-dictionary-section",
   templateUrl: "./user-dictionary-section.component.html",
-  styleUrls: [
-    "./user-dictionary-section.component.scss",
-    "../../dashboard.component.scss"
-  ]
+  styleUrls: ["./user-dictionary-section.component.scss", "../../dashboard.component.scss"],
 })
 export class UserDictionarySectionComponent {
   constructor(
@@ -79,9 +76,7 @@ export class UserDictionarySectionComponent {
    *
    * @param dictionary: the dictionary that user wants to remove
    */
-  public openNgbdModalResourceDeleteComponent(
-    dictionary: UserDictionary
-  ): void {
+  public openNgbdModalResourceDeleteComponent(dictionary: UserDictionary): void {
     const modalRef = this.modalService.open(NgbdModalResourceDeleteComponent);
     modalRef.componentInstance.dictionary = cloneDeep(dictionary);
 
@@ -152,9 +147,7 @@ export class UserDictionarySectionComponent {
   }
 
   public limitPreviewItemSize(item: string): string {
-    return item.length <= DICTIONARY_ITEM_PREVIEW_SIZE
-      ? item
-      : item.substr(0, DICTIONARY_ITEM_PREVIEW_SIZE) + "...";
+    return item.length <= DICTIONARY_ITEM_PREVIEW_SIZE ? item : item.substr(0, DICTIONARY_ITEM_PREVIEW_SIZE) + "...";
   }
 
   /**

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/ngbd-modal-file-add/ngbd-modal-file-add.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/ngbd-modal-file-add/ngbd-modal-file-add.component.html
@@ -1,11 +1,6 @@
 <div class="modal-header">
   <h4 class="modal-title">Add Files</h4>
-  <button
-    (click)="activeModal.dismiss('close')"
-    aria-label="Close"
-    class="close"
-    type="button"
-  >
+  <button (click)="activeModal.dismiss('close')" aria-label="Close" class="close" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
 </div>
@@ -21,13 +16,7 @@
   >
     Drop Files Here
     <div id="hide">
-      <input
-        #clickUpload
-        (change)="handleClickUploadFile($event)"
-        accept=".txt"
-        multiple
-        type="file"
-      />
+      <input #clickUpload (change)="handleClickUploadFile($event)" accept=".txt" multiple type="file" />
     </div>
   </div>
   <div *ngIf="getFileArrayLength()">
@@ -55,10 +44,5 @@
       upload
     </button>
   </div>
-  <button
-    (click)="activeModal.dismiss('close')"
-    class="btn btn-outline-dark bottom-size"
-  >
-    Close
-  </button>
+  <button (click)="activeModal.dismiss('close')" class="btn btn-outline-dark bottom-size">Close</button>
 </div>

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/ngbd-modal-file-add/ngbd-modal-file-add.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/ngbd-modal-file-add/ngbd-modal-file-add.component.spec.ts
@@ -24,7 +24,7 @@ describe("NgbdModalFileAddComponent", () => {
           { provide: UserService, useClass: StubUserService },
           UserFileService,
           UserFileUploadService,
-          NgbActiveModal
+          NgbActiveModal,
         ],
         imports: [
           CustomNgMaterialModule,
@@ -32,8 +32,8 @@ describe("NgbdModalFileAddComponent", () => {
           FormsModule,
           FileUploadModule,
           ReactiveFormsModule,
-          HttpClientTestingModule
-        ]
+          HttpClientTestingModule,
+        ],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/ngbd-modal-file-add/ngbd-modal-file-add.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/ngbd-modal-file-add/ngbd-modal-file-add.component.ts
@@ -7,7 +7,7 @@ import { FileUploadItem } from "../../../../type/dashboard-user-file-entry";
 @Component({
   selector: "texera-ngbd-modal-file-add",
   templateUrl: "./ngbd-modal-file-add.component.html",
-  styleUrls: ["./ngbd-modal-file-add.component.scss"]
+  styleUrls: ["./ngbd-modal-file-add.component.scss"],
 })
 export class NgbdModalFileAddComponent {
   // This checks whether the user has hover a file over the file upload area
@@ -17,10 +17,7 @@ export class NgbdModalFileAddComponent {
   //  inside the uploader queue.
   public uploader: FileUploader = new FileUploader({ url: "" });
 
-  constructor(
-    public activeModal: NgbActiveModal,
-    private userFileUploadService: UserFileUploadService
-  ) {}
+  constructor(public activeModal: NgbActiveModal, private userFileUploadService: UserFileUploadService) {}
 
   public getFileArray(): ReadonlyArray<Readonly<FileUploadItem>> {
     return this.userFileUploadService.getFilesToBeUploaded();
@@ -39,9 +36,7 @@ export class NgbdModalFileAddComponent {
   }
 
   public isUploadAllButtonDisabled(): boolean {
-    return this.userFileUploadService
-      .getFilesToBeUploaded()
-      .every((fileUploadItem) => fileUploadItem.isUploadingFlag);
+    return this.userFileUploadService.getFilesToBeUploaded().every(fileUploadItem => fileUploadItem.isUploadingFlag);
   }
 
   public haveFileOver(fileOverEvent: boolean): void {
@@ -59,9 +54,7 @@ export class NgbdModalFileAddComponent {
     this.uploader.clearQueue();
   }
 
-  public handleClickUploadFile(clickUploadEvent: {
-    target: HTMLInputElement;
-  }): void {
+  public handleClickUploadFile(clickUploadEvent: { target: HTMLInputElement }): void {
     const fileList: FileList | null = clickUploadEvent.target.files;
     if (fileList === null) {
       throw new Error("browser upload does not work as intended");

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/ngbd-modal-file-share-access/ngbd-modal-user-file-share-access.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/ngbd-modal-file-share-access/ngbd-modal-user-file-share-access.component.html
@@ -1,39 +1,20 @@
 <div class="modal-header">
-  <h4 class="modal-title" id="modal-basic-title">
-    Share This File With Someone
-  </h4>
-  <button
-    (click)="activeModal.dismiss('Cross click')"
-    aria-label="Close"
-    class="close"
-    type="button"
-  >
+  <h4 class="modal-title" id="modal-basic-title">Share This File With Someone</h4>
+  <button (click)="activeModal.dismiss('Cross click')" aria-label="Close" class="close" type="button">
     <span aria-hidden="true"> × </span>
   </button>
 </div>
 <div class="modal-body">
-  <form
-    (ngSubmit)="onClickShareUserFile(dashboardUserFileEntry)"
-    [formGroup]="shareForm"
-  >
+  <form (ngSubmit)="onClickShareUserFile(dashboardUserFileEntry)" [formGroup]="shareForm">
     <div class="form-group">
       <label for="username"> Username of the target user to share </label>
-      <input
-        class="form-control"
-        formControlName="username"
-        id="username"
-        type="text"
-      />
+      <input class="form-control" formControlName="username" id="username" type="text" />
       <br />
       <label for="accessLevel"> Access Level </label>
       <div id="accessLevel">
         <select class="custom-select" formControlName="accessLevel">
           <option disabled value="">Choose Access Level To Be Shared</option>
-          <option
-            (change)="changeType($event)"
-            *ngFor="let accessLevel of accessLevels"
-            [ngValue]="accessLevel"
-          >
+          <option (change)="changeType($event)" *ngFor="let accessLevel of accessLevels" [ngValue]="accessLevel">
             {{ accessLevel }}
           </option>
         </select>
@@ -43,11 +24,7 @@
     </div>
   </form>
   <br />
-  <button
-    (click)="refreshGrantedUserFileAccessList(dashboardUserFileEntry)"
-    class="btn"
-    type="button"
-  >
+  <button (click)="refreshGrantedUserFileAccessList(dashboardUserFileEntry)" class="btn" type="button">
     <i class="fa fa-refresh"></i>
   </button>
   <label for="current-share">Shared Access:</label>

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/ngbd-modal-file-share-access/ngbd-modal-user-file-share-access.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/ngbd-modal-file-share-access/ngbd-modal-user-file-share-access.component.spec.ts
@@ -4,10 +4,7 @@ import { HttpClient, HttpHandler } from "@angular/common/http";
 import { NgbActiveModal } from "@ng-bootstrap/ng-bootstrap";
 import { NgbdModalUserFileShareAccessComponent } from "./ngbd-modal-user-file-share-access.component";
 import { UserFileService } from "../../../../service/user-file/user-file.service";
-import {
-  DashboardUserFileEntry,
-  UserFile
-} from "../../../../type/dashboard-user-file-entry";
+import { DashboardUserFileEntry, UserFile } from "../../../../type/dashboard-user-file-entry";
 import { StubUserFileService } from "../../../../service/user-file/stub-user-file-service";
 import { StubUserService } from "src/app/common/service/user/stub-user.service";
 import { GoogleApiService, GoogleAuthService } from "ng-gapi";
@@ -27,13 +24,13 @@ describe("NgbdModalFileShareAccessComponent", () => {
     name: name,
     path: path,
     size: size,
-    description: description
+    description: description,
   };
   const file: DashboardUserFileEntry = {
     ownerName: "Texera",
     file: fileContent,
     accessLevel: "Write",
-    isOwner: true
+    isOwner: true,
   };
 
   beforeEach(
@@ -50,9 +47,9 @@ describe("NgbdModalFileShareAccessComponent", () => {
           StubUserService,
           {
             provide: UserFileService,
-            useClass: StubUserFileService
-          }
-        ]
+            useClass: StubUserFileService,
+          },
+        ],
       });
     })
   );
@@ -76,9 +73,7 @@ describe("NgbdModalFileShareAccessComponent", () => {
     const mySpy = spyOn(service, "getUserFileAccessList").and.callThrough();
     component.dashboardUserFileEntry = file;
     fixture.detectChanges();
-    component.refreshGrantedUserFileAccessList(
-      component.dashboardUserFileEntry
-    );
+    component.refreshGrantedUserFileAccessList(component.dashboardUserFileEntry);
     expect(mySpy).toHaveBeenCalled();
   });
 

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/ngbd-modal-file-share-access/ngbd-modal-user-file-share-access.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/ngbd-modal-file-share-access/ngbd-modal-user-file-share-access.component.ts
@@ -10,14 +10,14 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 @Component({
   selector: "texera-ngbd-modal-file-share-access",
   templateUrl: "./ngbd-modal-user-file-share-access.component.html",
-  styleUrls: ["./ngbd-modal-user-file-share-access.component.scss"]
+  styleUrls: ["./ngbd-modal-user-file-share-access.component.scss"],
 })
 export class NgbdModalUserFileShareAccessComponent implements OnInit {
   @Input() dashboardUserFileEntry!: DashboardUserFileEntry;
 
   public shareForm = this.formBuilder.group({
     username: ["", [Validators.required]],
-    accessLevel: ["", [Validators.required]]
+    accessLevel: ["", [Validators.required]],
   });
 
   public allUserFileAccess: ReadonlyArray<AccessEntry> = [];
@@ -40,16 +40,14 @@ export class NgbdModalUserFileShareAccessComponent implements OnInit {
    * get all shared access of the current dashboardUserFileEntry
    * @param dashboardUserFileEntry target/current dashboardUserFileEntry
    */
-  public refreshGrantedUserFileAccessList(
-    dashboardUserFileEntry: DashboardUserFileEntry
-  ): void {
+  public refreshGrantedUserFileAccessList(dashboardUserFileEntry: DashboardUserFileEntry): void {
     this.userFileService
       .getUserFileAccessList(dashboardUserFileEntry)
       .pipe(untilDestroyed(this))
       .subscribe(
         (userFileAccess: ReadonlyArray<AccessEntry>) => {
           const newAccessList: AccessEntry[] = [];
-          userFileAccess.map((accessEntry) => {
+          userFileAccess.map(accessEntry => {
             if (accessEntry.accessLevel === "Owner") {
               this.fileOwner = accessEntry.userName;
             } else {
@@ -67,9 +65,7 @@ export class NgbdModalUserFileShareAccessComponent implements OnInit {
    * triggered by clicking the SUBMIT button, offers access based on the input information
    * @param dashboardUserFileEntry target/current file
    */
-  public onClickShareUserFile(
-    dashboardUserFileEntry: DashboardUserFileEntry
-  ): void {
+  public onClickShareUserFile(dashboardUserFileEntry: DashboardUserFileEntry): void {
     if (this.shareForm.get("username")?.invalid) {
       alert("Please Fill in Username");
       return;
@@ -95,10 +91,7 @@ export class NgbdModalUserFileShareAccessComponent implements OnInit {
    * @param dashboardUserFileEntry target/current file.
    * @param userNameToRemove
    */
-  public onClickRemoveUserFileAccess(
-    dashboardUserFileEntry: DashboardUserFileEntry,
-    userNameToRemove: string
-  ): void {
+  public onClickRemoveUserFileAccess(dashboardUserFileEntry: DashboardUserFileEntry, userNameToRemove: string): void {
     this.userFileService
       .revokeUserFileAccess(dashboardUserFileEntry, userNameToRemove)
       .pipe(untilDestroyed(this))

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.html
@@ -16,16 +16,12 @@
 
   <nz-card class="user-file-list subsection-grid-container">
     <nz-list>
-      <nz-list-item
-        *ngFor="let dashboardUserFileEntry of getFileArray()"
-        class="user-file-list-item"
-      >
+      <nz-list-item *ngFor="let dashboardUserFileEntry of getFileArray()" class="user-file-list-item">
         <nz-list-item-meta>
           <nz-list-item-meta-title>
             <div class="file-name">
               <h4 class="file-title">
-                {{ dashboardUserFileEntry.ownerName + "/" +
-                dashboardUserFileEntry.file.name }}
+                {{ dashboardUserFileEntry.ownerName + "/" + dashboardUserFileEntry.file.name }}
               </h4>
               <i
                 *ngIf="dashboardUserFileEntry.isOwner"

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.spec.ts
@@ -1,9 +1,4 @@
-import {
-  ComponentFixture,
-  TestBed,
-  inject,
-  waitForAsync
-} from "@angular/core/testing";
+import { ComponentFixture, TestBed, inject, waitForAsync } from "@angular/core/testing";
 
 import { NgbModal, NgbModalRef, NgbModule } from "@ng-bootstrap/ng-bootstrap";
 import { CustomNgMaterialModule } from "../../../../common/custom-ng-material.module";
@@ -12,15 +7,9 @@ import { MatListModule } from "@angular/material/list";
 import { UserFileSectionComponent } from "./user-file-section.component";
 import { UserFileService } from "../../../service/user-file/user-file.service";
 import { UserService } from "../../../../common/service/user/user.service";
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from "@angular/common/http/testing";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
 import { StubUserService } from "../../../../common/service/user/stub-user.service";
-import {
-  DashboardUserFileEntry,
-  UserFile
-} from "../../../type/dashboard-user-file-entry";
+import { DashboardUserFileEntry, UserFile } from "../../../type/dashboard-user-file-entry";
 import { NgbdModalWorkflowShareAccessComponent } from "../saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component";
 import { NzMessageModule } from "ng-zorro-antd/message";
 
@@ -40,23 +29,19 @@ describe("UserFileSectionComponent", () => {
     name: name,
     path: path,
     size: size,
-    description: description
+    description: description,
   };
   const testFile: DashboardUserFileEntry = {
     ownerName: "Texera",
     file: fileContent,
     accessLevel: "Write",
-    isOwner: true
+    isOwner: true,
   };
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [UserFileSectionComponent],
-        providers: [
-          NgbModal,
-          { provide: UserService, useClass: StubUserService },
-          UserFileService
-        ],
+        providers: [NgbModal, { provide: UserService, useClass: StubUserService }, UserFileService],
         imports: [
           NzMessageModule,
           CustomNgMaterialModule,
@@ -64,8 +49,8 @@ describe("UserFileSectionComponent", () => {
           FormsModule,
           ReactiveFormsModule,
           MatListModule,
-          HttpClientTestingModule
-        ]
+          HttpClientTestingModule,
+        ],
       }).compileComponents();
     })
   );
@@ -78,9 +63,7 @@ describe("UserFileSectionComponent", () => {
   });
 
   it("Modal Opened, then Closed", () => {
-    const modalRef: NgbModalRef = modalService.open(
-      NgbdModalWorkflowShareAccessComponent
-    );
+    const modalRef: NgbModalRef = modalService.open(NgbdModalWorkflowShareAccessComponent);
     spyOn(modalService, "open").and.returnValue(modalRef);
     component.onClickOpenShareAccess(testFile);
     expect(modalService.open).toHaveBeenCalled();
@@ -88,10 +71,7 @@ describe("UserFileSectionComponent", () => {
     modalRef.dismiss();
   });
 
-  it("should create", inject(
-    [HttpTestingController],
-    (httpMock: HttpTestingController) => {
-      expect(component).toBeTruthy();
-    }
-  ));
+  it("should create", inject([HttpTestingController], (httpMock: HttpTestingController) => {
+    expect(component).toBeTruthy();
+  }));
 });

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.ts
@@ -12,7 +12,7 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 @Component({
   selector: "texera-user-file-section",
   templateUrl: "./user-file-section.component.html",
-  styleUrls: ["./user-file-section.component.scss"]
+  styleUrls: ["./user-file-section.component.scss"],
 })
 export class UserFileSectionComponent {
   constructor(
@@ -28,12 +28,8 @@ export class UserFileSectionComponent {
     this.modalService.open(NgbdModalFileAddComponent);
   }
 
-  public onClickOpenShareAccess(
-    dashboardUserFileEntry: DashboardUserFileEntry
-  ): void {
-    const modalRef = this.modalService.open(
-      NgbdModalUserFileShareAccessComponent
-    );
+  public onClickOpenShareAccess(dashboardUserFileEntry: DashboardUserFileEntry): void {
+    const modalRef = this.modalService.open(NgbdModalUserFileShareAccessComponent);
     modalRef.componentInstance.dashboardUserFileEntry = dashboardUserFileEntry;
   }
 
@@ -70,9 +66,7 @@ export class UserFileSectionComponent {
 
           // create a download link and trigger it.
           const downloadLink = document.createElement("a");
-          downloadLink.href = URL.createObjectURL(
-            new Blob(binaryData, { type: dataType })
-          );
+          downloadLink.href = URL.createObjectURL(new Blob(binaryData, { type: dataType }));
           downloadLink.setAttribute("download", userFileEntry.file.name);
           document.body.appendChild(downloadLink);
           downloadLink.click();

--- a/core/new-gui/src/app/dashboard/component/top-bar/top-bar.component.html
+++ b/core/new-gui/src/app/dashboard/component/top-bar/top-bar.component.html
@@ -1,11 +1,4 @@
-<mat-toolbar
-  class="
-    navbar navbar-expand-lg navbar-dark
-    bg-dark
-    texera-navigation-body
-    justify-content-between
-  "
->
+<mat-toolbar class="navbar navbar-expand-lg navbar-dark bg-dark texera-navigation-body justify-content-between">
   <a [routerLink]="['']" class="navbar-brand texera-brand">Texera</a>
 
   <texera-user-icon> </texera-user-icon>

--- a/core/new-gui/src/app/dashboard/component/top-bar/top-bar.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/top-bar/top-bar.component.spec.ts
@@ -17,15 +17,8 @@ describe("TopBarComponent", () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [TopBarComponent, UserIconComponent],
-        providers: [
-          NgbModal,
-          { provide: UserService, useClass: StubUserService }
-        ],
-        imports: [
-          HttpClientTestingModule,
-          RouterTestingModule,
-          CustomNgMaterialModule
-        ]
+        providers: [NgbModal, { provide: UserService, useClass: StubUserService }],
+        imports: [HttpClientTestingModule, RouterTestingModule, CustomNgMaterialModule],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/dashboard/component/top-bar/top-bar.component.ts
+++ b/core/new-gui/src/app/dashboard/component/top-bar/top-bar.component.ts
@@ -17,6 +17,6 @@ import { Component } from "@angular/core";
 @Component({
   selector: "texera-top-bar",
   templateUrl: "./top-bar.component.html",
-  styleUrls: ["./top-bar.component.scss"]
+  styleUrls: ["./top-bar.component.scss"],
 })
 export class TopBarComponent {}

--- a/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-icon.component.html
+++ b/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-icon.component.html
@@ -1,16 +1,8 @@
 <div ngbDropdown class="d-inline-block user-icon">
-  <button class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>
-    {{ user?.name || "Sign In" }}
-  </button>
+  <button class="btn btn-outline-primary" id="dropdownBasic1" ngbDropdownToggle>{{ user?.name || "Sign In" }}</button>
   <div aria-labelledby="dropdownBasic1" class="user-dropdown" ngbDropdownMenu>
-    <button (click)="onClickLogin()" *ngIf="!user" class="dropdown-item">
-      Sign In
-    </button>
-    <button (click)="onClickRegister()" *ngIf="!user" class="dropdown-item">
-      Sign up
-    </button>
-    <button (click)="onClickLogout()" *ngIf="user" class="dropdown-item">
-      Sign Out
-    </button>
+    <button (click)="onClickLogin()" *ngIf="!user" class="dropdown-item">Sign In</button>
+    <button (click)="onClickRegister()" *ngIf="!user" class="dropdown-item">Sign up</button>
+    <button (click)="onClickLogout()" *ngIf="user" class="dropdown-item">Sign Out</button>
   </div>
 </div>

--- a/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-icon.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-icon.component.spec.ts
@@ -14,11 +14,8 @@ describe("UserIconComponent", () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [UserIconComponent],
-        providers: [
-          NgbModal,
-          { provide: UserService, useClass: StubUserService }
-        ],
-        imports: [HttpClientTestingModule]
+        providers: [NgbModal, { provide: UserService, useClass: StubUserService }],
+        imports: [HttpClientTestingModule],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-icon.component.ts
+++ b/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-icon.component.ts
@@ -16,19 +16,16 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 @Component({
   selector: "texera-user-icon",
   templateUrl: "./user-icon.component.html",
-  styleUrls: ["./user-icon.component.scss"]
+  styleUrls: ["./user-icon.component.scss"],
 })
 export class UserIconComponent {
   public user: User | undefined;
 
-  constructor(
-    private modalService: NgbModal,
-    private userService: UserService
-  ) {
+  constructor(private modalService: NgbModal, private userService: UserService) {
     this.userService
       .userChanged()
       .pipe(untilDestroyed(this))
-      .subscribe((user) => (this.user = user));
+      .subscribe(user => (this.user = user));
   }
 
   /**
@@ -58,9 +55,7 @@ export class UserIconComponent {
    * @param mode 0 indicates login and 1 indicates registration
    */
   private openLoginComponent(mode: 0 | 1): void {
-    const modalRef: NgbModalRef = this.modalService.open(
-      NgbdModalUserLoginComponent
-    );
+    const modalRef: NgbModalRef = this.modalService.open(NgbdModalUserLoginComponent);
     modalRef.componentInstance.selectedTab = mode;
   }
 }

--- a/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-login/ngbdmodal-user-login.component.html
+++ b/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-login/ngbdmodal-user-login.component.html
@@ -1,48 +1,26 @@
 <div class="modal-header">
   <h4 class="modal-title">User Authorization</h4>
-  <button
-    (click)="activeModal.dismiss('close')"
-    aria-label="Close"
-    class="close"
-    type="button"
-  >
+  <button (click)="activeModal.dismiss('close')" aria-label="Close" class="close" type="button">
     <span aria-hidden="true">&times;</span>
   </button>
 </div>
 
 <div class="modal-body" [formGroup]="allForms">
-  <mat-tab-group
-    [selectedIndex]="selectedTab"
-    animationDuration="0ms"
-    mat-stretch-tabs
-  >
+  <mat-tab-group [selectedIndex]="selectedTab" animationDuration="0ms" mat-stretch-tabs>
     <!-- login tab -->
     <mat-tab label="Sign In">
       <div class="content">
         <mat-dialog-content>
           <mat-form-field>
-            <input
-              formControlName="loginUserName"
-              matInput
-              placeholder="Username"
-              required
-            />
-            <mat-error
-              *ngIf="allForms.controls['loginUserName'].errors?.required"
+            <input formControlName="loginUserName" matInput placeholder="Username" required />
+            <mat-error *ngIf="allForms.controls['loginUserName'].errors?.required"
               >{{ errorMessageUsernameNull() }}</mat-error
             >
           </mat-form-field>
           <br />
           <mat-form-field>
-            <input
-              formControlName="loginPassword"
-              matInput
-              placeholder="Password"
-              required
-              type="password"
-            />
-            <mat-error
-              *ngIf="allForms.controls['loginPassword'].errors?.required"
+            <input formControlName="loginPassword" matInput placeholder="Password" required type="password" />
+            <mat-error *ngIf="allForms.controls['loginPassword'].errors?.required"
               >{{ errorMessagePasswordNull() }}</mat-error
             >
           </mat-form-field>
@@ -53,17 +31,12 @@
         <div (click)="authenticate()" class="g-sign-in-button">
           <div class="content-wrapper">
             <div class="logo-wrapper">
-              <img
-                alt="g-sign-in-button"
-                src="https://developers.google.com/identity/images/g-logo.png"
-              />
+              <img alt="g-sign-in-button" src="https://developers.google.com/identity/images/g-logo.png" />
             </div>
             <span class="text-container"><span>Sign in with Google</span></span>
           </div>
         </div>
-        <p *ngIf="loginErrorMessage" style="color: red">
-          {{ loginErrorMessage }}
-        </p>
+        <p *ngIf="loginErrorMessage" style="color: red">{{ loginErrorMessage }}</p>
       </div>
     </mat-tab>
 
@@ -72,14 +45,8 @@
       <div class="content">
         <mat-dialog-content>
           <mat-form-field>
-            <input
-              formControlName="registerUserName"
-              matInput
-              placeholder="Username"
-              required
-            />
-            <mat-error
-              *ngIf="allForms.controls['registerUserName'].errors?.required"
+            <input formControlName="registerUserName" matInput placeholder="Username" required />
+            <mat-error *ngIf="allForms.controls['registerUserName'].errors?.required"
               >{{ errorMessageUsernameNull() }}</mat-error
             >
           </mat-form-field>
@@ -93,8 +60,7 @@
               required
               type="password"
             />
-            <mat-error
-              *ngIf="allForms.controls['registerPassword'].errors?.required"
+            <mat-error *ngIf="allForms.controls['registerPassword'].errors?.required"
               >{{ errorMessagePasswordNull() }}</mat-error
             >
           </mat-form-field>
@@ -119,15 +85,11 @@
         <div>
           <button (click)="register()" class="btn btn-info">Sign Up</button>
         </div>
-        <p *ngIf="registerErrorMessage" style="color: red">
-          {{ registerErrorMessage }}
-        </p>
+        <p *ngIf="registerErrorMessage" style="color: red">{{ registerErrorMessage }}</p>
       </div>
     </mat-tab>
   </mat-tab-group>
 </div>
 <div class="modal-footer">
-  <button (click)="activeModal.dismiss('close')" class="btn btn-outline-dark">
-    Close
-  </button>
+  <button (click)="activeModal.dismiss('close')" class="btn btn-outline-dark">Close</button>
 </div>

--- a/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-login/ngbdmodal-user-login.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-login/ngbdmodal-user-login.component.spec.ts
@@ -20,11 +20,7 @@ describe("UserLoginComponent", () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [NgbdModalUserLoginComponent],
-        providers: [
-          NgbActiveModal,
-          { provide: UserService, useClass: StubUserService },
-          FormBuilder
-        ],
+        providers: [NgbActiveModal, { provide: UserService, useClass: StubUserService }, FormBuilder],
         imports: [
           BrowserAnimationsModule,
           HttpClientTestingModule,
@@ -34,8 +30,8 @@ describe("UserLoginComponent", () => {
           NgbModule,
           FormsModule,
           ReactiveFormsModule,
-          MatDialogModule
-        ]
+          MatDialogModule,
+        ],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-login/ngbdmodal-user-login.component.ts
+++ b/core/new-gui/src/app/dashboard/component/top-bar/user-icon/user-login/ngbdmodal-user-login.component.ts
@@ -2,12 +2,7 @@ import { Component, OnInit } from "@angular/core";
 import { NgbActiveModal } from "@ng-bootstrap/ng-bootstrap";
 import { UserService } from "../../../../../common/service/user/user.service";
 import { User } from "../../../../../common/type/user";
-import {
-  FormBuilder,
-  FormControl,
-  FormGroup,
-  Validators
-} from "@angular/forms";
+import { FormBuilder, FormControl, FormGroup, Validators } from "@angular/forms";
 import { isDefined } from "../../../../../common/util/predicate";
 import { filter } from "rxjs/operators";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
@@ -21,7 +16,7 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 @Component({
   selector: "texera-ngbdmodal-user-login",
   templateUrl: "./ngbdmodal-user-login.component.html",
-  styleUrls: ["./ngbdmodal-user-login.component.scss"]
+  styleUrls: ["./ngbdmodal-user-login.component.scss"],
 })
 export class NgbdModalUserLoginComponent implements OnInit {
   public selectedTab = 0;
@@ -29,17 +24,13 @@ export class NgbdModalUserLoginComponent implements OnInit {
   public registerErrorMessage: string | undefined;
   public allForms: FormGroup;
 
-  constructor(
-    private formBuilder: FormBuilder,
-    public activeModal: NgbActiveModal,
-    private userService: UserService
-  ) {
+  constructor(private formBuilder: FormBuilder, public activeModal: NgbActiveModal, private userService: UserService) {
     this.allForms = this.formBuilder.group({
       loginUserName: new FormControl("", [Validators.required]),
       registerUserName: new FormControl("", [Validators.required]),
       loginPassword: new FormControl("", [Validators.required]),
       registerPassword: new FormControl("", [Validators.required]),
-      registerConfirmationPassword: new FormControl("", [Validators.required])
+      registerConfirmationPassword: new FormControl("", [Validators.required]),
     });
   }
 
@@ -54,9 +45,7 @@ export class NgbdModalUserLoginComponent implements OnInit {
   public errorMessagePasswordNull(): string {
     return this.allForms.controls["registerPassword"].hasError("required")
       ? "Password required"
-      : this.allForms.controls["registerConfirmationPassword"].hasError(
-          "required"
-        )
+      : this.allForms.controls["registerConfirmationPassword"].hasError("required")
       ? "Confirmation required"
       : this.allForms.controls["loginPassword"].hasError("required")
       ? "Password required"
@@ -70,9 +59,7 @@ export class NgbdModalUserLoginComponent implements OnInit {
   public login(): void {
     // validate the credentials format
     this.loginErrorMessage = undefined;
-    const validation = this.userService.validateUsername(
-      this.allForms.get("loginUserName")?.value
-    );
+    const validation = this.userService.validateUsername(this.allForms.get("loginUserName")?.value);
     if (!validation.result) {
       this.loginErrorMessage = validation.message;
       return;
@@ -102,15 +89,9 @@ export class NgbdModalUserLoginComponent implements OnInit {
     // validate the credentials format
     this.registerErrorMessage = undefined;
     const registerPassword = this.allForms.get("registerPassword")?.value;
-    const registerConfirmationPassword = this.allForms.get(
-      "registerConfirmationPassword"
-    )?.value;
-    const registerUserName = this.allForms
-      .get("registerUserName")
-      ?.value.trim();
-    const validation = this.userService.validateUsername(
-      this.allForms.get("registerUserName")?.value.trim()
-    );
+    const registerConfirmationPassword = this.allForms.get("registerConfirmationPassword")?.value;
+    const registerUserName = this.allForms.get("registerUserName")?.value.trim();
+    const validation = this.userService.validateUsername(this.allForms.get("registerUserName")?.value.trim());
     if (registerPassword.length < 6) {
       this.registerErrorMessage = "Password length should be greater than 5";
       return;
@@ -132,9 +113,7 @@ export class NgbdModalUserLoginComponent implements OnInit {
           this.userService.changeUser(<User>{ name: registerUserName });
           this.activeModal.close();
         },
-        () =>
-          (this.registerErrorMessage =
-            "Registration failed. Could due to duplicate username.")
+        () => (this.registerErrorMessage = "Registration failed. Could due to duplicate username.")
       );
   }
 
@@ -147,14 +126,14 @@ export class NgbdModalUserLoginComponent implements OnInit {
     this.userService
       .getGoogleAuthInstance()
       .pipe(untilDestroyed(this))
-      .subscribe((Auth) => {
+      .subscribe(Auth => {
         // grantOfflineAccess allows application to access specified scopes offline
-        Auth.grantOfflineAccess().then((code) =>
+        Auth.grantOfflineAccess().then(code =>
           this.userService
             .googleLogin(code["code"])
             .pipe(untilDestroyed(this))
             .subscribe(
-              (googleUser) => {
+              googleUser => {
                 this.userService.changeUser(<User>{ name: googleUser.name });
                 this.activeModal.close();
               },

--- a/core/new-gui/src/app/dashboard/service/user-dictionary/dictionary.service.spec.ts
+++ b/core/new-gui/src/app/dashboard/service/user-dictionary/dictionary.service.spec.ts
@@ -1,7 +1,4 @@
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from "@angular/common/http/testing";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
 import { fakeAsync, flush, inject, TestBed, tick } from "@angular/core/testing";
 import { AppSettings } from "src/app/common/app-setting";
 import { DictionaryService, UserDictionary } from "./dictionary.service";
@@ -14,23 +11,17 @@ describe("DictionaryService", () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        { provide: UserService, useClass: StubUserService },
-        DictionaryService
-      ],
-      imports: [HttpClientTestingModule]
+      providers: [{ provide: UserService, useClass: StubUserService }, DictionaryService],
+      imports: [HttpClientTestingModule],
     });
 
     dictionaryService = TestBed.inject(DictionaryService);
     testDict = { a: "a", b: "b", c: "c" }; // sample dictionary used throughout testing
   });
 
-  it("should be created", inject(
-    [DictionaryService],
-    (injectedService: DictionaryService) => {
-      expect(injectedService).toBeTruthy();
-    }
-  ));
+  it("should be created", inject([DictionaryService], (injectedService: DictionaryService) => {
+    expect(injectedService).toBeTruthy();
+  }));
 
   describe("Dictionary Service", () => {
     describe("Backend interface", () => {
@@ -40,21 +31,12 @@ describe("DictionaryService", () => {
       beforeEach(() => {
         httpMock = TestBed.inject(HttpTestingController);
         // handle the getAll() request created when initializing dictionaryService
-        httpMock
-          .expectOne(
-            `${AppSettings.getApiEndpoint()}/${
-              DictionaryService.USER_DICTIONARY_ENDPOINT
-            }`
-          )
-          .flush({});
+        httpMock.expectOne(`${AppSettings.getApiEndpoint()}/${DictionaryService.USER_DICTIONARY_ENDPOINT}`).flush({});
 
         // clear dict
         (dictionaryService as any).updateDict({});
 
-        dictEventSubjectNextSpy = spyOn(
-          (dictionaryService as any).dictionaryChangedSubject,
-          "next"
-        );
+        dictEventSubjectNextSpy = spyOn((dictionaryService as any).dictionaryChangedSubject, "next");
         dictEventSubjectNextSpy.calls.reset();
       });
 
@@ -63,9 +45,7 @@ describe("DictionaryService", () => {
         dictionaryService.fetchKey(testKey);
         // get() generates a POST request to this url
         const req = httpMock.expectOne(
-          `${AppSettings.getApiEndpoint()}/${
-            DictionaryService.USER_DICTIONARY_ENDPOINT
-          }/${testKey}`
+          `${AppSettings.getApiEndpoint()}/${DictionaryService.USER_DICTIONARY_ENDPOINT}/${testKey}`
         );
         // POST request should have a properly formatted json payload
         expect(req.request.method).toEqual("GET");
@@ -79,11 +59,7 @@ describe("DictionaryService", () => {
       it("should produce a GET request when fetchAll() is called", fakeAsync(() => {
         dictionaryService.fetchAll();
         // getAll() generates a POST request to this url
-        const req = httpMock.expectOne(
-          `${AppSettings.getApiEndpoint()}/${
-            DictionaryService.USER_DICTIONARY_ENDPOINT
-          }`
-        );
+        const req = httpMock.expectOne(`${AppSettings.getApiEndpoint()}/${DictionaryService.USER_DICTIONARY_ENDPOINT}`);
         // POST request should have a properly formatted json payload
         expect(req.cancelled).toBeFalsy();
         expect(req.request.method).toEqual("GET");
@@ -100,9 +76,7 @@ describe("DictionaryService", () => {
         dictionaryService.set(testKey, testValue);
         // set() generates a POST request to this url
         const req = httpMock.expectOne(
-          `${AppSettings.getApiEndpoint()}/${
-            DictionaryService.USER_DICTIONARY_ENDPOINT
-          }/${testKey}`
+          `${AppSettings.getApiEndpoint()}/${DictionaryService.USER_DICTIONARY_ENDPOINT}/${testKey}`
         );
         // POST request should have a properly formatted json payload
         expect(req.request.method).toEqual("PUT");
@@ -117,9 +91,7 @@ describe("DictionaryService", () => {
         const testKey = "testkey4";
         dictionaryService.set(testKey, "testvalue4");
         const setReq = httpMock.expectOne(
-          `${AppSettings.getApiEndpoint()}/${
-            DictionaryService.USER_DICTIONARY_ENDPOINT
-          }/${testKey}`
+          `${AppSettings.getApiEndpoint()}/${DictionaryService.USER_DICTIONARY_ENDPOINT}/${testKey}`
         );
         setReq.flush({});
         dictEventSubjectNextSpy.calls.reset();
@@ -127,9 +99,7 @@ describe("DictionaryService", () => {
         dictionaryService.delete(testKey);
         // delete() generates a DELETE request to this url
         const req = httpMock.expectOne(
-          `${AppSettings.getApiEndpoint()}/${
-            DictionaryService.USER_DICTIONARY_ENDPOINT
-          }/${testKey}`
+          `${AppSettings.getApiEndpoint()}/${DictionaryService.USER_DICTIONARY_ENDPOINT}/${testKey}`
         );
         // DELETE request should have a properly formatted json payload
         expect(req.cancelled).toBeFalsy();

--- a/core/new-gui/src/app/dashboard/service/user-dictionary/dictionary.service.ts
+++ b/core/new-gui/src/app/dashboard/service/user-dictionary/dictionary.service.ts
@@ -10,7 +10,7 @@ export type UserDictionary = {
 };
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class DictionaryService {
   public static readonly USER_DICTIONARY_ENDPOINT = "users/dictionary";
@@ -49,11 +49,9 @@ export class DictionaryService {
     if (key.trim().length === 0) {
       throw new Error("Dictionary Service: key cannot be empty");
     }
-    const url = `${AppSettings.getApiEndpoint()}/${
-      DictionaryService.USER_DICTIONARY_ENDPOINT
-    }/${key}`;
+    const url = `${AppSettings.getApiEndpoint()}/${DictionaryService.USER_DICTIONARY_ENDPOINT}/${key}`;
     const req = this.http.get<string>(url).pipe(
-      tap((res) => this.updateEntry(key, res)),
+      tap(res => this.updateEntry(key, res)),
       shareReplay(1)
     );
     req.subscribe(); // causes post request to be sent regardless caller's subscription
@@ -68,11 +66,9 @@ export class DictionaryService {
     if (!this.userService.isLogin()) {
       throw new Error("user not logged in");
     }
-    const url = `${AppSettings.getApiEndpoint()}/${
-      DictionaryService.USER_DICTIONARY_ENDPOINT
-    }`;
+    const url = `${AppSettings.getApiEndpoint()}/${DictionaryService.USER_DICTIONARY_ENDPOINT}`;
     const req = this.http.get<UserDictionary>(url).pipe(
-      tap((res) => this.updateDict(res)),
+      tap(res => this.updateDict(res)),
       shareReplay(1)
     );
     req.subscribe(); // causes post request to be sent regardless caller's subscription
@@ -93,11 +89,9 @@ export class DictionaryService {
     if (key.trim().length === 0) {
       throw new Error("Dictionary Service: key cannot be empty");
     }
-    const url = `${AppSettings.getApiEndpoint()}/${
-      DictionaryService.USER_DICTIONARY_ENDPOINT
-    }/${key}`;
+    const url = `${AppSettings.getApiEndpoint()}/${DictionaryService.USER_DICTIONARY_ENDPOINT}/${key}`;
     const req = this.http.put<void>(url, { value: value }).pipe(
-      tap((_) => this.updateEntry(key, value)),
+      tap(_ => this.updateEntry(key, value)),
       shareReplay(1)
     );
     req.subscribe();
@@ -120,11 +114,9 @@ export class DictionaryService {
     if (!(key in this.localUserDictionary)) {
       return of();
     }
-    const url = `${AppSettings.getApiEndpoint()}/${
-      DictionaryService.USER_DICTIONARY_ENDPOINT
-    }/${key}`;
+    const url = `${AppSettings.getApiEndpoint()}/${DictionaryService.USER_DICTIONARY_ENDPOINT}/${key}`;
     const req = this.http.delete<void>(url).pipe(
-      tap((_) => this.updateEntry(key, undefined)),
+      tap(_ => this.updateEntry(key, undefined)),
       shareReplay(1)
     );
     req.subscribe();

--- a/core/new-gui/src/app/dashboard/service/user-dictionary/user-dictionary-upload.service.ts
+++ b/core/new-gui/src/app/dashboard/service/user-dictionary/user-dictionary-upload.service.ts
@@ -2,29 +2,21 @@ import { HttpClient, HttpHeaders } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Observable, of } from "rxjs";
 import { AppSettings } from "src/app/common/app-setting";
-import {
-  GenericWebResponse,
-  GenericWebResponseCode
-} from "../../../common/type/generic-web-response";
-import {
-  DictionaryUploadItem,
-  ManualDictionaryUploadItem
-} from "../../../common/type/user-dictionary";
+import { GenericWebResponse, GenericWebResponseCode } from "../../../common/type/generic-web-response";
+import { DictionaryUploadItem, ManualDictionaryUploadItem } from "../../../common/type/user-dictionary";
 import { UserService } from "../../../common/service/user/user.service";
 import { UserDictionaryService } from "./user-dictionary.service";
 import { mergeMap } from "rxjs/operators";
 
 export const USER_DICTIONARY_UPLOAD_URL = "user/dictionary/upload";
-export const USER_MANUAL_DICTIONARY_UPLOAD_URL =
-  "user/dictionary/upload-manual-dict";
+export const USER_MANUAL_DICTIONARY_UPLOAD_URL = "user/dictionary/upload-manual-dict";
 export const USER_DICTIONARY_VALIDATE_URL = "user/dictionary/validate";
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class UserDictionaryUploadService {
-  private manualDictionary: ManualDictionaryUploadItem =
-    UserDictionaryUploadService.createEmptyManualDictionary();
+  private manualDictionary: ManualDictionaryUploadItem = UserDictionaryUploadService.createEmptyManualDictionary();
   private dictionaryUploadItemArray: DictionaryUploadItem[] = [];
 
   constructor(
@@ -35,9 +27,7 @@ export class UserDictionaryUploadService {
     this.detectUserChanges();
   }
 
-  public getDictionariesToBeUploaded(): ReadonlyArray<
-    Readonly<DictionaryUploadItem>
-  > {
+  public getDictionariesToBeUploaded(): ReadonlyArray<Readonly<DictionaryUploadItem>> {
     return this.dictionaryUploadItemArray;
   }
 
@@ -50,16 +40,14 @@ export class UserDictionaryUploadService {
    * eg. name and content is not empty.
    */
   public validateManualDictionary(): boolean {
-    return (
-      this.manualDictionary.name !== "" && this.manualDictionary.content !== ""
-    );
+    return this.manualDictionary.name !== "" && this.manualDictionary.content !== "";
   }
 
   /**
    * check if all the item in the service is valid so that we can upload them.
    */
   public validateAllDictionaryUploadItems(): boolean {
-    return this.dictionaryUploadItemArray.every((dictionaryUploadItem) =>
+    return this.dictionaryUploadItemArray.every(dictionaryUploadItem =>
       this.validateDictionaryUploadItem(dictionaryUploadItem)
     );
   }
@@ -69,21 +57,12 @@ export class UserDictionaryUploadService {
    * eg. the type is text and the name is unique
    * @param dictionaryUploadItem
    */
-  public validateDictionaryUploadItem(
-    dictionaryUploadItem: DictionaryUploadItem
-  ): boolean {
-    return (
-      dictionaryUploadItem.file.type.includes("text/plain") &&
-      this.isItemNameUnique(dictionaryUploadItem)
-    );
+  public validateDictionaryUploadItem(dictionaryUploadItem: DictionaryUploadItem): boolean {
+    return dictionaryUploadItem.file.type.includes("text/plain") && this.isItemNameUnique(dictionaryUploadItem);
   }
 
   public isItemNameUnique(dictionaryUploadItem: DictionaryUploadItem): boolean {
-    return (
-      this.dictionaryUploadItemArray.filter(
-        (item) => item.name === dictionaryUploadItem.name
-      ).length === 1
-    );
+    return this.dictionaryUploadItemArray.filter(item => item.name === dictionaryUploadItem.name).length === 1;
   }
 
   /**
@@ -91,17 +70,11 @@ export class UserDictionaryUploadService {
    * @param file
    */
   public addDictionaryToUploadArray(file: File): void {
-    this.dictionaryUploadItemArray.push(
-      UserDictionaryUploadService.createDictionaryUploadItem(file)
-    );
+    this.dictionaryUploadItemArray.push(UserDictionaryUploadService.createDictionaryUploadItem(file));
   }
 
-  public removeFileFromUploadArray(
-    dictionaryUploadItem: DictionaryUploadItem
-  ): void {
-    this.dictionaryUploadItemArray = this.dictionaryUploadItemArray.filter(
-      (dict) => dict !== dictionaryUploadItem
-    );
+  public removeFileFromUploadArray(dictionaryUploadItem: DictionaryUploadItem): void {
+    this.dictionaryUploadItemArray = this.dictionaryUploadItemArray.filter(dict => dict !== dictionaryUploadItem);
   }
 
   /**
@@ -111,22 +84,18 @@ export class UserDictionaryUploadService {
    */
   public uploadAllDictionaries() {
     this.dictionaryUploadItemArray
-      .filter((dictionaryUploadItem) => !dictionaryUploadItem.isUploadingFlag)
-      .forEach((dictionaryUploadItem) =>
-        this.validateAndUploadDictionary(dictionaryUploadItem).subscribe(
-          (res) => {
-            if (res.code === GenericWebResponseCode.SUCCESS) {
-              this.removeFileFromUploadArray(dictionaryUploadItem);
-              this.userDictionaryService.refreshDictionaries();
-            } else {
-              dictionaryUploadItem.isUploadingFlag = false;
-              // TODO: user friendly error message.
-              alert(
-                `Uploading dictionary ${dictionaryUploadItem.name} failed\nMessage: ${res.message}`
-              );
-            }
+      .filter(dictionaryUploadItem => !dictionaryUploadItem.isUploadingFlag)
+      .forEach(dictionaryUploadItem =>
+        this.validateAndUploadDictionary(dictionaryUploadItem).subscribe(res => {
+          if (res.code === GenericWebResponseCode.SUCCESS) {
+            this.removeFileFromUploadArray(dictionaryUploadItem);
+            this.userDictionaryService.refreshDictionaries();
+          } else {
+            dictionaryUploadItem.isUploadingFlag = false;
+            // TODO: user friendly error message.
+            alert(`Uploading dictionary ${dictionaryUploadItem.name} failed\nMessage: ${res.message}`);
           }
-        )
+        })
       );
   }
 
@@ -147,21 +116,16 @@ export class UserDictionaryUploadService {
     }
     this.manualDictionary.isUploadingFlag = true;
 
-    this.manualDictionaryUploadHttpRequest(this.manualDictionary).subscribe(
-      (res) => {
-        if (res.code === GenericWebResponseCode.SUCCESS) {
-          this.manualDictionary =
-            UserDictionaryUploadService.createEmptyManualDictionary();
-          this.userDictionaryService.refreshDictionaries();
-        } else {
-          this.manualDictionary.isUploadingFlag = false;
-          // TODO: user friendly error message.
-          alert(
-            `Uploading dictionary ${this.manualDictionary.name} failed\nMessage: ${res.message}`
-          );
-        }
+    this.manualDictionaryUploadHttpRequest(this.manualDictionary).subscribe(res => {
+      if (res.code === GenericWebResponseCode.SUCCESS) {
+        this.manualDictionary = UserDictionaryUploadService.createEmptyManualDictionary();
+        this.userDictionaryService.refreshDictionaries();
+      } else {
+        this.manualDictionary.isUploadingFlag = false;
+        // TODO: user friendly error message.
+        alert(`Uploading dictionary ${this.manualDictionary.name} failed\nMessage: ${res.message}`);
       }
-    );
+    });
   }
 
   private manualDictionaryUploadHttpRequest(
@@ -172,26 +136,21 @@ export class UserDictionaryUploadService {
       JSON.stringify(manualDictionary),
       {
         headers: new HttpHeaders({
-          "Content-Type": "application/json"
-        })
+          "Content-Type": "application/json",
+        }),
       }
     );
   }
 
-  private validateAndUploadDictionary(
-    dictionaryUploadItem: DictionaryUploadItem
-  ): Observable<GenericWebResponse> {
+  private validateAndUploadDictionary(dictionaryUploadItem: DictionaryUploadItem): Observable<GenericWebResponse> {
     const formData: FormData = new FormData();
     formData.append("name", dictionaryUploadItem.name);
     formData.append("size", dictionaryUploadItem.file.size.toString());
 
     return this.http
-      .post<GenericWebResponse>(
-        `${AppSettings.getApiEndpoint()}/${USER_DICTIONARY_VALIDATE_URL}`,
-        formData
-      )
+      .post<GenericWebResponse>(`${AppSettings.getApiEndpoint()}/${USER_DICTIONARY_VALIDATE_URL}`, formData)
       .pipe(
-        mergeMap((res) => {
+        mergeMap(res => {
           if (res.code === GenericWebResponseCode.SUCCESS) {
             return this.uploadDictionary(dictionaryUploadItem);
           } else {
@@ -206,25 +165,17 @@ export class UserDictionaryUploadService {
    * It will pack the dictionaryUploadItem into formData and upload it to the backend.
    * @param dictionaryUploadItem
    */
-  private uploadDictionary(
-    dictionaryUploadItem: DictionaryUploadItem
-  ): Observable<GenericWebResponse> {
+  private uploadDictionary(dictionaryUploadItem: DictionaryUploadItem): Observable<GenericWebResponse> {
     if (!this.userService.isLogin()) {
       throw new Error("Can not upload dictionary when not login");
     }
     if (dictionaryUploadItem.isUploadingFlag) {
-      throw new Error(
-        `Dictionary ${dictionaryUploadItem.file.name} is already uploading`
-      );
+      throw new Error(`Dictionary ${dictionaryUploadItem.file.name} is already uploading`);
     }
 
     dictionaryUploadItem.isUploadingFlag = true;
     const formData: FormData = new FormData();
-    formData.append(
-      "file",
-      dictionaryUploadItem.file,
-      dictionaryUploadItem.name
-    );
+    formData.append("file", dictionaryUploadItem.file, dictionaryUploadItem.name);
     formData.append("size", dictionaryUploadItem.file.size.toString());
     formData.append("description", dictionaryUploadItem.description);
 
@@ -247,8 +198,7 @@ export class UserDictionaryUploadService {
 
   private clearUserDictionary(): void {
     this.dictionaryUploadItemArray = [];
-    this.manualDictionary =
-      UserDictionaryUploadService.createEmptyManualDictionary();
+    this.manualDictionary = UserDictionaryUploadService.createEmptyManualDictionary();
   }
 
   private static createEmptyManualDictionary(): ManualDictionaryUploadItem {
@@ -257,7 +207,7 @@ export class UserDictionaryUploadService {
       content: "",
       separator: "",
       description: "",
-      isUploadingFlag: false
+      isUploadingFlag: false,
     };
   }
 
@@ -266,7 +216,7 @@ export class UserDictionaryUploadService {
       file: file,
       name: file.name,
       description: "",
-      isUploadingFlag: false
+      isUploadingFlag: false,
     };
   }
 }

--- a/core/new-gui/src/app/dashboard/service/user-dictionary/user-dictionary.service.ts
+++ b/core/new-gui/src/app/dashboard/service/user-dictionary/user-dictionary.service.ts
@@ -22,9 +22,7 @@ export const USER_DICTIONARY_UPDATE_URL = "user/dictionary/update";
 @Injectable()
 export class UserDictionaryService {
   private userDictionaries: UserDictionary[] | undefined;
-  private userDictionariesChanged = new Subject<
-    ReadonlyArray<UserDictionary> | undefined
-  >();
+  private userDictionariesChanged = new Subject<ReadonlyArray<UserDictionary> | undefined>();
 
   constructor(private http: HttpClient, private userService: UserService) {
     this.detectUserChanges();
@@ -34,9 +32,7 @@ export class UserDictionaryService {
     return this.userDictionaries;
   }
 
-  public getUserDictionariesChangedEvent(): Observable<
-    ReadonlyArray<UserDictionary> | undefined
-  > {
+  public getUserDictionariesChangedEvent(): Observable<ReadonlyArray<UserDictionary> | undefined> {
     return this.userDictionariesChanged.asObservable();
   }
 
@@ -50,10 +46,8 @@ export class UserDictionaryService {
     }
 
     this.http
-      .get<UserDictionary[]>(
-        `${AppSettings.getApiEndpoint()}/${USER_DICTIONARY_LIST_URL}`
-      )
-      .subscribe((dictionaries) => {
+      .get<UserDictionary[]>(`${AppSettings.getApiEndpoint()}/${USER_DICTIONARY_LIST_URL}`)
+      .subscribe(dictionaries => {
         this.userDictionaries = dictionaries;
         this.userDictionariesChanged.next(this.userDictionaries);
       });
@@ -61,9 +55,7 @@ export class UserDictionaryService {
 
   public deleteDictionary(dictID: number) {
     this.http
-      .delete<GenericWebResponse>(
-        `${AppSettings.getApiEndpoint()}/${USER_DICTIONARY_DELETE_URL}/${dictID}`
-      )
+      .delete<GenericWebResponse>(`${AppSettings.getApiEndpoint()}/${USER_DICTIONARY_DELETE_URL}/${dictID}`)
       .subscribe(() => this.refreshDictionaries());
   }
 
@@ -78,8 +70,8 @@ export class UserDictionaryService {
         JSON.stringify(userDictionary),
         {
           headers: new HttpHeaders({
-            "Content-Type": "application/json"
-          })
+            "Content-Type": "application/json",
+          }),
         }
       )
       .subscribe(() => this.refreshDictionaries());

--- a/core/new-gui/src/app/dashboard/service/user-file/stub-user-file-service.ts
+++ b/core/new-gui/src/app/dashboard/service/user-file/stub-user-file-service.ts
@@ -1,9 +1,6 @@
 import { Injectable } from "@angular/core";
 import { Observable, of, Subject } from "rxjs";
-import {
-  DashboardUserFileEntry,
-  UserFile
-} from "../../type/dashboard-user-file-entry";
+import { DashboardUserFileEntry, UserFile } from "../../type/dashboard-user-file-entry";
 import { PublicInterfaceOf } from "../../../common/util/stub";
 import { UserFileService } from "./user-file.service";
 import { HttpClient } from "@angular/common/http";
@@ -11,7 +8,7 @@ import { StubUserService } from "../../../common/service/user/stub-user.service"
 import { AccessEntry } from "../../type/access.interface";
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class StubUserFileService implements PublicInterfaceOf<UserFileService> {
   public testUFAs: AccessEntry[] = [];
@@ -30,16 +27,11 @@ export class StubUserFileService implements PublicInterfaceOf<UserFileService> {
     return of();
   }
 
-  public getUserFileAccessList(
-    dashboardUserFileEntry: DashboardUserFileEntry
-  ): Observable<ReadonlyArray<AccessEntry>> {
+  public getUserFileAccessList(dashboardUserFileEntry: DashboardUserFileEntry): Observable<ReadonlyArray<AccessEntry>> {
     return of();
   }
 
-  public revokeUserFileAccess(
-    dashboardUserFileEntry: DashboardUserFileEntry,
-    username: string
-  ): Observable<Response> {
+  public revokeUserFileAccess(dashboardUserFileEntry: DashboardUserFileEntry, username: string): Observable<Response> {
     return of();
   }
 
@@ -60,9 +52,7 @@ export class StubUserFileService implements PublicInterfaceOf<UserFileService> {
    * this function will automatically refresh the files in the service when succeed.
    * @param targetFile
    */
-  public deleteDashboardUserFileEntry(
-    targetFile: DashboardUserFileEntry
-  ): void {
+  public deleteDashboardUserFileEntry(targetFile: DashboardUserFileEntry): void {
     return;
   }
 

--- a/core/new-gui/src/app/dashboard/service/user-file/user-file-upload.service.ts
+++ b/core/new-gui/src/app/dashboard/service/user-file/user-file-upload.service.ts
@@ -12,18 +12,14 @@ export const USER_FILE_UPLOAD_URL = "user/file/upload";
 // export const USER_FILE_VALIDATE_URL = 'user/file/validate';
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class UserFileUploadService {
   // files a user added to the upload list,
   // these files won't be uploaded until the user hits the "upload" button
   private filesToBeUploaded: FileUploadItem[] = [];
 
-  constructor(
-    private userService: UserService,
-    private userFileService: UserFileService,
-    private http: HttpClient
-  ) {
+  constructor(private userService: UserService, private userFileService: UserFileService, private http: HttpClient) {
     this.detectUserChanges();
   }
 
@@ -39,18 +35,14 @@ export class UserFileUploadService {
    * @param file
    */
   public addFileToUploadArray(file: File): void {
-    this.filesToBeUploaded.push(
-      UserFileUploadService.createFileUploadItem(file)
-    );
+    this.filesToBeUploaded.push(UserFileUploadService.createFileUploadItem(file));
   }
 
   /**
    * removes a file from the "to be uploaded" file array.
    */
   public removeFileFromUploadArray(fileUploadItem: FileUploadItem): void {
-    this.filesToBeUploaded = this.filesToBeUploaded.filter(
-      (file) => file !== fileUploadItem
-    );
+    this.filesToBeUploaded = this.filesToBeUploaded.filter(file => file !== fileUploadItem);
   }
 
   /**
@@ -59,7 +51,7 @@ export class UserFileUploadService {
    */
   public uploadAllFiles(): void {
     this.filesToBeUploaded
-      .filter((fileUploadItem) => !fileUploadItem.isUploadingFlag)
+      .filter(fileUploadItem => !fileUploadItem.isUploadingFlag)
       .forEach((fileUploadItem: FileUploadItem) =>
         this.uploadFile(fileUploadItem).subscribe(
           () => {
@@ -96,30 +88,24 @@ export class UserFileUploadService {
     formData.append("description", fileUploadItem.description);
 
     return this.http
-      .post<Response>(
-        `${AppSettings.getApiEndpoint()}/${USER_FILE_UPLOAD_URL}`,
-        formData,
-        { reportProgress: true, observe: "events" }
-      )
+      .post<Response>(`${AppSettings.getApiEndpoint()}/${USER_FILE_UPLOAD_URL}`, formData, {
+        reportProgress: true,
+        observe: "events",
+      })
       .pipe(
-        filter((event) => {
+        filter(event => {
           // retrieve and remove upload progress
           if (event.type === HttpEventType.UploadProgress) {
             fileUploadItem.uploadProgress = event.loaded;
             const total = event.total ? event.total : fileUploadItem.file.size;
             // TODO the upload progress does not fit the speed user feel, it seems faster
             // TODO show progress in user friendly way
-            console.log(
-              `File ${fileUploadItem.name} is ${(
-                (100 * event.loaded) /
-                total
-              ).toFixed(1)}% uploaded.`
-            );
+            console.log(`File ${fileUploadItem.name} is ${((100 * event.loaded) / total).toFixed(1)}% uploaded.`);
             return false;
           }
           return event.type === HttpEventType.Response;
         }),
-        map((event) => {
+        map(event => {
           // convert the type HttpEvent<GenericWebResponse> into GenericWebResponse
           if (event.type === HttpEventType.Response) {
             fileUploadItem.isUploadingFlag = false;
@@ -154,7 +140,7 @@ export class UserFileUploadService {
       name: file.name,
       description: "",
       uploadProgress: 0,
-      isUploadingFlag: false
+      isUploadingFlag: false,
     };
   }
 }

--- a/core/new-gui/src/app/dashboard/service/user-file/user-file.service.spec.ts
+++ b/core/new-gui/src/app/dashboard/service/user-file/user-file.service.spec.ts
@@ -1,17 +1,11 @@
 import { TestBed } from "@angular/core/testing";
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from "@angular/common/http/testing";
-import {
-  DashboardUserFileEntry,
-  UserFile
-} from "../../type/dashboard-user-file-entry";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
+import { DashboardUserFileEntry, UserFile } from "../../type/dashboard-user-file-entry";
 import {
   USER_FILE_ACCESS_GRANT_URL,
   USER_FILE_ACCESS_LIST_URL,
   USER_FILE_ACCESS_REVOKE_URL,
-  UserFileService
+  UserFileService,
 } from "./user-file.service";
 import { UserService } from "../../../common/service/user/user.service";
 import { StubUserService } from "../../../common/service/user/stub-user.service";
@@ -29,13 +23,13 @@ const testFile: UserFile = {
   name: name,
   path: path,
   size: size,
-  description: description
+  description: description,
 };
 const testFileEntry: DashboardUserFileEntry = {
   ownerName: "Texera",
   file: testFile,
   accessLevel: "Write",
-  isOwner: true
+  isOwner: true,
 };
 
 describe("UserFileService", () => {
@@ -44,11 +38,8 @@ describe("UserFileService", () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        UserFileService,
-        { provide: UserService, useClass: StubUserService }
-      ],
-      imports: [HttpClientTestingModule]
+      providers: [UserFileService, { provide: UserService, useClass: StubUserService }],
+      imports: [HttpClientTestingModule],
     });
     httpMock = TestBed.get(HttpTestingController);
     service = TestBed.get(UserFileService);
@@ -63,10 +54,7 @@ describe("UserFileService", () => {
   });
 
   it("can share access", () => {
-    service
-      .grantUserFileAccess(testFileEntry, username, accessLevel)
-      .pipe(first())
-      .subscribe();
+    service.grantUserFileAccess(testFileEntry, username, accessLevel).pipe(first()).subscribe();
     const req = httpMock.expectOne(
       `${USER_FILE_ACCESS_GRANT_URL}/${testFileEntry.file.name}/${testFileEntry.ownerName}/${username}/${accessLevel}`
     );
@@ -75,10 +63,7 @@ describe("UserFileService", () => {
   });
 
   it("can revoke access", () => {
-    service
-      .revokeUserFileAccess(testFileEntry, username)
-      .pipe(first())
-      .subscribe();
+    service.revokeUserFileAccess(testFileEntry, username).pipe(first()).subscribe();
     const req = httpMock.expectOne(
       `${USER_FILE_ACCESS_REVOKE_URL}/${testFileEntry.file.name}/${testFileEntry.ownerName}/${username}`
     );

--- a/core/new-gui/src/app/dashboard/service/user-file/user-file.service.ts
+++ b/core/new-gui/src/app/dashboard/service/user-file/user-file.service.ts
@@ -2,10 +2,7 @@ import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Observable, Subject } from "rxjs";
 import { AppSettings } from "../../../common/app-setting";
-import {
-  DashboardUserFileEntry,
-  UserFile
-} from "../../type/dashboard-user-file-entry";
+import { DashboardUserFileEntry, UserFile } from "../../type/dashboard-user-file-entry";
 import { UserService } from "../../../common/service/user/user.service";
 import { AccessEntry } from "../../type/access.interface";
 
@@ -19,7 +16,7 @@ export const USER_FILE_ACCESS_LIST_URL = `${USER_FILE_ACCESS_BASE_URL}/list`;
 export const USER_FILE_ACCESS_REVOKE_URL = `${USER_FILE_ACCESS_BASE_URL}/revoke`;
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class UserFileService {
   private dashboardUserFileEntries: ReadonlyArray<DashboardUserFileEntry> = [];
@@ -52,12 +49,10 @@ export class UserFileService {
       return;
     }
 
-    this.retrieveDashboardUserFileEntryList().subscribe(
-      (dashboardUserFileEntries) => {
-        this.dashboardUserFileEntries = dashboardUserFileEntries;
-        this.dashboardUserFileEntryChanged.next();
-      }
-    );
+    this.retrieveDashboardUserFileEntryList().subscribe(dashboardUserFileEntries => {
+      this.dashboardUserFileEntries = dashboardUserFileEntries;
+      this.dashboardUserFileEntryChanged.next();
+    });
   }
 
   /**
@@ -65,13 +60,9 @@ export class UserFileService {
    * this function will automatically refresh the files in the service when succeed.
    * @param targetUserFileEntry
    */
-  public deleteDashboardUserFileEntry(
-    targetUserFileEntry: DashboardUserFileEntry
-  ): void {
+  public deleteDashboardUserFileEntry(targetUserFileEntry: DashboardUserFileEntry): void {
     this.http
-      .delete<Response>(
-        `${USER_FILE_DELETE_URL}/${targetUserFileEntry.file.name}/${targetUserFileEntry.ownerName}`
-      )
+      .delete<Response>(`${USER_FILE_DELETE_URL}/${targetUserFileEntry.file.name}/${targetUserFileEntry.ownerName}`)
       .subscribe(
         () => this.refreshDashboardUserFileEntries(),
         // @ts-ignore // TODO: fix this with notification component
@@ -90,17 +81,7 @@ export class UserFileService {
     }
 
     let i = 0;
-    const byteUnits = [
-      " Byte",
-      " KB",
-      " MB",
-      " GB",
-      " TB",
-      " PB",
-      " EB",
-      " ZB",
-      " YB"
-    ];
+    const byteUnits = [" Byte", " KB", " MB", " GB", " TB", " PB", " EB", " ZB", " YB"];
     while (fileSize > 1024 && i < byteUnits.length - 1) {
       fileSize = fileSize / 1024;
       i++;
@@ -131,9 +112,7 @@ export class UserFileService {
    * @param userFileEntry the current dashboardUserFileEntry
    * @return ReadonlyArray<AccessEntry> an array of UserFileAccesses, Ex: [{username: TestUser, fileAccess: read}]
    */
-  public getUserFileAccessList(
-    userFileEntry: DashboardUserFileEntry
-  ): Observable<ReadonlyArray<AccessEntry>> {
+  public getUserFileAccessList(userFileEntry: DashboardUserFileEntry): Observable<ReadonlyArray<AccessEntry>> {
     return this.http.get<ReadonlyArray<AccessEntry>>(
       `${USER_FILE_ACCESS_LIST_URL}/${userFileEntry.file.name}/${userFileEntry.ownerName}`
     );
@@ -145,10 +124,7 @@ export class UserFileService {
    * @param username the username of target user
    * @return message of success
    */
-  public revokeUserFileAccess(
-    userFileEntry: DashboardUserFileEntry,
-    username: string
-  ): Observable<Response> {
+  public revokeUserFileAccess(userFileEntry: DashboardUserFileEntry, username: string): Observable<Response> {
     return this.http.post<Response>(
       `${USER_FILE_ACCESS_REVOKE_URL}/${userFileEntry.file.name}/${userFileEntry.ownerName}/${username}`,
       null
@@ -160,12 +136,8 @@ export class UserFileService {
     return this.http.get(requestURL, { responseType: "blob" });
   }
 
-  private retrieveDashboardUserFileEntryList(): Observable<
-    ReadonlyArray<DashboardUserFileEntry>
-  > {
-    return this.http.get<ReadonlyArray<DashboardUserFileEntry>>(
-      `${USER_FILE_LIST_URL}`
-    );
+  private retrieveDashboardUserFileEntryList(): Observable<ReadonlyArray<DashboardUserFileEntry>> {
+    return this.http.get<ReadonlyArray<DashboardUserFileEntry>>(`${USER_FILE_LIST_URL}`);
   }
 
   /**

--- a/core/new-gui/src/app/dashboard/service/workflow-access/stub-workflow-access.service.ts
+++ b/core/new-gui/src/app/dashboard/service/workflow-access/stub-workflow-access.service.ts
@@ -13,7 +13,7 @@ export const MOCK_WORKFLOW: Workflow = {
     " {\"operators\":[],\"operatorPositions\":{},\"links\":[],\"groups\":[],\"breakpoints\":{}}"
   ),
   creationTime: 1,
-  lastModifiedTime: 2
+  lastModifiedTime: 2,
 };
 
 type PublicInterfaceOf<Class> = {
@@ -21,8 +21,7 @@ type PublicInterfaceOf<Class> = {
 };
 
 @Injectable()
-export class StubWorkflowAccessService
-  implements PublicInterfaceOf<WorkflowAccessService> {
+export class StubWorkflowAccessService implements PublicInterfaceOf<WorkflowAccessService> {
   public workflow: Workflow;
 
   public message: string = "This is testing";
@@ -33,30 +32,19 @@ export class StubWorkflowAccessService
     this.workflow = MOCK_WORKFLOW;
   }
 
-  public retrieveGrantedWorkflowAccessList(
-    workflow: Workflow
-  ): Observable<ReadonlyArray<AccessEntry>> {
+  public retrieveGrantedWorkflowAccessList(workflow: Workflow): Observable<ReadonlyArray<AccessEntry>> {
     return of(this.mapString);
   }
 
-  public grantUserWorkflowAccess(
-    workflow: Workflow,
-    username: string,
-    accessLevel: string
-  ): Observable<Response> {
+  public grantUserWorkflowAccess(workflow: Workflow, username: string, accessLevel: string): Observable<Response> {
     return of();
   }
 
-  public revokeWorkflowAccess(
-    workflow: Workflow,
-    username: string
-  ): Observable<Response> {
+  public revokeWorkflowAccess(workflow: Workflow, username: string): Observable<Response> {
     return of();
   }
 
-  public getWorkflowOwner(
-    workflow: Workflow
-  ): Observable<Readonly<{ ownerName: string }>> {
+  public getWorkflowOwner(workflow: Workflow): Observable<Readonly<{ ownerName: string }>> {
     return of();
   }
 }

--- a/core/new-gui/src/app/dashboard/service/workflow-access/workflow-access.service.spec.ts
+++ b/core/new-gui/src/app/dashboard/service/workflow-access/workflow-access.service.spec.ts
@@ -1,15 +1,12 @@
 import { TestBed } from "@angular/core/testing";
 import { Workflow, WorkflowContent } from "../../../common/type/workflow";
 import { jsonCast } from "../../../common/util/storage";
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from "@angular/common/http/testing";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
 import {
   WORKFLOW_ACCESS_GRANT_URL,
   WORKFLOW_ACCESS_LIST_URL,
   WORKFLOW_ACCESS_REVOKE_URL,
-  WorkflowAccessService
+  WorkflowAccessService,
 } from "./workflow-access.service";
 import { AppSettings } from "../../../common/app-setting";
 import { first } from "rxjs/operators";
@@ -22,7 +19,7 @@ describe("WorkflowAccessService", () => {
       " {\"operators\":[],\"operatorPositions\":{},\"links\":[],\"groups\":[],\"breakpoints\":{}}"
     ),
     creationTime: 1,
-    lastModifiedTime: 2
+    lastModifiedTime: 2,
   };
 
   const username = "Jim";
@@ -34,7 +31,7 @@ describe("WorkflowAccessService", () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [WorkflowAccessService],
-      imports: [HttpClientTestingModule]
+      imports: [HttpClientTestingModule],
     });
     service = TestBed.get(WorkflowAccessService);
     httpMock = TestBed.get(HttpTestingController);
@@ -48,15 +45,10 @@ describe("WorkflowAccessService", () => {
     expect(service).toBeTruthy();
   });
   it("grantUserWorkflowAccess works as expected", () => {
-    service
-      .grantUserWorkflowAccess(TestWorkflow, username, accessType)
-      .pipe(first())
-      .subscribe();
+    service.grantUserWorkflowAccess(TestWorkflow, username, accessType).pipe(first()).subscribe();
     console.log(httpMock);
     const req = httpMock.expectOne(
-      `${AppSettings.getApiEndpoint()}/${WORKFLOW_ACCESS_GRANT_URL}/${
-        TestWorkflow.wid
-      }/${username}/${accessType}`
+      `${AppSettings.getApiEndpoint()}/${WORKFLOW_ACCESS_GRANT_URL}/${TestWorkflow.wid}/${username}/${accessType}`
     );
     console.log(req.request);
     expect(req.request.method).toEqual("POST");
@@ -64,28 +56,16 @@ describe("WorkflowAccessService", () => {
   });
 
   it("retrieveGrantedWorkflowAccessList works as expected", () => {
-    service
-      .retrieveGrantedWorkflowAccessList(TestWorkflow)
-      .pipe(first())
-      .subscribe();
-    const req = httpMock.expectOne(
-      `${AppSettings.getApiEndpoint()}/${WORKFLOW_ACCESS_LIST_URL}/${
-        TestWorkflow.wid
-      }`
-    );
+    service.retrieveGrantedWorkflowAccessList(TestWorkflow).pipe(first()).subscribe();
+    const req = httpMock.expectOne(`${AppSettings.getApiEndpoint()}/${WORKFLOW_ACCESS_LIST_URL}/${TestWorkflow.wid}`);
     expect(req.request.method).toEqual("GET");
     req.flush({ code: 0, message: "" });
   });
 
   it("revokeWorkflowAccess works as expected", () => {
-    service
-      .revokeWorkflowAccess(TestWorkflow, username)
-      .pipe(first())
-      .subscribe();
+    service.revokeWorkflowAccess(TestWorkflow, username).pipe(first()).subscribe();
     const req = httpMock.expectOne(
-      `${AppSettings.getApiEndpoint()}/${WORKFLOW_ACCESS_REVOKE_URL}/${
-        TestWorkflow.wid
-      }/${username}`
+      `${AppSettings.getApiEndpoint()}/${WORKFLOW_ACCESS_REVOKE_URL}/${TestWorkflow.wid}/${username}`
     );
     expect(req.request.method).toEqual("POST");
     req.flush({ code: 0, message: "" });

--- a/core/new-gui/src/app/dashboard/service/workflow-access/workflow-access.service.ts
+++ b/core/new-gui/src/app/dashboard/service/workflow-access/workflow-access.service.ts
@@ -12,7 +12,7 @@ export const WORKFLOW_ACCESS_REVOKE_URL = WORKFLOW_ACCESS_URL + "/revoke";
 export const WORKFLOW_OWNER_URL = WORKFLOW_ACCESS_URL + "/owner";
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class WorkflowAccessService {
   constructor(private http: HttpClient) {}
@@ -24,15 +24,9 @@ export class WorkflowAccessService {
    * @param accessLevel the type of access offered
    * @return hashmap indicating all current accesses, ex: {"Jim": "Write"}
    */
-  public grantUserWorkflowAccess(
-    workflow: Workflow,
-    username: string,
-    accessLevel: string
-  ): Observable<Response> {
+  public grantUserWorkflowAccess(workflow: Workflow, username: string, accessLevel: string): Observable<Response> {
     return this.http.post<Response>(
-      `${AppSettings.getApiEndpoint()}/${WORKFLOW_ACCESS_GRANT_URL}/${
-        workflow.wid
-      }/${username}/${accessLevel}`,
+      `${AppSettings.getApiEndpoint()}/${WORKFLOW_ACCESS_GRANT_URL}/${workflow.wid}/${username}/${accessLevel}`,
       null
     );
   }
@@ -42,13 +36,9 @@ export class WorkflowAccessService {
    * @param workflow the current workflow
    * @return message of success
    */
-  public retrieveGrantedWorkflowAccessList(
-    workflow: Workflow
-  ): Observable<ReadonlyArray<AccessEntry>> {
+  public retrieveGrantedWorkflowAccessList(workflow: Workflow): Observable<ReadonlyArray<AccessEntry>> {
     return this.http.get<ReadonlyArray<AccessEntry>>(
-      `${AppSettings.getApiEndpoint()}/${WORKFLOW_ACCESS_LIST_URL}/${
-        workflow.wid
-      }`
+      `${AppSettings.getApiEndpoint()}/${WORKFLOW_ACCESS_LIST_URL}/${workflow.wid}`
     );
   }
 
@@ -58,21 +48,14 @@ export class WorkflowAccessService {
    * @param username the username of target user
    * @return message of success
    */
-  public revokeWorkflowAccess(
-    workflow: Workflow,
-    username: string
-  ): Observable<Response> {
+  public revokeWorkflowAccess(workflow: Workflow, username: string): Observable<Response> {
     return this.http.post<Response>(
-      `${AppSettings.getApiEndpoint()}/${WORKFLOW_ACCESS_REVOKE_URL}/${
-        workflow.wid
-      }/${username}`,
+      `${AppSettings.getApiEndpoint()}/${WORKFLOW_ACCESS_REVOKE_URL}/${workflow.wid}/${username}`,
       null
     );
   }
 
-  public getWorkflowOwner(
-    workflow: Workflow
-  ): Observable<Readonly<{ ownerName: string }>> {
+  public getWorkflowOwner(workflow: Workflow): Observable<Readonly<{ ownerName: string }>> {
     return this.http.get<Readonly<{ ownerName: string }>>(
       `${AppSettings.getApiEndpoint()}/${WORKFLOW_OWNER_URL}/${workflow.wid}`
     );

--- a/core/new-gui/src/app/workspace/component/code-editor-dialog/code-editor-dialog.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/code-editor-dialog/code-editor-dialog.component.spec.ts
@@ -17,12 +17,12 @@ describe("CodeEditorDialogComponent", () => {
             provide: MatDialogRef,
             useValue: {
               keydownEvents: () => EMPTY,
-              backdropClick: () => EMPTY
-            }
+              backdropClick: () => EMPTY,
+            },
           },
-          { provide: MAT_DIALOG_DATA, useValue: {} }
+          { provide: MAT_DIALOG_DATA, useValue: {} },
         ],
-        imports: [HttpClientTestingModule]
+        imports: [HttpClientTestingModule],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/workspace/component/code-editor-dialog/code-editor-dialog.component.ts
+++ b/core/new-gui/src/app/workspace/component/code-editor-dialog/code-editor-dialog.component.ts
@@ -15,14 +15,14 @@ import { OperatorPredicate } from "../../types/workflow-common.interface";
 @Component({
   selector: "texera-code-editor-dialog",
   templateUrl: "./code-editor-dialog.component.html",
-  styleUrls: ["./code-editor-dialog.component.scss"]
+  styleUrls: ["./code-editor-dialog.component.scss"],
 })
 export class CodeEditorDialogComponent {
   editorOptions = {
     theme: "vs-dark",
     language: "python",
     fontSize: "11",
-    automaticLayout: true
+    automaticLayout: true,
   };
   code: string;
 
@@ -40,13 +40,12 @@ export class CodeEditorDialogComponent {
     const currentOperatorId: string = this.workflowActionService
       .getJointGraphWrapper()
       .getCurrentHighlightedOperatorIDs()[0];
-    const currentOperatorPredicate: OperatorPredicate =
-      this.workflowActionService
-        .getTexeraGraph()
-        .getOperator(currentOperatorId);
+    const currentOperatorPredicate: OperatorPredicate = this.workflowActionService
+      .getTexeraGraph()
+      .getOperator(currentOperatorId);
     this.workflowActionService.setOperatorProperty(currentOperatorId, {
       ...currentOperatorPredicate.operatorProperties,
-      code
+      code,
     });
   }
 }

--- a/core/new-gui/src/app/workspace/component/codearea-custom-template/codearea-custom-template.component.html
+++ b/core/new-gui/src/app/workspace/component/codearea-custom-template/codearea-custom-template.component.html
@@ -1,11 +1,5 @@
 <div class="attribute-container">
-  <button
-    (click)="onClickEditor()"
-    class="edit-code-button"
-    nz-button
-    nzShape="round"
-    nzType="primary"
-  >
+  <button (click)="onClickEditor()" class="edit-code-button" nz-button nzShape="round" nzType="primary">
     Edit code content
   </button>
 </div>

--- a/core/new-gui/src/app/workspace/component/codearea-custom-template/codearea-custom-template.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/codearea-custom-template/codearea-custom-template.component.spec.ts
@@ -15,7 +15,7 @@ describe("CodeareaCustomTemplateComponent", () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [CodeareaCustomTemplateComponent],
-        imports: [MatDialogModule]
+        imports: [MatDialogModule],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/workspace/component/codearea-custom-template/codearea-custom-template.component.ts
+++ b/core/new-gui/src/app/workspace/component/codearea-custom-template/codearea-custom-template.component.ts
@@ -16,7 +16,7 @@ import { CodeEditorDialogComponent } from "../code-editor-dialog/code-editor-dia
 @Component({
   selector: "texera-codearea-custom-template",
   templateUrl: "./codearea-custom-template.component.html",
-  styleUrls: ["./codearea-custom-template.component.scss"]
+  styleUrls: ["./codearea-custom-template.component.scss"],
 })
 export class CodeareaCustomTemplateComponent extends FieldType {
   constructor(public dialog: MatDialog) {
@@ -25,7 +25,7 @@ export class CodeareaCustomTemplateComponent extends FieldType {
 
   onClickEditor(): void {
     this.dialog.open(CodeEditorDialogComponent, {
-      data: this?.formControl?.value || ""
+      data: this?.formControl?.value || "",
     });
   }
 }

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -26,20 +26,10 @@
 
     <div class="texera-navigation-dashboard">
       <nz-button-group nzSize="large">
-        <button
-          *ngIf="userSystemEnabled"
-          [routerLink]="'/dashboard'"
-          nz-button
-          title="dashboard"
-        >
+        <button *ngIf="userSystemEnabled" [routerLink]="'/dashboard'" nz-button title="dashboard">
           <i nz-icon nzTheme="outline" nzType="profile"></i>
         </button>
-        <button
-          (click)="onClickCreateNewWorkflow()"
-          *ngIf="userSystemEnabled"
-          nz-button
-          title="create new"
-        >
+        <button (click)="onClickCreateNewWorkflow()" *ngIf="userSystemEnabled" nz-button title="create new">
           <i nz-icon nzTheme="outline" nzType="form"></i>
         </button>
         <button
@@ -50,19 +40,9 @@
           title="save"
         >
           <i *ngIf="!isSaving" nz-icon nzTheme="outline" nzType="save"></i>
-          <i
-            *ngIf="isSaving"
-            [nzSpin]="true"
-            [nzType]="'sync'"
-            nz-icon
-            nzTheme="outline"
-          ></i>
+          <i *ngIf="isSaving" [nzSpin]="true" [nzType]="'sync'" nz-icon nzTheme="outline"></i>
         </button>
-        <button
-          (click)="onClickDeleteAllOperators()"
-          nz-button
-          title="delete all"
-        >
+        <button (click)="onClickDeleteAllOperators()" nz-button title="delete all">
           <i nz-icon nzTheme="outline" nzType="delete"></i>
         </button>
       </nz-button-group>
@@ -79,11 +59,7 @@
         <button nz-button (click)="onClickAutoLayout()" title="auto layout">
           <i nz-icon nzType="partition" nzTheme="outline"></i>
         </button>
-        <button
-          (click)="onClickRestoreZoomOffsetDefault()"
-          nz-button
-          title="reset zoom"
-        >
+        <button (click)="onClickRestoreZoomOffsetDefault()" nz-button title="reset zoom">
           <i nz-icon nzTheme="outline" nzType="fullscreen"></i>
         </button>
         <button
@@ -103,22 +79,12 @@
           <ul nz-menu nzSelectable>
             <!--             <li nz-menu-item class="drop-down-item" (click)="onClickDownloadExecutionResult('json')">Json File-->
             <!--              (*.json)-->
-            <li
-              (click)="onClickExportExecutionResult('csv')"
-              class="drop-down-item"
-              nz-menu-item
-            >
-              CSV File (*.csv)
-            </li>
+            <li (click)="onClickExportExecutionResult('csv')" class="drop-down-item" nz-menu-item>CSV File (*.csv)</li>
             <!--            <li nz-menu-item class="drop-down-item" (click)="onClickDownloadExecutionResult('xlsx')">XLSX-->
             <!--              File-->
             <!--              (*.xlsx)-->
             <!--            </li> -->
-            <li
-              (click)="onClickExportExecutionResult('google_sheet')"
-              class="drop-down-item"
-              nz-menu-item
-            >
+            <li (click)="onClickExportExecutionResult('google_sheet')" class="drop-down-item" nz-menu-item>
               Google Sheet
             </li>
           </ul>
@@ -206,12 +172,7 @@
         >
           <i nz-icon nzTheme="outline" nzType="redo"></i>
         </button>
-        <button
-          (click)="tourService.toggle()"
-          class="animate-to-reveal-stop-button"
-          nz-button
-          nzType="default"
-        >
+        <button (click)="tourService.toggle()" class="animate-to-reveal-stop-button" nz-button nzType="default">
           <i nz-icon nzTheme="outline" nzType="question-circle"></i>
         </button>
         <button
@@ -237,12 +198,7 @@
           nz-button
           nzType="primary"
         >
-          <i
-            class="texera-navigation-run-button-icon"
-            nz-icon
-            nzTheme="outline"
-            nzType="{{ runIcon }}"
-          ></i>
+          <i class="texera-navigation-run-button-icon" nz-icon nzTheme="outline" nzType="{{ runIcon }}"></i>
           <span> {{ runButtonText }} </span>
         </button>
         <div [ngStyle]="{ 'margin-left': '5px' }">

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -37,7 +37,7 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 @Component({
   selector: "texera-navigation",
   templateUrl: "./navigation.component.html",
-  styleUrls: ["./navigation.component.scss"]
+  styleUrls: ["./navigation.component.scss"],
 })
 export class NavigationComponent {
   public executionState: ExecutionState; // set this to true when the workflow is started
@@ -83,10 +83,7 @@ export class NavigationComponent {
     this.executionState = executeWorkflowService.getExecutionState().state;
     // return the run button after the execution is finished, either
     //  when the value is valid or invalid
-    const initBehavior = this.getRunButtonBehavior(
-      this.executionState,
-      this.isWorkflowValid
-    );
+    const initBehavior = this.getRunButtonBehavior(this.executionState, this.isWorkflowValid);
     this.runButtonText = initBehavior.text;
     this.runIcon = initBehavior.icon;
     this.runDisable = initBehavior.disable;
@@ -96,22 +93,18 @@ export class NavigationComponent {
     executeWorkflowService
       .getExecutionStateStream()
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
+      .subscribe(event => {
         this.executionState = event.current.state;
-        this.applyRunButtonBehavior(
-          this.getRunButtonBehavior(this.executionState, this.isWorkflowValid)
-        );
+        this.applyRunButtonBehavior(this.getRunButtonBehavior(this.executionState, this.isWorkflowValid));
       });
 
     // set the map of operatorStatusMap
     validationWorkflowService
       .getWorkflowValidationErrorStream()
       .pipe(untilDestroyed(this))
-      .subscribe((value) => {
+      .subscribe(value => {
         this.isWorkflowValid = Object.keys(value.errors).length === 0;
-        this.applyRunButtonBehavior(
-          this.getRunButtonBehavior(this.executionState, this.isWorkflowValid)
-        );
+        this.applyRunButtonBehavior(this.getRunButtonBehavior(this.executionState, this.isWorkflowValid));
       });
 
     this.registerWorkflowMetadataDisplayRefresh();
@@ -121,12 +114,7 @@ export class NavigationComponent {
   }
 
   // apply a behavior to the run button via bound variables
-  public applyRunButtonBehavior(behavior: {
-    text: string;
-    icon: string;
-    disable: boolean;
-    onClick: () => void;
-  }) {
+  public applyRunButtonBehavior(behavior: { text: string; icon: string; disable: boolean; onClick: () => void }) {
     this.runButtonText = behavior.text;
     this.runIcon = behavior.icon;
     this.runDisable = behavior.disable;
@@ -147,7 +135,7 @@ export class NavigationComponent {
         text: "Error",
         icon: "exclamation-circle",
         disable: true,
-        onClick: () => {}
+        onClick: () => {},
       };
     }
     switch (executionState) {
@@ -158,21 +146,21 @@ export class NavigationComponent {
           text: "Run",
           icon: "play-circle",
           disable: false,
-          onClick: () => this.executeWorkflowService.executeWorkflow()
+          onClick: () => this.executeWorkflowService.executeWorkflow(),
         };
       case ExecutionState.WaitingToRun:
         return {
           text: "Submitting",
           icon: "loading",
           disable: true,
-          onClick: () => {}
+          onClick: () => {},
         };
       case ExecutionState.Running:
         return {
           text: "Pause",
           icon: "loading",
           disable: false,
-          onClick: () => this.executeWorkflowService.pauseWorkflow()
+          onClick: () => this.executeWorkflowService.pauseWorkflow(),
         };
       case ExecutionState.Paused:
       case ExecutionState.BreakpointTriggered:
@@ -180,28 +168,28 @@ export class NavigationComponent {
           text: "Resume",
           icon: "pause-circle",
           disable: false,
-          onClick: () => this.executeWorkflowService.resumeWorkflow()
+          onClick: () => this.executeWorkflowService.resumeWorkflow(),
         };
       case ExecutionState.Pausing:
         return {
           text: "Pausing",
           icon: "loading",
           disable: true,
-          onClick: () => {}
+          onClick: () => {},
         };
       case ExecutionState.Resuming:
         return {
           text: "Resuming",
           icon: "loading",
           disable: true,
-          onClick: () => {}
+          onClick: () => {},
         };
       case ExecutionState.Recovering:
         return {
           text: "Recovering",
           icon: "loading",
           disable: true,
-          onClick: () => {}
+          onClick: () => {},
         };
     }
   }
@@ -243,8 +231,7 @@ export class NavigationComponent {
     this.workflowActionService
       .getJointGraphWrapper()
       .setZoomProperty(
-        this.workflowActionService.getJointGraphWrapper().getZoomRatio() -
-          JointGraphWrapper.ZOOM_CLICK_DIFF
+        this.workflowActionService.getJointGraphWrapper().getZoomRatio() - JointGraphWrapper.ZOOM_CLICK_DIFF
       );
   }
 
@@ -265,8 +252,7 @@ export class NavigationComponent {
     this.workflowActionService
       .getJointGraphWrapper()
       .setZoomProperty(
-        this.workflowActionService.getJointGraphWrapper().getZoomRatio() +
-          JointGraphWrapper.ZOOM_CLICK_DIFF
+        this.workflowActionService.getJointGraphWrapper().getZoomRatio() + JointGraphWrapper.ZOOM_CLICK_DIFF
       );
   }
 
@@ -286,19 +272,14 @@ export class NavigationComponent {
    *
    */
   public onClickExportExecutionResult(exportType: string): void {
-    this.workflowResultExportService.exportWorkflowExecutionResult(
-      exportType,
-      this.currentWorkflowName
-    );
+    this.workflowResultExportService.exportWorkflowExecutionResult(exportType, this.currentWorkflowName);
   }
 
   /**
    * Restore paper default zoom ratio and paper offset
    */
   public onClickRestoreZoomOffsetDefault(): void {
-    this.workflowActionService
-      .getJointGraphWrapper()
-      .restoreDefaultZoomAndOffset();
+    this.workflowActionService.getJointGraphWrapper().restoreDefaultZoomAndOffset();
   }
 
   /**
@@ -308,7 +289,7 @@ export class NavigationComponent {
     const allOperatorIDs = this.workflowActionService
       .getTexeraGraph()
       .getAllOperators()
-      .map((op) => op.operatorID);
+      .map(op => op.operatorID);
     this.workflowActionService.deleteOperatorsAndLinks(allOperatorIDs, []);
   }
 
@@ -316,22 +297,16 @@ export class NavigationComponent {
    * Returns true if there's any operator on the graph; false otherwise
    */
   public hasOperators(): boolean {
-    return (
-      this.workflowActionService.getTexeraGraph().getAllOperators().length > 0
-    );
+    return this.workflowActionService.getTexeraGraph().getAllOperators().length > 0;
   }
 
   /**
    * Groups highlighted operators on the graph.
    */
   public onClickGroupOperators(): void {
-    const highlightedOperators = this.workflowActionService
-      .getJointGraphWrapper()
-      .getCurrentHighlightedOperatorIDs();
+    const highlightedOperators = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs();
     if (this.highlightedElementsGroupable()) {
-      const group = this.workflowActionService
-        .getOperatorGroup()
-        .getNewGroup(highlightedOperators);
+      const group = this.workflowActionService.getOperatorGroup().getNewGroup(highlightedOperators);
       this.workflowActionService.addGroups(group);
     }
   }
@@ -341,16 +316,10 @@ export class NavigationComponent {
    * and if they are groupable.
    */
   public highlightedElementsGroupable(): boolean {
-    const highlightedOperators = this.workflowActionService
-      .getJointGraphWrapper()
-      .getCurrentHighlightedOperatorIDs();
+    const highlightedOperators = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs();
     return (
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getCurrentHighlightedGroupIDs().length === 0 &&
-      this.workflowActionService
-        .getOperatorGroup()
-        .operatorsGroupable(highlightedOperators)
+      this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedGroupIDs().length === 0 &&
+      this.workflowActionService.getOperatorGroup().operatorsGroupable(highlightedOperators)
     );
   }
 
@@ -358,9 +327,7 @@ export class NavigationComponent {
    * Ungroups highlighted groups on the graph.
    */
   public onClickUngroupOperators(): void {
-    const highlightedGroups = this.workflowActionService
-      .getJointGraphWrapper()
-      .getCurrentHighlightedGroupIDs();
+    const highlightedGroups = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedGroupIDs();
     if (this.highlightedElementsUngroupable()) {
       this.workflowActionService.unGroupGroups(...highlightedGroups);
     }
@@ -372,11 +339,11 @@ export class NavigationComponent {
    */
   public onClickDisableOperators(): void {
     if (this.isDisableOperator) {
-      this.effectivelyHighlightedOperators().forEach((op) => {
+      this.effectivelyHighlightedOperators().forEach(op => {
         this.workflowActionService.getTexeraGraph().disableOperator(op);
       });
     } else {
-      this.effectivelyHighlightedOperators().forEach((op) => {
+      this.effectivelyHighlightedOperators().forEach(op => {
         this.workflowActionService.getTexeraGraph().enableOperator(op);
       });
     }
@@ -384,11 +351,11 @@ export class NavigationComponent {
 
   public onClickCacheOperators(): void {
     if (this.isCacheOperator) {
-      this.effectivelyHighlightedOperators().forEach((op) => {
+      this.effectivelyHighlightedOperators().forEach(op => {
         this.workflowActionService.getTexeraGraph().cacheOperator(op);
       });
     } else {
-      this.effectivelyHighlightedOperators().forEach((op) => {
+      this.effectivelyHighlightedOperators().forEach(op => {
         this.workflowActionService.getTexeraGraph().unCacheOperator(op);
       });
     }
@@ -399,12 +366,8 @@ export class NavigationComponent {
    */
   public highlightedElementsUngroupable(): boolean {
     return (
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getCurrentHighlightedGroupIDs().length > 0 &&
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getCurrentHighlightedOperatorIDs().length === 0
+      this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedGroupIDs().length > 0 &&
+      this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs().length === 0
     );
   }
 
@@ -446,16 +409,13 @@ export class NavigationComponent {
       .pipe(debounceTime(100))
       .pipe(untilDestroyed(this))
       .subscribe(() => {
-        this.currentWorkflowName =
-          this.workflowActionService.getWorkflowMetadata()?.name;
+        this.currentWorkflowName = this.workflowActionService.getWorkflowMetadata()?.name;
         this.autoSaveState =
-          this.workflowActionService.getWorkflowMetadata().lastModifiedTime ===
-          undefined
+          this.workflowActionService.getWorkflowMetadata().lastModifiedTime === undefined
             ? ""
             : "Saved at " +
               this.datePipe.transform(
-                this.workflowActionService.getWorkflowMetadata()
-                  .lastModifiedTime,
+                this.workflowActionService.getWorkflowMetadata().lastModifiedTime,
                 "MM/dd/yyyy HH:mm:ss zzz",
                 Intl.DateTimeFormat().resolvedOptions().timeZone,
                 "en"
@@ -470,65 +430,41 @@ export class NavigationComponent {
    */
   handleDisableOperatorStatusChange() {
     merge(
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointOperatorHighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointOperatorUnhighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointGroupHighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointGroupUnhighlightStream(),
-      this.workflowActionService
-        .getTexeraGraph()
-        .getDisabledOperatorsChangedStream()
+      this.workflowActionService.getJointGraphWrapper().getJointOperatorHighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getJointOperatorUnhighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getJointGroupHighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getJointGroupUnhighlightStream(),
+      this.workflowActionService.getTexeraGraph().getDisabledOperatorsChangedStream()
     )
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
-        const effectiveHighlightedOperators =
-          this.effectivelyHighlightedOperators();
-        const allDisabled = this.effectivelyHighlightedOperators().every((op) =>
+      .subscribe(event => {
+        const effectiveHighlightedOperators = this.effectivelyHighlightedOperators();
+        const allDisabled = this.effectivelyHighlightedOperators().every(op =>
           this.workflowActionService.getTexeraGraph().isOperatorDisabled(op)
         );
 
         this.isDisableOperator = !allDisabled;
-        this.isDisableOperatorClickable =
-          effectiveHighlightedOperators.length !== 0;
+        this.isDisableOperatorClickable = effectiveHighlightedOperators.length !== 0;
       });
   }
 
   handleCacheOperatorStatusChange() {
     merge(
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointOperatorHighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointOperatorUnhighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointGroupHighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointGroupUnhighlightStream(),
-      this.workflowActionService
-        .getTexeraGraph()
-        .getCachedOperatorsChangedStream()
+      this.workflowActionService.getJointGraphWrapper().getJointOperatorHighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getJointOperatorUnhighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getJointGroupHighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getJointGroupUnhighlightStream(),
+      this.workflowActionService.getTexeraGraph().getCachedOperatorsChangedStream()
     )
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
-        const effectiveHighlightedOperators =
-          this.effectivelyHighlightedOperators();
-        const allCached = this.effectivelyHighlightedOperators().every((op) =>
+      .subscribe(event => {
+        const effectiveHighlightedOperators = this.effectivelyHighlightedOperators();
+        const allCached = this.effectivelyHighlightedOperators().every(op =>
           this.workflowActionService.getTexeraGraph().isOperatorCached(op)
         );
 
         this.isCacheOperator = !allCached;
-        this.isCacheOperatorClickable =
-          effectiveHighlightedOperators.length !== 0;
+        this.isCacheOperatorClickable = effectiveHighlightedOperators.length !== 0;
       });
   }
 
@@ -536,28 +472,16 @@ export class NavigationComponent {
    * Gets all highlighted operators, and all operators in the highlighted groups
    */
   effectivelyHighlightedOperators(): readonly string[] {
-    const highlightedOperators = this.workflowActionService
-      .getJointGraphWrapper()
-      .getCurrentHighlightedOperatorIDs();
-    const highlightedGroups = this.workflowActionService
-      .getJointGraphWrapper()
-      .getCurrentHighlightedGroupIDs();
+    const highlightedOperators = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs();
+    const highlightedGroups = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedGroupIDs();
 
-    const operatorInHighlightedGroups: string[] = highlightedGroups.flatMap(
-      (g) =>
-        Array.from(
-          this.workflowActionService
-            .getOperatorGroup()
-            .getGroup(g)
-            .operators.keys()
-        )
+    const operatorInHighlightedGroups: string[] = highlightedGroups.flatMap(g =>
+      Array.from(this.workflowActionService.getOperatorGroup().getGroup(g).operators.keys())
     );
 
     const effectiveHighlightedOperators = new Set<string>();
-    highlightedOperators.forEach((op) => effectiveHighlightedOperators.add(op));
-    operatorInHighlightedGroups.forEach((op) =>
-      effectiveHighlightedOperators.add(op)
-    );
+    highlightedOperators.forEach(op => effectiveHighlightedOperators.add(op));
+    operatorInHighlightedGroups.forEach(op => effectiveHighlightedOperators.add(op));
     return Array.from(effectiveHighlightedOperators);
   }
 }

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -351,14 +351,10 @@ export class NavigationComponent {
   }
 
   public onClickCacheOperators(): void {
-    const effectiveHighlightedOperators =
-      this.effectivelyHighlightedOperators();
-    const effectiveHighlightedOperatorsExcludeSink =
-      effectiveHighlightedOperators.filter(
-        (op) =>
-          this.workflowActionService.getTexeraGraph().getOperator(op)
-            .operatorType !== VIEW_RESULT_OP_TYPE
-      );
+    const effectiveHighlightedOperators = this.effectivelyHighlightedOperators();
+    const effectiveHighlightedOperatorsExcludeSink = effectiveHighlightedOperators.filter(
+      op => this.workflowActionService.getTexeraGraph().getOperator(op).operatorType !== VIEW_RESULT_OP_TYPE
+    );
 
     if (this.isCacheOperator) {
       effectiveHighlightedOperatorsExcludeSink.forEach(op => {
@@ -469,12 +465,9 @@ export class NavigationComponent {
       .pipe(untilDestroyed(this))
       .subscribe(event => {
         const effectiveHighlightedOperators = this.effectivelyHighlightedOperators();
-        const effectiveHighlightedOperatorsExcludeSink =
-          effectiveHighlightedOperators.filter(
-            (op) =>
-              this.workflowActionService.getTexeraGraph().getOperator(op)
-                .operatorType !== VIEW_RESULT_OP_TYPE
-          );
+        const effectiveHighlightedOperatorsExcludeSink = effectiveHighlightedOperators.filter(
+          op => this.workflowActionService.getTexeraGraph().getOperator(op).operatorType !== VIEW_RESULT_OP_TYPE
+        );
 
         const allCached = effectiveHighlightedOperatorsExcludeSink.every(op =>
           this.workflowActionService.getTexeraGraph().isOperatorCached(op)

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.html
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.html
@@ -14,8 +14,6 @@
     class="texera-operator-label-body"
     title="{{ operator?.additionalMetadata.operatorDescription }}"
   >
-    <span class="text">
-      {{ operator?.additionalMetadata.userFriendlyName }}
-    </span>
+    <span class="text"> {{ operator?.additionalMetadata.userFriendlyName }} </span>
   </div>
 </div>

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.spec.ts
@@ -33,7 +33,7 @@ describe("OperatorLabelComponent", () => {
           CustomNgMaterialModule,
           RouterTestingModule.withRoutes([]),
           TourNgBootstrapModule.forRoot(),
-          NgbModule
+          NgbModule,
         ],
         providers: [
           DragDropService,
@@ -43,10 +43,10 @@ describe("OperatorLabelComponent", () => {
           UndoRedoService,
           {
             provide: OperatorMetadataService,
-            useClass: StubOperatorMetadataService
+            useClass: StubOperatorMetadataService,
           },
-          TourService
-        ]
+          TourService,
+        ],
       }).compileComponents();
     })
   );
@@ -69,13 +69,8 @@ describe("OperatorLabelComponent", () => {
   });
 
   it("should display operator user friendly name on the UI", () => {
-    const element = <HTMLElement>(
-      fixture.debugElement.query(By.css(".texera-operator-label-body"))
-        .nativeElement
-    );
-    expect(element.firstChild?.textContent?.trim()).toEqual(
-      mockOperatorData.additionalMetadata.userFriendlyName
-    );
+    const element = <HTMLElement>fixture.debugElement.query(By.css(".texera-operator-label-body")).nativeElement;
+    expect(element.firstChild?.textContent?.trim()).toEqual(mockOperatorData.additionalMetadata.userFriendlyName);
   });
 
   it("should register itself as a draggable element", () => {
@@ -85,27 +80,21 @@ describe("OperatorLabelComponent", () => {
 
   it("should call the mouseLeave function once the cursor leaves a operator label", () => {
     const spy = spyOn<any>(component, "mouseLeave");
-    const operatorLabelElement = fixture.debugElement.query(
-      By.css("#" + component.operatorLabelID)
-    );
+    const operatorLabelElement = fixture.debugElement.query(By.css("#" + component.operatorLabelID));
     operatorLabelElement.triggerEventHandler("mouseleave", component);
     expect(spy).toHaveBeenCalled();
   });
 
   it("should call the mouseDown function once the cursor clicks the operator label", () => {
     const spy = spyOn<any>(component, "mouseDown");
-    const operatorLabelElement = fixture.debugElement.query(
-      By.css("#" + component.operatorLabelID)
-    );
+    const operatorLabelElement = fixture.debugElement.query(By.css("#" + component.operatorLabelID));
     operatorLabelElement.triggerEventHandler("mousedown", component);
     expect(spy).toHaveBeenCalled();
   });
 
   it("should call the mouseUp function once the cursor un-clicks operator label", () => {
     const spy = spyOn<any>(component, "mouseUp");
-    const operatorLabelElement = fixture.debugElement.query(
-      By.css("#" + component.operatorLabelID)
-    );
+    const operatorLabelElement = fixture.debugElement.query(By.css("#" + component.operatorLabelID));
     operatorLabelElement.triggerEventHandler("mouseup", component);
     expect(spy).toHaveBeenCalled();
   });

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.ts
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-label/operator-label.component.ts
@@ -14,12 +14,11 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 @Component({
   selector: "texera-operator-label",
   templateUrl: "./operator-label.component.html",
-  styleUrls: ["./operator-label.component.scss"]
+  styleUrls: ["./operator-label.component.scss"],
 })
 export class OperatorLabelComponent implements OnInit, AfterViewInit {
   public static operatorLabelPrefix = "texera-operator-label-";
-  public static operatorLabelSearchBoxPrefix =
-    "texera-operator-label-search-result-";
+  public static operatorLabelSearchBoxPrefix = "texera-operator-label-search-result-";
 
   // tooltipWindow is an instance of ngbTooltip (popup box)
   @Input() operator?: OperatorSchema;
@@ -34,10 +33,7 @@ export class OperatorLabelComponent implements OnInit, AfterViewInit {
   // is mouse down over this label
   private isMouseDown = false;
 
-  constructor(
-    private dragDropService: DragDropService,
-    private workflowActionService: WorkflowActionService
-  ) {}
+  constructor(private dragDropService: DragDropService, private workflowActionService: WorkflowActionService) {}
 
   ngOnInit() {
     this.handleWorkFlowModificationEnabled();
@@ -45,12 +41,9 @@ export class OperatorLabelComponent implements OnInit, AfterViewInit {
       throw new Error("operator label component: operator is not specified");
     }
     if (this.fromSearchBox) {
-      this.operatorLabelID =
-        OperatorLabelComponent.operatorLabelSearchBoxPrefix +
-        this.operator.operatorType;
+      this.operatorLabelID = OperatorLabelComponent.operatorLabelSearchBoxPrefix + this.operator.operatorType;
     } else {
-      this.operatorLabelID =
-        OperatorLabelComponent.operatorLabelPrefix + this.operator.operatorType;
+      this.operatorLabelID = OperatorLabelComponent.operatorLabelPrefix + this.operator.operatorType;
     }
   }
 
@@ -58,10 +51,7 @@ export class OperatorLabelComponent implements OnInit, AfterViewInit {
     if (!this.operatorLabelID || !this.operator) {
       throw new Error("operator label component: operator is not specified");
     }
-    this.dragDropService.registerOperatorLabelDrag(
-      this.operatorLabelID,
-      this.operator.operatorType
-    );
+    this.dragDropService.registerOperatorLabelDrag(this.operatorLabelID, this.operator.operatorType);
   }
 
   // mouseDownEventStream sends out a value
@@ -98,14 +88,12 @@ export class OperatorLabelComponent implements OnInit, AfterViewInit {
     this.workflowActionService
       .getWorkflowModificationEnabledStream()
       .pipe(untilDestroyed(this))
-      .subscribe((canModify) => {
+      .subscribe(canModify => {
         this.draggable = canModify;
       });
   }
 
   public static isOperatorLabelElementFromSearchBox(elementID: string) {
-    return elementID.startsWith(
-      OperatorLabelComponent.operatorLabelSearchBoxPrefix
-    );
+    return elementID.startsWith(OperatorLabelComponent.operatorLabelSearchBoxPrefix);
   }
 }

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.html
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.html
@@ -19,53 +19,27 @@
       (optionSelected)="onSearchOperatorSelected($event)"
       class="texera-workspace-operator-panel-search-box-dropdown"
     >
-      <ul
-        class="texera-workspace-operator-panel-search-box-dropdown-menu"
-        nz-menu
-        nzBordered
-        nzSelectable="false"
-      >
-        <li
-          *ngFor="let operatorSchema of operatorSearchResults | async"
-          class="dropdown-menu-items"
-          nz-menu-item
-        >
+      <ul class="texera-workspace-operator-panel-search-box-dropdown-menu" nz-menu nzBordered nzSelectable="false">
+        <li *ngFor="let operatorSchema of operatorSearchResults | async" class="dropdown-menu-items" nz-menu-item>
           <texera-operator-label
             [fromSearchBox]="true"
             [operator]="operatorSchema"
-            class="
-              texera-workspace-operator-panel-search-box-dropdown-menu-name-wrapper
-            "
+            class="texera-workspace-operator-panel-search-box-dropdown-menu-name-wrapper"
           ></texera-operator-label>
         </li>
       </ul>
     </nz-dropdown-menu>
   </div>
-  <nz-collapse
-    [nzBordered]="false"
-    class="texera-workspace-operator-panel-menu"
-    nzAccordion
-  >
+  <nz-collapse [nzBordered]="false" class="texera-workspace-operator-panel-menu" nzAccordion>
     <nz-collapse-panel
       *ngFor="let groupName of groupNamesOrdered"
       [nzHeader]="groupName"
       [tourAnchor]="groupName"
       class="texera-workspace-operator-panel-subgroup"
     >
-      <ul
-        class="texera-workspace-operator-panel-subgroup-menu"
-        nz-menu
-        nzSelectable="false"
-      >
-        <li
-          *ngFor="let operatorSchema of operatorGroupMap.get(groupName)"
-          class="texera-operator-label"
-          nz-menu-item
-        >
-          <texera-operator-label
-            [fromSearchBox]="false"
-            [operator]="operatorSchema"
-          ></texera-operator-label>
+      <ul class="texera-workspace-operator-panel-subgroup-menu" nz-menu nzSelectable="false">
+        <li *ngFor="let operatorSchema of operatorGroupMap.get(groupName)" class="texera-operator-label" nz-menu-item>
+          <texera-operator-label [fromSearchBox]="false" [operator]="operatorSchema"></texera-operator-label>
         </li>
       </ul>
     </nz-collapse-panel>

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.spec.ts
@@ -9,20 +9,17 @@ import { OperatorPanelComponent } from "./operator-panel.component";
 import { OperatorLabelComponent } from "./operator-label/operator-label.component";
 import {
   EMPTY_OPERATOR_METADATA,
-  OperatorMetadataService
+  OperatorMetadataService,
 } from "../../service/operator-metadata/operator-metadata.service";
 import { StubOperatorMetadataService } from "../../service/operator-metadata/stub-operator-metadata.service";
 import { TourNgBootstrapModule, TourService } from "ngx-tour-ng-bootstrap";
-import {
-  GroupInfo,
-  OperatorSchema
-} from "../../types/operator-schema.interface";
+import { GroupInfo, OperatorSchema } from "../../types/operator-schema.interface";
 import { RouterTestingModule } from "@angular/router/testing";
 
 import {
   mockOperatorGroup,
   mockOperatorMetaData,
-  mockOperatorSchemaList
+  mockOperatorSchemaList,
 } from "../../service/operator-metadata/mock-operator-metadata.data";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 import { JointUIService } from "../../service/joint-ui/joint-ui.service";
@@ -41,22 +38,22 @@ describe("OperatorPanelComponent", () => {
         providers: [
           {
             provide: OperatorMetadataService,
-            useClass: StubOperatorMetadataService
+            useClass: StubOperatorMetadataService,
           },
           DragDropService,
           WorkflowActionService,
           UndoRedoService,
           WorkflowUtilService,
           JointUIService,
-          TourService
+          TourService,
         ],
         imports: [
           NzDropDownModule,
           NzCollapseModule,
           BrowserAnimationsModule,
           RouterTestingModule.withRoutes([]),
-          TourNgBootstrapModule.forRoot()
-        ]
+          TourNgBootstrapModule.forRoot(),
+        ],
       }).compileComponents();
     })
   );
@@ -82,7 +79,7 @@ describe("OperatorPanelComponent", () => {
   it("should sort group names correctly based on order relatively. ex: (100, 1) -> (1, 100)", () => {
     const groups: GroupInfo[] = [
       { groupName: "group_1", groupOrder: 1 },
-      { groupName: "group_2", groupOrder: 100 }
+      { groupName: "group_2", groupOrder: 100 },
     ];
 
     const result = c.getGroupNamesSorted(groups);
@@ -101,14 +98,10 @@ describe("OperatorPanelComponent", () => {
 
     const result = c.getOperatorGroupMap(opMetadata);
 
-    const sourceOperators = opMetadata.operators.filter(
-      (op) => op.additionalMetadata.operatorGroupName === "Source"
-    );
-    const analysisOperators = opMetadata.operators.filter(
-      (op) => op.additionalMetadata.operatorGroupName === "Analysis"
-    );
+    const sourceOperators = opMetadata.operators.filter(op => op.additionalMetadata.operatorGroupName === "Source");
+    const analysisOperators = opMetadata.operators.filter(op => op.additionalMetadata.operatorGroupName === "Analysis");
     const resultOperators = opMetadata.operators.filter(
-      (op) => op.additionalMetadata.operatorGroupName === "View Results"
+      op => op.additionalMetadata.operatorGroupName === "View Results"
     );
 
     const expectedResult = new Map<string, OperatorSchema[]>();
@@ -130,40 +123,30 @@ describe("OperatorPanelComponent", () => {
   it("should receive operator metadata from service", () => {
     // if the length of our schema list is equal to the length of mock data
     // we assume the mock data has been received
-    expect(component.operatorSchemaList.length).toEqual(
-      mockOperatorSchemaList.length
-    );
-    expect(component.groupNamesOrdered.length).toEqual(
-      mockOperatorGroup.length
-    );
+    expect(component.operatorSchemaList.length).toEqual(mockOperatorSchemaList.length);
+    expect(component.groupNamesOrdered.length).toEqual(mockOperatorGroup.length);
   });
 
   it("should have all group names shown in the UI side panel", () => {
     const groupNamesInUI = fixture.debugElement
       .queryAll(By.css(".texera-workspace-operator-panel-subgroup"))
-      .map(
-        (el) => el.nativeElement.querySelector(".ant-collapse-header").innerText
-      );
+      .map(el => el.nativeElement.querySelector(".ant-collapse-header").innerText);
 
-    expect(groupNamesInUI).toEqual(
-      mockOperatorGroup.map((group) => group.groupName)
-    );
+    expect(groupNamesInUI).toEqual(mockOperatorGroup.map(group => group.groupName));
   });
 
   it("should create child operator label component for all operators", () => {
     const operatorLabels = fixture.debugElement
       .queryAll(By.directive(OperatorLabelComponent))
-      .map((debugEl) => <OperatorLabelComponent>debugEl.componentInstance)
-      .map((operatorLabel) => operatorLabel.operator);
+      .map(debugEl => <OperatorLabelComponent>debugEl.componentInstance)
+      .map(operatorLabel => operatorLabel.operator);
 
-    expect(operatorLabels.length).toEqual(
-      mockOperatorMetaData.operators.length
-    );
+    expect(operatorLabels.length).toEqual(mockOperatorMetaData.operators.length);
   });
 
   it("should search an operator by its user friendly name", () => {
     let searchResults: OperatorSchema[] = [];
-    component.operatorSearchResults.subscribe((res) => (searchResults = res));
+    component.operatorSearchResults.subscribe(res => (searchResults = res));
 
     component.operatorSearchFormControl.setValue("Source: Scan");
 
@@ -174,7 +157,7 @@ describe("OperatorPanelComponent", () => {
 
   it("should support fuzzy search on operator user friendly name", () => {
     let searchResults: OperatorSchema[] = [];
-    component.operatorSearchResults.subscribe((res) => (searchResults = res));
+    component.operatorSearchResults.subscribe(res => (searchResults = res));
 
     component.operatorSearchFormControl.setValue("scan");
 
@@ -190,8 +173,7 @@ describe("OperatorPanelComponent", () => {
     dragDropService.operatorDroppedSubject.next({
       operatorType: "ScanSource",
       offset: { x: 1, y: 1 },
-      dragElementID:
-        OperatorLabelComponent.operatorLabelSearchBoxPrefix + "ScanSource"
+      dragElementID: OperatorLabelComponent.operatorLabelSearchBoxPrefix + "ScanSource",
     });
 
     expect(component.operatorSearchFormControl.value).toBeFalsy();

--- a/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/operator-panel/operator-panel.component.ts
@@ -6,11 +6,7 @@ import { Observable } from "rxjs";
 import { map } from "rxjs/operators";
 import { OperatorMetadataService } from "../../service/operator-metadata/operator-metadata.service";
 
-import {
-  GroupInfo,
-  OperatorMetadata,
-  OperatorSchema
-} from "../../types/operator-schema.interface";
+import { GroupInfo, OperatorMetadata, OperatorSchema } from "../../types/operator-schema.interface";
 import { DragDropService } from "../../service/drag-drop/drag-drop.service";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 import { WorkflowUtilService } from "../../service/workflow-graph/util/workflow-util.service";
@@ -40,7 +36,7 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
   providers: [
     // uncomment this line for manual testing without opening backend server
     // { provide: OperatorMetadataService, useClass: StubOperatorMetadataService }
-  ]
+  ],
 })
 export class OperatorPanelComponent implements OnInit {
   // a list of all operator's schema
@@ -62,7 +58,7 @@ export class OperatorPanelComponent implements OnInit {
     distance: 100,
     maxPatternLength: 32,
     minMatchCharLength: 1,
-    keys: ["additionalMetadata.userFriendlyName"]
+    keys: ["additionalMetadata.userFriendlyName"],
   });
 
   constructor(
@@ -73,10 +69,8 @@ export class OperatorPanelComponent implements OnInit {
   ) {
     // create the search results observable
     // whenever the search box text is changed, perform the search using fuse.js
-    this.operatorSearchResults = (
-      this.operatorSearchFormControl.valueChanges as Observable<string>
-    ).pipe(
-      map((v) => {
+    this.operatorSearchResults = (this.operatorSearchFormControl.valueChanges as Observable<string>).pipe(
+      map(v => {
         if (v === null || v.trim().length === 0) {
           this.operatorSearchHasResults = false;
           return [];
@@ -91,12 +85,8 @@ export class OperatorPanelComponent implements OnInit {
     this.dragDropService
       .getOperatorDropStream()
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
-        if (
-          OperatorLabelComponent.isOperatorLabelElementFromSearchBox(
-            event.dragElementID
-          )
-        ) {
+      .subscribe(event => {
+        if (OperatorLabelComponent.isOperatorLabelElementFromSearchBox(event.dragElementID)) {
           this.operatorSearchFormControl.setValue("");
         }
       });
@@ -109,7 +99,7 @@ export class OperatorPanelComponent implements OnInit {
     this.operatorMetadataService
       .getOperatorMetadata()
       .pipe(untilDestroyed(this))
-      .subscribe((value) => this.processOperatorMetadata(value));
+      .subscribe(value => this.processOperatorMetadata(value));
   }
 
   /**
@@ -119,12 +109,12 @@ export class OperatorPanelComponent implements OnInit {
   onSearchOperatorSelected(event: MatAutocompleteSelectedEvent): void {
     const userFriendlyName = event.option.value as string;
     const operator = this.operatorSchemaList.filter(
-      (op) => op.additionalMetadata.userFriendlyName === userFriendlyName
+      op => op.additionalMetadata.userFriendlyName === userFriendlyName
     )[0];
-    this.workflowActionService.addOperator(
-      this.workflowUtilService.getNewOperatorPredicate(operator.operatorType),
-      { x: 800, y: 400 }
-    );
+    this.workflowActionService.addOperator(this.workflowUtilService.getNewOperatorPredicate(operator.operatorType), {
+      x: 800,
+      y: 400,
+    });
     this.operatorSearchFormControl.setValue("");
   }
 
@@ -145,27 +135,19 @@ export class OperatorPanelComponent implements OnInit {
 
 // generates a list of group names sorted by the order
 // slice() will make a copy of the list, because we don't want to sort the original list
-export function getGroupNamesSorted(
-  groupInfoList: ReadonlyArray<GroupInfo>
-): string[] {
+export function getGroupNamesSorted(groupInfoList: ReadonlyArray<GroupInfo>): string[] {
   return groupInfoList
     .slice()
     .sort((a, b) => a.groupOrder - b.groupOrder)
-    .map((groupInfo) => groupInfo.groupName);
+    .map(groupInfo => groupInfo.groupName);
 }
 
 // returns a new empty map from the group name to a list of OperatorSchema
-export function getOperatorGroupMap(
-  operatorMetadata: OperatorMetadata
-): Map<string, OperatorSchema[]> {
-  const groups = operatorMetadata.groups.map(
-    (groupInfo) => groupInfo.groupName
-  );
+export function getOperatorGroupMap(operatorMetadata: OperatorMetadata): Map<string, OperatorSchema[]> {
+  const groups = operatorMetadata.groups.map(groupInfo => groupInfo.groupName);
   const operatorGroupMap = new Map<string, OperatorSchema[]>();
-  groups.forEach((groupName) => {
-    const operators = operatorMetadata.operators.filter(
-      (x) => x.additionalMetadata.operatorGroupName === groupName
-    );
+  groups.forEach(groupName => {
+    const operators = operatorMetadata.operators.filter(x => x.additionalMetadata.operatorGroupName === groupName);
     operatorGroupMap.set(groupName, operators);
   });
   return operatorGroupMap;

--- a/core/new-gui/src/app/workspace/component/product-tour/product-tour.component.html
+++ b/core/new-gui/src/app/workspace/component/product-tour/product-tour.component.html
@@ -15,18 +15,9 @@
       >
         Next »
       </button>
-      <button
-        (click)="tourService.end()"
-        class="btn btn-sm btn-danger"
-        id="EndButton"
-      >
-        End
-      </button>
+      <button (click)="tourService.end()" class="btn btn-sm btn-danger" id="EndButton">End</button>
     </div>
     <br />
-    <p
-      [innerHTML]="tourService.currentStep.content"
-      class="tour-step-content"
-    ></p>
+    <p [innerHTML]="tourService.currentStep.content" class="tour-step-content"></p>
   </ng-template>
 </tour-step-template>

--- a/core/new-gui/src/app/workspace/component/product-tour/product-tour.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/product-tour/product-tour.component.spec.ts
@@ -1,10 +1,6 @@
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { ProductTourComponent } from "./product-tour.component";
-import {
-  TourNgBootstrapModule,
-  TourService,
-  IStepOption
-} from "ngx-tour-ng-bootstrap";
+import { TourNgBootstrapModule, TourService, IStepOption } from "ngx-tour-ng-bootstrap";
 import { RouterTestingModule } from "@angular/router/testing";
 import { marbles } from "rxjs-marbles";
 import { map, tap } from "rxjs/operators";
@@ -17,12 +13,9 @@ describe("ProductTourComponent", () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [
-          RouterTestingModule.withRoutes([]),
-          TourNgBootstrapModule.forRoot()
-        ],
+        imports: [RouterTestingModule.withRoutes([]), TourNgBootstrapModule.forRoot()],
         declarations: [ProductTourComponent],
-        providers: [TourService]
+        providers: [TourService],
       }).compileComponents();
     })
   );
@@ -47,14 +40,12 @@ describe("ProductTourComponent", () => {
       expect(steps[1].placement).toEqual("right");
     });
 
-    const mockComponent: ProductTourComponent = new ProductTourComponent(
-      tourService
-    );
+    const mockComponent: ProductTourComponent = new ProductTourComponent(tourService);
   });
 
   it(
     "should trigger a start event when the toggle() method call is execute",
-    marbles((m) => {
+    marbles(m => {
       const tourServiceStartStream = tourService.start$.pipe(map(() => "a"));
       m.hot("-a-")
         .pipe(tap(() => tourService.toggle()))
@@ -66,7 +57,7 @@ describe("ProductTourComponent", () => {
 
   it(
     "should trigger an end event when the end() method call is executed",
-    marbles((m) => {
+    marbles(m => {
       const tourServiceEndStream = tourService.end$.pipe(map(() => "a"));
       m.hot("-a-")
         .pipe(tap(() => tourService.end()))

--- a/core/new-gui/src/app/workspace/component/product-tour/product-tour.component.ts
+++ b/core/new-gui/src/app/workspace/component/product-tour/product-tour.component.ts
@@ -25,7 +25,7 @@ import { TourService, IStepOption } from "ngx-tour-ng-bootstrap";
 @Component({
   selector: "texera-product-tour",
   templateUrl: "./product-tour.component.html",
-  styleUrls: ["./product-tour.component.scss"]
+  styleUrls: ["./product-tour.component.scss"],
 })
 export class ProductTourComponent {
   private steps: IStepOption[] = [
@@ -50,7 +50,7 @@ export class ProductTourComponent {
     `,
       placement: "bottom",
       title: "Welcome",
-      preventScrolling: true
+      preventScrolling: true,
     },
     {
       anchorId: "texera-operator-panel",
@@ -63,7 +63,7 @@ export class ProductTourComponent {
     `,
       placement: "right",
       title: "Operator Panel",
-      preventScrolling: true
+      preventScrolling: true,
     },
     {
       anchorId: "texera-operator-panel",
@@ -75,7 +75,7 @@ export class ProductTourComponent {
     `,
       title: "Select Operator",
       placement: "right",
-      preventScrolling: true
+      preventScrolling: true,
     },
     {
       anchorId: "texera-property-editor-grid-container",
@@ -88,7 +88,7 @@ export class ProductTourComponent {
     `,
       placement: "left",
       title: "Property Editor",
-      preventScrolling: true
+      preventScrolling: true,
     },
     {
       anchorId: "texera-operator-panel",
@@ -98,7 +98,7 @@ export class ProductTourComponent {
     `,
       placement: "right",
       title: "Operator Panel",
-      preventScrolling: true
+      preventScrolling: true,
     },
     {
       anchorId: "texera-operator-panel",
@@ -109,7 +109,7 @@ export class ProductTourComponent {
     `,
       placement: "right",
       title: "Select Operator",
-      preventScrolling: true
+      preventScrolling: true,
     },
     {
       anchorId: "texera-property-editor-grid-container",
@@ -120,7 +120,7 @@ export class ProductTourComponent {
     `,
       placement: "left",
       title: "Connecting operators",
-      preventScrolling: true
+      preventScrolling: true,
     },
     {
       anchorId: "texera-workspace-navigation-run",
@@ -129,7 +129,7 @@ export class ProductTourComponent {
     `,
       title: "Running the workflow",
       placement: "bottom",
-      preventScrolling: true
+      preventScrolling: true,
     },
     {
       anchorId: "texera-result-view-grid-container",
@@ -138,7 +138,7 @@ export class ProductTourComponent {
     `,
       placement: "top",
       title: "Viewing the results",
-      preventScrolling: true
+      preventScrolling: true,
     },
     {
       anchorId: "texera-navigation-grid-container",
@@ -151,8 +151,8 @@ export class ProductTourComponent {
     `,
       placement: "bottom",
       title: "Ending of tutorial",
-      preventScrolling: true
-    }
+      preventScrolling: true,
+    },
   ];
 
   constructor(public tourService: TourService) {

--- a/core/new-gui/src/app/workspace/component/property-editor/breakpoint-property-edit-frame/breakpoint-property-edit-frame.component.html
+++ b/core/new-gui/src/app/workspace/component/property-editor/breakpoint-property-edit-frame/breakpoint-property-edit-frame.component.html
@@ -1,16 +1,6 @@
-<h3
-  *ngIf="formTitle"
-  class="texera-workspace-property-editor-title"
-  mat-subheader
->
-  {{ formTitle }}
-</h3>
+<h3 *ngIf="formTitle" class="texera-workspace-property-editor-title" mat-subheader>{{ formTitle }}</h3>
 
-<form
-  *ngIf="formlyFields"
-  [formGroup]="formlyFormGroup"
-  class="texera-workspace-property-editor-form"
->
+<form *ngIf="formlyFields" [formGroup]="formlyFormGroup" class="texera-workspace-property-editor-form">
   <formly-form
     (modelChange)="onFormChanges($event)"
     [fields]="formlyFields"

--- a/core/new-gui/src/app/workspace/component/property-editor/breakpoint-property-edit-frame/breakpoint-property-edit-frame.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/breakpoint-property-edit-frame/breakpoint-property-edit-frame.component.spec.ts
@@ -7,7 +7,7 @@ import {
   mockPoint,
   mockResultPredicate,
   mockScanPredicate,
-  mockScanResultLink
+  mockScanResultLink,
 } from "../../../service/workflow-graph/model/mock-workflow-data";
 import { By } from "@angular/platform-browser";
 import { mockBreakpointSchema } from "../../../service/operator-metadata/mock-operator-metadata.data";
@@ -36,14 +36,14 @@ describe("BreakpointPropertyEditFrameComponent", () => {
           BreakpointPropertyEditFrameComponent,
           ArrayTypeComponent,
           ObjectTypeComponent,
-          MultiSchemaTypeComponent
+          MultiSchemaTypeComponent,
         ],
         providers: [
           WorkflowActionService,
           {
             provide: OperatorMetadataService,
-            useClass: StubOperatorMetadataService
-          }
+            useClass: StubOperatorMetadataService,
+          },
         ],
         imports: [
           BrowserAnimationsModule,
@@ -54,8 +54,8 @@ describe("BreakpointPropertyEditFrameComponent", () => {
           // use formly material module instead
           FormlyMaterialModule,
           ReactiveFormsModule,
-          HttpClientTestingModule
-        ]
+          HttpClientTestingModule,
+        ],
       }).compileComponents();
     })
   );
@@ -86,11 +86,7 @@ describe("BreakpointPropertyEditFrameComponent", () => {
       workflowActionService.addLink(mockScanResultLink);
 
       component.ngOnChanges({
-        currentLinkId: new SimpleChange(
-          undefined,
-          mockScanResultLink.linkID,
-          true
-        )
+        currentLinkId: new SimpleChange(undefined, mockScanResultLink.linkID, true),
       });
 
       fixture.detectChanges();
@@ -99,25 +95,17 @@ describe("BreakpointPropertyEditFrameComponent", () => {
       expect(component.formData).toEqual({});
 
       // check HTML form are displayed
-      const jsonSchemaFormElement = fixture.debugElement.query(
-        By.css(".texera-workspace-property-editor-form")
-      );
+      const jsonSchemaFormElement = fixture.debugElement.query(By.css(".texera-workspace-property-editor-form"));
       // check if the form has the all the json schema property names
-      Object.values(
-        (mockBreakpointSchema.jsonSchema.oneOf as any)[0].properties
-      ).forEach((property: unknown) => {
+      Object.values((mockBreakpointSchema.jsonSchema.oneOf as any)[0].properties).forEach((property: unknown) => {
         assertType<{ type: string; title: string }>(property);
-        expect(
-          (jsonSchemaFormElement.nativeElement as HTMLElement).innerHTML
-        ).toContain(property.title);
+        expect((jsonSchemaFormElement.nativeElement as HTMLElement).innerHTML).toContain(property.title);
       });
     });
 
     it("should add a breakpoint upon clicking add breakpoint button", () => {
       // for some reason, all the breakpoint interaction buttons (add, modify, remove) are class 'breakpointRemoveButton' ???
-      let buttonState = fixture.debugElement.query(
-        By.css(".breakpointRemoveButton")
-      );
+      let buttonState = fixture.debugElement.query(By.css(".breakpointRemoveButton"));
       expect(buttonState).toBeFalsy();
 
       workflowActionService.addOperator(mockScanPredicate, mockPoint);
@@ -125,18 +113,12 @@ describe("BreakpointPropertyEditFrameComponent", () => {
       workflowActionService.addLink(mockScanResultLink);
 
       component.ngOnChanges({
-        currentLinkId: new SimpleChange(
-          undefined,
-          mockScanResultLink.linkID,
-          true
-        )
+        currentLinkId: new SimpleChange(undefined, mockScanResultLink.linkID, true),
       });
       fixture.detectChanges();
 
       // after adding breakpoint, this should be the add breakpoint button
-      buttonState = fixture.debugElement.query(
-        By.css(".breakpointRemoveButton")
-      );
+      buttonState = fixture.debugElement.query(By.css(".breakpointRemoveButton"));
       expect(buttonState).toBeTruthy();
 
       spyOn(workflowActionService, "setLinkBreakpoint");
@@ -148,9 +130,7 @@ describe("BreakpointPropertyEditFrameComponent", () => {
 
     it("should clear and hide the property editor panel correctly upon clicking the remove button on breakpoint editor", () => {
       // for some reason, all the breakpoint interaction buttons (add, modify, remove) are class 'breakpointRemoveButton' ???
-      let buttonState = fixture.debugElement.query(
-        By.css(".breakpointRemoveButton")
-      );
+      let buttonState = fixture.debugElement.query(By.css(".breakpointRemoveButton"));
       expect(buttonState).toBeFalsy();
 
       workflowActionService.addOperator(mockScanPredicate, mockPoint);
@@ -158,11 +138,7 @@ describe("BreakpointPropertyEditFrameComponent", () => {
       workflowActionService.addLink(mockScanResultLink);
 
       component.ngOnChanges({
-        currentLinkId: new SimpleChange(
-          undefined,
-          mockScanResultLink.linkID,
-          true
-        )
+        currentLinkId: new SimpleChange(undefined, mockScanResultLink.linkID, true),
       });
       fixture.detectChanges();
 
@@ -172,21 +148,15 @@ describe("BreakpointPropertyEditFrameComponent", () => {
       fixture.detectChanges();
 
       // after adding breakpoint, this should now be the remove breakpoint button
-      buttonState = fixture.debugElement.query(
-        By.css(".breakpointRemoveButton")
-      );
+      buttonState = fixture.debugElement.query(By.css(".breakpointRemoveButton"));
       expect(buttonState).toBeTruthy();
 
       buttonState.triggerEventHandler("click", null);
       fixture.detectChanges();
       expect(component.currentLinkId).toBeUndefined();
       // check HTML form are not displayed
-      const formTitleElement = fixture.debugElement.query(
-        By.css(".texera-workspace-property-editor-title")
-      );
-      const jsonSchemaFormElement = fixture.debugElement.query(
-        By.css(".texera-workspace-property-editor-form")
-      );
+      const formTitleElement = fixture.debugElement.query(By.css(".texera-workspace-property-editor-title"));
+      const jsonSchemaFormElement = fixture.debugElement.query(By.css(".texera-workspace-property-editor-form"));
 
       expect(formTitleElement).toBeFalsy();
       expect(jsonSchemaFormElement).toBeFalsy();
@@ -200,11 +170,7 @@ describe("BreakpointPropertyEditFrameComponent", () => {
       workflowActionService.addLink(mockScanResultLink);
 
       component.ngOnChanges({
-        currentLinkId: new SimpleChange(
-          undefined,
-          mockScanResultLink.linkID,
-          true
-        )
+        currentLinkId: new SimpleChange(undefined, mockScanResultLink.linkID, true),
       });
       fixture.detectChanges();
 
@@ -215,26 +181,20 @@ describe("BreakpointPropertyEditFrameComponent", () => {
       fixture.detectChanges();
 
       // check breakpoint
-      let linkBreakpoint = workflowActionService
-        .getTexeraGraph()
-        .getLinkBreakpoint(mockScanResultLink.linkID);
+      let linkBreakpoint = workflowActionService.getTexeraGraph().getLinkBreakpoint(mockScanResultLink.linkID);
       if (!linkBreakpoint) {
         throw new Error(`link ${mockScanResultLink.linkID} is undefined`);
       }
       expect(linkBreakpoint).toEqual(formData);
 
       // simulate button click
-      const buttonState = fixture.debugElement.query(
-        By.css(".breakpointRemoveButton")
-      );
+      const buttonState = fixture.debugElement.query(By.css(".breakpointRemoveButton"));
       expect(buttonState).toBeTruthy();
 
       buttonState.triggerEventHandler("click", null);
       fixture.detectChanges();
 
-      linkBreakpoint = workflowActionService
-        .getTexeraGraph()
-        .getLinkBreakpoint(mockScanResultLink.linkID);
+      linkBreakpoint = workflowActionService.getTexeraGraph().getLinkBreakpoint(mockScanResultLink.linkID);
       expect(linkBreakpoint).toBeUndefined();
     });
   });

--- a/core/new-gui/src/app/workspace/component/property-editor/breakpoint-property-edit-frame/breakpoint-property-edit-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/breakpoint-property-edit-frame/breakpoint-property-edit-frame.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  Input,
-  OnChanges,
-  OnInit,
-  SimpleChanges
-} from "@angular/core";
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from "@angular/core";
 import { cloneDeep, isEqual } from "lodash-es";
 import { ExecuteWorkflowService } from "../../../service/execute-workflow/execute-workflow.service";
 import { DynamicSchemaService } from "../../../service/dynamic-schema/dynamic-schema.service";
@@ -39,7 +33,7 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 @Component({
   selector: "texera-breakpoint-frame",
   templateUrl: "./breakpoint-property-edit-frame.component.html",
-  styleUrls: ["./breakpoint-property-edit-frame.component.scss"]
+  styleUrls: ["./breakpoint-property-edit-frame.component.scss"],
 })
 export class BreakpointPropertyEditFrameComponent implements OnInit, OnChanges {
   @Input() currentLinkId: string | undefined;
@@ -50,9 +44,8 @@ export class BreakpointPropertyEditFrameComponent implements OnInit, OnChanges {
   // the source event stream of form change triggered by library at each user input
   sourceFormChangeEventStream = new Subject<Record<string, unknown>>();
 
-  breakpointChangeStream = createOutputFormChangeEventStream(
-    this.sourceFormChangeEventStream,
-    (data) => this.checkBreakpoint(data)
+  breakpointChangeStream = createOutputFormChangeEventStream(this.sourceFormChangeEventStream, data =>
+    this.checkBreakpoint(data)
   );
 
   // inputs and two-way bindings to formly component
@@ -96,34 +89,17 @@ export class BreakpointPropertyEditFrameComponent implements OnInit, OnChanges {
     if (!this.currentLinkId) {
       return false;
     }
-    return (
-      this.workflowActionService
-        .getTexeraGraph()
-        .getLinkBreakpoint(this.currentLinkId) !== undefined
-    );
+    return this.workflowActionService.getTexeraGraph().getLinkBreakpoint(this.currentLinkId) !== undefined;
   }
 
   handleAddBreakpoint() {
-    if (
-      this.currentLinkId &&
-      this.workflowActionService
-        .getTexeraGraph()
-        .hasLinkWithID(this.currentLinkId)
-    ) {
-      this.workflowActionService.setLinkBreakpoint(
-        this.currentLinkId,
-        this.formData
-      );
+    if (this.currentLinkId && this.workflowActionService.getTexeraGraph().hasLinkWithID(this.currentLinkId)) {
+      this.workflowActionService.setLinkBreakpoint(this.currentLinkId, this.formData);
       if (
-        this.executeWorkflowService.getExecutionState().state ===
-          ExecutionState.Paused ||
-        this.executeWorkflowService.getExecutionState().state ===
-          ExecutionState.BreakpointTriggered
+        this.executeWorkflowService.getExecutionState().state === ExecutionState.Paused ||
+        this.executeWorkflowService.getExecutionState().state === ExecutionState.BreakpointTriggered
       ) {
-        this.executeWorkflowService.addBreakpointRuntime(
-          this.currentLinkId,
-          this.formData
-        );
+        this.executeWorkflowService.addBreakpointRuntime(this.currentLinkId, this.formData);
       }
     }
   }
@@ -137,9 +113,7 @@ export class BreakpointPropertyEditFrameComponent implements OnInit, OnChanges {
     if (this.currentLinkId) {
       // remove breakpoint in texera workflow first, then unhighlight it
       this.workflowActionService.removeLinkBreakpoint(this.currentLinkId);
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .unhighlightLinks(this.currentLinkId);
+      this.workflowActionService.getJointGraphWrapper().unhighlightLinks(this.currentLinkId);
     }
     this.clearPropertyEditor();
   }
@@ -150,13 +124,10 @@ export class BreakpointPropertyEditFrameComponent implements OnInit, OnChanges {
     }
     // set the operator data needed
     this.currentLinkId = linkID;
-    const breakpointSchema =
-      this.autocompleteService.getDynamicBreakpointSchema(linkID).jsonSchema;
+    const breakpointSchema = this.autocompleteService.getDynamicBreakpointSchema(linkID).jsonSchema;
 
     this.formTitle = "Breakpoint";
-    const breakpoint = this.workflowActionService
-      .getTexeraGraph()
-      .getLinkBreakpoint(linkID);
+    const breakpoint = this.workflowActionService.getTexeraGraph().getLinkBreakpoint(linkID);
     this.formData = breakpoint !== undefined ? cloneDeep(breakpoint) : {};
     this.setFormlyFormBinding(breakpointSchema);
 
@@ -166,7 +137,7 @@ export class BreakpointPropertyEditFrameComponent implements OnInit, OnChanges {
         ExecutionState.Uninitialized,
         ExecutionState.Paused,
         ExecutionState.BreakpointTriggered,
-        ExecutionState.Completed
+        ExecutionState.Completed,
       ];
     this.setInteractivity(interactive);
   }
@@ -209,17 +180,12 @@ export class BreakpointPropertyEditFrameComponent implements OnInit, OnChanges {
       return false;
     }
     // check if the link still exists
-    const link = this.workflowActionService
-      .getTexeraGraph()
-      .getLinkWithID(this.currentLinkId);
+    const link = this.workflowActionService.getTexeraGraph().getLinkWithID(this.currentLinkId);
     if (!link) {
       return false;
     }
     // only emit change event if the form data actually changes
-    return !isEqual(
-      formData,
-      this.workflowActionService.getTexeraGraph().getLinkBreakpoint(link.linkID)
-    );
+    return !isEqual(formData, this.workflowActionService.getTexeraGraph().getLinkBreakpoint(link.linkID));
   }
 
   /**
@@ -234,26 +200,16 @@ export class BreakpointPropertyEditFrameComponent implements OnInit, OnChanges {
       .getTexeraGraph()
       .getBreakpointChangeStream()
       .pipe(
-        filter((_) => this.currentLinkId !== undefined),
-        filter((event) => event.linkID === this.currentLinkId),
+        filter(_ => this.currentLinkId !== undefined),
+        filter(event => event.linkID === this.currentLinkId),
         filter(
-          (event) =>
-            !isEqual(
-              this.formData,
-              this.workflowActionService
-                .getTexeraGraph()
-                .getLinkBreakpoint(event.linkID)
-            )
+          event => !isEqual(this.formData, this.workflowActionService.getTexeraGraph().getLinkBreakpoint(event.linkID))
         )
       )
       .pipe(untilDestroyed(this))
       .subscribe(
-        (event) =>
-          (this.formData = cloneDeep(
-            this.workflowActionService
-              .getTexeraGraph()
-              .getLinkBreakpoint(event.linkID)
-          ))
+        event =>
+          (this.formData = cloneDeep(this.workflowActionService.getTexeraGraph().getLinkBreakpoint(event.linkID)))
       );
   }
 
@@ -278,14 +234,14 @@ export class BreakpointPropertyEditFrameComponent implements OnInit, OnChanges {
     this.formlyOptions = {};
     // convert the json schema to formly config, pass a copy because formly mutates the schema object
     const field = this.formlyJsonschema.toFieldConfig(cloneDeep(schema), {
-      map: jsonSchemaMapIntercept
+      map: jsonSchemaMapIntercept,
     });
     field.hooks = {
-      onInit: (fieldConfig) => {
+      onInit: fieldConfig => {
         if (!this.interactive) {
           fieldConfig?.form?.disable();
         }
-      }
+      },
     };
     this.formlyFields = field.fieldGroup;
   }

--- a/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.html
+++ b/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.html
@@ -1,9 +1,5 @@
 <div *ngIf="!editingTitle" id="formly-title">
-  <h3
-    *ngIf="!editingTitle && formTitle"
-    class="texera-workspace-property-editor-title"
-    mat-subheader
-  >
+  <h3 *ngIf="!editingTitle && formTitle" class="texera-workspace-property-editor-title" mat-subheader>
     {{ formTitle }}
   </h3>
   <button
@@ -27,11 +23,7 @@
   value="{{formTitle}}"
 />
 
-<form
-  *ngIf="formlyFields"
-  [formGroup]="formlyFormGroup"
-  class="texera-workspace-property-editor-form"
->
+<form *ngIf="formlyFields" [formGroup]="formlyFormGroup" class="texera-workspace-property-editor-form">
   <formly-form
     (modelChange)="onFormChanges($event)"
     [fields]="formlyFields"

--- a/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.spec.ts
@@ -1,11 +1,4 @@
-import {
-  ComponentFixture,
-  discardPeriodicTasks,
-  fakeAsync,
-  TestBed,
-  tick,
-  waitForAsync
-} from "@angular/core/testing";
+import { ComponentFixture, discardPeriodicTasks, fakeAsync, TestBed, tick, waitForAsync } from "@angular/core/testing";
 
 import { OperatorPropertyEditFrameComponent } from "./operator-property-edit-frame.component";
 import { WorkflowActionService } from "../../../service/workflow-graph/model/workflow-action.service";
@@ -24,11 +17,11 @@ import { HttpClientTestingModule } from "@angular/common/http/testing";
 import {
   mockPoint,
   mockResultPredicate,
-  mockScanPredicate
+  mockScanPredicate,
 } from "../../../service/workflow-graph/model/mock-workflow-data";
 import {
   mockScanSourceSchema,
-  mockViewResultsSchema
+  mockViewResultsSchema,
 } from "../../../service/operator-metadata/mock-operator-metadata.data";
 import { JSONSchema7 } from "json-schema";
 import { configure } from "rxjs-marbles";
@@ -51,10 +44,10 @@ describe("OperatorPropertyEditFrameComponent", () => {
           WorkflowActionService,
           {
             provide: OperatorMetadataService,
-            useClass: StubOperatorMetadataService
+            useClass: StubOperatorMetadataService,
           },
           LoggerConfig,
-          DatePipe
+          DatePipe,
         ],
         imports: [
           BrowserAnimationsModule,
@@ -65,8 +58,8 @@ describe("OperatorPropertyEditFrameComponent", () => {
           // use formly material module instead
           FormlyMaterialModule,
           ReactiveFormsModule,
-          HttpClientTestingModule
-        ]
+          HttpClientTestingModule,
+        ],
       }).compileComponents();
     })
   );
@@ -95,41 +88,31 @@ describe("OperatorPropertyEditFrameComponent", () => {
     workflowActionService.addOperator(predicate, mockPoint);
 
     component.ngOnChanges({
-      currentOperatorId: new SimpleChange(undefined, predicate.operatorID, true)
+      currentOperatorId: new SimpleChange(undefined, predicate.operatorID, true),
     });
     fixture.detectChanges();
     // check variables are set correctly
     expect(component.formData).toEqual(predicate.operatorProperties);
 
     // check HTML form are displayed
-    const formTitleElement = fixture.debugElement.query(
-      By.css(".texera-workspace-property-editor-title")
-    );
-    const jsonSchemaFormElement = fixture.debugElement.query(
-      By.css(".texera-workspace-property-editor-form")
-    );
+    const formTitleElement = fixture.debugElement.query(By.css(".texera-workspace-property-editor-title"));
+    const jsonSchemaFormElement = fixture.debugElement.query(By.css(".texera-workspace-property-editor-form"));
     // check the panel title
     expect((formTitleElement.nativeElement as HTMLElement).innerText).toEqual(
       mockScanSourceSchema.additionalMetadata.userFriendlyName
     );
 
     // check if the form has the all the json schema property names
-    Object.entries(mockScanSourceSchema.jsonSchema.properties as any).forEach(
-      (entry) => {
-        const propertyTitle = (entry[1] as JSONSchema7).title;
-        if (propertyTitle) {
-          expect(
-            (jsonSchemaFormElement.nativeElement as HTMLElement).innerHTML
-          ).toContain(propertyTitle);
-        }
-        const propertyDescription = (entry[1] as JSONSchema7).description;
-        if (propertyDescription) {
-          expect(
-            (jsonSchemaFormElement.nativeElement as HTMLElement).innerHTML
-          ).toContain(propertyDescription);
-        }
+    Object.entries(mockScanSourceSchema.jsonSchema.properties as any).forEach(entry => {
+      const propertyTitle = (entry[1] as JSONSchema7).title;
+      if (propertyTitle) {
+        expect((jsonSchemaFormElement.nativeElement as HTMLElement).innerHTML).toContain(propertyTitle);
       }
-    );
+      const propertyDescription = (entry[1] as JSONSchema7).description;
+      if (propertyDescription) {
+        expect((jsonSchemaFormElement.nativeElement as HTMLElement).innerHTML).toContain(propertyDescription);
+      }
+    });
   });
 
   it("should change Texera graph property when the form is edited by the user", fakeAsync(() => {
@@ -138,11 +121,7 @@ describe("OperatorPropertyEditFrameComponent", () => {
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
 
     component.ngOnChanges({
-      currentOperatorId: new SimpleChange(
-        undefined,
-        mockScanPredicate.operatorID,
-        true
-      )
+      currentOperatorId: new SimpleChange(undefined, mockScanPredicate.operatorID, true),
     });
     fixture.detectChanges();
 
@@ -159,9 +138,7 @@ describe("OperatorPropertyEditFrameComponent", () => {
 
     // then get the operator, because operator is immutable, the operator before the tick
     //   is a different object reference from the operator after the tick
-    const operator = workflowActionService
-      .getTexeraGraph()
-      .getOperator(mockScanPredicate.operatorID);
+    const operator = workflowActionService.getTexeraGraph().getOperator(mockScanPredicate.operatorID);
     if (!operator) {
       throw new Error(`operator ${mockScanPredicate.operatorID} is undefined`);
     }
@@ -174,7 +151,7 @@ describe("OperatorPropertyEditFrameComponent", () => {
 
   xit(
     "should debounce the user form input to avoid emitting event too frequently",
-    marbles((m) => {
+    marbles(m => {
       const jointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
       // add an operator and highlight the operator so that the
@@ -190,12 +167,9 @@ describe("OperatorPropertyEditFrameComponent", () => {
         b: { tableName: "ta" },
         c: { tableName: "tab" },
         d: { tableName: "tabl" },
-        e: { tableName: "table" }
+        e: { tableName: "table" },
       };
-      const formUserInputEventStream = m.hot(
-        formUserInputMarbleString,
-        formUserInputMarbleValue
-      );
+      const formUserInputEventStream = m.hot(formUserInputMarbleString, formUserInputMarbleValue);
 
       // prepare the expected output stream after debounce time
       const formChangeEventMarbleString =
@@ -205,12 +179,9 @@ describe("OperatorPropertyEditFrameComponent", () => {
         "-".repeat(FORM_DEBOUNCE_TIME_MS / 10) +
         "e-";
       const formChangeEventMarbleValue = {
-        e: { tableName: "table" } as object
+        e: { tableName: "table" } as object,
       };
-      const expectedFormChangeEventStream = m.hot(
-        formChangeEventMarbleString,
-        formChangeEventMarbleValue
-      );
+      const expectedFormChangeEventStream = m.hot(formChangeEventMarbleString, formChangeEventMarbleValue);
 
       m.bind();
 
@@ -228,16 +199,9 @@ describe("OperatorPropertyEditFrameComponent", () => {
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
     const mockOperatorProperty = { tableName: "table" };
     // set operator property first before displaying the operator property in property panel
-    workflowActionService.setOperatorProperty(
-      mockScanPredicate.operatorID,
-      mockOperatorProperty
-    );
+    workflowActionService.setOperatorProperty(mockScanPredicate.operatorID, mockOperatorProperty);
     component.ngOnChanges({
-      currentOperatorId: new SimpleChange(
-        undefined,
-        mockScanPredicate.operatorID,
-        true
-      )
+      currentOperatorId: new SimpleChange(undefined, mockScanPredicate.operatorID, true),
     });
     fixture.detectChanges();
 
@@ -263,21 +227,12 @@ describe("OperatorPropertyEditFrameComponent", () => {
     // expected form output should fill in all default values instead of an empty object
     workflowActionService.addOperator(mockResultPredicate, mockPoint);
     component.ngOnChanges({
-      currentOperatorId: new SimpleChange(
-        undefined,
-        mockResultPredicate.operatorID,
-        true
-      )
+      currentOperatorId: new SimpleChange(undefined, mockResultPredicate.operatorID, true),
     });
     fixture.detectChanges();
     const ajv = new Ajv({ useDefaults: true });
-    const expectedResultOperatorProperties = cloneDeep(
-      mockResultPredicate.operatorProperties
-    );
-    ajv.validate(
-      mockViewResultsSchema.jsonSchema,
-      expectedResultOperatorProperties
-    );
+    const expectedResultOperatorProperties = cloneDeep(mockResultPredicate.operatorProperties);
+    ajv.validate(mockViewResultsSchema.jsonSchema, expectedResultOperatorProperties);
 
     expect(component.formData).toEqual(expectedResultOperatorProperties);
   });

--- a/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  Input,
-  OnChanges,
-  OnInit,
-  SimpleChanges
-} from "@angular/core";
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from "@angular/core";
 import { ExecuteWorkflowService } from "../../../service/execute-workflow/execute-workflow.service";
 import { Subject } from "rxjs";
 import { filter } from "rxjs/operators";
@@ -20,24 +14,23 @@ import { ExecutionState } from "src/app/workspace/types/execute-workflow.interfa
 import { DynamicSchemaService } from "../../../service/dynamic-schema/dynamic-schema.service";
 import {
   SchemaAttribute,
-  SchemaPropagationService
+  SchemaPropagationService,
 } from "../../../service/dynamic-schema/schema-propagation/schema-propagation.service";
 import {
   createOutputFormChangeEventStream,
   setChildTypeDependency,
-  setHideExpression
+  setHideExpression,
 } from "src/app/common/formly/formly-utils";
 import {
   TYPE_CASTING_OPERATOR_TYPE,
-  TypeCastingDisplayComponent
+  TypeCastingDisplayComponent,
 } from "../typecasting-display/type-casting-display.component";
 import { DynamicComponentConfig } from "../../../../common/type/dynamic-component-config";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 
 export type PropertyDisplayComponent = TypeCastingDisplayComponent;
 
-export type PropertyDisplayComponentConfig =
-  DynamicComponentConfig<PropertyDisplayComponent>;
+export type PropertyDisplayComponentConfig = DynamicComponentConfig<PropertyDisplayComponent>;
 
 /**
  * Property Editor uses JSON Schema to automatically generate the form from the JSON Schema of an operator.
@@ -59,7 +52,7 @@ export type PropertyDisplayComponentConfig =
 @Component({
   selector: "texera-formly-form-frame",
   templateUrl: "./operator-property-edit-frame.component.html",
-  styleUrls: ["./operator-property-edit-frame.component.scss"]
+  styleUrls: ["./operator-property-edit-frame.component.scss"],
 })
 export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges {
   @Input() currentOperatorId: string | undefined = undefined;
@@ -74,9 +67,8 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges {
   sourceFormChangeEventStream = new Subject<Record<string, unknown>>();
 
   // the output form change event stream after debounce time and filtering out values
-  operatorPropertyChangeStream = createOutputFormChangeEventStream(
-    this.sourceFormChangeEventStream,
-    (data) => this.checkOperatorProperty(data)
+  operatorPropertyChangeStream = createOutputFormChangeEventStream(this.sourceFormChangeEventStream, data =>
+    this.checkOperatorProperty(data)
   );
 
   // inputs and two-way bindings to formly component
@@ -113,8 +105,7 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges {
   switchDisplayComponent(targetConfig?: PropertyDisplayComponentConfig) {
     if (
       this.extraDisplayComponentConfig?.component === targetConfig?.component &&
-      this.extraDisplayComponentConfig?.component ===
-        targetConfig?.componentInputs
+      this.extraDisplayComponentConfig?.component === targetConfig?.componentInputs
     ) {
       return;
     }
@@ -152,18 +143,12 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges {
    * @param operatorId
    */
   showOperatorPropertyEditor(operatorId: string): void {
-    const operator = this.workflowActionService
-      .getTexeraGraph()
-      .getOperator(operatorId);
+    const operator = this.workflowActionService.getTexeraGraph().getOperator(operatorId);
     // set the operator data needed
     this.currentOperatorId = operatorId;
-    const currentOperatorSchema = this.dynamicSchemaService.getDynamicSchema(
-      this.currentOperatorId
-    );
+    const currentOperatorSchema = this.dynamicSchemaService.getDynamicSchema(this.currentOperatorId);
     this.setFormlyFormBinding(currentOperatorSchema.jsonSchema);
-    this.formTitle =
-      operator.customDisplayName ??
-      currentOperatorSchema.additionalMetadata.userFriendlyName;
+    this.formTitle = operator.customDisplayName ?? currentOperatorSchema.additionalMetadata.userFriendlyName;
 
     /**
      * Important: make a deep copy of the initial property data object.
@@ -191,17 +176,15 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges {
     ) {
       this.switchDisplayComponent({
         component: TypeCastingDisplayComponent,
-        componentInputs: { currentOperatorId: this.currentOperatorId }
+        componentInputs: { currentOperatorId: this.currentOperatorId },
       });
     } else {
       this.switchDisplayComponent(undefined);
     }
 
     const interactive =
-      this.executeWorkflowService.getExecutionState().state ===
-        ExecutionState.Uninitialized ||
-      this.executeWorkflowService.getExecutionState().state ===
-        ExecutionState.Completed;
+      this.executeWorkflowService.getExecutionState().state === ExecutionState.Uninitialized ||
+      this.executeWorkflowService.getExecutionState().state === ExecutionState.Completed;
     this.setInteractivity(interactive);
   }
 
@@ -222,9 +205,7 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges {
       return false;
     }
     // check if the operator still exists, it might be deleted during debounce time
-    const operator = this.workflowActionService
-      .getTexeraGraph()
-      .getOperator(this.currentOperatorId);
+    const operator = this.workflowActionService.getTexeraGraph().getOperator(this.currentOperatorId);
     if (!operator) {
       return false;
     }
@@ -246,13 +227,10 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges {
     this.dynamicSchemaService
       .getOperatorDynamicSchemaChangedStream()
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
+      .subscribe(event => {
         if (event.operatorID === this.currentOperatorId) {
-          const currentOperatorSchema =
-            this.dynamicSchemaService.getDynamicSchema(this.currentOperatorId);
-          const operator = this.workflowActionService
-            .getTexeraGraph()
-            .getOperator(event.operatorID);
+          const currentOperatorSchema = this.dynamicSchemaService.getDynamicSchema(this.currentOperatorId);
+          const operator = this.workflowActionService.getTexeraGraph().getOperator(event.operatorID);
           if (!operator) {
             throw new Error(`operator ${event.operatorID} does not exist`);
           }
@@ -273,23 +251,12 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges {
       .getTexeraGraph()
       .getOperatorPropertyChangeStream()
       .pipe(
-        filter((_) => this.currentOperatorId !== undefined),
-        filter(
-          (operatorChanged) =>
-            operatorChanged.operator.operatorID === this.currentOperatorId
-        ),
-        filter(
-          (operatorChanged) =>
-            !isEqual(this.formData, operatorChanged.operator.operatorProperties)
-        )
+        filter(_ => this.currentOperatorId !== undefined),
+        filter(operatorChanged => operatorChanged.operator.operatorID === this.currentOperatorId),
+        filter(operatorChanged => !isEqual(this.formData, operatorChanged.operator.operatorProperties))
       )
       .pipe(untilDestroyed(this))
-      .subscribe(
-        (operatorChanged) =>
-          (this.formData = cloneDeep(
-            operatorChanged.operator.operatorProperties
-          ))
-      );
+      .subscribe(operatorChanged => (this.formData = cloneDeep(operatorChanged.operator.operatorProperties)));
   }
 
   /**
@@ -297,29 +264,21 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges {
    *  in the texera graph.
    */
   registerOnFormChangeHandler(): void {
-    this.operatorPropertyChangeStream
-      .pipe(untilDestroyed(this))
-      .subscribe((formData) => {
-        // set the operator property to be the new form data
-        if (this.currentOperatorId) {
-          this.workflowActionService.setOperatorProperty(
-            this.currentOperatorId,
-            cloneDeep(formData)
-          );
-        }
-      });
+    this.operatorPropertyChangeStream.pipe(untilDestroyed(this)).subscribe(formData => {
+      // set the operator property to be the new form data
+      if (this.currentOperatorId) {
+        this.workflowActionService.setOperatorProperty(this.currentOperatorId, cloneDeep(formData));
+      }
+    });
   }
 
   registerDisableEditorInteractivityHandler(): void {
     this.executeWorkflowService
       .getExecutionStateStream()
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
+      .subscribe(event => {
         if (this.currentOperatorId) {
-          if (
-            event.current.state === ExecutionState.Completed ||
-            event.current.state === ExecutionState.Failed
-          ) {
+          if (event.current.state === ExecutionState.Completed || event.current.state === ExecutionState.Failed) {
             this.setInteractivity(true);
           } else {
             this.setInteractivity(false);
@@ -349,14 +308,14 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges {
     this.formlyOptions = {};
     // convert the json schema to formly config, pass a copy because formly mutates the schema object
     const field = this.formlyJsonschema.toFieldConfig(cloneDeep(schema), {
-      map: jsonSchemaMapIntercept
+      map: jsonSchemaMapIntercept,
     });
     field.hooks = {
-      onInit: (fieldConfig) => {
+      onInit: fieldConfig => {
         if (!this.interactive) {
           fieldConfig?.form?.disable();
         }
-      }
+      },
     };
 
     const schemaProperties = schema.properties;
@@ -364,32 +323,22 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges {
 
     // adding custom options, relational N-to-M mapping.
     if (schemaProperties && fields) {
-      Object.entries(schemaProperties).forEach(
-        ([propertyName, propertyValue]) => {
-          if (typeof propertyValue === "boolean") {
-            return;
-          }
-          if (propertyValue.toggleHidden) {
-            setHideExpression(propertyValue.toggleHidden, fields, propertyName);
-          }
+      Object.entries(schemaProperties).forEach(([propertyName, propertyValue]) => {
+        if (typeof propertyValue === "boolean") {
+          return;
+        }
+        if (propertyValue.toggleHidden) {
+          setHideExpression(propertyValue.toggleHidden, fields, propertyName);
+        }
 
-          if (propertyValue.dependOn) {
-            if (isDefined(this.currentOperatorId)) {
-              const attributes:
-                | ReadonlyArray<ReadonlyArray<SchemaAttribute> | null>
-                | undefined = this.schemaPropagationService.getOperatorInputSchema(
-                this.currentOperatorId
-              );
-              setChildTypeDependency(
-                attributes,
-                propertyValue.dependOn,
-                fields,
-                propertyName
-              );
-            }
+        if (propertyValue.dependOn) {
+          if (isDefined(this.currentOperatorId)) {
+            const attributes: ReadonlyArray<ReadonlyArray<SchemaAttribute> | null> | undefined =
+              this.schemaPropagationService.getOperatorInputSchema(this.currentOperatorId);
+            setChildTypeDependency(attributes, propertyValue.dependOn, fields, propertyName);
           }
         }
-      );
+      });
     }
 
     this.formlyFields = fields;
@@ -408,18 +357,14 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges {
 
   confirmChangeOperatorCustomName(customDisplayName: string) {
     if (this.currentOperatorId) {
-      const currentOperatorSchema = this.dynamicSchemaService.getDynamicSchema(
-        this.currentOperatorId
-      );
+      const currentOperatorSchema = this.dynamicSchemaService.getDynamicSchema(this.currentOperatorId);
 
       // fall back to the original userFriendlyName if no valid name is provided
       const newDisplayName =
         customDisplayName === "" || customDisplayName === undefined
           ? currentOperatorSchema.additionalMetadata.userFriendlyName
           : customDisplayName;
-      this.workflowActionService
-        .getTexeraGraph()
-        .changeOperatorDisplayName(this.currentOperatorId, newDisplayName);
+      this.workflowActionService.getTexeraGraph().changeOperatorDisplayName(this.currentOperatorId, newDisplayName);
       this.formTitle = newDisplayName;
     }
 

--- a/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.html
+++ b/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.html
@@ -1,6 +1,4 @@
-<div
-  class="texera-workspace-property-editor-body texera-workflow-component-body"
->
+<div class="texera-workspace-property-editor-body texera-workflow-component-body">
   <ndc-dynamic
     [ndcDynamicComponent]="frameComponentConfig?.component"
     [ndcDynamicInputs]="frameComponentConfig?.componentInputs"

--- a/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.spec.ts
@@ -8,7 +8,7 @@ import {
   mockScanResultLink,
   mockScanSentimentLink,
   mockSentimentPredicate,
-  mockSentimentResultLink
+  mockSentimentResultLink,
 } from "../../service/workflow-graph/model/mock-workflow-data";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 import { OperatorPropertyEditFrameComponent } from "./operator-property-edit-frame/operator-property-edit-frame.component";
@@ -30,9 +30,9 @@ describe("PropertyEditorComponent", () => {
         providers: [
           {
             provide: OperatorMetadataService,
-            useClass: StubOperatorMetadataService
-          }
-        ]
+            useClass: StubOperatorMetadataService,
+          },
+        ],
       }).compileComponents();
     })
   );
@@ -61,11 +61,9 @@ describe("PropertyEditorComponent", () => {
 
     fixture.detectChanges();
 
-    expect(component.frameComponentConfig?.component).toBe(
-      OperatorPropertyEditFrameComponent
-    );
+    expect(component.frameComponentConfig?.component).toBe(OperatorPropertyEditFrameComponent);
     expect(component.frameComponentConfig?.componentInputs).toEqual({
-      currentOperatorId: mockScanPredicate.operatorID
+      currentOperatorId: mockScanPredicate.operatorID,
     });
 
     // unhighlight the operator
@@ -85,22 +83,15 @@ describe("PropertyEditorComponent", () => {
     workflowActionService.addOperatorsAndLinks(
       [
         { op: mockScanPredicate, pos: mockPoint },
-        { op: mockResultPredicate, pos: mockPoint }
+        { op: mockResultPredicate, pos: mockPoint },
       ],
       []
     );
-    jointGraphWrapper.highlightOperators(
-      mockScanPredicate.operatorID,
-      mockResultPredicate.operatorID
-    );
+    jointGraphWrapper.highlightOperators(mockScanPredicate.operatorID, mockResultPredicate.operatorID);
 
     // assert that multiple operators are highlighted
-    expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(
-      mockResultPredicate.operatorID
-    );
-    expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(
-      mockScanPredicate.operatorID
-    );
+    expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(mockResultPredicate.operatorID);
+    expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(mockScanPredicate.operatorID);
     fixture.detectChanges();
 
     // expect that the property editor is cleared
@@ -119,11 +110,9 @@ describe("PropertyEditorComponent", () => {
     fixture.detectChanges();
 
     // check the variables
-    expect(component.frameComponentConfig?.component).toBe(
-      OperatorPropertyEditFrameComponent
-    );
+    expect(component.frameComponentConfig?.component).toBe(OperatorPropertyEditFrameComponent);
     expect(component.frameComponentConfig?.componentInputs).toEqual({
-      currentOperatorId: mockScanPredicate.operatorID
+      currentOperatorId: mockScanPredicate.operatorID,
     });
 
     // unhighlight the operator
@@ -136,11 +125,9 @@ describe("PropertyEditorComponent", () => {
     jointGraphWrapper.highlightOperators(mockResultPredicate.operatorID);
     fixture.detectChanges();
 
-    expect(component.frameComponentConfig?.component).toBe(
-      OperatorPropertyEditFrameComponent
-    );
+    expect(component.frameComponentConfig?.component).toBe(OperatorPropertyEditFrameComponent);
     expect(component.frameComponentConfig?.componentInputs).toEqual({
-      currentOperatorId: mockResultPredicate.operatorID
+      currentOperatorId: mockResultPredicate.operatorID,
     });
   });
 
@@ -155,11 +142,9 @@ describe("PropertyEditorComponent", () => {
     jointGraphWrapper.highlightLink(mockScanResultLink.linkID);
     fixture.detectChanges();
 
-    expect(component.frameComponentConfig?.component).toBe(
-      BreakpointPropertyEditFrameComponent
-    );
+    expect(component.frameComponentConfig?.component).toBe(BreakpointPropertyEditFrameComponent);
     expect(component.frameComponentConfig?.componentInputs).toEqual({
-      currentLinkId: mockScanResultLink.linkID
+      currentLinkId: mockScanResultLink.linkID,
     });
 
     // unhighlight the highlighted link
@@ -182,11 +167,9 @@ describe("PropertyEditorComponent", () => {
     jointGraphWrapper.highlightLink(mockScanSentimentLink.linkID);
 
     fixture.detectChanges();
-    expect(component.frameComponentConfig?.component).toBe(
-      BreakpointPropertyEditFrameComponent
-    );
+    expect(component.frameComponentConfig?.component).toBe(BreakpointPropertyEditFrameComponent);
     expect(component.frameComponentConfig?.componentInputs).toEqual({
-      currentLinkId: mockScanSentimentLink.linkID
+      currentLinkId: mockScanSentimentLink.linkID,
     });
 
     // unhighlight the link
@@ -197,11 +180,9 @@ describe("PropertyEditorComponent", () => {
     // highlight the second link
     jointGraphWrapper.highlightLink(mockSentimentResultLink.linkID);
     fixture.detectChanges();
-    expect(component.frameComponentConfig?.component).toBe(
-      BreakpointPropertyEditFrameComponent
-    );
+    expect(component.frameComponentConfig?.component).toBe(BreakpointPropertyEditFrameComponent);
     expect(component.frameComponentConfig?.componentInputs).toEqual({
-      currentLinkId: mockSentimentResultLink.linkID
+      currentLinkId: mockSentimentResultLink.linkID,
     });
   });
 });

--- a/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.ts
@@ -6,12 +6,9 @@ import { BreakpointPropertyEditFrameComponent } from "./breakpoint-property-edit
 import { DynamicComponentConfig } from "../../../common/type/dynamic-component-config";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 
-export type PropertyEditFrameComponent =
-  | OperatorPropertyEditFrameComponent
-  | BreakpointPropertyEditFrameComponent;
+export type PropertyEditFrameComponent = OperatorPropertyEditFrameComponent | BreakpointPropertyEditFrameComponent;
 
-export type PropertyEditFrameConfig =
-  DynamicComponentConfig<PropertyEditFrameComponent>;
+export type PropertyEditFrameConfig = DynamicComponentConfig<PropertyEditFrameComponent>;
 
 /**
  * PropertyEditorComponent is the panel that allows user to edit operator properties.
@@ -23,7 +20,7 @@ export type PropertyEditFrameConfig =
 @Component({
   selector: "texera-property-editor",
   templateUrl: "./property-editor.component.html",
-  styleUrls: ["./property-editor.component.scss"]
+  styleUrls: ["./property-editor.component.scss"],
 })
 export class PropertyEditorComponent implements OnInit {
   frameComponentConfig?: PropertyEditFrameConfig;
@@ -37,8 +34,7 @@ export class PropertyEditorComponent implements OnInit {
   switchFrameComponent(targetConfig?: PropertyEditFrameConfig) {
     if (
       this.frameComponentConfig?.component === targetConfig?.component &&
-      this.frameComponentConfig?.componentInputs ===
-        targetConfig?.componentInputs
+      this.frameComponentConfig?.componentInputs === targetConfig?.componentInputs
     ) {
       return;
     }
@@ -55,54 +51,30 @@ export class PropertyEditorComponent implements OnInit {
    */
   registerHighlightEventsHandler() {
     merge(
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointOperatorHighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointOperatorUnhighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointGroupHighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointGroupUnhighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getLinkHighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getLinkUnhighlightStream()
+      this.workflowActionService.getJointGraphWrapper().getJointOperatorHighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getJointOperatorUnhighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getJointGroupHighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getJointGroupUnhighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getLinkHighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getLinkUnhighlightStream()
     )
       .pipe(untilDestroyed(this))
       .subscribe(() => {
         const highlightedOperators = this.workflowActionService
           .getJointGraphWrapper()
           .getCurrentHighlightedOperatorIDs();
-        const highlightedGroups = this.workflowActionService
-          .getJointGraphWrapper()
-          .getCurrentHighlightedGroupIDs();
-        const highlightLinks = this.workflowActionService
-          .getJointGraphWrapper()
-          .getCurrentHighlightedLinkIDs();
+        const highlightedGroups = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedGroupIDs();
+        const highlightLinks = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedLinkIDs();
 
-        if (
-          highlightedOperators.length === 1 &&
-          highlightedGroups.length === 0 &&
-          highlightLinks.length === 0
-        ) {
+        if (highlightedOperators.length === 1 && highlightedGroups.length === 0 && highlightLinks.length === 0) {
           this.switchFrameComponent({
             component: OperatorPropertyEditFrameComponent,
-            componentInputs: { currentOperatorId: highlightedOperators[0] }
+            componentInputs: { currentOperatorId: highlightedOperators[0] },
           });
-        } else if (
-          highlightLinks.length === 1 &&
-          highlightedGroups.length === 0 &&
-          highlightedOperators.length === 0
-        ) {
+        } else if (highlightLinks.length === 1 && highlightedGroups.length === 0 && highlightedOperators.length === 0) {
           this.switchFrameComponent({
             component: BreakpointPropertyEditFrameComponent,
-            componentInputs: { currentLinkId: highlightLinks[0] }
+            componentInputs: { currentLinkId: highlightLinks[0] },
           });
         } else {
           this.switchFrameComponent(undefined);

--- a/core/new-gui/src/app/workspace/component/property-editor/typecasting-display/type-casting-display.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/typecasting-display/type-casting-display.component.spec.ts
@@ -1,8 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from "@angular/common/http/testing";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
 import { SchemaPropagationService } from "../../../service/dynamic-schema/schema-propagation/schema-propagation.service";
 
 import { TypeCastingDisplayComponent } from "./type-casting-display.component";
@@ -25,15 +22,15 @@ describe("TypecastingDisplayComponent", () => {
         providers: [
           {
             provide: OperatorMetadataService,
-            useClass: StubOperatorMetadataService
+            useClass: StubOperatorMetadataService,
           },
           JointUIService,
           UndoRedoService,
           WorkflowUtilService,
           WorkflowActionService,
-          SchemaPropagationService
+          SchemaPropagationService,
         ],
-        declarations: [TypeCastingDisplayComponent]
+        declarations: [TypeCastingDisplayComponent],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/workspace/component/property-editor/typecasting-display/type-casting-display.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/typecasting-display/type-casting-display.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnChanges, OnInit } from "@angular/core";
 import { WorkflowActionService } from "src/app/workspace/service/workflow-graph/model/workflow-action.service";
 import {
   SchemaAttribute,
-  SchemaPropagationService
+  SchemaPropagationService,
 } from "src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service";
 import { OperatorPredicate } from "src/app/workspace/types/workflow-common.interface";
 import { filter, map } from "rxjs/operators";
@@ -15,7 +15,7 @@ export const TYPE_CASTING_OPERATOR_TYPE = "TypeCasting";
 @Component({
   selector: "texera-type-casting-display",
   templateUrl: "./type-casting-display.component.html",
-  styleUrls: ["./type-casting-display.component.scss"]
+  styleUrls: ["./type-casting-display.component.scss"],
 })
 export class TypeCastingDisplayComponent implements OnInit, OnChanges {
   @Input() currentOperatorId: string | undefined;
@@ -39,9 +39,7 @@ export class TypeCastingDisplayComponent implements OnInit, OnChanges {
       this.displayTypeCastingSchemaInformation = false;
       return;
     }
-    const op = this.workflowActionService
-      .getTexeraGraph()
-      .getOperator(this.currentOperatorId);
+    const op = this.workflowActionService.getTexeraGraph().getOperator(this.currentOperatorId);
     if (op.operatorType !== TYPE_CASTING_OPERATOR_TYPE) {
       this.displayTypeCastingSchemaInformation = false;
       return;
@@ -55,12 +53,12 @@ export class TypeCastingDisplayComponent implements OnInit, OnChanges {
       .getTexeraGraph()
       .getOperatorPropertyChangeStream()
       .pipe(
-        filter((op) => op.operator.operatorID === this.currentOperatorId),
-        filter((op) => op.operator.operatorType === TYPE_CASTING_OPERATOR_TYPE),
-        map((event) => event.operator)
+        filter(op => op.operator.operatorID === this.currentOperatorId),
+        filter(op => op.operator.operatorType === TYPE_CASTING_OPERATOR_TYPE),
+        map(event => event.operator)
       )
       .pipe(untilDestroyed(this))
-      .subscribe((op) => {
+      .subscribe(op => {
         this.updateComponent(op);
       });
   }
@@ -70,24 +68,21 @@ export class TypeCastingDisplayComponent implements OnInit, OnChanges {
       return;
     }
     this.schemaToDisplay = [];
-    const inputSchema = this.schemaPropagationService.getOperatorInputSchema(
-      this.currentOperatorId
-    );
+    const inputSchema = this.schemaPropagationService.getOperatorInputSchema(this.currentOperatorId);
 
     const castTypeMap = op.operatorProperties["typeCastingUnits"].reduce(
-      (
-        map_: { [x: string]: any },
-        castTo: { attribute: string; resultType: string }
-      ) => ((map_[castTo.attribute] = castTo.resultType), map_),
+      (map_: { [x: string]: any }, castTo: { attribute: string; resultType: string }) => (
+        (map_[castTo.attribute] = castTo.resultType), map_
+      ),
       {}
     );
 
-    inputSchema?.forEach((schema) =>
-      schema?.forEach((attr) => {
+    inputSchema?.forEach(schema =>
+      schema?.forEach(attr => {
         if (attr.attributeName in castTypeMap) {
           const castedAttr: Partial<SchemaAttribute> = {
             attributeName: attr.attributeName,
-            attributeType: castTypeMap[attr.attributeName]
+            attributeType: castTypeMap[attr.attributeName],
           };
           this.schemaToDisplay.push(castedAttr);
         } else {

--- a/core/new-gui/src/app/workspace/component/result-panel-toggle/result-panel-toggle.component.html
+++ b/core/new-gui/src/app/workspace/component/result-panel-toggle/result-panel-toggle.component.html
@@ -1,8 +1,3 @@
 <div class="texera-result-panel-toggle" (click)="onClickResultBar()">
-  <i
-    class="toggle-icon"
-    nz-icon
-    nzTheme="outline"
-    nzType="{{ showResultPanel ? 'down' : 'up' }}"
-  ></i>
+  <i class="toggle-icon" nz-icon nzTheme="outline" nzType="{{ showResultPanel ? 'down' : 'up' }}"></i>
 </div>

--- a/core/new-gui/src/app/workspace/component/result-panel-toggle/result-panel-toggle.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel-toggle/result-panel-toggle.component.spec.ts
@@ -10,7 +10,7 @@ describe("ResultPanelToggleComponent", () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         declarations: [ResultPanelToggleComponent],
-        providers: [ResultPanelToggleService]
+        providers: [ResultPanelToggleService],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/workspace/component/result-panel-toggle/result-panel-toggle.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel-toggle/result-panel-toggle.component.ts
@@ -13,7 +13,7 @@ import { ResultPanelToggleService } from "../../service/result-panel-toggle/resu
 @Component({
   selector: "texera-result-panel-toggle",
   templateUrl: "./result-panel-toggle.component.html",
-  styleUrls: ["./result-panel-toggle.component.scss"]
+  styleUrls: ["./result-panel-toggle.component.scss"],
 })
 export class ResultPanelToggleComponent {
   public showResultPanel: boolean = false;
@@ -22,7 +22,7 @@ export class ResultPanelToggleComponent {
     this.resultPanelToggleService
       .getToggleChangeStream()
       .pipe(untilDestroyed(this))
-      .subscribe((newPanelStatus) => (this.showResultPanel = newPanelStatus));
+      .subscribe(newPanelStatus => (this.showResultPanel = newPanelStatus));
   }
 
   /**

--- a/core/new-gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.spec.ts
@@ -17,9 +17,9 @@ describe("ConsoleFrameComponent", () => {
         providers: [
           {
             provide: OperatorMetadataService,
-            useClass: StubOperatorMetadataService
-          }
-        ]
+            useClass: StubOperatorMetadataService,
+          },
+        ],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  Input,
-  OnChanges,
-  OnInit,
-  SimpleChanges
-} from "@angular/core";
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from "@angular/core";
 import { ExecuteWorkflowService } from "../../../service/execute-workflow/execute-workflow.service";
 import { BreakpointTriggerInfo } from "../../../types/workflow-common.interface";
 import { ExecutionState } from "src/app/workspace/types/execute-workflow.interface";
@@ -15,7 +9,7 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 @Component({
   selector: "texera-console-frame",
   templateUrl: "./console-frame.component.html",
-  styleUrls: ["./console-frame.component.scss"]
+  styleUrls: ["./console-frame.component.scss"],
 })
 export class ConsoleFrameComponent implements OnInit, OnChanges {
   @Input() operatorId?: string;
@@ -47,7 +41,7 @@ export class ConsoleFrameComponent implements OnInit, OnChanges {
     this.executeWorkflowService
       .getExecutionStateStream()
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
+      .subscribe(event => {
         if (
           event.previous.state === ExecutionState.BreakpointTriggered &&
           event.current.state === ExecutionState.Completed
@@ -69,7 +63,7 @@ export class ConsoleFrameComponent implements OnInit, OnChanges {
     this.workflowConsoleService
       .getConsoleMessageUpdateStream()
       .pipe(untilDestroyed(this))
-      .subscribe((_) => this.renderConsole());
+      .subscribe(_ => this.renderConsole());
   }
 
   onClickSkipTuples(): void {
@@ -85,8 +79,7 @@ export class ConsoleFrameComponent implements OnInit, OnChanges {
 
   renderConsole() {
     // try to fetch if we have breakpoint info
-    const breakpointTriggerInfo =
-      this.executeWorkflowService.getBreakpointTriggerInfo();
+    const breakpointTriggerInfo = this.executeWorkflowService.getBreakpointTriggerInfo();
 
     if (this.operatorId) {
       // first display error messages if applicable
@@ -109,7 +102,7 @@ export class ConsoleFrameComponent implements OnInit, OnChanges {
     // const result = breakpointTriggerInfo.report.map(r => r.faultedTuple.tuple).filter(t => t !== undefined);
     // this.setupResultTable(result, result.length);
     const errorsMessages: Record<string, string> = {};
-    breakpointTriggerInfo.report.forEach((r) => {
+    breakpointTriggerInfo.report.forEach(r => {
       const splitPath = r.actorPath.split("/");
       const workerName = splitPath[splitPath.length - 1];
       const workerText = "Worker " + workerName + ":                ";
@@ -125,8 +118,6 @@ export class ConsoleFrameComponent implements OnInit, OnChanges {
   }
 
   displayConsoleMessages(operatorId: string) {
-    this.consoleMessages = operatorId
-      ? this.workflowConsoleService.getConsoleMessages(operatorId) || []
-      : [];
+    this.consoleMessages = operatorId ? this.workflowConsoleService.getConsoleMessages(operatorId) || [] : [];
   }
 }

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel-modal.component.html
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel-modal.component.html
@@ -1,6 +1,3 @@
 <div class="modal-body content-body">
-  <ngx-json-viewer
-    [expanded]="false"
-    [json]="currentDisplayRowData"
-  ></ngx-json-viewer>
+  <ngx-json-viewer [expanded]="false" [json]="currentDisplayRowData"></ngx-json-viewer>
 </div>

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel-modal.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel-modal.component.ts
@@ -17,7 +17,7 @@ import { NzModalRef } from "ng-zorro-antd/modal";
 @Component({
   selector: "texera-row-modal-content",
   templateUrl: "./result-panel-modal.component.html",
-  styleUrls: ["./result-panel.component.scss"]
+  styleUrls: ["./result-panel.component.scss"],
 })
 export class RowModalComponent {
   // when modal is opened, currentDisplayRow will be passed as

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.html
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.html
@@ -1,7 +1,4 @@
-<div
-  [hidden]="!showResultPanel"
-  class="texera-workspace-result-panel-body texera-workflow-component-body"
->
+<div [hidden]="!showResultPanel" class="texera-workspace-result-panel-body texera-workflow-component-body">
   <ndc-dynamic
     [ndcDynamicComponent]="frameComponentConfig?.component"
     [ndcDynamicInputs]="frameComponentConfig?.componentInputs"

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.scss
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.scss
@@ -22,5 +22,5 @@ $type-colors: (
   object: #999,
   function: #999,
   "null": #fff,
-  undefined: #fff
+  undefined: #fff,
 );

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.spec.ts
@@ -32,9 +32,9 @@ describe("ResultPanelComponent", () => {
         ResultPanelToggleService,
         {
           provide: OperatorMetadataService,
-          useClass: StubOperatorMetadataService
-        }
-      ]
+          useClass: StubOperatorMetadataService,
+        },
+      ],
     }).compileComponents();
   }));
 
@@ -184,20 +184,16 @@ describe("ResultPanelComponent", () => {
     (executeWorkflowService as any).updateExecutionState({
       state: ExecutionState.Completed,
       resultID: "resultID",
-      resultMap: new Map([])
+      resultMap: new Map([]),
     });
     fixture.detectChanges();
-    const resultPanelDiv = fixture.debugElement.query(
-      By.css(".texera-workspace-result-panel-body")
-    );
+    const resultPanelDiv = fixture.debugElement.query(By.css(".texera-workspace-result-panel-body"));
     const resultPanelHtmlElement: HTMLElement = resultPanelDiv.nativeElement;
     expect(resultPanelHtmlElement.hasAttribute("hidden")).toBeFalsy();
   });
 
   it("should show the result panel if the current status of the result panel is hidden and when the toggle is triggered", () => {
-    const resultPanelDiv = fixture.debugElement.query(
-      By.css(".texera-workspace-result-panel-body")
-    );
+    const resultPanelDiv = fixture.debugElement.query(By.css(".texera-workspace-result-panel-body"));
     const resultPanelHtmlElement: HTMLElement = resultPanelDiv.nativeElement;
 
     expect(resultPanelHtmlElement.hasAttribute("hidden")).toBeTruthy();
@@ -210,15 +206,13 @@ describe("ResultPanelComponent", () => {
 
   it(`should hide the result panel if the current status of the result panel is already
       shown when the toggle is triggered`, () => {
-    const resultPanelDiv = fixture.debugElement.query(
-      By.css(".texera-workspace-result-panel-body")
-    );
+    const resultPanelDiv = fixture.debugElement.query(By.css(".texera-workspace-result-panel-body"));
     const resultPanelHtmlElement: HTMLElement = resultPanelDiv.nativeElement;
 
     (executeWorkflowService as any).updateExecutionState({
       state: ExecutionState.Completed,
       resultID: "resultID",
-      resultMap: new Map([])
+      resultMap: new Map([]),
     });
     fixture.detectChanges();
     expect(resultPanelHtmlElement.hasAttribute("hidden")).toBeFalsy();

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -3,10 +3,7 @@ import { merge } from "rxjs";
 import { ExecuteWorkflowService } from "../../service/execute-workflow/execute-workflow.service";
 import { ResultPanelToggleService } from "../../service/result-panel-toggle/result-panel-toggle.service";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
-import {
-  ExecutionState,
-  ExecutionStateInfo
-} from "../../types/execute-workflow.interface";
+import { ExecutionState, ExecutionStateInfo } from "../../types/execute-workflow.interface";
 import { ResultTableFrameComponent } from "./result-table-frame/result-table-frame.component";
 import { ConsoleFrameComponent } from "./console-frame/console-frame.component";
 import { WorkflowResultService } from "../../service/workflow-result/workflow-result.service";
@@ -15,13 +12,9 @@ import { filter } from "rxjs/operators";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { DynamicComponentConfig } from "../../../common/type/dynamic-component-config";
 
-export type ResultFrameComponent =
-  | ResultTableFrameComponent
-  | VisualizationFrameComponent
-  | ConsoleFrameComponent;
+export type ResultFrameComponent = ResultTableFrameComponent | VisualizationFrameComponent | ConsoleFrameComponent;
 
-export type ResultFrameComponentConfig =
-  DynamicComponentConfig<ResultFrameComponent>;
+export type ResultFrameComponentConfig = DynamicComponentConfig<ResultFrameComponent>;
 
 /**
  * ResultPanelComponent is the bottom level area that displays the
@@ -31,7 +24,7 @@ export type ResultFrameComponentConfig =
 @Component({
   selector: "texera-result-panel",
   templateUrl: "./result-panel.component.html",
-  styleUrls: ["./result-panel.component.scss"]
+  styleUrls: ["./result-panel.component.scss"],
 })
 export class ResultPanelComponent implements OnInit {
   frameComponentConfig?: ResultFrameComponentConfig;
@@ -57,41 +50,29 @@ export class ResultPanelComponent implements OnInit {
     this.executeWorkflowService
       .getExecutionStateStream()
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
+      .subscribe(event => {
         const currentlyHighlighted = this.workflowActionService
           .getJointGraphWrapper()
           .getCurrentHighlightedOperatorIDs();
         if (event.current.state === ExecutionState.BreakpointTriggered) {
-          const breakpointOperator =
-            this.executeWorkflowService.getBreakpointTriggerInfo()?.operatorID;
+          const breakpointOperator = this.executeWorkflowService.getBreakpointTriggerInfo()?.operatorID;
           if (breakpointOperator) {
-            this.workflowActionService
-              .getJointGraphWrapper()
-              .unhighlightOperators(...currentlyHighlighted);
-            this.workflowActionService
-              .getJointGraphWrapper()
-              .highlightOperators(breakpointOperator);
+            this.workflowActionService.getJointGraphWrapper().unhighlightOperators(...currentlyHighlighted);
+            this.workflowActionService.getJointGraphWrapper().highlightOperators(breakpointOperator);
           }
           this.resultPanelToggleService.openResultPanel();
         }
         if (event.current.state === ExecutionState.Failed) {
           this.resultPanelToggleService.openResultPanel();
         }
-        if (
-          event.current.state === ExecutionState.Completed ||
-          event.current.state === ExecutionState.Running
-        ) {
+        if (event.current.state === ExecutionState.Completed || event.current.state === ExecutionState.Running) {
           const sinkOperators = this.workflowActionService
             .getTexeraGraph()
             .getAllOperators()
-            .filter((op) => op.operatorType.toLowerCase().includes("sink"));
+            .filter(op => op.operatorType.toLowerCase().includes("sink"));
           if (sinkOperators.length > 0 && !this.currentOperatorId) {
-            this.workflowActionService
-              .getJointGraphWrapper()
-              .unhighlightOperators(...currentlyHighlighted);
-            this.workflowActionService
-              .getJointGraphWrapper()
-              .highlightOperators(sinkOperators[0].operatorID);
+            this.workflowActionService.getJointGraphWrapper().unhighlightOperators(...currentlyHighlighted);
+            this.workflowActionService.getJointGraphWrapper().highlightOperators(sinkOperators[0].operatorID);
           }
           this.resultPanelToggleService.openResultPanel();
         }
@@ -102,33 +83,22 @@ export class ResultPanelComponent implements OnInit {
     merge(
       this.executeWorkflowService
         .getExecutionStateStream()
-        .pipe(
-          filter((event) =>
-            ResultPanelComponent.needRerenderOnStateChange(event)
-          )
-        ),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointOperatorHighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointOperatorUnhighlightStream(),
+        .pipe(filter(event => ResultPanelComponent.needRerenderOnStateChange(event))),
+      this.workflowActionService.getJointGraphWrapper().getJointOperatorHighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getJointOperatorUnhighlightStream(),
       this.resultPanelToggleService.getToggleChangeStream(),
       this.workflowResultService.getResultInitiateStream()
     )
       .pipe(untilDestroyed(this))
-      .subscribe((_) => {
+      .subscribe(_ => {
         this.rerenderResultPanel();
       });
   }
 
   rerenderResultPanel(): void {
     // update highlighted operator
-    const highlightedOperators = this.workflowActionService
-      .getJointGraphWrapper()
-      .getCurrentHighlightedOperatorIDs();
-    const currentHighlightedOperator =
-      highlightedOperators.length === 1 ? highlightedOperators[0] : undefined;
+    const highlightedOperators = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs();
+    const currentHighlightedOperator = highlightedOperators.length === 1 ? highlightedOperators[0] : undefined;
     if (this.currentOperatorId !== currentHighlightedOperator) {
       // clear everything, prepare for state change
 
@@ -142,37 +112,29 @@ export class ResultPanelComponent implements OnInit {
     }
 
     const executionState = this.executeWorkflowService.getExecutionState();
-    if (
-      executionState.state in
-      [ExecutionState.Failed, ExecutionState.BreakpointTriggered]
-    ) {
+    if (executionState.state in [ExecutionState.Failed, ExecutionState.BreakpointTriggered]) {
       this.switchFrameComponent({
         component: ConsoleFrameComponent,
-        componentInputs: { operatorId: this.currentOperatorId }
+        componentInputs: { operatorId: this.currentOperatorId },
       });
     } else {
       if (this.currentOperatorId) {
-        const resultService = this.workflowResultService.getResultService(
-          this.currentOperatorId
-        );
-        const paginatedResultService =
-          this.workflowResultService.getPaginatedResultService(
-            this.currentOperatorId
-          );
+        const resultService = this.workflowResultService.getResultService(this.currentOperatorId);
+        const paginatedResultService = this.workflowResultService.getPaginatedResultService(this.currentOperatorId);
         if (paginatedResultService) {
           this.switchFrameComponent({
             component: ResultTableFrameComponent,
-            componentInputs: { operatorId: this.currentOperatorId }
+            componentInputs: { operatorId: this.currentOperatorId },
           });
         } else if (resultService && resultService.getChartType()) {
           this.switchFrameComponent({
             component: VisualizationFrameComponent,
-            componentInputs: { operatorId: this.currentOperatorId }
+            componentInputs: { operatorId: this.currentOperatorId },
           });
         } else {
           this.switchFrameComponent({
             component: ConsoleFrameComponent,
-            componentInputs: { operatorId: this.currentOperatorId }
+            componentInputs: { operatorId: this.currentOperatorId },
           });
         }
       }
@@ -185,10 +147,8 @@ export class ResultPanelComponent implements OnInit {
 
   switchFrameComponent(targetComponentConfig?: ResultFrameComponentConfig) {
     if (
-      this.frameComponentConfig?.component ===
-        targetComponentConfig?.component &&
-      this.frameComponentConfig?.componentInputs ===
-        targetComponentConfig?.componentInputs
+      this.frameComponentConfig?.component === targetComponentConfig?.component &&
+      this.frameComponentConfig?.componentInputs === targetComponentConfig?.componentInputs
     ) {
       return;
     }
@@ -209,10 +169,7 @@ export class ResultPanelComponent implements OnInit {
     }
 
     // transition from uninitialized / completed to anything else indicates a new execution of the workflow
-    if (
-      event.previous.state === ExecutionState.Uninitialized ||
-      event.previous.state === ExecutionState.Completed
-    ) {
+    if (event.previous.state === ExecutionState.Uninitialized || event.previous.state === ExecutionState.Completed) {
       return true;
     }
     return false;

--- a/core/new-gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
@@ -21,12 +21,7 @@
     </thead>
     <tbody>
       <tr *ngFor="let row of basicTable.data; let i = index">
-        <td
-          (click)="open(row)"
-          *ngFor="let column of currentColumns"
-          class="table-row"
-          nzEllipsis
-        >
+        <td (click)="open(row)" *ngFor="let column of currentColumns" class="table-row" nzEllipsis>
           {{ column.getCell(row) }}
         </td>
       </tr>

--- a/core/new-gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.spec.ts
@@ -18,9 +18,9 @@ describe("ResultTableFrameComponent", () => {
         providers: [
           {
             provide: OperatorMetadataService,
-            useClass: StubOperatorMetadataService
-          }
-        ]
+            useClass: StubOperatorMetadataService,
+          },
+        ],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  Input,
-  OnChanges,
-  OnInit,
-  SimpleChanges
-} from "@angular/core";
+import { Component, Input, OnChanges, OnInit, SimpleChanges } from "@angular/core";
 import { isEqual } from "lodash-es";
 import { NzModalRef, NzModalService } from "ng-zorro-antd/modal";
 import { NzTableQueryParams } from "ng-zorro-antd/table";
@@ -13,15 +7,9 @@ import { trimDisplayJsonData } from "../../../../common/util/json";
 import { ExecuteWorkflowService } from "../../../service/execute-workflow/execute-workflow.service";
 import { ResultPanelToggleService } from "../../../service/result-panel-toggle/result-panel-toggle.service";
 import { WorkflowActionService } from "../../../service/workflow-graph/model/workflow-action.service";
-import {
-  DEFAULT_PAGE_SIZE,
-  WorkflowResultService
-} from "../../../service/workflow-result/workflow-result.service";
+import { DEFAULT_PAGE_SIZE, WorkflowResultService } from "../../../service/workflow-result/workflow-result.service";
 import { isWebPaginationUpdate } from "../../../types/execute-workflow.interface";
-import {
-  IndexableObject,
-  TableColumn
-} from "../../../types/result-table.interface";
+import { IndexableObject, TableColumn } from "../../../types/result-table.interface";
 import { RowModalComponent } from "../result-panel-modal.component";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 
@@ -37,7 +25,7 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 @Component({
   selector: "texera-result-table-frame",
   templateUrl: "./result-table-frame.component.html",
-  styleUrls: ["./result-table-frame.component.scss"]
+  styleUrls: ["./result-table-frame.component.scss"],
 })
 export class ResultTableFrameComponent implements OnInit, OnChanges {
   @Input() operatorId?: string;
@@ -74,8 +62,7 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
   ngOnChanges(changes: SimpleChanges): void {
     this.operatorId = changes.operatorId?.currentValue;
     if (this.operatorId) {
-      const paginatedResultService =
-        this.workflowResultService.getPaginatedResultService(this.operatorId);
+      const paginatedResultService = this.workflowResultService.getPaginatedResultService(this.operatorId);
       if (paginatedResultService) {
         this.isFrontPagination = false;
         this.totalNumTuples = paginatedResultService.getCurrentTotalNumTuples();
@@ -89,7 +76,7 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
     this.workflowResultService
       .getResultUpdateStream()
       .pipe(untilDestroyed(this))
-      .subscribe((update) => {
+      .subscribe(update => {
         if (!this.operatorId) {
           return;
         }
@@ -139,15 +126,10 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
    * @param rowData the object containing the data of the current row in columnDef and cellData pairs
    */
   open(rowData: Record<string, unknown>): void {
-    let selectedRowIndex = this.currentResult.findIndex((eachRow) =>
-      isEqual(eachRow, rowData)
-    );
+    let selectedRowIndex = this.currentResult.findIndex(eachRow => isEqual(eachRow, rowData));
 
     // generate a new row data that shortens the column text to limit rendering time for pretty json
-    const rowDataCopy = trimDisplayJsonData(
-      rowData as IndexableObject,
-      this.PRETTY_JSON_TEXT_LIMIT
-    );
+    const rowDataCopy = trimDisplayJsonData(rowData as IndexableObject, this.PRETTY_JSON_TEXT_LIMIT);
 
     // open the modal component
     const modalRef: NzModalRef = this.modalService.create({
@@ -159,7 +141,7 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
         // set the currentDisplayRowData of the modal to be the data of clicked row
         currentDisplayRowData: rowDataCopy,
         // set the index value and page size to the modal for navigation
-        currentDisplayRowIndex: selectedRowIndex
+        currentDisplayRowIndex: selectedRowIndex,
       },
       // prevent browser focusing close button (ugly square highlight)
       nzAutofocus: null,
@@ -170,29 +152,27 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
           onClick: () => {
             selectedRowIndex -= 1;
             assertType<RowModalComponent>(modalRef.componentInstance);
-            modalRef.componentInstance.currentDisplayRowData =
-              this.currentResult[selectedRowIndex];
+            modalRef.componentInstance.currentDisplayRowData = this.currentResult[selectedRowIndex];
           },
-          disabled: () => selectedRowIndex === 0
+          disabled: () => selectedRowIndex === 0,
         },
         {
           label: ">",
           onClick: () => {
             selectedRowIndex += 1;
             assertType<RowModalComponent>(modalRef.componentInstance);
-            modalRef.componentInstance.currentDisplayRowData =
-              this.currentResult[selectedRowIndex];
+            modalRef.componentInstance.currentDisplayRowData = this.currentResult[selectedRowIndex];
           },
-          disabled: () => selectedRowIndex === this.currentResult.length - 1
+          disabled: () => selectedRowIndex === this.currentResult.length - 1,
         },
         {
           label: "OK",
           onClick: () => {
             modalRef.destroy();
           },
-          type: "primary"
-        }
-      ]
+          type: "primary",
+        },
+      ],
     });
   }
 
@@ -204,8 +184,7 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
     if (!this.operatorId) {
       return;
     }
-    const paginatedResultService =
-      this.workflowResultService.getPaginatedResultService(this.operatorId);
+    const paginatedResultService = this.workflowResultService.getPaginatedResultService(this.operatorId);
     if (!paginatedResultService) {
       return;
     }
@@ -213,12 +192,9 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
     paginatedResultService
       .selectPage(this.currentPageIndex, DEFAULT_PAGE_SIZE)
       .pipe(untilDestroyed(this))
-      .subscribe((pageData) => {
+      .subscribe(pageData => {
         if (this.currentPageIndex === pageData.pageIndex) {
-          this.setupResultTable(
-            pageData.table,
-            paginatedResultService.getCurrentTotalNumTuples()
-          );
+          this.setupResultTable(pageData.table, paginatedResultService.getCurrentTotalNumTuples());
         }
       });
   }
@@ -230,10 +206,7 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
    * @param resultData rows of the result (may not be all rows if displaying result for workflow completed event)
    * @param totalRowCount
    */
-  setupResultTable(
-    resultData: ReadonlyArray<Record<string, unknown>>,
-    totalRowCount: number
-  ) {
+  setupResultTable(resultData: ReadonlyArray<Record<string, unknown>>, totalRowCount: number) {
     if (!this.operatorId) {
       return;
     }
@@ -253,8 +226,8 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
 
     let columns: { columnKey: any; columnText: string }[];
 
-    const columnKeys = Object.keys(resultData[0]).filter((x) => x !== "_id");
-    columns = columnKeys.map((v) => ({ columnKey: v, columnText: v }));
+    const columnKeys = Object.keys(resultData[0]).filter(x => x !== "_id");
+    columns = columnKeys.map(v => ({ columnKey: v, columnText: v }));
 
     // generate columnDef from first row, column definition is in order
     this.currentColumns = this.generateColumns(columns);
@@ -266,10 +239,8 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
    *
    * @param columns
    */
-  generateColumns(
-    columns: { columnKey: any; columnText: string }[]
-  ): TableColumn[] {
-    return columns.map((col) => ({
+  generateColumns(columns: { columnKey: any; columnText: string }[]): TableColumn[] {
+    return columns.map(col => ({
       columnDef: col.columnKey,
       header: col.columnText,
       getCell: (row: IndexableObject) => {
@@ -279,7 +250,7 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
           // allowing null value from backend
           return "";
         }
-      }
+      },
     }));
   }
 

--- a/core/new-gui/src/app/workspace/component/result-panel/visualization-frame/visualization-frame.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/visualization-frame/visualization-frame.component.spec.ts
@@ -10,10 +10,7 @@ import { UndoRedoService } from "../../../service/undo-redo/undo-redo.service";
 import { WorkflowActionService } from "../../../service/workflow-graph/model/workflow-action.service";
 import { WorkflowUtilService } from "../../../service/workflow-graph/util/workflow-util.service";
 import { VisualizationFrameComponent } from "./visualization-frame.component";
-import {
-  OperatorResultService,
-  WorkflowResultService
-} from "../../../service/workflow-result/workflow-result.service";
+import { OperatorResultService, WorkflowResultService } from "../../../service/workflow-result/workflow-result.service";
 import { WebDataUpdate } from "../../../types/execute-workflow.interface";
 import { ChartType } from "../../../types/visualization.interface";
 
@@ -25,7 +22,7 @@ describe("VisualizationFameComponent", () => {
   const testData: WebDataUpdate = {
     mode: { type: "SetSnapshotMode" },
     chartType: ChartType.BAR,
-    table: []
+    table: [],
   };
 
   beforeEach(
@@ -40,11 +37,11 @@ describe("VisualizationFameComponent", () => {
           WorkflowActionService,
           {
             provide: OperatorMetadataService,
-            useClass: StubOperatorMetadataService
+            useClass: StubOperatorMetadataService,
           },
           WorkflowResultService,
-          ExecuteWorkflowService
-        ]
+          ExecuteWorkflowService,
+        ],
       }).compileComponents();
     })
   );
@@ -55,13 +52,10 @@ describe("VisualizationFameComponent", () => {
     fixture.detectChanges();
 
     workflowResultService = TestBed.get(WorkflowResultService);
-    const operatorResultService: OperatorResultService =
-      new OperatorResultService(operatorID);
+    const operatorResultService: OperatorResultService = new OperatorResultService(operatorID);
     operatorResultService.handleResultUpdate(testData);
 
-    spyOn(workflowResultService, "getResultService").and.returnValue(
-      operatorResultService
-    );
+    spyOn(workflowResultService, "getResultService").and.returnValue(operatorResultService);
   });
 
   it("should create", () => {

--- a/core/new-gui/src/app/workspace/component/result-panel/visualization-frame/visualization-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/visualization-frame/visualization-frame.component.ts
@@ -11,7 +11,7 @@ import { VisualizationFrameContentComponent } from "../../visualization-panel-co
 @Component({
   selector: "texera-visualization-frame",
   templateUrl: "./visualization-frame.component.html",
-  styleUrls: ["./visualization-frame.component.scss"]
+  styleUrls: ["./visualization-frame.component.scss"],
 })
 export class VisualizationFrameComponent {
   @Input() operatorId?: string;
@@ -31,8 +31,8 @@ export class VisualizationFrameComponent {
       nzFooter: null, // null indicates that the footer of the window would be hidden
       nzContent: VisualizationFrameContentComponent,
       nzComponentParams: {
-        operatorId: this.operatorId
-      }
+        operatorId: this.operatorId,
+      },
     });
   }
 }

--- a/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-frame-content.component.html
+++ b/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-frame-content.component.html
@@ -8,11 +8,7 @@
       [ngModel]="wordCloudControls.scale"
       [nzDropdownMatchSelectWidth]="false"
     >
-      <nz-option
-        *ngFor="let option of wordCloudScaleOptions"
-        [nzLabel]="option"
-        [nzValue]="option"
-      ></nz-option>
+      <nz-option *ngFor="let option of wordCloudScaleOptions" [nzLabel]="option" [nzValue]="option"></nz-option>
     </nz-select>
   </nz-space>
 </div>
@@ -21,8 +17,4 @@
 <div id="texera-result-chart-content"></div>
 <!-- this id should be identical to VisualizationFrameContentComponent.MAP_CONTAINER -->
 <div [hidden]="displayMap" id="texera-result-map-container"></div>
-<iframe
-  *ngIf="displayHTML"
-  [srcdoc]="htmlData"
-  id="texera-result-html-content-container"
-></iframe>
+<iframe *ngIf="displayHTML" [srcdoc]="htmlData" id="texera-result-html-content-container"></iframe>

--- a/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-frame-content.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-frame-content.component.spec.ts
@@ -12,10 +12,7 @@ import { WorkflowStatusService } from "../../service/workflow-status/workflow-st
 import { WebDataUpdate } from "../../types/execute-workflow.interface";
 import { ChartType } from "../../types/visualization.interface";
 import { VisualizationFrameContentComponent } from "./visualization-frame-content.component";
-import {
-  OperatorResultService,
-  WorkflowResultService
-} from "../../service/workflow-result/workflow-result.service";
+import { OperatorResultService, WorkflowResultService } from "../../service/workflow-result/workflow-result.service";
 
 describe("VisualizationFrameContentComponent", () => {
   let component: VisualizationFrameContentComponent;
@@ -36,11 +33,11 @@ describe("VisualizationFrameContentComponent", () => {
           WorkflowActionService,
           {
             provide: OperatorMetadataService,
-            useClass: StubOperatorMetadataService
+            useClass: StubOperatorMetadataService,
           },
           WorkflowStatusService,
-          ExecuteWorkflowService
-        ]
+          ExecuteWorkflowService,
+        ],
       }).compileComponents();
     })
   );
@@ -51,9 +48,7 @@ describe("VisualizationFrameContentComponent", () => {
     component.operatorId = operatorID;
     workflowResultService = TestBed.get(WorkflowResultService);
     operatorResultService = new OperatorResultService(operatorID);
-    spyOn(workflowResultService, "getResultService").and.returnValue(
-      operatorResultService
-    );
+    spyOn(workflowResultService, "getResultService").and.returnValue(operatorResultService);
   });
 
   it("should create", () => {
@@ -64,7 +59,7 @@ describe("VisualizationFrameContentComponent", () => {
     const testData: WebDataUpdate = {
       mode: { type: "SetSnapshotMode" },
       table: [{ id: 1, data: 2 }],
-      chartType: ChartType.PIE
+      chartType: ChartType.PIE,
     };
     operatorResultService.handleResultUpdate(testData);
 
@@ -80,9 +75,9 @@ describe("VisualizationFrameContentComponent", () => {
       mode: { type: "SetSnapshotMode" },
       table: [
         { word: "foo", count: 120 },
-        { word: "bar", count: 100 }
+        { word: "bar", count: 100 },
       ],
-      chartType: ChartType.WORD_CLOUD
+      chartType: ChartType.WORD_CLOUD,
     };
     operatorResultService.handleResultUpdate(testData);
 
@@ -98,9 +93,9 @@ describe("VisualizationFrameContentComponent", () => {
       mode: { type: "SetSnapshotMode" },
       table: [
         { xColumn: -90.285434, yColumn: 29.969126 },
-        { xColumn: -76.711521, yColumn: 39.197211 }
+        { xColumn: -76.711521, yColumn: 39.197211 },
       ],
-      chartType: ChartType.SPATIAL_SCATTERPLOT
+      chartType: ChartType.SPATIAL_SCATTERPLOT,
     };
     operatorResultService.handleResultUpdate(testData);
 
@@ -116,9 +111,9 @@ describe("VisualizationFrameContentComponent", () => {
       mode: { type: "SetSnapshotMode" },
       table: [
         { employees: 1000, sales: 30000 },
-        { employees: 500, sales: 21000 }
+        { employees: 500, sales: 21000 },
       ],
-      chartType: ChartType.SIMPLE_SCATTERPLOT
+      chartType: ChartType.SIMPLE_SCATTERPLOT,
     };
     operatorResultService.handleResultUpdate(testData);
 
@@ -133,7 +128,7 @@ describe("VisualizationFrameContentComponent", () => {
     const testData: WebDataUpdate = {
       mode: { type: "SetSnapshotMode" },
       table: [{ "html-content": "<div>sample</div>" }],
-      chartType: ChartType.HTML_VIZ
+      chartType: ChartType.HTML_VIZ,
     };
     operatorResultService.handleResultUpdate(testData);
 

--- a/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-frame-content.component.ts
+++ b/core/new-gui/src/app/workspace/component/visualization-panel-content/visualization-frame-content.component.ts
@@ -17,11 +17,7 @@ import { untilDestroyed, UntilDestroy } from "@ngneat/until-destroy";
 
 (mapboxgl as any).accessToken = environment.mapbox.accessToken;
 
-export const wordCloudScaleOptions = [
-  "linear",
-  "square root",
-  "logarithmic"
-] as const;
+export const wordCloudScaleOptions = ["linear", "square root", "logarithmic"] as const;
 type WordCloudControlsType = {
   scale: typeof wordCloudScaleOptions[number];
 };
@@ -37,10 +33,9 @@ type WordCloudControlsType = {
 @Component({
   selector: "texera-visualization-panel-content",
   templateUrl: "./visualization-frame-content.component.html",
-  styleUrls: ["./visualization-frame-content.component.scss"]
+  styleUrls: ["./visualization-frame-content.component.scss"],
 })
-export class VisualizationFrameContentComponent
-  implements AfterContentInit, OnDestroy {
+export class VisualizationFrameContentComponent implements AfterContentInit, OnDestroy {
   // this readonly variable must be the same as HTML element ID for visualization
   public static readonly CHART_ID = "#texera-result-chart-content";
   public static readonly MAP_CONTAINER = "texera-result-map-container";
@@ -59,17 +54,14 @@ export class VisualizationFrameContentComponent
     radiusScale: 100,
     radiusMinPixels: 1,
     radiusMaxPixels: 25,
-    getPosition: (d: { xColumn: number; yColumn: number }) => [
-      d.xColumn,
-      d.yColumn
-    ],
-    getFillColor: [57, 73, 171]
+    getPosition: (d: { xColumn: number; yColumn: number }) => [d.xColumn, d.yColumn],
+    getFillColor: [57, 73, 171],
   };
 
   wordCloudScaleOptions = wordCloudScaleOptions; // make this a class variable so template can access it
   // word cloud related controls
   wordCloudControls: WordCloudControlsType = {
-    scale: "linear"
+    scale: "linear",
   };
 
   wordCloudControlUpdateObservable = new Subject<WordCloudControlsType>();
@@ -85,19 +77,11 @@ export class VisualizationFrameContentComponent
   chartType?: ChartType;
   columns: string[] = [];
 
-  private wordCloudElement?: d3.Selection<
-    SVGGElement,
-    unknown,
-    HTMLElement,
-    any
-  >;
+  private wordCloudElement?: d3.Selection<SVGGElement, unknown, HTMLElement, any>;
   private c3ChartElement?: c3.ChartAPI;
   private map?: mapboxgl.Map;
 
-  constructor(
-    private workflowResultService: WorkflowResultService,
-    private sanitizer: DomSanitizer
-  ) {}
+  constructor(private workflowResultService: WorkflowResultService, private sanitizer: DomSanitizer) {}
 
   ngAfterContentInit() {
     // attempt to draw chart immediately
@@ -109,9 +93,7 @@ export class VisualizationFrameContentComponent
       .getResultUpdateStream()
       .pipe(auditTime(VisualizationFrameContentComponent.UPDATE_INTERVAL_MS));
     const controlUpdate = this.wordCloudControlUpdateObservable.pipe(
-      debounceTime(
-        VisualizationFrameContentComponent.WORD_CLOUD_CONTROL_UPDATE_INTERVAL_MS
-      )
+      debounceTime(VisualizationFrameContentComponent.WORD_CLOUD_CONTROL_UPDATE_INTERVAL_MS)
     );
     merge(resultUpdate, controlUpdate)
       .pipe(untilDestroyed(this))
@@ -136,9 +118,7 @@ export class VisualizationFrameContentComponent
     if (!this.operatorId) {
       return;
     }
-    const operatorResultService = this.workflowResultService.getResultService(
-      this.operatorId
-    );
+    const operatorResultService = this.workflowResultService.getResultService(this.operatorId);
     if (!operatorResultService) {
       return;
     }
@@ -195,28 +175,28 @@ export class VisualizationFrameContentComponent
     this.c3ChartElement = c3.generate({
       size: {
         height: VisualizationFrameContentComponent.HEIGHT,
-        width: VisualizationFrameContentComponent.WIDTH
+        width: VisualizationFrameContentComponent.WIDTH,
       },
       data: {
         json: result,
         keys: {
           x: xLabel,
-          value: [yLabel]
+          value: [yLabel],
         },
-        type: this.chartType as c3.ChartType
+        type: this.chartType as c3.ChartType,
       },
       axis: {
         x: {
           label: xLabel,
           tick: {
-            fit: true
-          }
+            fit: true,
+          },
         },
         y: {
-          label: yLabel
-        }
+          label: yLabel,
+        },
       },
-      bindto: VisualizationFrameContentComponent.CHART_ID
+      bindto: VisualizationFrameContentComponent.CHART_ID,
     });
   }
 
@@ -239,7 +219,7 @@ export class VisualizationFrameContentComponent
       center: [-96.35, 39.5],
       zoom: 3,
       maxZoom: 17,
-      minZoom: 0
+      minZoom: 0,
     });
   }
 
@@ -255,7 +235,7 @@ export class VisualizationFrameContentComponent
       id: "scatter",
       type: ScatterplotLayer,
       data: this.data,
-      pickable: true
+      pickable: true,
     });
     clusterLayer.setProps(VisualizationFrameContentComponent.props);
     this.map.addLayer(clusterLayer);
@@ -300,32 +280,26 @@ export class VisualizationFrameContentComponent
 
       const wordCloudData = this.wordCloudElement
         .selectAll<d3.BaseType, cloud.Word>("g text")
-        .data(words, (d) => d.text ?? "");
+        .data(words, d => d.text ?? "");
 
       wordCloudData
         .enter()
         .append("text")
-        .style("font-size", (d) => d.size ?? 0 + "px")
-        .style("fill", (d) => d3Fill(d.text ?? ""))
+        .style("font-size", d => d.size ?? 0 + "px")
+        .style("fill", d => d3Fill(d.text ?? ""))
         .attr("font-family", "Impact")
         .attr("text-anchor", "middle")
-        .attr(
-          "transform",
-          (d) => "translate(" + [d.x, d.y] + ")rotate(" + d.rotate + ")"
-        )
+        .attr("transform", d => "translate(" + [d.x, d.y] + ")rotate(" + d.rotate + ")")
         // this text() call must be at the end or it won't work
-        .text((d) => d.text ?? "");
+        .text(d => d.text ?? "");
 
       // Entering and existing words
       wordCloudData
         .transition()
         .duration(300)
         .attr("font-family", "Impact")
-        .style("font-size", (d) => d.size + "px")
-        .attr(
-          "transform",
-          (d) => "translate(" + [d.x, d.y] + ")rotate(" + d.rotate + ")"
-        )
+        .style("font-size", d => d.size + "px")
+        .attr("transform", d => "translate(" + [d.x, d.y] + ")rotate(" + d.rotate + ")")
         .style("fill-opacity", 1);
 
       // Exiting words
@@ -339,8 +313,8 @@ export class VisualizationFrameContentComponent
         .remove();
     };
 
-    const minCount = Math.min(...wordCloudTuples.map((t) => t.count));
-    const maxCount = Math.max(...wordCloudTuples.map((t) => t.count));
+    const minCount = Math.min(...wordCloudTuples.map(t => t.count));
+    const maxCount = Math.max(...wordCloudTuples.map(t => t.count));
 
     const minFontSize = 50;
     const maxFontSize = 150;
@@ -359,18 +333,13 @@ export class VisualizationFrameContentComponent
     d3Scale.domain([minCount, maxCount]).range([minFontSize, maxFontSize]);
 
     const layout = cloud()
-      .size([
-        VisualizationFrameContentComponent.WIDTH,
-        VisualizationFrameContentComponent.HEIGHT
-      ])
-      .words(
-        wordCloudTuples.map((t) => ({ text: t.word, size: d3Scale(t.count) }))
-      )
-      .text((d) => d.text ?? "")
+      .size([VisualizationFrameContentComponent.WIDTH, VisualizationFrameContentComponent.HEIGHT])
+      .words(wordCloudTuples.map(t => ({ text: t.word, size: d3Scale(t.count) })))
+      .text(d => d.text ?? "")
       .padding(5)
       .rotate(() => 0)
       .font("Impact")
-      .fontSize((d) => d.size ?? 0)
+      .fontSize(d => d.size ?? 0)
       .random(() => 1)
       .on("end", drawWordCloud);
 
@@ -404,19 +373,19 @@ export class VisualizationFrameContentComponent
     this.c3ChartElement = c3.generate({
       size: {
         height: VisualizationFrameContentComponent.HEIGHT,
-        width: VisualizationFrameContentComponent.WIDTH
+        width: VisualizationFrameContentComponent.WIDTH,
       },
       data: {
         columns: dataToDisplay,
-        type: this.chartType as c3.ChartType
+        type: this.chartType as c3.ChartType,
       },
       axis: {
         x: {
           type: "category",
-          categories: category
-        }
+          categories: category,
+        },
       },
-      bindto: VisualizationFrameContentComponent.CHART_ID
+      bindto: VisualizationFrameContentComponent.CHART_ID,
     });
   }
 
@@ -424,8 +393,6 @@ export class VisualizationFrameContentComponent
     if (!this.data) {
       return;
     }
-    this.htmlData = this.sanitizer.bypassSecurityTrustHtml(
-      Object(this.data[0])["html-content"]
-    ); // this line bypasses angular security
+    this.htmlData = this.sanitizer.bypassSecurityTrustHtml(Object(this.data[0])["html-content"]); // this line bypasses angular security
   }
 }

--- a/core/new-gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.html
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.html
@@ -5,10 +5,7 @@
 
   <div [hidden]="!show" class="texera-mini-map-square-container">
     <div class="texera-mini-map-body texera-mini-map-component-body">
-      <div
-        [attr.id]="MINI_MAP_JOINTJS_MAP_ID"
-        class="texera-workspace-mini-map-jointjs"
-      ></div>
+      <div [attr.id]="MINI_MAP_JOINTJS_MAP_ID" class="texera-workspace-mini-map-jointjs"></div>
     </div>
   </div>
 

--- a/core/new-gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.spec.ts
@@ -28,10 +28,10 @@ describe("MiniMapComponent", () => {
           UndoRedoService,
           {
             provide: OperatorMetadataService,
-            useClass: StubOperatorMetadataService
-          }
+            useClass: StubOperatorMetadataService,
+          },
         ],
-        imports: [HttpClientTestingModule]
+        imports: [HttpClientTestingModule],
       }).compileComponents();
     })
   );

--- a/core/new-gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.ts
@@ -33,7 +33,7 @@ export const MINI_MAP_GRID_SIZE = 45;
 @Component({
   selector: "texera-mini-map",
   templateUrl: "./mini-map.component.html",
-  styleUrls: ["./mini-map.component.scss"]
+  styleUrls: ["./mini-map.component.scss"],
 })
 export class MiniMapComponent implements AfterViewInit {
   // the DOM element ID of map. It can be used by jQuery and jointJS to find the DOM element
@@ -43,13 +43,12 @@ export class MiniMapComponent implements AfterViewInit {
   public readonly MINI_MAP_NAVIGATOR_ID = MINI_MAP_NAVIGATOR_ID;
   public readonly MINI_MAP_GRID_SIZE = 45;
 
-  public readonly MAIN_PAPER_JOINTJS_WRAPPER_ID =
-    WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID;
+  public readonly MAIN_PAPER_JOINTJS_WRAPPER_ID = WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID;
 
   public MINI_MAP_ZOOM_SCALE = 0;
   public MINI_MAP_SIZE = {
     width: 0,
-    height: 0
+    height: 0,
   };
 
   public show: boolean = true;
@@ -66,16 +65,14 @@ export class MiniMapComponent implements AfterViewInit {
   }
 
   public handleMouseEvents() {
-    const navigatorElement = document.getElementById(
-      this.MINI_MAP_NAVIGATOR_ID
-    );
+    const navigatorElement = document.getElementById(this.MINI_MAP_NAVIGATOR_ID);
     if (navigatorElement == null) {
       throw new Error("minimap: cannot find navigator element");
     }
 
     fromEvent<MouseEvent>(navigatorElement, "mousedown")
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
+      .subscribe(event => {
         const x = event.screenX;
         const y = event.screenY;
         if (x !== undefined && y !== undefined) {
@@ -91,22 +88,16 @@ export class MiniMapComponent implements AfterViewInit {
 
     fromEvent<MouseEvent>(document, "mousemove")
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
+      .subscribe(event => {
         if (this.mouseDownPosition) {
           const newCoordinate = { x: event.screenX, y: event.screenY };
           const panDelta = {
-            deltaX:
-              -(newCoordinate.x - this.mouseDownPosition.x) /
-              this.MINI_MAP_ZOOM_SCALE,
-            deltaY:
-              -(newCoordinate.y - this.mouseDownPosition.y) /
-              this.MINI_MAP_ZOOM_SCALE
+            deltaX: -(newCoordinate.x - this.mouseDownPosition.x) / this.MINI_MAP_ZOOM_SCALE,
+            deltaY: -(newCoordinate.y - this.mouseDownPosition.y) / this.MINI_MAP_ZOOM_SCALE,
           };
           this.mouseDownPosition = newCoordinate;
 
-          this.workflowActionService
-            .getJointGraphWrapper()
-            .navigatorMoveDelta.next(panDelta);
+          this.workflowActionService.getJointGraphWrapper().navigatorMoveDelta.next(panDelta);
         }
       });
   }
@@ -126,11 +117,9 @@ export class MiniMapComponent implements AfterViewInit {
       background: { color: "#F6F6F6" },
       interactive: false,
       width: this.MINI_MAP_SIZE.width,
-      height: this.MINI_MAP_SIZE.height
+      height: this.MINI_MAP_SIZE.height,
     };
-    this.miniMapPaper = this.workflowActionService
-      .getJointGraphWrapper()
-      .attachMiniMapJointPaper(miniMapPaperOptions);
+    this.miniMapPaper = this.workflowActionService.getJointGraphWrapper().attachMiniMapJointPaper(miniMapPaperOptions);
 
     const origin = this.mainPaperToMiniMapPoint({ x: 0, y: 0 });
     this.miniMapPaper.translate(origin.x, origin.y);
@@ -140,7 +129,7 @@ export class MiniMapComponent implements AfterViewInit {
       .getJointGraphWrapper()
       .getMainJointPaperAttachedStream()
       .pipe(untilDestroyed(this))
-      .subscribe((mainPaper) => {
+      .subscribe(mainPaper => {
         this.updateNavigatorOffset();
         this.updateNavigatorDimension();
 
@@ -203,9 +192,7 @@ export class MiniMapComponent implements AfterViewInit {
       .getJointGraphWrapper()
       .pageToJointLocalCoordinate(this.getMainPaperWrapperElementOffset());
     const miniMapPoint = this.mainPaperToMiniMapPoint(mainPaperPoint);
-    const miniMapWrapperOffset = jQuery(
-      "#" + this.MINI_MAP_WRAPPER_ID
-    ).offset();
+    const miniMapWrapperOffset = jQuery("#" + this.MINI_MAP_WRAPPER_ID).offset();
     if (!miniMapWrapperOffset) {
       throw new Error("cannot find minimap wrapper");
     }
@@ -213,7 +200,7 @@ export class MiniMapComponent implements AfterViewInit {
     const top = miniMapWrapperOffset.top + miniMapPoint.y;
     jQuery("#" + this.MINI_MAP_NAVIGATOR_ID).css({
       left: left + "px",
-      top: top + "px"
+      top: top + "px",
     });
   }
 
@@ -221,19 +208,16 @@ export class MiniMapComponent implements AfterViewInit {
    * This method sets the dimension of the navigator based on the browser size.
    */
   private updateNavigatorDimension(): void {
-    const { width: mainPaperWidth, height: mainPaperHeight } =
-      this.getOriginalWrapperElementSize();
-    const mainPaperScale = this.workflowActionService
-      .getJointGraphWrapper()
-      .getMainJointPaper()
-      ?.scale() ?? { sx: 1, sy: 1 };
+    const { width: mainPaperWidth, height: mainPaperHeight } = this.getOriginalWrapperElementSize();
+    const mainPaperScale = this.workflowActionService.getJointGraphWrapper().getMainJointPaper()?.scale() ?? {
+      sx: 1,
+      sy: 1,
+    };
 
     // set navigator dimension size, mainPaperDimension * MINI_MAP_ZOOM_SCALE is the
     //  main paper's size in the mini-map
-    const width =
-      (mainPaperWidth / mainPaperScale.sx) * this.MINI_MAP_ZOOM_SCALE;
-    const height =
-      (mainPaperHeight / mainPaperScale.sy) * this.MINI_MAP_ZOOM_SCALE;
+    const width = (mainPaperWidth / mainPaperScale.sx) * this.MINI_MAP_ZOOM_SCALE;
+    const height = (mainPaperHeight / mainPaperScale.sy) * this.MINI_MAP_ZOOM_SCALE;
     jQuery("#" + this.MINI_MAP_NAVIGATOR_ID).width(width);
     jQuery("#" + this.MINI_MAP_NAVIGATOR_ID).height(height);
   }

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor-constants.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor-constants.ts
@@ -2,6 +2,6 @@ export const MAIN_CANVAS_LIMIT = {
   xMin: -960,
   xMax: 2688, // xMin * 2.8
   yMin: -540,
-  yMax: 1512 // yMin * 2.8
+  yMax: 1512, // yMin * 2.8
 };
 // x : y = 16 : 9

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.html
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.html
@@ -3,9 +3,6 @@
     [attr.id]="WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID"
     class="texera-workspace-workflow-editor-body texera-workflow-component-body"
   >
-    <div
-      [attr.id]="WORKFLOW_EDITOR_JOINTJS_ID"
-      class="texera-workspace-workflow-jointjs"
-    ></div>
+    <div [attr.id]="WORKFLOW_EDITOR_JOINTJS_ID" class="texera-workspace-workflow-jointjs"></div>
   </div>
 </div>

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.scss
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.scss
@@ -20,9 +20,7 @@
 //   box-shadow: -2px 2px 2px rgba(0,0,0,0.2);
 // }
 
-::ng-deep
-  .texera-workspace-workflow-editor-body
-  .custom-highlighted-link.connection {
+::ng-deep .texera-workspace-workflow-editor-body .custom-highlighted-link.connection {
   stroke: #e59700 !important ;
 }
 
@@ -54,11 +52,7 @@
   transform: translate(-12px, -12px) !important;
 }
 
-::ng-deep
-  .texera-workspace-workflow-editor-body
-  .link-tools
-  .tool-remove
-  circle {
+::ng-deep .texera-workspace-workflow-editor-body .link-tools .tool-remove circle {
   fill-opacity: 0 !important;
 }
 

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
@@ -18,15 +18,12 @@ import {
   mockScanPredicate,
   mockScanResultLink,
   mockScanSentimentLink,
-  mockSentimentPredicate
+  mockSentimentPredicate,
 } from "../../service/workflow-graph/model/mock-workflow-data";
 import { WorkflowStatusService } from "../../service/workflow-status/workflow-status.service";
 import { ExecuteWorkflowService } from "../../service/execute-workflow/execute-workflow.service";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
-import {
-  OperatorLink,
-  OperatorPredicate
-} from "../../types/workflow-common.interface";
+import { OperatorLink, OperatorPredicate } from "../../types/workflow-common.interface";
 import { tap } from "rxjs/operators";
 
 describe("WorkflowEditorComponent", () => {
@@ -55,11 +52,11 @@ describe("WorkflowEditorComponent", () => {
             WorkflowActionService,
             {
               provide: OperatorMetadataService,
-              useClass: StubOperatorMetadataService
+              useClass: StubOperatorMetadataService,
             },
             WorkflowStatusService,
-            ExecuteWorkflowService
-          ]
+            ExecuteWorkflowService,
+          ],
         }).compileComponents();
       })
     );
@@ -84,9 +81,7 @@ describe("WorkflowEditorComponent", () => {
 
       jointGraph.addCell(element);
 
-      expect(
-        component.getJointPaper().findViewByModel(element.id)
-      ).toBeTruthy();
+      expect(component.getJointPaper().findViewByModel(element.id)).toBeTruthy();
     });
 
     it("should create a graph of multiple cells in the UI", () => {
@@ -95,19 +90,19 @@ describe("WorkflowEditorComponent", () => {
 
       const element1 = new joint.shapes.basic.Rect({
         size: { width: 100, height: 50 },
-        position: { x: 100, y: 400 }
+        position: { x: 100, y: 400 },
       });
       element1.set("id", operator1);
 
       const element2 = new joint.shapes.basic.Rect({
         size: { width: 100, height: 50 },
-        position: { x: 100, y: 400 }
+        position: { x: 100, y: 400 },
       });
       element2.set("id", operator2);
 
       const link1 = new joint.dia.Link({
         source: { id: operator1 },
-        target: { id: operator2 }
+        target: { id: operator2 },
       });
 
       jointGraph.addCell(element1);
@@ -115,23 +110,13 @@ describe("WorkflowEditorComponent", () => {
       jointGraph.addCell(link1);
 
       // check the model is added correctly
-      expect(
-        jointGraph.getElements().find((el) => el.id === operator1)
-      ).toBeTruthy();
-      expect(
-        jointGraph.getElements().find((el) => el.id === operator2)
-      ).toBeTruthy();
-      expect(
-        jointGraph.getLinks().find((link) => link.id === link1.id)
-      ).toBeTruthy();
+      expect(jointGraph.getElements().find(el => el.id === operator1)).toBeTruthy();
+      expect(jointGraph.getElements().find(el => el.id === operator2)).toBeTruthy();
+      expect(jointGraph.getLinks().find(link => link.id === link1.id)).toBeTruthy();
 
       // check the view is updated correctly
-      expect(
-        component.getJointPaper().findViewByModel(element1.id)
-      ).toBeTruthy();
-      expect(
-        component.getJointPaper().findViewByModel(element2.id)
-      ).toBeTruthy();
+      expect(component.getJointPaper().findViewByModel(element1.id)).toBeTruthy();
+      expect(component.getJointPaper().findViewByModel(element2.id)).toBeTruthy();
       expect(component.getJointPaper().findViewByModel(link1.id)).toBeTruthy();
     });
   });
@@ -163,11 +148,11 @@ describe("WorkflowEditorComponent", () => {
             DragDropService,
             {
               provide: OperatorMetadataService,
-              useClass: StubOperatorMetadataService
+              useClass: StubOperatorMetadataService,
             },
             WorkflowStatusService,
-            ExecuteWorkflowService
-          ]
+            ExecuteWorkflowService,
+          ],
         }).compileComponents();
       })
     );
@@ -191,10 +176,7 @@ describe("WorkflowEditorComponent", () => {
     it("should try to highlight the operator when user mouse clicks on an operator", () => {
       const jointGraphWrapper = workflowActionService.getJointGraphWrapper();
       // install a spy on the highlight operator function and pass the call through
-      const highlightOperatorFunctionSpy = spyOn(
-        jointGraphWrapper,
-        "highlightOperators"
-      ).and.callThrough();
+      const highlightOperatorFunctionSpy = spyOn(jointGraphWrapper, "highlightOperators").and.callThrough();
 
       workflowActionService.addOperator(mockScanPredicate, mockPoint);
 
@@ -202,9 +184,7 @@ describe("WorkflowEditorComponent", () => {
       jointGraphWrapper.unhighlightOperators(mockScanPredicate.operatorID);
 
       // find the joint Cell View object of the operator element
-      const jointCellView = component
-        .getJointPaper()
-        .findViewByModel(mockScanPredicate.operatorID);
+      const jointCellView = component.getJointPaper().findViewByModel(mockScanPredicate.operatorID);
 
       // trigger a click on the cell view using its jQuery element
       jointCellView.$el.trigger("mousedown");
@@ -214,9 +194,7 @@ describe("WorkflowEditorComponent", () => {
       // assert the function is called once
       // expect(highlightOperatorFunctionSpy.calls.count()).toEqual(1);
       // assert the highlighted operator is correct
-      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toEqual([
-        mockScanPredicate.operatorID
-      ]);
+      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toEqual([mockScanPredicate.operatorID]);
     });
 
     it("should unhighlight all highlighted operators when user mouse clicks on the blank space", () => {
@@ -226,34 +204,25 @@ describe("WorkflowEditorComponent", () => {
       workflowActionService.addOperatorsAndLinks(
         [
           { op: mockScanPredicate, pos: mockPoint },
-          { op: mockResultPredicate, pos: mockPoint }
+          { op: mockResultPredicate, pos: mockPoint },
         ],
         []
       );
-      jointGraphWrapper.highlightOperators(
-        mockScanPredicate.operatorID,
-        mockResultPredicate.operatorID
-      );
+      jointGraphWrapper.highlightOperators(mockScanPredicate.operatorID, mockResultPredicate.operatorID);
 
       // assert that both operators are highlighted
-      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(
-        mockScanPredicate.operatorID
-      );
-      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(
-        mockResultPredicate.operatorID
-      );
+      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(mockScanPredicate.operatorID);
+      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(mockResultPredicate.operatorID);
 
       // find a blank area on the JointJS paper
       const blankPoint = { x: mockPoint.x + 100, y: mockPoint.y + 100 };
-      expect(component.getJointPaper().findViewsFromPoint(blankPoint)).toEqual(
-        []
-      );
+      expect(component.getJointPaper().findViewsFromPoint(blankPoint)).toEqual([]);
 
       // trigger a click on the blank area using JointJS paper's jQuery element
       const point = component.getJointPaper().localToClientPoint(blankPoint);
       const event = jQuery.Event("mousedown", {
         clientX: point.x,
-        clientY: point.y
+        clientY: point.y,
       });
       component.getJointPaper().$el.trigger(event);
 
@@ -271,14 +240,10 @@ describe("WorkflowEditorComponent", () => {
       jointGraphWrapper.highlightOperators(mockScanPredicate.operatorID);
 
       // find the joint Cell View object of the operator element
-      const jointCellView = component
-        .getJointPaper()
-        .findViewByModel(mockScanPredicate.operatorID);
+      const jointCellView = component.getJointPaper().findViewByModel(mockScanPredicate.operatorID);
 
       // find the cell's child element with the joint highlighter class name `joint-highlight-stroke`
-      const jointHighlighterElements = jointCellView.$el.children(
-        ".joint-highlight-stroke"
-      );
+      const jointHighlighterElements = jointCellView.$el.children(".joint-highlight-stroke");
 
       // the element should have the highlighter element in it
       expect(jointHighlighterElements.length).toEqual(1);
@@ -292,14 +257,10 @@ describe("WorkflowEditorComponent", () => {
       jointGraphWrapper.highlightOperators(mockScanPredicate.operatorID);
 
       // find the joint Cell View object of the operator element
-      const jointCellView = component
-        .getJointPaper()
-        .findViewByModel(mockScanPredicate.operatorID);
+      const jointCellView = component.getJointPaper().findViewByModel(mockScanPredicate.operatorID);
 
       // find the cell's child element with the joint highlighter class name `joint-highlight-stroke`
-      const jointHighlighterElements = jointCellView.$el.children(
-        ".joint-highlight-stroke"
-      );
+      const jointHighlighterElements = jointCellView.$el.children(".joint-highlight-stroke");
 
       // the element should have the highlighter element in it right now
       expect(jointHighlighterElements.length).toEqual(1);
@@ -308,8 +269,7 @@ describe("WorkflowEditorComponent", () => {
       jointGraphWrapper.unhighlightOperators(mockScanPredicate.operatorID);
 
       // the highlighter element should not exist
-      const jointHighlighterElementAfterUnhighlight =
-        jointCellView.$el.children(".joint-highlight-stroke");
+      const jointHighlighterElementAfterUnhighlight = jointCellView.$el.children(".joint-highlight-stroke");
       expect(jointHighlighterElementAfterUnhighlight.length).toEqual(0);
     });
 
@@ -319,16 +279,9 @@ describe("WorkflowEditorComponent", () => {
       workflowActionService.addOperator(mockResultPredicate, mockPoint);
       workflowActionService.addLink(mockScanResultLink);
       const newProperty = { tableName: "test-table" };
-      workflowActionService.setOperatorProperty(
-        mockScanPredicate.operatorID,
-        newProperty
-      );
-      const operator1 = component
-        .getJointPaper()
-        .getModelById(mockScanPredicate.operatorID);
-      const operator2 = component
-        .getJointPaper()
-        .getModelById(mockResultPredicate.operatorID);
+      workflowActionService.setOperatorProperty(mockScanPredicate.operatorID, newProperty);
+      const operator1 = component.getJointPaper().getModelById(mockScanPredicate.operatorID);
+      const operator2 = component.getJointPaper().getModelById(mockResultPredicate.operatorID);
       expect(operator1.attr("rect/stroke")).toEqual("#CFCFCF");
       expect(operator2.attr("rect/stroke")).toEqual("#CFCFCF");
     });
@@ -336,7 +289,7 @@ describe("WorkflowEditorComponent", () => {
     it("should validate operator connections correctly", () => {
       const mockScan2Predicate = {
         ...mockScanPredicate,
-        operatorID: "mockScan2"
+        operatorID: "mockScan2",
       };
 
       workflowActionService.addOperator(mockScanPredicate, mockPoint);
@@ -420,7 +373,7 @@ describe("WorkflowEditorComponent", () => {
         inputPorts: [{ portID: "input-0" }],
         outputPorts: [{ portID: "output-0" }],
         showAdvanced: false,
-        isDisabled: false
+        isDisabled: false,
       };
 
       const jointGraphWrapper = workflowActionService.getJointGraphWrapper();
@@ -453,12 +406,12 @@ describe("WorkflowEditorComponent", () => {
         linkID: "mockScanUnion",
         source: {
           operatorID: mockScanPredicate.operatorID,
-          portID: "output-0"
+          portID: "output-0",
         },
         target: {
           operatorID: mockUnionPredicate.operatorID,
-          portID: "input-0"
-        }
+          portID: "input-0",
+        },
       };
       workflowActionService.addLink(mockScanUnionLink);
 
@@ -475,16 +428,10 @@ describe("WorkflowEditorComponent", () => {
 
     it(
       "should react to jointJS paper zoom event",
-      marbles((m) => {
+      marbles(m => {
         const mockScaleRatio = 0.5;
         m.hot("-e-")
-          .pipe(
-            tap(() =>
-              workflowActionService
-                .getJointGraphWrapper()
-                .setZoomProperty(mockScaleRatio)
-            )
-          )
+          .pipe(tap(() => workflowActionService.getJointGraphWrapper().setZoomProperty(mockScaleRatio)))
           .subscribe(() => {
             const currentScale = component.getJointPaper().scale();
             expect(currentScale.sx).toEqual(mockScaleRatio);
@@ -495,31 +442,17 @@ describe("WorkflowEditorComponent", () => {
 
     it(
       "should react to jointJS paper restore default offset event",
-      marbles((m) => {
+      marbles(m => {
         const mockTranslation = 20;
         const originalOffset = component.getJointPaper().translate();
         component.getJointPaper().translate(mockTranslation, mockTranslation);
-        expect(component.getJointPaper().translate().tx).not.toEqual(
-          originalOffset.tx
-        );
-        expect(component.getJointPaper().translate().ty).not.toEqual(
-          originalOffset.ty
-        );
+        expect(component.getJointPaper().translate().tx).not.toEqual(originalOffset.tx);
+        expect(component.getJointPaper().translate().ty).not.toEqual(originalOffset.ty);
         m.hot("-e-")
-          .pipe(
-            tap(() =>
-              workflowActionService
-                .getJointGraphWrapper()
-                .restoreDefaultZoomAndOffset()
-            )
-          )
+          .pipe(tap(() => workflowActionService.getJointGraphWrapper().restoreDefaultZoomAndOffset()))
           .subscribe(() => {
-            expect(component.getJointPaper().translate().tx).toEqual(
-              originalOffset.tx
-            );
-            expect(component.getJointPaper().translate().ty).toEqual(
-              originalOffset.ty
-            );
+            expect(component.getJointPaper().translate().tx).toEqual(originalOffset.tx);
+            expect(component.getJointPaper().translate().ty).toEqual(originalOffset.ty);
           });
       })
     );
@@ -674,22 +607,15 @@ describe("WorkflowEditorComponent", () => {
       workflowActionService.addOperatorsAndLinks(
         [
           { op: mockScanPredicate, pos: mockPoint },
-          { op: mockResultPredicate, pos: mockPoint }
+          { op: mockResultPredicate, pos: mockPoint },
         ],
         []
       );
-      jointGraphWrapper.highlightOperators(
-        mockScanPredicate.operatorID,
-        mockResultPredicate.operatorID
-      );
+      jointGraphWrapper.highlightOperators(mockScanPredicate.operatorID, mockResultPredicate.operatorID);
 
       // assert that all operators are highlighted
-      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(
-        mockScanPredicate.operatorID
-      );
-      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(
-        mockResultPredicate.operatorID
-      );
+      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(mockScanPredicate.operatorID);
+      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(mockResultPredicate.operatorID);
 
       // dispatch a keydown event on the backspace key
       const event = new KeyboardEvent("keydown", { key: "Backspace" });
@@ -699,9 +625,7 @@ describe("WorkflowEditorComponent", () => {
 
       // assert that all highlighted operators are deleted
       expect(texeraGraph.hasOperator(mockScanPredicate.operatorID)).toBeFalsy();
-      expect(
-        texeraGraph.hasOperator(mockResultPredicate.operatorID)
-      ).toBeFalsy();
+      expect(texeraGraph.hasOperator(mockResultPredicate.operatorID)).toBeFalsy();
     });
 
     it(`should create and highlight a new operator with the same metadata when user
@@ -719,8 +643,7 @@ describe("WorkflowEditorComponent", () => {
       document.dispatchEvent(pasteEvent);
 
       // the pasted operator should be highlighted
-      const pastedOperatorID =
-        jointGraphWrapper.getCurrentHighlightedOperatorIDs()[0];
+      const pastedOperatorID = jointGraphWrapper.getCurrentHighlightedOperatorIDs()[0];
       expect(pastedOperatorID).toBeDefined();
 
       // get the pasted operator
@@ -733,19 +656,11 @@ describe("WorkflowEditorComponent", () => {
       // two operators should have same metadata
       expect(pastedOperatorID).not.toEqual(mockScanPredicate.operatorID);
       if (pastedOperator) {
-        expect(pastedOperator.operatorType).toEqual(
-          mockScanPredicate.operatorType
-        );
-        expect(pastedOperator.operatorProperties).toEqual(
-          mockScanPredicate.operatorProperties
-        );
+        expect(pastedOperator.operatorType).toEqual(mockScanPredicate.operatorType);
+        expect(pastedOperator.operatorProperties).toEqual(mockScanPredicate.operatorProperties);
         expect(pastedOperator.inputPorts).toEqual(mockScanPredicate.inputPorts);
-        expect(pastedOperator.outputPorts).toEqual(
-          mockScanPredicate.outputPorts
-        );
-        expect(pastedOperator.showAdvanced).toEqual(
-          mockScanPredicate.showAdvanced
-        );
+        expect(pastedOperator.outputPorts).toEqual(mockScanPredicate.outputPorts);
+        expect(pastedOperator.showAdvanced).toEqual(mockScanPredicate.showAdvanced);
       }
     });
 
@@ -769,8 +684,7 @@ describe("WorkflowEditorComponent", () => {
       }).toThrowError(new RegExp("does not exist"));
 
       // the pasted operator should be highlighted
-      const pastedOperatorID =
-        jointGraphWrapper.getCurrentHighlightedOperatorIDs()[0];
+      const pastedOperatorID = jointGraphWrapper.getCurrentHighlightedOperatorIDs()[0];
       expect(pastedOperatorID).toBeDefined();
 
       // get the pasted operator
@@ -783,19 +697,11 @@ describe("WorkflowEditorComponent", () => {
       // two operators should have same metadata
       expect(pastedOperatorID).not.toEqual(mockScanPredicate.operatorID);
       if (pastedOperator) {
-        expect(pastedOperator.operatorType).toEqual(
-          mockScanPredicate.operatorType
-        );
-        expect(pastedOperator.operatorProperties).toEqual(
-          mockScanPredicate.operatorProperties
-        );
+        expect(pastedOperator.operatorType).toEqual(mockScanPredicate.operatorType);
+        expect(pastedOperator.operatorProperties).toEqual(mockScanPredicate.operatorProperties);
         expect(pastedOperator.inputPorts).toEqual(mockScanPredicate.inputPorts);
-        expect(pastedOperator.outputPorts).toEqual(
-          mockScanPredicate.outputPorts
-        );
-        expect(pastedOperator.showAdvanced).toEqual(
-          mockScanPredicate.showAdvanced
-        );
+        expect(pastedOperator.outputPorts).toEqual(mockScanPredicate.outputPorts);
+        expect(pastedOperator.showAdvanced).toEqual(mockScanPredicate.showAdvanced);
       }
     });
 
@@ -812,11 +718,9 @@ describe("WorkflowEditorComponent", () => {
       document.dispatchEvent(pasteEvent);
       fixture.detectChanges();
       // get the pasted operator
-      const pastedOperatorID =
-        jointGraphWrapper.getCurrentHighlightedOperatorIDs()[0];
+      const pastedOperatorID = jointGraphWrapper.getCurrentHighlightedOperatorIDs()[0];
       if (pastedOperatorID) {
-        const pastedOperatorPosition =
-          jointGraphWrapper.getElementPosition(pastedOperatorID);
+        const pastedOperatorPosition = jointGraphWrapper.getElementPosition(pastedOperatorID);
         expect(pastedOperatorPosition).not.toEqual(mockPoint);
       }
     });
@@ -829,17 +733,11 @@ describe("WorkflowEditorComponent", () => {
       jointGraphWrapper.highlightOperators(mockResultPredicate.operatorID);
 
       // assert that only the last operator is highlighted
-      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(
-        mockResultPredicate.operatorID
-      );
-      expect(
-        jointGraphWrapper.getCurrentHighlightedOperatorIDs()
-      ).not.toContain(mockScanPredicate.operatorID);
+      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(mockResultPredicate.operatorID);
+      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).not.toContain(mockScanPredicate.operatorID);
 
       // find the joint Cell View object of the first operator element
-      const jointCellView = component
-        .getJointPaper()
-        .findViewByModel(mockScanPredicate.operatorID);
+      const jointCellView = component.getJointPaper().findViewByModel(mockScanPredicate.operatorID);
 
       // trigger a shift click on the cell view using its jQuery element
       const event = jQuery.Event("mousedown", { shiftKey: true });
@@ -848,12 +746,8 @@ describe("WorkflowEditorComponent", () => {
       fixture.detectChanges();
 
       // assert that both operators are highlighted
-      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(
-        mockScanPredicate.operatorID
-      );
-      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(
-        mockResultPredicate.operatorID
-      );
+      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(mockScanPredicate.operatorID);
+      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(mockResultPredicate.operatorID);
     });
 
     it("should unhighlight the highlighted operator when user clicks on it with shift key pressed", () => {
@@ -863,14 +757,10 @@ describe("WorkflowEditorComponent", () => {
       jointGraphWrapper.highlightOperators(mockScanPredicate.operatorID);
 
       // assert that the operator is highlighted
-      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(
-        mockScanPredicate.operatorID
-      );
+      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(mockScanPredicate.operatorID);
 
       // find the joint Cell View object of the operator element
-      const jointCellView = component
-        .getJointPaper()
-        .findViewByModel(mockScanPredicate.operatorID);
+      const jointCellView = component.getJointPaper().findViewByModel(mockScanPredicate.operatorID);
 
       // trigger a shift click on the cell view using its jQuery element
       const event = jQuery.Event("mousedown", { shiftKey: true });
@@ -879,9 +769,7 @@ describe("WorkflowEditorComponent", () => {
       fixture.detectChanges();
 
       // assert that the operator is unhighlighted
-      expect(
-        jointGraphWrapper.getCurrentHighlightedOperatorIDs()
-      ).not.toContain(mockScanPredicate.operatorID);
+      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).not.toContain(mockScanPredicate.operatorID);
     });
 
     it("should highlight all operators when user presses command + A", () => {
@@ -891,10 +779,7 @@ describe("WorkflowEditorComponent", () => {
       workflowActionService.addOperator(mockResultPredicate, mockPoint);
 
       // unhighlight operators in case of automatic highlight
-      jointGraphWrapper.unhighlightOperators(
-        mockScanPredicate.operatorID,
-        mockResultPredicate.operatorID
-      );
+      jointGraphWrapper.unhighlightOperators(mockScanPredicate.operatorID, mockResultPredicate.operatorID);
 
       // dispatch a keydown event on the command + A key comb
       const event = new KeyboardEvent("keydown", { key: "a", metaKey: true });
@@ -903,12 +788,8 @@ describe("WorkflowEditorComponent", () => {
       fixture.detectChanges();
 
       // assert that all operators are highlighted
-      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(
-        mockScanPredicate.operatorID
-      );
-      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(
-        mockResultPredicate.operatorID
-      );
+      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(mockScanPredicate.operatorID);
+      expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(mockResultPredicate.operatorID);
     });
   });
 });

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -9,31 +9,17 @@ import { environment } from "../../../../environments/environment";
 import { DragDropService } from "../../service/drag-drop/drag-drop.service";
 import { DynamicSchemaService } from "../../service/dynamic-schema/dynamic-schema.service";
 import { ExecuteWorkflowService } from "../../service/execute-workflow/execute-workflow.service";
-import {
-  JointUIService,
-  linkPathStrokeColor
-} from "../../service/joint-ui/joint-ui.service";
+import { JointUIService, linkPathStrokeColor } from "../../service/joint-ui/joint-ui.service";
 import { ResultPanelToggleService } from "../../service/result-panel-toggle/result-panel-toggle.service";
 import { ValidationWorkflowService } from "../../service/validation/validation-workflow.service";
 import { JointGraphWrapper } from "../../service/workflow-graph/model/joint-graph-wrapper";
-import {
-  Group,
-  LinkInfo,
-  OperatorInfo
-} from "../../service/workflow-graph/model/operator-group";
+import { Group, LinkInfo, OperatorInfo } from "../../service/workflow-graph/model/operator-group";
 import { MAIN_CANVAS_LIMIT } from "./workflow-editor-constants";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 import { WorkflowUtilService } from "../../service/workflow-graph/util/workflow-util.service";
 import { WorkflowStatusService } from "../../service/workflow-status/workflow-status.service";
-import {
-  ExecutionState,
-  OperatorState
-} from "../../types/execute-workflow.interface";
-import {
-  OperatorLink,
-  OperatorPredicate,
-  Point
-} from "../../types/workflow-common.interface";
+import { ExecutionState, OperatorState } from "../../types/execute-workflow.interface";
+import { OperatorLink, OperatorPredicate, Point } from "../../types/workflow-common.interface";
 import { auditTime, filter, map } from "rxjs/operators";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 
@@ -74,13 +60,11 @@ const disableInteractiveOption = {
   arrowheadMove: false,
   vertexMove: false,
   vertexAdd: false,
-  vertexRemove: false
+  vertexRemove: false,
 };
 
-export const WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID =
-  "texera-workflow-editor-jointjs-wrapper-id";
-export const WORKFLOW_EDITOR_JOINTJS_ID =
-  "texera-workflow-editor-jointjs-body-id";
+export const WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID = "texera-workflow-editor-jointjs-wrapper-id";
+export const WORKFLOW_EDITOR_JOINTJS_ID = "texera-workflow-editor-jointjs-body-id";
 
 /**
  * WorkflowEditorComponent is the component for the main workflow editor part of the UI.
@@ -99,13 +83,12 @@ export const WORKFLOW_EDITOR_JOINTJS_ID =
 @Component({
   selector: "texera-workflow-editor",
   templateUrl: "./workflow-editor.component.html",
-  styleUrls: ["./workflow-editor.component.scss"]
+  styleUrls: ["./workflow-editor.component.scss"],
 })
 export class WorkflowEditorComponent implements AfterViewInit {
   // the DOM element ID of the main editor. It can be used by jQuery and jointJS to find the DOM element
   // in the HTML template, the div element ID is set using this variable
-  public readonly WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID =
-    WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID;
+  public readonly WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID = WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID;
   public readonly WORKFLOW_EDITOR_JOINTJS_ID = WORKFLOW_EDITOR_JOINTJS_ID;
 
   public readonly COPY_OFFSET = 20;
@@ -164,9 +147,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
 
     this.handlePaperMouseZoom();
     this.handleOperatorSuggestionHighlightEvent();
-    this.dragDropService.registerWorkflowEditorDrop(
-      this.WORKFLOW_EDITOR_JOINTJS_ID
-    );
+    this.dragDropService.registerWorkflowEditorDrop(this.WORKFLOW_EDITOR_JOINTJS_ID);
 
     this.handleElementDelete();
     this.handleElementSelectAll();
@@ -186,9 +167,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
     // attach the DOM element to the paper
     jointPaperOptions.el = jQuery(`#${this.WORKFLOW_EDITOR_JOINTJS_ID}`);
     // attach the JointJS graph (model) to the paper (view)
-    this.paper = this.workflowActionService
-      .getJointGraphWrapper()
-      .attachMainJointPaper(jointPaperOptions);
+    this.paper = this.workflowActionService.getJointGraphWrapper().attachMainJointPaper(jointPaperOptions);
 
     this.setJointPaperOriginOffset();
     this.setJointPaperDimensions();
@@ -198,7 +177,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
     this.workflowActionService
       .getWorkflowModificationEnabledStream()
       .pipe(untilDestroyed(this))
-      .subscribe((enabled) => {
+      .subscribe(enabled => {
         if (enabled) {
           this.interactive = true;
           this.getJointPaper().setInteractivity(defaultInteractiveOption);
@@ -226,34 +205,23 @@ export class WorkflowEditorComponent implements AfterViewInit {
     this.workflowStatusService
       .getStatusUpdateStream()
       .pipe(untilDestroyed(this))
-      .subscribe((status) => {
-        Object.keys(status).forEach((operatorID) => {
-          if (
-            !this.workflowActionService.getTexeraGraph().hasOperator(operatorID)
-          ) {
+      .subscribe(status => {
+        Object.keys(status).forEach(operatorID => {
+          if (!this.workflowActionService.getTexeraGraph().hasOperator(operatorID)) {
             return;
           }
-          if (
-            this.executeWorkflowService.getExecutionState().state ===
-            ExecutionState.Recovering
-          ) {
+          if (this.executeWorkflowService.getExecutionState().state === ExecutionState.Recovering) {
             status[operatorID] = {
               ...status[operatorID],
-              operatorState: OperatorState.Recovering
+              operatorState: OperatorState.Recovering,
             };
           }
           // if operator is part of a group, find it
-          const parentGroup = this.workflowActionService
-            .getOperatorGroup()
-            .getGroupByOperator(operatorID);
+          const parentGroup = this.workflowActionService.getOperatorGroup().getGroupByOperator(operatorID);
 
           // if operator is not in a group or in a group that isn't collapsed, it is okay to draw statistics on it
           if (!parentGroup || !parentGroup.collapsed) {
-            this.jointUIService.changeOperatorStatistics(
-              this.getJointPaper(),
-              operatorID,
-              status[operatorID]
-            );
+            this.jointUIService.changeOperatorStatistics(this.getJointPaper(), operatorID, status[operatorID]);
           }
 
           // if operator is in a group, write statistics to the group's operatorInfo
@@ -271,14 +239,10 @@ export class WorkflowEditorComponent implements AfterViewInit {
       .getOperatorGroup()
       .getGroupExpandStream()
       .pipe(untilDestroyed(this))
-      .subscribe((group) => {
+      .subscribe(group => {
         group.operators.forEach((operatorInfo, operatorID) => {
           if (operatorInfo.statistics) {
-            this.jointUIService.changeOperatorStatistics(
-              this.getJointPaper(),
-              operatorID,
-              operatorInfo.statistics
-            );
+            this.jointUIService.changeOperatorStatistics(this.getJointPaper(), operatorID, operatorInfo.statistics);
           }
         });
       });
@@ -286,7 +250,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
     this.executeWorkflowService
       .getExecutionStateStream()
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
+      .subscribe(event => {
         if (event.previous.state === ExecutionState.Recovering) {
           let operatorState: OperatorState;
           if (event.current.state === ExecutionState.Paused) {
@@ -296,20 +260,13 @@ export class WorkflowEditorComponent implements AfterViewInit {
           } else if (event.current.state === ExecutionState.Running) {
             operatorState = OperatorState.Running;
           } else {
-            throw new Error(
-              "unknown state transition from recovering state: " +
-                event.current.state
-            );
+            throw new Error("unknown state transition from recovering state: " + event.current.state);
           }
           this.workflowActionService
             .getTexeraGraph()
             .getAllOperators()
-            .forEach((op) => {
-              this.jointUIService.changeOperatorState(
-                this.getJointPaper(),
-                op.operatorID,
-                operatorState
-              );
+            .forEach(op => {
+              this.jointUIService.changeOperatorState(this.getJointPaper(), op.operatorID, operatorState);
             });
         }
       });
@@ -338,7 +295,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
       .getJointGraphWrapper()
       .getWorkflowEditorZoomStream()
       .pipe(untilDestroyed(this))
-      .subscribe((newRatio) => {
+      .subscribe(newRatio => {
         // set jointjs scale
         this.getJointPaper().scale(newRatio, newRatio);
       });
@@ -360,38 +317,32 @@ export class WorkflowEditorComponent implements AfterViewInit {
   private handlePaperMouseZoom(): void {
     fromEvent<WheelEvent>(document, "mousewheel")
       .pipe(
-        filter((event) => event !== undefined),
-        filter((event) => this.elementRef.nativeElement.contains(event.target))
+        filter(event => event !== undefined),
+        filter(event => this.elementRef.nativeElement.contains(event.target))
       )
-      .forEach((event) => {
+      .forEach(event => {
         if (event.metaKey || event.ctrlKey) {
           if (event.deltaY < 0) {
             // if zoom ratio already at minimum, do not zoom out.
-            if (
-              this.workflowActionService.getJointGraphWrapper().isZoomRatioMin()
-            ) {
+            if (this.workflowActionService.getJointGraphWrapper().isZoomRatioMin()) {
               return;
             }
             this.workflowActionService
               .getJointGraphWrapper()
               .setZoomProperty(
-                this.workflowActionService
-                  .getJointGraphWrapper()
-                  .getZoomRatio() - JointGraphWrapper.ZOOM_MOUSEWHEEL_DIFF
+                this.workflowActionService.getJointGraphWrapper().getZoomRatio() -
+                  JointGraphWrapper.ZOOM_MOUSEWHEEL_DIFF
               );
           } else {
             // if zoom ratio already at maximum, do not zoom in.
-            if (
-              this.workflowActionService.getJointGraphWrapper().isZoomRatioMax()
-            ) {
+            if (this.workflowActionService.getJointGraphWrapper().isZoomRatioMax()) {
               return;
             }
             this.workflowActionService
               .getJointGraphWrapper()
               .setZoomProperty(
-                this.workflowActionService
-                  .getJointGraphWrapper()
-                  .getZoomRatio() + JointGraphWrapper.ZOOM_MOUSEWHEEL_DIFF
+                this.workflowActionService.getJointGraphWrapper().getZoomRatio() +
+                  JointGraphWrapper.ZOOM_MOUSEWHEEL_DIFF
               );
           }
         }
@@ -417,31 +368,19 @@ export class WorkflowEditorComponent implements AfterViewInit {
   private checkBounding(limitx: number[], limity: number[]): void {
     // check if operator out of right bound after WrapperElement changes its size
     if (this.getJointPaper().translate().tx > limitx[0]) {
-      this.getJointPaper().translate(
-        limitx[0],
-        this.getJointPaper().translate().ty
-      );
+      this.getJointPaper().translate(limitx[0], this.getJointPaper().translate().ty);
     }
     // check left bound
     if (this.getJointPaper().translate().tx < limitx[1]) {
-      this.getJointPaper().translate(
-        limitx[1],
-        this.getJointPaper().translate().ty
-      );
+      this.getJointPaper().translate(limitx[1], this.getJointPaper().translate().ty);
     }
     // check lower bound
     if (this.getJointPaper().translate().ty > limity[0]) {
-      this.getJointPaper().translate(
-        this.getJointPaper().translate().tx,
-        limity[0]
-      );
+      this.getJointPaper().translate(this.getJointPaper().translate().tx, limity[0]);
     }
     // check upper bound
     if (this.getJointPaper().translate().ty < limity[1]) {
-      this.getJointPaper().translate(
-        this.getJointPaper().translate().tx,
-        limity[1]
-      );
+      this.getJointPaper().translate(this.getJointPaper().translate().tx, limity[1]);
     }
   }
 
@@ -458,7 +397,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
     // pointer down event to start the panning, this will record the original paper offset
     fromEvent<JointPointerDownEvent>(this.getJointPaper(), "blank:pointerdown")
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
+      .subscribe(event => {
         const x = event[0].screenX;
         const y = event[0].screenY;
         if (x !== undefined && y !== undefined) {
@@ -481,7 +420,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
      */
     const mousePanEvent = fromEvent<MouseEvent>(document, "mousemove").pipe(
       filter(() => this.mouseDown !== undefined),
-      map((event) => {
+      map(event => {
         event.preventDefault();
         if (this.mouseDown === undefined) {
           throw new Error("Error: Mouse down is undefined after the filter");
@@ -489,7 +428,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
         const newCoordinate = { x: event.screenX, y: event.screenY };
         const panDelta = {
           deltaX: newCoordinate.x - this.mouseDown.x,
-          deltaY: newCoordinate.y - this.mouseDown.y
+          deltaY: newCoordinate.y - this.mouseDown.y,
         };
         this.mouseDown = newCoordinate;
         return panDelta;
@@ -497,9 +436,9 @@ export class WorkflowEditorComponent implements AfterViewInit {
     );
 
     const mouseWheelEvent = fromEvent<WheelEvent>(document, "mousewheel").pipe(
-      filter((event) => this.elementRef.nativeElement.contains(event.target)),
-      filter((event) => !(event.metaKey || event.ctrlKey)),
-      map((event) => {
+      filter(event => this.elementRef.nativeElement.contains(event.target)),
+      filter(event => !(event.metaKey || event.ctrlKey)),
+      map(event => {
         return { deltaX: -event.deltaX, deltaY: -event.deltaY };
       })
     );
@@ -508,21 +447,21 @@ export class WorkflowEditorComponent implements AfterViewInit {
       mousePanEvent,
       mouseWheelEvent,
       this.workflowActionService.getJointGraphWrapper().navigatorMoveDelta.pipe(
-        map((event) => {
+        map(event => {
           const scale = this.getJointPaper().scale();
           return {
             deltaX: event.deltaX * scale.sx,
-            deltaY: event.deltaY * scale.sy
+            deltaY: event.deltaY * scale.sy,
           };
         })
       )
     )
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
+      .subscribe(event => {
         const oldOrigin = this.getJointPaper().translate();
         const newOrigin = {
           x: oldOrigin.tx + event.deltaX,
-          y: oldOrigin.ty + event.deltaY
+          y: oldOrigin.ty + event.deltaY,
         };
 
         const scale = this.getJointPaper().scale();
@@ -537,16 +476,10 @@ export class WorkflowEditorComponent implements AfterViewInit {
         if (-newOrigin.y <= translateLimit.yMin) {
           newOrigin.y = -translateLimit.yMin;
         }
-        if (
-          -newOrigin.x >=
-          translateLimit.xMax - elementSize.width / scale.sx
-        ) {
+        if (-newOrigin.x >= translateLimit.xMax - elementSize.width / scale.sx) {
           newOrigin.x = -(translateLimit.xMax - elementSize.width / scale.sx);
         }
-        if (
-          -newOrigin.y >=
-          translateLimit.yMax - elementSize.height / scale.sy
-        ) {
+        if (-newOrigin.y >= translateLimit.yMax - elementSize.height / scale.sy) {
           newOrigin.y = -(translateLimit.yMax - elementSize.height / scale.sy);
         }
 
@@ -588,15 +521,10 @@ export class WorkflowEditorComponent implements AfterViewInit {
       .getTexeraGraph()
       .getDisabledOperatorsChangedStream()
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
-        event.newDisabled.concat(event.newEnabled).forEach((opID) => {
-          const op = this.workflowActionService
-            .getTexeraGraph()
-            .getOperator(opID);
-          this.jointUIService.changeOperatorDisableStatus(
-            this.getJointPaper(),
-            op
-          );
+      .subscribe(event => {
+        event.newDisabled.concat(event.newEnabled).forEach(opID => {
+          const op = this.workflowActionService.getTexeraGraph().getOperator(opID);
+          this.jointUIService.changeOperatorDisableStatus(this.getJointPaper(), op);
         });
       });
   }
@@ -607,14 +535,8 @@ export class WorkflowEditorComponent implements AfterViewInit {
       .getOperatorDisplayNameChangedStream()
       .pipe(untilDestroyed(this))
       .subscribe(({ operatorID, newDisplayName }) => {
-        const op = this.workflowActionService
-          .getTexeraGraph()
-          .getOperator(operatorID);
-        this.jointUIService.changeOperatorJointDisplayName(
-          op,
-          this.getJointPaper(),
-          newDisplayName
-        );
+        const op = this.workflowActionService.getTexeraGraph().getOperator(operatorID);
+        this.jointUIService.changeOperatorJointDisplayName(op, this.getJointPaper(), newDisplayName);
       });
   }
 
@@ -630,69 +552,41 @@ export class WorkflowEditorComponent implements AfterViewInit {
     fromEvent<JointPaperEvent>(this.getJointPaper(), "cell:pointerdown")
       // event[0] is the JointJS CellView; event[1] is the original JQuery Event
       .pipe(
-        filter((event) => event[0].model.isElement()),
+        filter(event => event[0].model.isElement()),
         filter(
-          (event) =>
-            this.workflowActionService
-              .getTexeraGraph()
-              .hasOperator(event[0].model.id.toString()) ||
-            this.workflowActionService
-              .getOperatorGroup()
-              .hasGroup(event[0].model.id.toString())
+          event =>
+            this.workflowActionService.getTexeraGraph().hasOperator(event[0].model.id.toString()) ||
+            this.workflowActionService.getOperatorGroup().hasGroup(event[0].model.id.toString())
         )
       )
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
+      .subscribe(event => {
         // multiselect mode on if holding shift
-        this.workflowActionService
-          .getJointGraphWrapper()
-          .setMultiSelectMode(<boolean>event[1].shiftKey);
+        this.workflowActionService.getJointGraphWrapper().setMultiSelectMode(<boolean>event[1].shiftKey);
 
         const elementID = event[0].model.id.toString();
         const highlightedOperatorIDs = this.workflowActionService
           .getJointGraphWrapper()
           .getCurrentHighlightedOperatorIDs();
-        const highlightedGroupIDs = this.workflowActionService
-          .getJointGraphWrapper()
-          .getCurrentHighlightedGroupIDs();
+        const highlightedGroupIDs = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedGroupIDs();
 
         if (event[1].shiftKey) {
           // if in multiselect toggle highlights on click
           if (highlightedOperatorIDs.includes(elementID)) {
-            this.workflowActionService
-              .getJointGraphWrapper()
-              .unhighlightOperators(elementID);
+            this.workflowActionService.getJointGraphWrapper().unhighlightOperators(elementID);
           } else if (highlightedGroupIDs.includes(elementID)) {
-            this.workflowActionService
-              .getJointGraphWrapper()
-              .unhighlightGroups(elementID);
-          } else if (
-            this.workflowActionService.getTexeraGraph().hasOperator(elementID)
-          ) {
-            this.workflowActionService
-              .getJointGraphWrapper()
-              .highlightOperators(elementID);
-          } else if (
-            this.workflowActionService.getOperatorGroup().hasGroup(elementID)
-          ) {
-            this.workflowActionService
-              .getJointGraphWrapper()
-              .highlightGroups(elementID);
+            this.workflowActionService.getJointGraphWrapper().unhighlightGroups(elementID);
+          } else if (this.workflowActionService.getTexeraGraph().hasOperator(elementID)) {
+            this.workflowActionService.getJointGraphWrapper().highlightOperators(elementID);
+          } else if (this.workflowActionService.getOperatorGroup().hasGroup(elementID)) {
+            this.workflowActionService.getJointGraphWrapper().highlightGroups(elementID);
           }
         } else {
           // else only highlight a single operator or group
-          if (
-            this.workflowActionService.getTexeraGraph().hasOperator(elementID)
-          ) {
-            this.workflowActionService
-              .getJointGraphWrapper()
-              .highlightOperators(elementID);
-          } else if (
-            this.workflowActionService.getOperatorGroup().hasGroup(elementID)
-          ) {
-            this.workflowActionService
-              .getJointGraphWrapper()
-              .highlightGroups(elementID);
+          if (this.workflowActionService.getTexeraGraph().hasOperator(elementID)) {
+            this.workflowActionService.getJointGraphWrapper().highlightOperators(elementID);
+          } else if (this.workflowActionService.getOperatorGroup().hasGroup(elementID)) {
+            this.workflowActionService.getJointGraphWrapper().highlightGroups(elementID);
           }
         }
       });
@@ -704,21 +598,11 @@ export class WorkflowEditorComponent implements AfterViewInit {
         const highlightedOperatorIDs = this.workflowActionService
           .getJointGraphWrapper()
           .getCurrentHighlightedOperatorIDs();
-        const highlightedGroupIDs = this.workflowActionService
-          .getJointGraphWrapper()
-          .getCurrentHighlightedGroupIDs();
-        const highlightedLinkIDs = this.workflowActionService
-          .getJointGraphWrapper()
-          .getCurrentHighlightedLinkIDs();
-        this.workflowActionService
-          .getJointGraphWrapper()
-          .unhighlightOperators(...highlightedOperatorIDs);
-        this.workflowActionService
-          .getJointGraphWrapper()
-          .unhighlightGroups(...highlightedGroupIDs);
-        this.workflowActionService
-          .getJointGraphWrapper()
-          .unhighlightLinks(...highlightedLinkIDs);
+        const highlightedGroupIDs = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedGroupIDs();
+        const highlightedLinkIDs = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedLinkIDs();
+        this.workflowActionService.getJointGraphWrapper().unhighlightOperators(...highlightedOperatorIDs);
+        this.workflowActionService.getJointGraphWrapper().unhighlightGroups(...highlightedGroupIDs);
+        this.workflowActionService.getJointGraphWrapper().unhighlightLinks(...highlightedLinkIDs);
       });
   }
 
@@ -730,44 +614,32 @@ export class WorkflowEditorComponent implements AfterViewInit {
       options: {
         attrs: {
           "stroke-width": 2,
-          stroke: "#4A95FF"
-        }
-      }
+          stroke: "#4A95FF",
+        },
+      },
     };
 
     // highlight on OperatorHighlightStream or GroupHighlightStream
     merge(
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointOperatorHighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointGroupHighlightStream()
+      this.workflowActionService.getJointGraphWrapper().getJointOperatorHighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getJointGroupHighlightStream()
     )
       .pipe(untilDestroyed(this))
-      .subscribe((elementIDs) =>
-        elementIDs.forEach((elementID) =>
-          this.getJointPaper()
-            .findViewByModel(elementID)
-            .highlight("rect", { highlighter: highlightOptions })
+      .subscribe(elementIDs =>
+        elementIDs.forEach(elementID =>
+          this.getJointPaper().findViewByModel(elementID).highlight("rect", { highlighter: highlightOptions })
         )
       );
 
     // unhighlight on OperatorUnhighlightStream or GroupUnhighlightStream
     merge(
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointOperatorUnhighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointGroupUnhighlightStream()
+      this.workflowActionService.getJointGraphWrapper().getJointOperatorUnhighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getJointGroupUnhighlightStream()
     )
       .pipe(untilDestroyed(this))
-      .subscribe((elementIDs) =>
-        elementIDs.forEach((elementID) =>
-          this.getJointPaper()
-            .findViewByModel(elementID)
-            .unhighlight("rect", { highlighter: highlightOptions })
+      .subscribe(elementIDs =>
+        elementIDs.forEach(elementID =>
+          this.getJointPaper().findViewByModel(elementID).unhighlight("rect", { highlighter: highlightOptions })
         )
       );
   }
@@ -778,27 +650,23 @@ export class WorkflowEditorComponent implements AfterViewInit {
       options: {
         attrs: {
           "stroke-width": 5,
-          stroke: "#551A8B70"
-        }
-      }
+          stroke: "#551A8B70",
+        },
+      },
     };
 
     this.dragDropService
       .getOperatorSuggestionHighlightStream()
       .pipe(untilDestroyed(this))
-      .subscribe((value) =>
-        this.getJointPaper()
-          .findViewByModel(value)
-          .highlight("rect", { highlighter: highlightOptions })
+      .subscribe(value =>
+        this.getJointPaper().findViewByModel(value).highlight("rect", { highlighter: highlightOptions })
       );
 
     this.dragDropService
       .getOperatorSuggestionUnhighlightStream()
       .pipe(untilDestroyed(this))
-      .subscribe((value) =>
-        this.getJointPaper()
-          .findViewByModel(value)
-          .unhighlight("rect", { highlighter: highlightOptions })
+      .subscribe(value =>
+        this.getJointPaper().findViewByModel(value).unhighlight("rect", { highlighter: highlightOptions })
       );
   }
 
@@ -840,14 +708,12 @@ export class WorkflowEditorComponent implements AfterViewInit {
     // bind the delete button event to call the delete operator function in joint model action
     fromEvent<JointPaperEvent>(this.getJointPaper(), "element:delete")
       .pipe(
-        filter((value) => this.interactive),
-        map((value) => value[0])
+        filter(value => this.interactive),
+        map(value => value[0])
       )
       .pipe(untilDestroyed(this))
-      .subscribe((elementView) => {
-        this.workflowActionService.deleteOperator(
-          elementView.model.id.toString()
-        );
+      .subscribe(elementView => {
+        this.workflowActionService.deleteOperator(elementView.model.id.toString());
       });
   }
 
@@ -862,14 +728,12 @@ export class WorkflowEditorComponent implements AfterViewInit {
   private handleViewDeleteLink(): void {
     fromEvent<JointPaperEvent>(this.getJointPaper(), "tool:remove")
       .pipe(
-        filter((value) => this.interactive),
-        map((value) => value[0])
+        filter(value => this.interactive),
+        map(value => value[0])
       )
       .pipe(untilDestroyed(this))
-      .subscribe((elementView) => {
-        this.workflowActionService.deleteLinkWithID(
-          elementView.model.id.toString()
-        );
+      .subscribe(elementView => {
+        this.workflowActionService.deleteLinkWithID(elementView.model.id.toString());
       });
   }
 
@@ -885,9 +749,9 @@ export class WorkflowEditorComponent implements AfterViewInit {
    */
   private handleViewCollapseGroup(): void {
     fromEvent<JointPaperEvent>(this.getJointPaper(), "element:collapse")
-      .pipe(map((value) => value[0]))
+      .pipe(map(value => value[0]))
       .pipe(untilDestroyed(this))
-      .subscribe((elementView) => {
+      .subscribe(elementView => {
         const groupID = elementView.model.id.toString();
         this.workflowActionService.collapseGroups(groupID);
       });
@@ -905,9 +769,9 @@ export class WorkflowEditorComponent implements AfterViewInit {
    */
   private handleViewExpandGroup(): void {
     fromEvent<JointPaperEvent>(this.getJointPaper(), "element:expand")
-      .pipe(map((value) => value[0]))
+      .pipe(map(value => value[0]))
       .pipe(untilDestroyed(this))
-      .subscribe((elementView) => {
+      .subscribe(elementView => {
         const groupID = elementView.model.id.toString();
         this.workflowActionService.expandGroups(groupID);
       });
@@ -920,17 +784,9 @@ export class WorkflowEditorComponent implements AfterViewInit {
     this.validationWorkflowService
       .getOperatorValidationStream()
       .pipe(untilDestroyed(this))
-      .subscribe((value) => {
-        if (
-          !this.workflowActionService
-            .getOperatorGroup()
-            .getGroupByOperator(value.operatorID)?.collapsed
-        ) {
-          this.jointUIService.changeOperatorColor(
-            this.getJointPaper(),
-            value.operatorID,
-            value.validation.isValid
-          );
+      .subscribe(value => {
+        if (!this.workflowActionService.getOperatorGroup().getGroupByOperator(value.operatorID)?.collapsed) {
+          this.jointUIService.changeOperatorColor(this.getJointPaper(), value.operatorID, value.validation.isValid);
         }
       });
   }
@@ -947,34 +803,24 @@ export class WorkflowEditorComponent implements AfterViewInit {
       .getOperatorGroup()
       .getGroupCollapseStream()
       .pipe(untilDestroyed(this))
-      .subscribe((group) => {
-        this.jointUIService.hideGroupCollapseButton(
-          this.getJointPaper(),
-          group.groupID
-        );
+      .subscribe(group => {
+        this.jointUIService.hideGroupCollapseButton(this.getJointPaper(), group.groupID);
       });
 
     this.workflowActionService
       .getOperatorGroup()
       .getGroupExpandStream()
       .pipe(untilDestroyed(this))
-      .subscribe((group) => {
-        this.jointUIService.hideGroupExpandButton(
-          this.getJointPaper(),
-          group.groupID
-        );
+      .subscribe(group => {
+        this.jointUIService.hideGroupExpandButton(this.getJointPaper(), group.groupID);
       });
 
     this.workflowActionService
       .getOperatorGroup()
       .getGroupResizeStream()
       .pipe(untilDestroyed(this))
-      .subscribe((value) => {
-        this.jointUIService.repositionGroupCollapseButton(
-          this.getJointPaper(),
-          value.groupID,
-          value.width
-        );
+      .subscribe(value => {
+        this.jointUIService.repositionGroupCollapseButton(this.getJointPaper(), value.groupID, value.width);
       });
   }
 
@@ -983,9 +829,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
    */
   private getWrapperElementSize(): { width: number; height: number } {
     const width = jQuery("#" + this.WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID).width();
-    const height = jQuery(
-      "#" + this.WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID
-    ).height();
+    const height = jQuery("#" + this.WORKFLOW_EDITOR_JOINTJS_WRAPPER_ID).height();
 
     if (width === undefined || height === undefined) {
       throw new Error("fail to get Workflow Editor wrapper element size");
@@ -1006,11 +850,9 @@ export class WorkflowEditorComponent implements AfterViewInit {
       // disable jointjs default action that can make a link not connect to an operator
       linkPinning: false,
       // provide a validation to determine if two ports could be connected (only output connect to input is allowed)
-      validateConnection: (...args) =>
-        this.validateJointOperatorConnection(...args),
+      validateConnection: (...args) => this.validateJointOperatorConnection(...args),
       // provide a validation to determine if the port where link starts from is an out port
-      validateMagnet: (...args) =>
-        WorkflowEditorComponent.validateOperatorMagnet(...args),
+      validateMagnet: (...args) => WorkflowEditorComponent.validateOperatorMagnet(...args),
       // marks all the available magnets or elements when a link is dragged
       markAvailable: true,
       // disable jointjs default action of adding vertexes to the link
@@ -1024,10 +866,10 @@ export class WorkflowEditorComponent implements AfterViewInit {
       // draw dots in the background of the paper
       drawGrid: {
         name: "fixedDot",
-        args: { color: "black", scaleFactor: 8, thickness: 1.2 }
+        args: { color: "black", scaleFactor: 8, thickness: 1.2 },
       },
       // set grid size
-      gridSize: 2
+      gridSize: 2,
     };
 
     return jointPaperOptions;
@@ -1062,12 +904,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
     const targetCellID = targetView.model.id.toString();
     const targetPortID = targetMagnet?.getAttribute("port");
 
-    return this.validateOperatorConnection(
-      sourceCellID,
-      sourcePortID,
-      targetCellID,
-      targetPortID
-    );
+    return this.validateOperatorConnection(sourceCellID, sourcePortID, targetCellID, targetPortID);
   }
 
   private validateOperatorConnection(
@@ -1098,18 +935,12 @@ export class WorkflowEditorComponent implements AfterViewInit {
     const connectedLinksToTargetPort = this.workflowActionService
       .getTexeraGraph()
       .getAllLinks()
-      .filter(
-        (link) =>
-          link.target.operatorID === targetCellID &&
-          link.target.portID === targetPortID
-      );
+      .filter(link => link.target.operatorID === targetCellID && link.target.portID === targetPortID);
 
     // check if this link already exists, duplicate links are not allowed
     const isDuplicateLink =
       connectedLinksToTargetPort.filter(
-        (link) =>
-          link.source.operatorID === sourceCellID &&
-          link.source.portID === sourcePortID
+        link => link.source.operatorID === sourceCellID && link.source.portID === sourcePortID
       ).length > 0;
     if (isDuplicateLink) {
       return false;
@@ -1120,11 +951,10 @@ export class WorkflowEditorComponent implements AfterViewInit {
       const portIndex = this.workflowActionService
         .getTexeraGraph()
         .getOperator(targetCellID)
-        .inputPorts.findIndex((p) => p.portID === targetPortID);
+        .inputPorts.findIndex(p => p.portID === targetPortID);
       if (portIndex >= 0) {
         const portInfo =
-          this.dynamicSchemaService.getDynamicSchema(targetCellID)
-            .additionalMetadata.inputPorts[portIndex];
+          this.dynamicSchemaService.getDynamicSchema(targetCellID).additionalMetadata.inputPorts[portIndex];
         allowMultiInput = portInfo.allowMultiInputs ?? false;
       }
     }
@@ -1143,23 +973,17 @@ export class WorkflowEditorComponent implements AfterViewInit {
   private handleElementDelete(): void {
     fromEvent<KeyboardEvent>(document, "keydown")
       .pipe(
-        filter((event) => document.activeElement === document.body),
-        filter((event) => this.interactive),
-        filter((event) => event.key === "Backspace" || event.key === "Delete")
+        filter(event => document.activeElement === document.body),
+        filter(event => this.interactive),
+        filter(event => event.key === "Backspace" || event.key === "Delete")
       )
       .pipe(untilDestroyed(this))
       .subscribe(() => {
         const highlightedOperatorIDs = this.workflowActionService
           .getJointGraphWrapper()
           .getCurrentHighlightedOperatorIDs();
-        const highlightedGroupIDs = this.workflowActionService
-          .getJointGraphWrapper()
-          .getCurrentHighlightedGroupIDs();
-        this.workflowActionService.deleteOperatorsAndLinks(
-          highlightedOperatorIDs,
-          [],
-          highlightedGroupIDs
-        );
+        const highlightedGroupIDs = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedGroupIDs();
+        this.workflowActionService.deleteOperatorsAndLinks(highlightedOperatorIDs, [], highlightedGroupIDs);
       });
   }
 
@@ -1169,35 +993,28 @@ export class WorkflowEditorComponent implements AfterViewInit {
   private handleElementSelectAll(): void {
     fromEvent<KeyboardEvent>(document, "keydown")
       .pipe(
-        filter((event) => document.activeElement === document.body),
-        filter((event) => (event.metaKey || event.ctrlKey) && event.key === "a")
+        filter(event => document.activeElement === document.body),
+        filter(event => (event.metaKey || event.ctrlKey) && event.key === "a")
       )
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
+      .subscribe(event => {
         event.preventDefault();
         const allOperators = this.workflowActionService
           .getTexeraGraph()
           .getAllOperators()
-          .map((operator) => operator.operatorID)
+          .map(operator => operator.operatorID)
           .filter(
-            (operatorID) =>
-              !this.workflowActionService
-                .getOperatorGroup()
-                .getGroupByOperator(operatorID)?.collapsed
+            operatorID => !this.workflowActionService.getOperatorGroup().getGroupByOperator(operatorID)?.collapsed
           );
         const allGroups = this.workflowActionService
           .getOperatorGroup()
           .getAllGroups()
-          .map((group) => group.groupID);
+          .map(group => group.groupID);
         this.workflowActionService
           .getJointGraphWrapper()
           .setMultiSelectMode(allOperators.length + allGroups.length > 1);
-        this.workflowActionService
-          .getJointGraphWrapper()
-          .highlightOperators(...allOperators);
-        this.workflowActionService
-          .getJointGraphWrapper()
-          .highlightGroups(...allGroups);
+        this.workflowActionService.getJointGraphWrapper().highlightOperators(...allOperators);
+        this.workflowActionService.getJointGraphWrapper().highlightGroups(...allGroups);
       });
   }
 
@@ -1208,19 +1025,14 @@ export class WorkflowEditorComponent implements AfterViewInit {
    */
   private handleElementCopy(): void {
     fromEvent<ClipboardEvent>(document, "copy")
-      .pipe(filter((event) => document.activeElement === document.body))
+      .pipe(filter(event => document.activeElement === document.body))
       .pipe(untilDestroyed(this))
       .subscribe(() => {
         const highlightedOperatorIDs = this.workflowActionService
           .getJointGraphWrapper()
           .getCurrentHighlightedOperatorIDs();
-        const highlightedGroupIDs = this.workflowActionService
-          .getJointGraphWrapper()
-          .getCurrentHighlightedGroupIDs();
-        if (
-          highlightedOperatorIDs.length > 0 ||
-          highlightedGroupIDs.length > 0
-        ) {
+        const highlightedGroupIDs = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedGroupIDs();
+        if (highlightedOperatorIDs.length > 0 || highlightedGroupIDs.length > 0) {
           this.clearCopiedElements();
           this.saveHighlighedElements();
         }
@@ -1235,28 +1047,19 @@ export class WorkflowEditorComponent implements AfterViewInit {
   private handleOperatorCut(): void {
     fromEvent<ClipboardEvent>(document, "cut")
       .pipe(
-        filter((event) => document.activeElement === document.body),
-        filter((event) => this.interactive)
+        filter(event => document.activeElement === document.body),
+        filter(event => this.interactive)
       )
       .pipe(untilDestroyed(this))
       .subscribe(() => {
         const highlightedOperatorIDs = this.workflowActionService
           .getJointGraphWrapper()
           .getCurrentHighlightedOperatorIDs();
-        const highlightedGroupIDs = this.workflowActionService
-          .getJointGraphWrapper()
-          .getCurrentHighlightedGroupIDs();
-        if (
-          highlightedOperatorIDs.length > 0 ||
-          highlightedGroupIDs.length > 0
-        ) {
+        const highlightedGroupIDs = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedGroupIDs();
+        if (highlightedOperatorIDs.length > 0 || highlightedGroupIDs.length > 0) {
           this.clearCopiedElements();
           this.saveHighlighedElements();
-          this.workflowActionService.deleteOperatorsAndLinks(
-            highlightedOperatorIDs,
-            [],
-            highlightedGroupIDs
-          );
+          this.workflowActionService.deleteOperatorsAndLinks(highlightedOperatorIDs, [], highlightedGroupIDs);
         }
       });
   }
@@ -1273,27 +1076,17 @@ export class WorkflowEditorComponent implements AfterViewInit {
    * saves highlighted elements to copiedOperators and copiedGroups
    */
   private saveHighlighedElements(): void {
-    const highlightedOperatorIDs = this.workflowActionService
-      .getJointGraphWrapper()
-      .getCurrentHighlightedOperatorIDs();
-    const highlightedGroupIDs = this.workflowActionService
-      .getJointGraphWrapper()
-      .getCurrentHighlightedGroupIDs();
+    const highlightedOperatorIDs = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs();
+    const highlightedGroupIDs = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedGroupIDs();
 
-    highlightedOperatorIDs.forEach((operatorID) =>
-      this.saveOperatorInfo(operatorID, false)
-    );
-    highlightedGroupIDs.forEach((groupID) => {
+    highlightedOperatorIDs.forEach(operatorID => this.saveOperatorInfo(operatorID, false));
+    highlightedGroupIDs.forEach(groupID => {
       this.saveGroupInfo(groupID);
 
-      const copiedGroup = this.workflowActionService
-        .getOperatorGroup()
-        .getGroup(groupID);
+      const copiedGroup = this.workflowActionService.getOperatorGroup().getGroup(groupID);
       assertType<Group>(copiedGroup);
       // do no copy operators that would be copied along with their groups (to avoid double counting)
-      copiedGroup.operators.forEach((operatorInfo, operatorID) =>
-        this.deleteOperatorInfo(operatorID)
-      );
+      copiedGroup.operators.forEach((operatorInfo, operatorID) => this.deleteOperatorInfo(operatorID));
     });
   }
 
@@ -1303,22 +1096,16 @@ export class WorkflowEditorComponent implements AfterViewInit {
    * @param includeOperator
    */
   private saveOperatorInfo(operatorID: string, includeOperator: boolean): void {
-    const operator = this.workflowActionService
-      .getTexeraGraph()
-      .getOperator(operatorID);
+    const operator = this.workflowActionService.getTexeraGraph().getOperator(operatorID);
     if (operator) {
-      const position = this.workflowActionService
-        .getJointGraphWrapper()
-        .getElementPosition(operatorID);
-      const layer = this.workflowActionService
-        .getJointGraphWrapper()
-        .getCellLayer(operatorID);
+      const position = this.workflowActionService.getJointGraphWrapper().getElementPosition(operatorID);
+      const layer = this.workflowActionService.getJointGraphWrapper().getCellLayer(operatorID);
       const pastedOperators = includeOperator ? [operatorID] : [];
       this.copiedOperators.set(operatorID, {
         operator,
         position,
         layer,
-        pastedOperatorIDs: pastedOperators
+        pastedOperatorIDs: pastedOperators,
       });
     }
   }
@@ -1335,13 +1122,9 @@ export class WorkflowEditorComponent implements AfterViewInit {
    */
   private saveGroupInfo(groupID: string): void {
     this.copiedGroups.set(groupID, {
-      group: this.copyGroup(
-        this.workflowActionService.getOperatorGroup().getGroup(groupID)
-      ),
-      position: this.workflowActionService
-        .getJointGraphWrapper()
-        .getElementPosition(groupID),
-      pastedGroupIDs: []
+      group: this.copyGroup(this.workflowActionService.getOperatorGroup().getGroup(groupID)),
+      position: this.workflowActionService.getJointGraphWrapper().getElementPosition(groupID),
+      pastedGroupIDs: [],
     });
   }
 
@@ -1353,37 +1136,30 @@ export class WorkflowEditorComponent implements AfterViewInit {
   private handleOperatorPaste(): void {
     fromEvent<ClipboardEvent>(document, "paste")
       .pipe(
-        filter((event) => document.activeElement === document.body),
-        filter((event) => this.interactive)
+        filter(event => document.activeElement === document.body),
+        filter(event => this.interactive)
       )
       .pipe(untilDestroyed(this))
       .subscribe(() => {
         // if there is something to paste
         if (this.copiedOperators.size > 0 || this.copiedGroups.size > 0) {
-          const operatorsAndPositions: { op: OperatorPredicate; pos: Point }[] =
-            [];
+          const operatorsAndPositions: { op: OperatorPredicate; pos: Point }[] = [];
           const links: OperatorLink[] = [];
           const groups: Group[] = [];
           const positions: Point[] = [];
 
           // sort operators by layer
           this.copiedOperators = new Map<string, CopiedOperator>(
-            Array.from(this.copiedOperators).sort(
-              (first, second) => first[1].layer - second[1].layer
-            )
+            Array.from(this.copiedOperators).sort((first, second) => first[1].layer - second[1].layer)
           );
 
           // make copies of each operator, and calculate their positions when pasted
           this.copiedOperators.forEach((copiedOperator, operatorID) => {
             const newOperator = this.copyOperator(copiedOperator.operator);
-            const newOperatorPosition = this.calcOperatorPosition(
-              newOperator.operatorID,
-              operatorID,
-              positions
-            );
+            const newOperatorPosition = this.calcOperatorPosition(newOperator.operatorID, operatorID, positions);
             operatorsAndPositions.push({
               op: newOperator,
-              pos: newOperatorPosition
+              pos: newOperatorPosition,
             });
             positions.push(newOperatorPosition);
           });
@@ -1393,17 +1169,13 @@ export class WorkflowEditorComponent implements AfterViewInit {
             const newGroup = this.copyGroup(copiedGroup.group);
 
             const oldPosition = copiedGroup.position;
-            const newPosition = this.calcGroupPosition(
-              newGroup.groupID,
-              groupID,
-              positions
-            );
+            const newPosition = this.calcGroupPosition(newGroup.groupID, groupID, positions);
             positions.push(newPosition);
 
             // delta between old position and new to apply to the copied group's operators
             const delta = {
               x: newPosition.x - oldPosition.x,
-              y: newPosition.y - oldPosition.y
+              y: newPosition.y - oldPosition.y,
             };
 
             newGroup.operators.forEach((operatorInfo, operatorID) => {
@@ -1412,7 +1184,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
 
               operatorsAndPositions.push({
                 op: operatorInfo.operator,
-                pos: operatorInfo.position
+                pos: operatorInfo.position,
               });
             });
 
@@ -1426,12 +1198,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
           });
 
           // actually add all operators, links, groups to the workflow
-          this.workflowActionService.addOperatorsAndLinks(
-            operatorsAndPositions,
-            links,
-            groups,
-            new Map()
-          );
+          this.workflowActionService.addOperatorsAndLinks(operatorsAndPositions, links, groups, new Map());
         }
       });
   }
@@ -1444,10 +1211,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
   private copyOperator(operator: OperatorPredicate): OperatorPredicate {
     return {
       ...operator,
-      operatorID:
-        operator.operatorType +
-        "-" +
-        this.workflowUtilService.getOperatorRandomUUID()
+      operatorID: operator.operatorType + "-" + this.workflowUtilService.getOperatorRandomUUID(),
     };
   }
 
@@ -1457,26 +1221,23 @@ export class WorkflowEditorComponent implements AfterViewInit {
     const operatorMap = new Map<string, string>();
 
     const operators = new Map(
-      Array.from(group.operators.values()).map((operatorInfo) => {
+      Array.from(group.operators.values()).map(operatorInfo => {
         const newOperatorInfo = {
           operator: this.copyOperator(operatorInfo.operator),
           position: {
             x: operatorInfo.position.x,
-            y: operatorInfo.position.y
+            y: operatorInfo.position.y,
           },
-          layer: operatorInfo.layer
+          layer: operatorInfo.layer,
         };
 
-        operatorMap.set(
-          operatorInfo.operator.operatorID,
-          newOperatorInfo.operator.operatorID
-        );
+        operatorMap.set(operatorInfo.operator.operatorID, newOperatorInfo.operator.operatorID);
         return [newOperatorInfo.operator.operatorID, newOperatorInfo];
       })
     );
 
     const links = new Map<string, LinkInfo>(
-      Array.from(group.links.values()).map((linkInfo) => {
+      Array.from(group.links.values()).map(linkInfo => {
         const sourceID = operatorMap.get(linkInfo.link.source.operatorID);
         const targetID = operatorMap.get(linkInfo.link.target.operatorID);
         assertType<string>(sourceID);
@@ -1487,14 +1248,14 @@ export class WorkflowEditorComponent implements AfterViewInit {
             linkID: this.workflowUtilService.getLinkRandomUUID(),
             source: {
               operatorID: sourceID,
-              portID: linkInfo.link.source.portID
+              portID: linkInfo.link.source.portID,
             },
             target: {
               operatorID: targetID,
-              portID: linkInfo.link.target.portID
-            }
+              portID: linkInfo.link.target.portID,
+            },
           },
-          layer: linkInfo.layer
+          layer: linkInfo.layer,
         };
 
         return [newLinkInfo.link.linkID, newLinkInfo];
@@ -1509,7 +1270,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
       links: links,
       inLinks: [],
       outLinks: [],
-      collapsed: group.collapsed
+      collapsed: group.collapsed,
     };
   }
 
@@ -1522,35 +1283,24 @@ export class WorkflowEditorComponent implements AfterViewInit {
    * @param copiedOperatorID
    * @param positions
    */
-  private calcOperatorPosition(
-    newOperatorID: string,
-    copiedOperatorID: string,
-    positions: Point[]
-  ): Point {
+  private calcOperatorPosition(newOperatorID: string, copiedOperatorID: string, positions: Point[]): Point {
     let i, position;
     const copiedOperator = this.copiedOperators.get(copiedOperatorID);
     if (!copiedOperator) {
-      throw Error(
-        `Internal error: cannot find ${copiedOperatorID} in copied operators`
-      );
+      throw Error(`Internal error: cannot find ${copiedOperatorID} in copied operators`);
     }
     const pastedOperators = copiedOperator.pastedOperatorIDs;
     for (i = 0; i < pastedOperators.length; ++i) {
       position = {
         x: copiedOperator.position.x + i * this.COPY_OFFSET,
-        y: copiedOperator.position.y + i * this.COPY_OFFSET
+        y: copiedOperator.position.y + i * this.COPY_OFFSET,
       };
       if (
         !positions.includes(position) &&
-        (!this.workflowActionService
-          .getTexeraGraph()
-          .hasOperator(pastedOperators[i]) ||
-          this.workflowActionService
-            .getOperatorGroup()
-            .getOperatorPositionByGroup(pastedOperators[i]).x !== position.x ||
-          this.workflowActionService
-            .getOperatorGroup()
-            .getOperatorPositionByGroup(pastedOperators[i]).y !== position.y)
+        (!this.workflowActionService.getTexeraGraph().hasOperator(pastedOperators[i]) ||
+          this.workflowActionService.getOperatorGroup().getOperatorPositionByGroup(pastedOperators[i]).x !==
+            position.x ||
+          this.workflowActionService.getOperatorGroup().getOperatorPositionByGroup(pastedOperators[i]).y !== position.y)
       ) {
         pastedOperators[i] = newOperatorID;
         return this.getNonOverlappingPosition(position, positions);
@@ -1559,7 +1309,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
     pastedOperators.push(newOperatorID);
     position = {
       x: copiedOperator.position.x + i * this.COPY_OFFSET,
-      y: copiedOperator.position.y + i * this.COPY_OFFSET
+      y: copiedOperator.position.y + i * this.COPY_OFFSET,
     };
     return this.getNonOverlappingPosition(position, positions);
   }
@@ -1573,17 +1323,11 @@ export class WorkflowEditorComponent implements AfterViewInit {
    * @param copiedGroupID
    * @param positions
    */
-  private calcGroupPosition(
-    newGroupID: string,
-    copiedGroupID: string,
-    positions: Point[]
-  ): Point {
+  private calcGroupPosition(newGroupID: string, copiedGroupID: string, positions: Point[]): Point {
     let i, position;
     const copiedGroup = this.copiedGroups.get(copiedGroupID);
     if (!copiedGroup) {
-      throw Error(
-        `Internal error: cannot find ${copiedGroupID} in copied groups`
-      );
+      throw Error(`Internal error: cannot find ${copiedGroupID} in copied groups`);
     }
     const copiedGroupPosition = copiedGroup.position;
     const pastedGroups = copiedGroup.pastedGroupIDs;
@@ -1591,19 +1335,13 @@ export class WorkflowEditorComponent implements AfterViewInit {
     for (i = 0; i < pastedGroups.length; ++i) {
       position = {
         x: copiedGroupPosition.x + i * this.COPY_OFFSET,
-        y: copiedGroupPosition.y + i * this.COPY_OFFSET
+        y: copiedGroupPosition.y + i * this.COPY_OFFSET,
       };
       if (
         !positions.includes(position) &&
-        (!this.workflowActionService
-          .getOperatorGroup()
-          .hasGroup(pastedGroups[i]) ||
-          this.workflowActionService
-            .getJointGraphWrapper()
-            .getElementPosition(pastedGroups[i]).x !== position.x ||
-          this.workflowActionService
-            .getJointGraphWrapper()
-            .getElementPosition(pastedGroups[i]).y !== position.y)
+        (!this.workflowActionService.getOperatorGroup().hasGroup(pastedGroups[i]) ||
+          this.workflowActionService.getJointGraphWrapper().getElementPosition(pastedGroups[i]).x !== position.x ||
+          this.workflowActionService.getJointGraphWrapper().getElementPosition(pastedGroups[i]).y !== position.y)
       ) {
         pastedGroups[i] = newGroupID;
         return this.getNonOverlappingPosition(position, positions);
@@ -1612,7 +1350,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
     pastedGroups.push(newGroupID);
     position = {
       x: copiedGroupPosition.x + i * this.COPY_OFFSET,
-      y: copiedGroupPosition.y + i * this.COPY_OFFSET
+      y: copiedGroupPosition.y + i * this.COPY_OFFSET,
     };
     return this.getNonOverlappingPosition(position, positions);
   }
@@ -1624,38 +1362,24 @@ export class WorkflowEditorComponent implements AfterViewInit {
    * @param position
    * @param positions
    */
-  private getNonOverlappingPosition(
-    position: Point,
-    positions: Point[]
-  ): Point {
+  private getNonOverlappingPosition(position: Point, positions: Point[]): Point {
     let overlapped = false;
     const operatorPositions = positions.concat(
       this.workflowActionService
         .getTexeraGraph()
         .getAllOperators()
-        .map((operator) =>
-          this.workflowActionService
-            .getOperatorGroup()
-            .getOperatorPositionByGroup(operator.operatorID)
-        ),
+        .map(operator => this.workflowActionService.getOperatorGroup().getOperatorPositionByGroup(operator.operatorID)),
       this.workflowActionService
         .getOperatorGroup()
         .getAllGroups()
-        .map((group) =>
-          this.workflowActionService
-            .getJointGraphWrapper()
-            .getElementPosition(group.groupID)
-        )
+        .map(group => this.workflowActionService.getJointGraphWrapper().getElementPosition(group.groupID))
     );
     do {
       for (const operatorPosition of operatorPositions) {
-        if (
-          operatorPosition.x === position.x &&
-          operatorPosition.y === position.y
-        ) {
+        if (operatorPosition.x === position.x && operatorPosition.y === position.y) {
           position = {
             x: position.x + this.COPY_OFFSET,
-            y: position.y + this.COPY_OFFSET
+            y: position.y + this.COPY_OFFSET,
           };
           overlapped = true;
           break;
@@ -1677,25 +1401,22 @@ export class WorkflowEditorComponent implements AfterViewInit {
   private handleLinkCursorHover(): void {
     // When the cursor hovers over a link, the delete button and the breakpoint button appear
     fromEvent<JointPaperEvent>(this.getJointPaper(), "link:mouseenter")
-      .pipe(map((value) => value[0]))
+      .pipe(map(value => value[0]))
       .pipe(untilDestroyed(this))
-      .subscribe((elementView) => {
+      .subscribe(elementView => {
         if (environment.linkBreakpointEnabled) {
           this.getJointPaper()
             .getModelById(elementView.model.id)
             .attr({
-              ".tool-remove": { display: "block" }
+              ".tool-remove": { display: "block" },
             });
-          this.getJointPaper()
-            .getModelById(elementView.model.id)
-            .findView(this.getJointPaper())
-            .showTools();
+          this.getJointPaper().getModelById(elementView.model.id).findView(this.getJointPaper()).showTools();
         } else {
           // only display the delete button
           this.getJointPaper()
             .getModelById(elementView.model.id)
             .attr({
-              ".tool-remove": { display: "block" }
+              ".tool-remove": { display: "block" },
             });
         }
       });
@@ -1706,24 +1427,19 @@ export class WorkflowEditorComponent implements AfterViewInit {
      * otherwise, the breakpoint button is not changed.
      */
     fromEvent<JointPaperEvent>(this.getJointPaper(), "link:mouseleave")
-      .pipe(map((value) => value[0]))
+      .pipe(map(value => value[0]))
       .pipe(untilDestroyed(this))
-      .subscribe((elementView) => {
+      .subscribe(elementView => {
         // ensure that the link element exists
         if (this.getJointPaper().getModelById(elementView.model.id)) {
-          const LinksWithBreakpoint = this.workflowActionService
-            .getJointGraphWrapper()
-            .getLinkIDsWithBreakpoint();
+          const LinksWithBreakpoint = this.workflowActionService.getJointGraphWrapper().getLinkIDsWithBreakpoint();
           if (!LinksWithBreakpoint.includes(elementView.model.id.toString())) {
-            this.getJointPaper()
-              .getModelById(elementView.model.id)
-              .findView(this.getJointPaper())
-              .hideTools();
+            this.getJointPaper().getModelById(elementView.model.id).findView(this.getJointPaper()).hideTools();
           }
           this.getJointPaper()
             .getModelById(elementView.model.id)
             .attr({
-              ".tool-remove": { display: "none" }
+              ".tool-remove": { display: "none" },
             });
         }
       });
@@ -1745,13 +1461,13 @@ export class WorkflowEditorComponent implements AfterViewInit {
       .getJointGraphWrapper()
       .getJointLinkCellAddStream()
       .pipe(untilDestroyed(this))
-      .subscribe((link) => {
+      .subscribe(link => {
         const linkView = link.findView(this.getJointPaper());
         const breakpointButtonTool = this.jointUIService.getBreakpointButton();
         const breakpointButton = new breakpointButtonTool();
         const toolsView = new joint.dia.ToolsView({
           name: "basic-tools",
-          tools: [breakpointButton]
+          tools: [breakpointButton],
         });
         linkView.addTools(toolsView);
         // tools remain hidden until the cursor hovers over it or a break point is added
@@ -1765,16 +1481,12 @@ export class WorkflowEditorComponent implements AfterViewInit {
    */
   private handleLinkBreakpointButtonClick(): void {
     fromEvent<JointPaperEvent>(this.getJointPaper(), "tool:breakpoint", {
-      passive: true
+      passive: true,
     })
       .pipe(untilDestroyed(this))
-      .subscribe((event) => {
-        this.workflowActionService
-          .getJointGraphWrapper()
-          .setMultiSelectMode(<boolean>event[1].shiftKey);
-        this.workflowActionService
-          .getJointGraphWrapper()
-          .highlightLinks(event[0].model.id.toString());
+      .subscribe(event => {
+        this.workflowActionService.getJointGraphWrapper().setMultiSelectMode(<boolean>event[1].shiftKey);
+        this.workflowActionService.getJointGraphWrapper().highlightLinks(event[0].model.id.toString());
       });
   }
 
@@ -1786,14 +1498,14 @@ export class WorkflowEditorComponent implements AfterViewInit {
       .getJointGraphWrapper()
       .getLinkHighlightStream()
       .pipe(untilDestroyed(this))
-      .subscribe((linkIDs) => {
-        linkIDs.forEach((linkID) => {
+      .subscribe(linkIDs => {
+        linkIDs.forEach(linkID => {
           this.getJointPaper()
             .getModelById(linkID)
             .attr({
               ".connection": { stroke: "orange" },
               ".marker-source": { fill: "orange" },
-              ".marker-target": { fill: "orange" }
+              ".marker-target": { fill: "orange" },
             });
         });
       });
@@ -1802,8 +1514,8 @@ export class WorkflowEditorComponent implements AfterViewInit {
       .getJointGraphWrapper()
       .getLinkUnhighlightStream()
       .pipe(untilDestroyed(this))
-      .subscribe((linkIDs) => {
-        linkIDs.forEach((linkID) => {
+      .subscribe(linkIDs => {
+        linkIDs.forEach(linkID => {
           const linkView = this.getJointPaper().findViewByModel(linkID);
           // ensure that the link still exist
           if (this.getJointPaper().getModelById(linkID)) {
@@ -1812,7 +1524,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
               .attr({
                 ".connection": { stroke: linkPathStrokeColor },
                 ".marker-source": { fill: "none" },
-                ".marker-target": { fill: "none" }
+                ".marker-target": { fill: "none" },
               });
           }
         });
@@ -1827,22 +1539,16 @@ export class WorkflowEditorComponent implements AfterViewInit {
       .getJointGraphWrapper()
       .getLinkBreakpointShowStream()
       .pipe(untilDestroyed(this))
-      .subscribe((linkID) => {
-        this.getJointPaper()
-          .getModelById(linkID.linkID)
-          .findView(this.getJointPaper())
-          .showTools();
+      .subscribe(linkID => {
+        this.getJointPaper().getModelById(linkID.linkID).findView(this.getJointPaper()).showTools();
       });
 
     this.workflowActionService
       .getJointGraphWrapper()
       .getLinkBreakpointHideStream()
       .pipe(untilDestroyed(this))
-      .subscribe((linkID) => {
-        this.getJointPaper()
-          .getModelById(linkID.linkID)
-          .findView(this.getJointPaper())
-          .hideTools();
+      .subscribe(linkID => {
+        this.getJointPaper().getModelById(linkID.linkID).findView(this.getJointPaper()).hideTools();
       });
   }
 

--- a/core/new-gui/src/app/workspace/component/workspace.component.html
+++ b/core/new-gui/src/app/workspace/component/workspace.component.html
@@ -13,18 +13,12 @@
   >
   </texera-navigation>
 
-  <texera-operator-panel
-    class="texera-operator-panel-grid-container grid-container"
-    tourAnchor="texera-operator-panel"
-  >
+  <texera-operator-panel class="texera-operator-panel-grid-container grid-container" tourAnchor="texera-operator-panel">
   </texera-operator-panel>
 
   <div class="texera-property-editor-grid-container grid-container">
     <div class="texera-right-side-bar-split-editor-minimap">
-      <texera-property-editor
-        style="overflow: auto"
-        tourAnchor="texera-property-editor-grid-container"
-      >
+      <texera-property-editor style="overflow: auto" tourAnchor="texera-property-editor-grid-container">
       </texera-property-editor>
       <texera-mini-map> </texera-mini-map>
     </div>
@@ -36,9 +30,7 @@
   >
   </texera-workflow-editor>
 
-  <texera-result-panel-toggle
-    class="texera-result-panel-toggle-grid-container grid-container"
-  >
+  <texera-result-panel-toggle class="texera-result-panel-toggle-grid-container grid-container">
   </texera-result-panel-toggle>
 
   <texera-result-panel

--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -28,7 +28,7 @@ import { OperatorCacheStatusService } from "../service/workflow-status/operator-
   providers: [
     // uncomment this line for manual testing without opening backend server
     // { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
-  ]
+  ],
 })
 export class WorkspaceComponent implements AfterViewInit {
   public gitCommitHash: string = Version.raw;
@@ -80,7 +80,7 @@ export class WorkspaceComponent implements AfterViewInit {
 
     this.operatorMetadataService
       .getOperatorMetadata()
-      .pipe(filter((metadata) => metadata.operators.length !== 0))
+      .pipe(filter(metadata => metadata.operators.length !== 0))
       .pipe(untilDestroyed(this))
       .subscribe(() => {
         if (environment.userSystemEnabled) {
@@ -99,9 +99,7 @@ export class WorkspaceComponent implements AfterViewInit {
           this.registerAutoPersistWorkflow();
         } else {
           // load the cached workflow
-          this.workflowActionService.reloadWorkflow(
-            this.workflowCacheService.getCachedWorkflow()
-          );
+          this.workflowActionService.reloadWorkflow(this.workflowCacheService.getCachedWorkflow());
           // clear stack
           this.undoRedoService.clearUndoStack();
           this.undoRedoService.clearRedoStack();
@@ -113,7 +111,7 @@ export class WorkspaceComponent implements AfterViewInit {
     this.resultPanelToggleService
       .getToggleChangeStream()
       .pipe(untilDestroyed(this))
-      .subscribe((value) => (this.showResultPanel = value));
+      .subscribe(value => (this.showResultPanel = value));
   }
 
   private registerAutoCacheWorkFlow(): void {
@@ -122,9 +120,7 @@ export class WorkspaceComponent implements AfterViewInit {
       .pipe(debounceTime(100))
       .pipe(untilDestroyed(this))
       .subscribe(() => {
-        this.workflowCacheService.setCacheWorkflow(
-          this.workflowActionService.getWorkflow()
-        );
+        this.workflowCacheService.setCacheWorkflow(this.workflowActionService.getWorkflow());
       });
   }
 
@@ -164,9 +160,7 @@ export class WorkspaceComponent implements AfterViewInit {
           this.undoRedoService.clearRedoStack();
         },
         () => {
-          this.message.error(
-            "You don't have access to this workflow, please log in with an appropriate account"
-          );
+          this.message.error("You don't have access to this workflow, please log in with an appropriate account");
         }
       );
   }

--- a/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.spec.ts
@@ -14,12 +14,9 @@ import {
   mockMultiInputOutputPredicate,
   mockResultPredicate,
   mockScanPredicate,
-  mockScanResultLink
+  mockScanResultLink,
 } from "../workflow-graph/model/mock-workflow-data";
-import {
-  OperatorLink,
-  OperatorPredicate
-} from "../../types/workflow-common.interface";
+import { OperatorLink, OperatorPredicate } from "../../types/workflow-common.interface";
 import { map } from "rxjs/operators";
 
 describe("DragDropService", () => {
@@ -35,33 +32,28 @@ describe("DragDropService", () => {
         DragDropService,
         {
           provide: OperatorMetadataService,
-          useClass: StubOperatorMetadataService
-        }
-      ]
+          useClass: StubOperatorMetadataService,
+        },
+      ],
     });
 
     dragDropService = TestBed.get(DragDropService);
 
     // custom equality disregards link ID (since I use DragDropService.getNew)
-    jasmine.addCustomEqualityTester(
-      (link1: OperatorLink, link2: OperatorLink) => {
-        if (typeof link1 === "object" && typeof link2 === "object") {
-          if (link1.source === link2.source && link1.target === link2.target) {
-            return true;
-          } else {
-            return false;
-          }
+    jasmine.addCustomEqualityTester((link1: OperatorLink, link2: OperatorLink) => {
+      if (typeof link1 === "object" && typeof link2 === "object") {
+        if (link1.source === link2.source && link1.target === link2.target) {
+          return true;
+        } else {
+          return false;
         }
       }
-    );
+    });
   });
 
-  it("should be created", inject(
-    [DragDropService],
-    (injectedService: DragDropService) => {
-      expect(injectedService).toBeTruthy();
-    }
-  ));
+  it("should be created", inject([DragDropService], (injectedService: DragDropService) => {
+    expect(injectedService).toBeTruthy();
+  }));
 
   it("should successfully register the element as draggable", () => {
     const dragElementID = "testing-draggable-1";
@@ -84,7 +76,7 @@ describe("DragDropService", () => {
 
   it(
     "should add an operator when the element is dropped",
-    marbles((m) => {
+    marbles(m => {
       const operatorType = mockOperatorMetaData.operators[0].operatorType;
 
       const marbleString = "-a-|";
@@ -92,17 +84,13 @@ describe("DragDropService", () => {
         a: {
           operatorType: operatorType,
           offset: { x: 100, y: 100 },
-          dragElementID: "mockID"
-        }
+          dragElementID: "mockID",
+        },
       };
 
-      spyOn(dragDropService, "getOperatorDropStream").and.returnValue(
-        m.hot(marbleString, marbleValues)
-      );
+      spyOn(dragDropService, "getOperatorDropStream").and.returnValue(m.hot(marbleString, marbleValues));
 
-      const workflowActionService: WorkflowActionService = TestBed.get(
-        WorkflowActionService
-      );
+      const workflowActionService: WorkflowActionService = TestBed.get(WorkflowActionService);
 
       dragDropService.handleOperatorDropEvent();
 
@@ -117,20 +105,18 @@ describe("DragDropService", () => {
   );
 
   it("should successfully create a new operator link given 2 operator predicates", () => {
-    const createdLink: OperatorLink = (
-      dragDropService as any
-    ).getNewOperatorLink(mockScanPredicate, mockResultPredicate);
+    const createdLink: OperatorLink = (dragDropService as any).getNewOperatorLink(
+      mockScanPredicate,
+      mockResultPredicate
+    );
 
     expect(createdLink.source).toEqual(mockScanResultLink.source);
     expect(createdLink.target).toEqual(mockScanResultLink.target);
   });
 
   it("should find 3 input operatorPredicates and 3 output operatorPredicates for an operatorPredicate with 3 input / 3 output ports", () => {
-    const workflowActionService: WorkflowActionService = TestBed.get(
-      WorkflowActionService
-    );
-    const workflowUtilService: WorkflowUtilService =
-      TestBed.get(WorkflowUtilService);
+    const workflowActionService: WorkflowActionService = TestBed.get(WorkflowActionService);
+    const workflowUtilService: WorkflowUtilService = TestBed.get(WorkflowUtilService);
 
     const input1 = workflowUtilService.getNewOperatorPredicate("ScanSource");
     const input2 = workflowUtilService.getNewOperatorPredicate("ScanSource");
@@ -155,44 +141,26 @@ describe("DragDropService", () => {
   });
 
   it("should publish operatorPredicates to highlight streams when calling \"updateHighlighting(prevHighlights,newHighlights)\"", async () => {
-    const workflowUtilService: WorkflowActionService = TestBed.get(
-      WorkflowActionService
-    );
+    const workflowUtilService: WorkflowActionService = TestBed.get(WorkflowActionService);
     const highlights: string[] = [];
     const unhighlights: string[] = [];
-    const expectedHighlights = [
-      mockScanPredicate.operatorID,
-      mockScanPredicate.operatorID
-    ];
-    const expectedUnhighlights = [
-      mockScanPredicate.operatorID,
-      mockResultPredicate.operatorID
-    ];
+    const expectedHighlights = [mockScanPredicate.operatorID, mockScanPredicate.operatorID];
+    const expectedUnhighlights = [mockScanPredicate.operatorID, mockResultPredicate.operatorID];
     // allow test to run for 10ms before checking, since observables are async
-    const timeout = new Promise((resolve) => setTimeout(resolve, 10));
+    const timeout = new Promise(resolve => setTimeout(resolve, 10));
 
-    dragDropService
-      .getOperatorSuggestionHighlightStream()
-      .subscribe((operatorID) => {
-        highlights.push(operatorID);
-      });
-    dragDropService
-      .getOperatorSuggestionUnhighlightStream()
-      .subscribe((operatorID) => {
-        unhighlights.push(operatorID);
-      });
+    dragDropService.getOperatorSuggestionHighlightStream().subscribe(operatorID => {
+      highlights.push(operatorID);
+    });
+    dragDropService.getOperatorSuggestionUnhighlightStream().subscribe(operatorID => {
+      unhighlights.push(operatorID);
+    });
 
     // highlighting update situations
-    (dragDropService as any).updateHighlighting(
-      [mockScanPredicate],
-      [mockScanPredicate]
-    ); // no change
+    (dragDropService as any).updateHighlighting([mockScanPredicate], [mockScanPredicate]); // no change
     (dragDropService as any).updateHighlighting([], [mockScanPredicate]); // new highlight
     (dragDropService as any).updateHighlighting([mockScanPredicate], []); // new unhighlight
-    (dragDropService as any).updateHighlighting(
-      [mockResultPredicate],
-      [mockScanPredicate]
-    ); // new highlight and unhighlight
+    (dragDropService as any).updateHighlighting([mockResultPredicate], [mockScanPredicate]); // new highlight and unhighlight
 
     // allow test to run for up to 500ms before checking, since observables are async
     await timeout;
@@ -201,16 +169,14 @@ describe("DragDropService", () => {
   });
 
   it("should not find any operator when the mouse coordinate is greater than the threshold defined", () => {
-    const workflowActionService: WorkflowActionService = TestBed.get(
-      WorkflowActionService
-    );
+    const workflowActionService: WorkflowActionService = TestBed.get(WorkflowActionService);
 
     workflowActionService.addOperator(mockScanPredicate, { x: 0, y: 0 });
 
     const [inputOps, outputOps] = (dragDropService as any).findClosestOperators(
       {
         x: DragDropService.SUGGESTION_DISTANCE_THRESHOLD + 10,
-        y: DragDropService.SUGGESTION_DISTANCE_THRESHOLD + 10
+        y: DragDropService.SUGGESTION_DISTANCE_THRESHOLD + 10,
       },
       mockResultPredicate
     );
@@ -220,12 +186,9 @@ describe("DragDropService", () => {
 
   it(
     "should update highlighting, add operator, and add links when an operator is dropped",
-    marbles(async (m) => {
-      const workflowActionService: WorkflowActionService = TestBed.get(
-        WorkflowActionService
-      );
-      const workflowUtilService: WorkflowUtilService =
-        TestBed.get(WorkflowUtilService);
+    marbles(async m => {
+      const workflowActionService: WorkflowActionService = TestBed.get(WorkflowActionService);
+      const workflowUtilService: WorkflowUtilService = TestBed.get(WorkflowUtilService);
       const graph = workflowActionService.getJointGraphWrapper();
 
       const operatorType = "MultiInputOutput";
@@ -236,25 +199,18 @@ describe("DragDropService", () => {
         e: {
           operatorType: operatorType,
           offset: { x: 1005, y: 1001 },
-          dragElementID: "mockID"
-        }
+          dragElementID: "mockID",
+        },
       };
 
       const input1 = workflowUtilService.getNewOperatorPredicate("ScanSource");
       const input2 = workflowUtilService.getNewOperatorPredicate("ScanSource");
       const input3 = workflowUtilService.getNewOperatorPredicate("ScanSource");
-      const output1 =
-        workflowUtilService.getNewOperatorPredicate("ViewResults");
-      const output2 =
-        workflowUtilService.getNewOperatorPredicate("ViewResults");
-      const output3 =
-        workflowUtilService.getNewOperatorPredicate("ViewResults");
+      const output1 = workflowUtilService.getNewOperatorPredicate("ViewResults");
+      const output2 = workflowUtilService.getNewOperatorPredicate("ViewResults");
+      const output3 = workflowUtilService.getNewOperatorPredicate("ViewResults");
       const heightSortedInputs: OperatorPredicate[] = [input1, input2, input3];
-      const heightSortedOutputs: OperatorPredicate[] = [
-        output1,
-        output2,
-        output3
-      ];
+      const heightSortedOutputs: OperatorPredicate[] = [output1, output2, output3];
 
       // lists to be populated by observables/streams
       const highlights: string[] = [];
@@ -268,31 +224,19 @@ describe("DragDropService", () => {
         input3.operatorID,
         output1.operatorID,
         output2.operatorID,
-        output3.operatorID
+        output3.operatorID,
       ];
       const expectedLinks: OperatorLink[] = []; // NOT EXPECTED EMPTY: populated below
 
       // populate expected links.
-      heightSortedInputs.forEach((inputOperator) => {
-        expectedLinks.push(
-          (dragDropService as any).getNewOperatorLink(
-            inputOperator,
-            operator,
-            expectedLinks
-          )
-        );
+      heightSortedInputs.forEach(inputOperator => {
+        expectedLinks.push((dragDropService as any).getNewOperatorLink(inputOperator, operator, expectedLinks));
       });
-      heightSortedOutputs.forEach((outputOperator) => {
-        expectedLinks.push(
-          (dragDropService as any).getNewOperatorLink(
-            operator,
-            outputOperator,
-            expectedLinks
-          )
-        );
+      heightSortedOutputs.forEach(outputOperator => {
+        expectedLinks.push((dragDropService as any).getNewOperatorLink(operator, outputOperator, expectedLinks));
       });
 
-      const timeout = new Promise((resolve) => setTimeout(resolve, 500)); // await 500ms before checking expect(s), since observables are async
+      const timeout = new Promise(resolve => setTimeout(resolve, 500)); // await 500ms before checking expect(s), since observables are async
 
       // add operators to graph
       workflowActionService.addOperator(input1, { x: 0, y: 10 });
@@ -303,27 +247,21 @@ describe("DragDropService", () => {
       workflowActionService.addOperator(output3, { x: 100, y: 30 });
 
       // subscribe to streams and push them to lists (in order to populate highlights,unhighlights,links)
-      dragDropService
-        .getOperatorSuggestionHighlightStream()
-        .subscribe((operatorID) => {
-          highlights.push(operatorID);
-        });
-      dragDropService
-        .getOperatorSuggestionUnhighlightStream()
-        .subscribe((operatorID) => {
-          unhighlights.push(operatorID);
-        });
+      dragDropService.getOperatorSuggestionHighlightStream().subscribe(operatorID => {
+        highlights.push(operatorID);
+      });
+      dragDropService.getOperatorSuggestionUnhighlightStream().subscribe(operatorID => {
+        unhighlights.push(operatorID);
+      });
       workflowActionService
         .getTexeraGraph()
         .getLinkAddStream()
-        .subscribe((link) => {
+        .subscribe(link => {
           links.push(link);
         });
 
       // replace dragDropService.getOperatorDropStream: observable with fake Marble observable that publishes only marbleValues['e']
-      spyOn(dragDropService, "getOperatorDropStream").and.returnValue(
-        m.hot(marbleString, marbleValues)
-      );
+      spyOn(dragDropService, "getOperatorDropStream").and.returnValue(m.hot(marbleString, marbleValues));
 
       // since dragDropService.getOperatorDropStream is replaced by Marble observable, will drop marbleValues['e']
       dragDropService.handleOperatorDropEvent();

--- a/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.spec.ts
@@ -122,12 +122,9 @@ describe("DragDropService", () => {
     const input1 = workflowUtilService.getNewOperatorPredicate("ScanSource");
     const input2 = workflowUtilService.getNewOperatorPredicate("ScanSource");
     const input3 = workflowUtilService.getNewOperatorPredicate("ScanSource");
-    const output1 =
-      workflowUtilService.getNewOperatorPredicate(VIEW_RESULT_OP_TYPE);
-    const output2 =
-      workflowUtilService.getNewOperatorPredicate(VIEW_RESULT_OP_TYPE);
-    const output3 =
-      workflowUtilService.getNewOperatorPredicate(VIEW_RESULT_OP_TYPE);
+    const output1 = workflowUtilService.getNewOperatorPredicate(VIEW_RESULT_OP_TYPE);
+    const output2 = workflowUtilService.getNewOperatorPredicate(VIEW_RESULT_OP_TYPE);
+    const output3 = workflowUtilService.getNewOperatorPredicate(VIEW_RESULT_OP_TYPE);
     const [inputOps, outputOps] = (dragDropService as any).findClosestOperators(
       { x: 50, y: 0 },
       mockMultiInputOutputPredicate

--- a/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.ts
+++ b/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.ts
@@ -1,8 +1,4 @@
-import {
-  OperatorLink,
-  OperatorPredicate,
-  Point
-} from "../../types/workflow-common.interface";
+import { OperatorLink, OperatorPredicate, Point } from "../../types/workflow-common.interface";
 import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
 import { fromEvent, Observable, Subject } from "rxjs";
 import { WorkflowUtilService } from "../workflow-graph/util/workflow-util.service";
@@ -55,16 +51,14 @@ import { filter, first, map } from "rxjs/operators";
  *
  */
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class DragDropService {
   // distance threshold for suggesting operators before user dropped an operator
   public static readonly SUGGESTION_DISTANCE_THRESHOLD = 300;
 
-  private static readonly DRAG_DROP_TEMP_ELEMENT_ID =
-    "drag-drop-temp-element-id";
-  private static readonly DRAG_DROP_TEMP_OPERATOR_TYPE =
-    "drag-drop-temp-operator-type";
+  private static readonly DRAG_DROP_TEMP_ELEMENT_ID = "drag-drop-temp-element-id";
+  private static readonly DRAG_DROP_TEMP_OPERATOR_TYPE = "drag-drop-temp-operator-type";
 
   private readonly operatorSuggestionHighlightStream = new Subject<string>();
   private readonly operatorSuggestionUnhighlightStream = new Subject<string>();
@@ -103,11 +97,9 @@ export class DragDropService {
    * **Proposal**: currently doesn't support multiple links to/from same suggested input/output
    */
   public handleOperatorDropEvent(): void {
-    this.getOperatorDropStream().subscribe((value) => {
+    this.getOperatorDropStream().subscribe(value => {
       // construct the operator from the drop stream value
-      const operator = this.workflowUtilService.getNewOperatorPredicate(
-        value.operatorType
-      );
+      const operator = this.workflowUtilService.getNewOperatorPredicate(value.operatorType);
 
       let coordinates: Point | undefined = this.workflowActionService
         .getJointGraphWrapper()
@@ -117,19 +109,14 @@ export class DragDropService {
         coordinates = value.offset;
       }
 
-      const scale = this.workflowActionService
-        .getJointGraphWrapper()
-        .getMainJointPaper()
-        ?.scale() ?? { sx: 1, sy: 1 };
+      const scale = this.workflowActionService.getJointGraphWrapper().getMainJointPaper()?.scale() ?? { sx: 1, sy: 1 };
 
       const newOperatorOffset = {
         x: coordinates.x / scale.sx,
-        y: coordinates.y / scale.sy
+        y: coordinates.y / scale.sy,
       };
 
-      const operatorsAndPositions: { op: OperatorPredicate; pos: Point }[] = [
-        { op: operator, pos: newOperatorOffset }
-      ];
+      const operatorsAndPositions: { op: OperatorPredicate; pos: Point }[] = [{ op: operator, pos: newOperatorOffset }];
       // create new links from suggestions
       const newLinks: OperatorLink[] = this.getNewOperatorLinks(
         operator,
@@ -137,10 +124,7 @@ export class DragDropService {
         this.suggestionOutputs
       );
 
-      this.workflowActionService.addOperatorsAndLinks(
-        operatorsAndPositions,
-        newLinks
-      );
+      this.workflowActionService.addOperatorsAndLinks(operatorsAndPositions, newLinks);
       this.resetSuggestions();
 
       // reset the current operator type to an non-exist type
@@ -201,30 +185,25 @@ export class DragDropService {
    * @param dragElementID the DOM Element ID
    * @param operatorType the operator type that the element corresponds to
    */
-  public registerOperatorLabelDrag(
-    dragElementID: string,
-    operatorType: string
-  ): void {
+  public registerOperatorLabelDrag(dragElementID: string, operatorType: string): void {
     this.elementOperatorTypeMap.set(dragElementID, operatorType);
 
     // register callback functions for jquery UI
     jQuery("#" + dragElementID).draggable({
-      helper: () =>
-        this.createFlyingOperatorElement(dragElementID, operatorType),
+      helper: () => this.createFlyingOperatorElement(dragElementID, operatorType),
       // declare event as type any because the jQueryUI type declaration is wrong
       // it should be of type JQuery.Event, which is incompatible with the the declared type Event
-      start: (event: JQueryEventObject, ui: JQueryUI.DraggableEventUIParams) =>
-        this.handleOperatorStartDrag(event, ui),
+      start: (event: JQueryEventObject, ui: JQueryUI.DraggableEventUIParams) => this.handleOperatorStartDrag(event, ui),
       // The draggable element will be created with the mouse starting point at the center
       cursorAt: {
         left: JointUIService.DEFAULT_OPERATOR_WIDTH / 2,
-        top: JointUIService.DEFAULT_OPERATOR_HEIGHT / 2
+        top: JointUIService.DEFAULT_OPERATOR_HEIGHT / 2,
       },
       stop: (event: JQueryEventObject, ui: JQueryUI.DraggableEventUIParams) => {
         this.resetSuggestions();
       },
       // prevents dragging from starting on elements of class disable-drag-drop
-      cancel: ".disable-drag-drop"
+      cancel: ".disable-drag-drop",
     });
   }
 
@@ -234,7 +213,7 @@ export class DragDropService {
    */
   public registerWorkflowEditorDrop(dropElementID: string): void {
     jQuery("#" + dropElementID).droppable({
-      drop: (event: any, ui) => this.handleOperatorDrop(event, ui)
+      drop: (event: any, ui) => this.handleOperatorDrop(event, ui),
     });
   }
 
@@ -248,27 +227,18 @@ export class DragDropService {
    *
    * @param operatorType - the type of the operator
    */
-  private createFlyingOperatorElement(
-    dragElementID: string,
-    operatorType: string
-  ): JQuery<HTMLElement> {
+  private createFlyingOperatorElement(dragElementID: string, operatorType: string): JQuery<HTMLElement> {
     // set the current operator type from an nonexist placeholder operator type
     //  to the operator type being dragged
     this.currentDragElementID = dragElementID;
     this.currentOperatorType = operatorType;
 
     // create a temporary ghost element
-    jQuery("body").append(
-      "<div id=\"flyingJointPaper\" style=\"position:fixed;z-index:1001;pointer-event:none;\"></div>"
-    );
+    jQuery("body").append("<div id=\"flyingJointPaper\" style=\"position:fixed;z-index:1001;pointer-event:none;\"></div>");
 
     // create an operator and get the UI element from the operator type
-    const operator =
-      this.workflowUtilService.getNewOperatorPredicate(operatorType);
-    const operatorUIElement = this.jointUIService.getJointOperatorElement(
-      operator,
-      { x: 0, y: 0 }
-    );
+    const operator = this.workflowUtilService.getNewOperatorPredicate(operatorType);
+    const operatorUIElement = this.jointUIService.getJointOperatorElement(operator, { x: 0, y: 0 });
 
     // create the jointjs model and paper of the ghost element
     const tempGhostModel = new joint.dia.Graph();
@@ -276,7 +246,7 @@ export class DragDropService {
       el: jQuery("#flyingJointPaper"),
       width: JointUIService.DEFAULT_OPERATOR_WIDTH,
       height: JointUIService.DEFAULT_OPERATOR_HEIGHT,
-      model: tempGhostModel
+      model: tempGhostModel,
     });
 
     // add the operator JointJS element to the paper
@@ -293,27 +263,18 @@ export class DragDropService {
    * @param event JQuery.Event type, although JQueryUI typing says the type is Event, the object's actual type is JQuery.Event
    * @param ui jQueryUI Draggable Event UI
    */
-  private handleOperatorStartDrag(
-    event: Event,
-    ui: JQueryUI.DraggableEventUIParams
-  ): void {
+  private handleOperatorStartDrag(event: Event, ui: JQueryUI.DraggableEventUIParams): void {
     const eventElement = event.target;
     if (!(eventElement instanceof Element)) {
-      throw new Error(
-        "Incorrect type: in most cases, this element is type Element"
-      );
+      throw new Error("Incorrect type: in most cases, this element is type Element");
     }
     if (eventElement === undefined) {
-      throw new Error(
-        "drag and drop: cannot find element when drag is started"
-      );
+      throw new Error("drag and drop: cannot find element when drag is started");
     }
     // get the operatorType based on the DOM element ID
     const operatorType = this.elementOperatorTypeMap.get(eventElement.id);
     if (operatorType === undefined) {
-      throw new Error(
-        `drag and drop: cannot find operator type ${operatorType} from DOM element ${eventElement}`
-      );
+      throw new Error(`drag and drop: cannot find operator type ${operatorType} from DOM element ${eventElement}`);
     }
     // set the currentOperatorType
     this.currentOperatorType = operatorType;
@@ -332,19 +293,16 @@ export class DragDropService {
    * @param event
    * @param ui
    */
-  private handleOperatorDrop(
-    event: JQuery.Event,
-    ui: JQueryUI.DraggableEventUIParams
-  ): void {
+  private handleOperatorDrop(event: JQuery.Event, ui: JQueryUI.DraggableEventUIParams): void {
     // notify the subject of the event
     // use ui.offset instead of ui.position because offset is relative to document root, where position is relative to parent element
     this.operatorDroppedSubject.next({
       operatorType: this.currentOperatorType,
       offset: {
         x: ui.offset.left,
-        y: ui.offset.top
+        y: ui.offset.top,
       },
-      dragElementID: this.currentDragElementID
+      dragElementID: this.currentDragElementID,
     });
   }
 
@@ -354,9 +312,7 @@ export class DragDropService {
    *
    */
   private handleOperatorRecommendationOnDrag(): void {
-    const currentOperator = this.workflowUtilService.getNewOperatorPredicate(
-      this.currentOperatorType
-    );
+    const currentOperator = this.workflowUtilService.getNewOperatorPredicate(this.currentOperatorType);
     let isOperatorDropped = false;
 
     fromEvent<MouseEvent>(window, "mouseup")
@@ -365,56 +321,43 @@ export class DragDropService {
 
     fromEvent<MouseEvent>(window, "mousemove")
       .pipe(
-        map((value) => [value.clientX, value.clientY]),
+        map(value => [value.clientX, value.clientY]),
         filter(() => !isOperatorDropped)
       )
-      .subscribe((mouseCoordinates) => {
+      .subscribe(mouseCoordinates => {
         const currentMouseCoordinates = {
           x: mouseCoordinates[0],
-          y: mouseCoordinates[1]
+          y: mouseCoordinates[1],
         };
 
         let coordinates: Point | undefined = this.workflowActionService
           .getJointGraphWrapper()
           .getMainJointPaper()
-          ?.pageToLocalPoint(
-            currentMouseCoordinates.x,
-            currentMouseCoordinates.y
-          );
+          ?.pageToLocalPoint(currentMouseCoordinates.x, currentMouseCoordinates.y);
         if (!coordinates) {
           coordinates = currentMouseCoordinates;
         }
 
-        let scale: { sx: number; sy: number } | undefined =
-          this.workflowActionService
-            .getJointGraphWrapper()
-            .getMainJointPaper()
-            ?.scale();
+        let scale: { sx: number; sy: number } | undefined = this.workflowActionService
+          .getJointGraphWrapper()
+          .getMainJointPaper()
+          ?.scale();
         if (scale === undefined) {
           scale = { sx: 1, sy: 1 };
         }
 
         const scaledMouseCoordinates = {
           x: coordinates.x / scale.sx,
-          y: coordinates.y / scale.sy
+          y: coordinates.y / scale.sy,
         };
 
         // search for nearby operators as suggested input/output operators
         let newInputs, newOutputs: OperatorPredicate[];
-        [newInputs, newOutputs] = this.findClosestOperators(
-          scaledMouseCoordinates,
-          currentOperator
-        );
+        [newInputs, newOutputs] = this.findClosestOperators(scaledMouseCoordinates, currentOperator);
         // update highlighting class vars to reflect new input/output operators
-        this.updateHighlighting(
-          this.suggestionInputs.concat(this.suggestionOutputs),
-          newInputs.concat(newOutputs)
-        );
+        this.updateHighlighting(this.suggestionInputs.concat(this.suggestionOutputs), newInputs.concat(newOutputs));
         // assign new suggestions
-        [this.suggestionInputs, this.suggestionOutputs] = [
-          newInputs,
-          newOutputs
-        ];
+        [this.suggestionInputs, this.suggestionOutputs] = [newInputs, newOutputs];
       });
   }
 
@@ -433,17 +376,12 @@ export class DragDropService {
     mouseCoordinate: Point,
     currentOperator: OperatorPredicate
   ): [OperatorPredicate[], OperatorPredicate[]] {
-    const operatorLinks = this.workflowActionService
-      .getTexeraGraph()
-      .getAllLinks();
+    const operatorLinks = this.workflowActionService.getTexeraGraph().getAllLinks();
     const operatorList = this.workflowActionService
       .getTexeraGraph()
       .getAllOperators()
       .filter(
-        (operator) =>
-          !this.workflowActionService
-            .getOperatorGroup()
-            .getGroupByOperator(operator.operatorID)?.collapsed
+        operator => !this.workflowActionService.getOperatorGroup().getGroupByOperator(operator.operatorID)?.collapsed
       );
 
     const numInputOps: number = currentOperator.inputPorts.length;
@@ -452,16 +390,13 @@ export class DragDropService {
     // These two functions are a performance concern
     const hasFreeOutputPorts = (operator: OperatorPredicate): boolean => {
       return (
-        operatorLinks.filter(
-          (link) => link.source.operatorID === operator.operatorID
-        ).length < operator.outputPorts.length
+        operatorLinks.filter(link => link.source.operatorID === operator.operatorID).length <
+        operator.outputPorts.length
       );
     };
     const hasFreeInputPorts = (operator: OperatorPredicate): boolean => {
       return (
-        operatorLinks.filter(
-          (link) => link.target.operatorID === operator.operatorID
-        ).length < operator.inputPorts.length
+        operatorLinks.filter(link => link.target.operatorID === operator.operatorID).length < operator.inputPorts.length
       );
     };
 
@@ -472,14 +407,10 @@ export class DragDropService {
     ): number => {
       return b.dist - a.dist;
     };
-    const inputOps: TinyQueue<{ op: OperatorPredicate; dist: number }> =
-      new TinyQueue([], compare);
-    const outputOps: TinyQueue<{ op: OperatorPredicate; dist: number }> =
-      new TinyQueue([], compare);
+    const inputOps: TinyQueue<{ op: OperatorPredicate; dist: number }> = new TinyQueue([], compare);
+    const outputOps: TinyQueue<{ op: OperatorPredicate; dist: number }> = new TinyQueue([], compare);
 
-    const greatestDistance = (
-      queue: TinyQueue<{ op: OperatorPredicate; dist: number }>
-    ): number => {
+    const greatestDistance = (queue: TinyQueue<{ op: OperatorPredicate; dist: number }>): number => {
       const greatest = queue.peek();
       if (greatest) {
         return greatest.dist;
@@ -489,23 +420,18 @@ export class DragDropService {
     };
 
     // for each operator, check if in range/has free ports/is on the right side/is closer than prev closest ops/
-    operatorList.forEach((operator) => {
+    operatorList.forEach(operator => {
       const operatorPosition = this.workflowActionService
         .getJointGraphWrapper()
         .getElementPosition(operator.operatorID);
       const distanceFromCurrentOperator = Math.sqrt(
-        (mouseCoordinate.x - operatorPosition.x) ** 2 +
-          (mouseCoordinate.y - operatorPosition.y) ** 2
+        (mouseCoordinate.x - operatorPosition.x) ** 2 + (mouseCoordinate.y - operatorPosition.y) ** 2
       );
-      if (
-        distanceFromCurrentOperator <
-        DragDropService.SUGGESTION_DISTANCE_THRESHOLD
-      ) {
+      if (distanceFromCurrentOperator < DragDropService.SUGGESTION_DISTANCE_THRESHOLD) {
         if (
           numInputOps > 0 &&
           operatorPosition.x < mouseCoordinate.x &&
-          (inputOps.length < numInputOps ||
-            distanceFromCurrentOperator < greatestDistance(inputOps)) &&
+          (inputOps.length < numInputOps || distanceFromCurrentOperator < greatestDistance(inputOps)) &&
           hasFreeOutputPorts(operator)
         ) {
           inputOps.push({ op: operator, dist: distanceFromCurrentOperator });
@@ -515,8 +441,7 @@ export class DragDropService {
         } else if (
           numOutputOps > 0 &&
           operatorPosition.x > mouseCoordinate.x &&
-          (outputOps.length < numOutputOps ||
-            distanceFromCurrentOperator < greatestDistance(outputOps)) &&
+          (outputOps.length < numOutputOps || distanceFromCurrentOperator < greatestDistance(outputOps)) &&
           hasFreeInputPorts(operator)
         ) {
           outputOps.push({ op: operator, dist: distanceFromCurrentOperator });
@@ -526,10 +451,7 @@ export class DragDropService {
         }
       }
     });
-    return [
-      <OperatorPredicate[]>inputOps.data.map((x) => x.op),
-      <OperatorPredicate[]>outputOps.data.map((x) => x.op)
-    ];
+    return [<OperatorPredicate[]>inputOps.data.map(x => x.op), <OperatorPredicate[]>outputOps.data.map(x => x.op)];
   }
 
   /**
@@ -538,31 +460,25 @@ export class DragDropService {
    * @param prevHighLights are highlighted (some may be unhighlighted)
    * @param newHighLights will be highlighted after execution
    */
-  private updateHighlighting(
-    prevHighlights: OperatorPredicate[],
-    newHighlights: OperatorPredicate[]
-  ) {
+  private updateHighlighting(prevHighlights: OperatorPredicate[], newHighlights: OperatorPredicate[]) {
     // unhighlight ops in prevHighlights but not in newHighlights
     prevHighlights
-      .filter((operator) => !newHighlights.includes(operator))
-      .forEach((operator) => {
+      .filter(operator => !newHighlights.includes(operator))
+      .forEach(operator => {
         this.operatorSuggestionUnhighlightStream.next(operator.operatorID);
       });
 
     // highlight ops in newHghlights but not in prevHighlights
     newHighlights
-      .filter((operator) => !prevHighlights.includes(operator))
-      .forEach((operator) => {
+      .filter(operator => !prevHighlights.includes(operator))
+      .forEach(operator => {
         this.operatorSuggestionHighlightStream.next(operator.operatorID);
       });
   }
 
   /**  Unhighlights suggestions and clears suggestion lists */
   private resetSuggestions(): void {
-    this.updateHighlighting(
-      this.suggestionInputs.concat(this.suggestionOutputs),
-      []
-    );
+    this.updateHighlighting(this.suggestionInputs.concat(this.suggestionOutputs), []);
     this.suggestionInputs = [];
     this.suggestionOutputs = [];
   }
@@ -585,28 +501,24 @@ export class DragDropService {
     }
     // find the port that has not being connected
     const allPortsFromSource = operatorLinks
-      .filter((link) => link.source.operatorID === sourceOperator.operatorID)
-      .map((link) => link.source.portID);
+      .filter(link => link.source.operatorID === sourceOperator.operatorID)
+      .map(link => link.source.portID);
 
     const allPortsFromTarget = operatorLinks
-      .filter((link) => link.target.operatorID === targetOperator.operatorID)
-      .map((link) => link.target.portID);
+      .filter(link => link.target.operatorID === targetOperator.operatorID)
+      .map(link => link.target.portID);
 
-    const validSourcePortsID = sourceOperator.outputPorts.filter(
-      (port) => !allPortsFromSource.includes(port.portID)
-    );
-    const validTargetPortsID = targetOperator.inputPorts.filter(
-      (port) => !allPortsFromTarget.includes(port.portID)
-    );
+    const validSourcePortsID = sourceOperator.outputPorts.filter(port => !allPortsFromSource.includes(port.portID));
+    const validTargetPortsID = targetOperator.inputPorts.filter(port => !allPortsFromTarget.includes(port.portID));
 
     const linkID = this.workflowUtilService.getLinkRandomUUID();
     const source = {
       operatorID: sourceOperator.operatorID,
-      portID: validSourcePortsID[0].portID
+      portID: validSourcePortsID[0].portID,
     };
     const target = {
       operatorID: targetOperator.operatorID,
-      portID: validTargetPortsID[0].portID
+      portID: validTargetPortsID[0].portID,
     };
     return { linkID, source, target };
   }
@@ -623,9 +535,7 @@ export class DragDropService {
     receiverOperators: OperatorPredicate[]
   ): OperatorLink[] {
     // remember newly created links to prevent multiple link assignment to same port
-    const occupiedLinks: OperatorLink[] = this.workflowActionService
-      .getTexeraGraph()
-      .getAllLinks();
+    const occupiedLinks: OperatorLink[] = this.workflowActionService.getTexeraGraph().getAllLinks();
     const newLinks: OperatorLink[] = [];
     const graph = this.workflowActionService.getJointGraphWrapper();
 
@@ -634,38 +544,22 @@ export class DragDropService {
     //              [first ... last] => [North ... South]
     const heightSortedInputs: OperatorPredicate[] = inputOperators
       .slice(0)
-      .sort(
-        (op1, op2) =>
-          graph.getElementPosition(op1.operatorID).y -
-          graph.getElementPosition(op2.operatorID).y
-      );
+      .sort((op1, op2) => graph.getElementPosition(op1.operatorID).y - graph.getElementPosition(op2.operatorID).y);
     const heightSortedOutputs: OperatorPredicate[] = receiverOperators
       .slice(0)
-      .sort(
-        (op1, op2) =>
-          graph.getElementPosition(op1.operatorID).y -
-          graph.getElementPosition(op2.operatorID).y
-      );
+      .sort((op1, op2) => graph.getElementPosition(op1.operatorID).y - graph.getElementPosition(op2.operatorID).y);
 
     // if new operator has suggested links, create them
     if (heightSortedInputs !== undefined) {
-      heightSortedInputs.forEach((inputOperator) => {
-        const newLink = this.getNewOperatorLink(
-          inputOperator,
-          hubOperator,
-          occupiedLinks
-        );
+      heightSortedInputs.forEach(inputOperator => {
+        const newLink = this.getNewOperatorLink(inputOperator, hubOperator, occupiedLinks);
         newLinks.push(newLink);
         occupiedLinks.push(newLink);
       });
     }
     if (heightSortedOutputs !== undefined) {
-      heightSortedOutputs.forEach((outputOperator) => {
-        const newLink = this.getNewOperatorLink(
-          hubOperator,
-          outputOperator,
-          occupiedLinks
-        );
+      heightSortedOutputs.forEach(outputOperator => {
+        const newLink = this.getNewOperatorLink(hubOperator, outputOperator, occupiedLinks);
         newLinks.push(newLink);
         occupiedLinks.push(newLink);
       });

--- a/core/new-gui/src/app/workspace/service/dynamic-schema/dynamic-schema.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/dynamic-schema.service.spec.ts
@@ -12,7 +12,7 @@ import {
   mockScanPredicate,
   mockPoint,
   mockResultPredicate,
-  mockScanResultLink
+  mockScanResultLink,
 } from "../workflow-graph/model/mock-workflow-data";
 import { OperatorPredicate } from "../../types/workflow-common.interface";
 import { mockScanSourceSchema } from "../operator-metadata/mock-operator-metadata.data";
@@ -25,30 +25,24 @@ describe("DynamicSchemaService", () => {
       providers: [
         {
           provide: OperatorMetadataService,
-          useClass: StubOperatorMetadataService
+          useClass: StubOperatorMetadataService,
         },
         JointUIService,
         WorkflowActionService,
         WorkflowUtilService,
         UndoRedoService,
-        DynamicSchemaService
-      ]
+        DynamicSchemaService,
+      ],
     });
   });
 
-  it("should be created", inject(
-    [DynamicSchemaService],
-    (service: DynamicSchemaService) => {
-      expect(service).toBeTruthy();
-    }
-  ));
+  it("should be created", inject([DynamicSchemaService], (service: DynamicSchemaService) => {
+    expect(service).toBeTruthy();
+  }));
 
   it("should update dynamic schema map when operator is added/deleted", () => {
-    const workflowActionService: WorkflowActionService = TestBed.get(
-      WorkflowActionService
-    );
-    const dynamicSchemaService: DynamicSchemaService =
-      TestBed.get(DynamicSchemaService);
+    const workflowActionService: WorkflowActionService = TestBed.get(WorkflowActionService);
+    const dynamicSchemaService: DynamicSchemaService = TestBed.get(DynamicSchemaService);
 
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
     expect(dynamicSchemaService.getDynamicSchemaMap().size === 1);
@@ -58,32 +52,19 @@ describe("DynamicSchemaService", () => {
   });
 
   it("should call all initial schema transformers when creating a new dynamic schema", () => {
-    const workflowActionService: WorkflowActionService = TestBed.get(
-      WorkflowActionService
-    );
-    const dynamicSchemaService: DynamicSchemaService =
-      TestBed.get(DynamicSchemaService);
+    const workflowActionService: WorkflowActionService = TestBed.get(WorkflowActionService);
+    const dynamicSchemaService: DynamicSchemaService = TestBed.get(DynamicSchemaService);
 
     const testTransformers = {
       transformer1: (op: OperatorPredicate, schema: OperatorSchema) => schema,
-      transformer2: (op: OperatorPredicate, schema: OperatorSchema) => schema
+      transformer2: (op: OperatorPredicate, schema: OperatorSchema) => schema,
     };
 
-    const transformer1Spy = spyOn(
-      testTransformers,
-      "transformer1"
-    ).and.callThrough();
-    const transformer2Spy = spyOn(
-      testTransformers,
-      "transformer2"
-    ).and.callThrough();
+    const transformer1Spy = spyOn(testTransformers, "transformer1").and.callThrough();
+    const transformer2Spy = spyOn(testTransformers, "transformer2").and.callThrough();
 
-    dynamicSchemaService.registerInitialSchemaTransformer(
-      testTransformers.transformer1
-    );
-    dynamicSchemaService.registerInitialSchemaTransformer(
-      testTransformers.transformer2
-    );
+    dynamicSchemaService.registerInitialSchemaTransformer(testTransformers.transformer1);
+    dynamicSchemaService.registerInitialSchemaTransformer(testTransformers.transformer2);
 
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
 
@@ -93,73 +74,53 @@ describe("DynamicSchemaService", () => {
 
   it(
     "should emit event when dynamic schema is changed",
-    marbles((m) => {
-      const workflowActionService: WorkflowActionService = TestBed.get(
-        WorkflowActionService
-      );
-      const dynamicSchemaService: DynamicSchemaService =
-        TestBed.get(DynamicSchemaService);
+    marbles(m => {
+      const workflowActionService: WorkflowActionService = TestBed.get(WorkflowActionService);
+      const dynamicSchemaService: DynamicSchemaService = TestBed.get(DynamicSchemaService);
 
       const newSchema: OperatorSchema = {
         ...mockScanSourceSchema,
         jsonSchema: {
           properties: {
             tableName: {
-              type: "string"
-            }
+              type: "string",
+            },
           },
-          type: "object"
-        }
+          type: "object",
+        },
       };
 
       const trigger = m.hot("-a-c-", {
-        a: () =>
-          workflowActionService.addOperator(mockScanPredicate, mockPoint),
-        c: () =>
-          dynamicSchemaService.setDynamicSchema(
-            mockScanPredicate.operatorID,
-            newSchema
-          )
+        a: () => workflowActionService.addOperator(mockScanPredicate, mockPoint),
+        c: () => dynamicSchemaService.setDynamicSchema(mockScanPredicate.operatorID, newSchema),
       });
 
-      trigger.subscribe((eventFunc) => eventFunc());
+      trigger.subscribe(eventFunc => eventFunc());
 
       const expected = m.hot("---e-", {
-        e: { operatorID: mockScanPredicate.operatorID }
+        e: { operatorID: mockScanPredicate.operatorID },
       });
 
-      m.expect(
-        dynamicSchemaService.getOperatorDynamicSchemaChangedStream()
-      ).toBeObservable(expected);
+      m.expect(dynamicSchemaService.getOperatorDynamicSchemaChangedStream()).toBeObservable(expected);
     })
   );
 
   it(
     "should not emit event if the updated dynamic schema is same",
-    marbles((m) => {
-      const workflowActionService: WorkflowActionService = TestBed.get(
-        WorkflowActionService
-      );
-      const dynamicSchemaService: DynamicSchemaService =
-        TestBed.get(DynamicSchemaService);
+    marbles(m => {
+      const workflowActionService: WorkflowActionService = TestBed.get(WorkflowActionService);
+      const dynamicSchemaService: DynamicSchemaService = TestBed.get(DynamicSchemaService);
 
       const trigger = m.hot("-a-c-", {
-        a: () =>
-          workflowActionService.addOperator(mockScanPredicate, mockPoint),
-        c: () =>
-          dynamicSchemaService.setDynamicSchema(
-            mockScanPredicate.operatorID,
-            mockScanSourceSchema
-          )
+        a: () => workflowActionService.addOperator(mockScanPredicate, mockPoint),
+        c: () => dynamicSchemaService.setDynamicSchema(mockScanPredicate.operatorID, mockScanSourceSchema),
       });
 
-      trigger.subscribe((eventFunc) => eventFunc());
+      trigger.subscribe(eventFunc => eventFunc());
 
       const expected = m.hot("-----");
 
-      m.expect(
-        dynamicSchemaService.getOperatorDynamicSchemaChangedStream()
-      ).toBeObservable(expected);
+      m.expect(dynamicSchemaService.getOperatorDynamicSchemaChangedStream()).toBeObservable(expected);
     })
   );
 
@@ -173,11 +134,8 @@ describe("DynamicSchemaService", () => {
     });
 
     it("should update dynamic breakpoint schema map when link is added/deleted", () => {
-      const workflowActionService: WorkflowActionService = TestBed.get(
-        WorkflowActionService
-      );
-      const dynamicSchemaService: DynamicSchemaService =
-        TestBed.get(DynamicSchemaService);
+      const workflowActionService: WorkflowActionService = TestBed.get(WorkflowActionService);
+      const dynamicSchemaService: DynamicSchemaService = TestBed.get(DynamicSchemaService);
 
       workflowActionService.addOperator(mockScanPredicate, mockPoint);
       workflowActionService.addOperator(mockResultPredicate, mockPoint);

--- a/core/new-gui/src/app/workspace/service/dynamic-schema/dynamic-schema.service.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/dynamic-schema.service.ts
@@ -5,17 +5,11 @@ import { Observable } from "rxjs";
 import { Subject } from "rxjs";
 import { CustomJSONSchema7 } from "../../types/custom-json-schema.interface";
 import { OperatorSchema } from "../../types/operator-schema.interface";
-import {
-  BreakpointSchema,
-  OperatorPredicate
-} from "../../types/workflow-common.interface";
+import { BreakpointSchema, OperatorPredicate } from "../../types/workflow-common.interface";
 import { OperatorMetadataService } from "../operator-metadata/operator-metadata.service";
 import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
 
-export type SchemaTransformer = (
-  operator: OperatorPredicate,
-  schema: OperatorSchema
-) => OperatorSchema;
+export type SchemaTransformer = (operator: OperatorPredicate, schema: OperatorSchema) => OperatorSchema;
 
 /**
  * Dynamic Schema Service associates each operator with its own OperatorSchema,
@@ -31,7 +25,7 @@ export type SchemaTransformer = (
  *
  */
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class DynamicSchemaService {
   // dynamic schema of operators in the current workflow, specific to an operator and different from the static schema
@@ -56,28 +50,21 @@ export class DynamicSchemaService {
     this.workflowActionService
       .getTexeraGraph()
       .getOperatorAddStream()
-      .subscribe((operator) => {
-        this.setDynamicSchema(
-          operator.operatorID,
-          this.getInitialDynamicSchema(operator)
-        );
+      .subscribe(operator => {
+        this.setDynamicSchema(operator.operatorID, this.getInitialDynamicSchema(operator));
       });
 
     // when an operator is deleted, remove it from the dynamic schema map
     this.workflowActionService
       .getTexeraGraph()
       .getOperatorDeleteStream()
-      .subscribe((event) =>
-        this.dynamicSchemaMap.delete(event.deletedOperator.operatorID)
-      );
+      .subscribe(event => this.dynamicSchemaMap.delete(event.deletedOperator.operatorID));
 
     // when a link is deleted, remove it from the dynamic schema map
     this.workflowActionService
       .getTexeraGraph()
       .getLinkDeleteStream()
-      .subscribe((event) =>
-        this.dynamicBreakpointSchemaMap.delete(event.deletedLink.linkID)
-      );
+      .subscribe(event => this.dynamicBreakpointSchemaMap.delete(event.deletedLink.linkID));
   }
 
   /**
@@ -87,9 +74,7 @@ export class DynamicSchemaService {
    * Note: multiple transformers might be invoked when first constructing the initial schema,
    * transformers needs to be careful to not override other transformer's work.
    */
-  public registerInitialSchemaTransformer(
-    schemaTransformer: SchemaTransformer
-  ) {
+  public registerInitialSchemaTransformer(schemaTransformer: SchemaTransformer) {
     this.initialSchemaTransformers.push(schemaTransformer);
   }
 
@@ -127,10 +112,7 @@ export class DynamicSchemaService {
    */
   public getDynamicBreakpointSchema(linkID: string): BreakpointSchema {
     if (!this.dynamicBreakpointSchemaMap.has(linkID)) {
-      this.dynamicBreakpointSchemaMap.set(
-        linkID,
-        this.operatorMetadataService.getBreakpointSchema()
-      );
+      this.dynamicBreakpointSchemaMap.set(linkID, this.operatorMetadataService.getBreakpointSchema());
     }
     const dynamicBreakpointSchema = this.dynamicBreakpointSchemaMap.get(linkID);
     if (!dynamicBreakpointSchema) {
@@ -142,10 +124,7 @@ export class DynamicSchemaService {
   /**
    * Returns the current dynamic breakpoint schema of all links.
    */
-  public getDynamicBreakpointSchemaMap(): ReadonlyMap<
-    string,
-    BreakpointSchema
-  > {
+  public getDynamicBreakpointSchemaMap(): ReadonlyMap<string, BreakpointSchema> {
     return this.dynamicBreakpointSchemaMap;
   }
 
@@ -156,10 +135,7 @@ export class DynamicSchemaService {
    * If the changed new dynamic schema invalidates some property, then the invalid properties fields will be dropped.
    *
    */
-  public setDynamicSchema(
-    operatorID: string,
-    dynamicSchema: OperatorSchema
-  ): void {
+  public setDynamicSchema(operatorID: string, dynamicSchema: OperatorSchema): void {
     const currentDynamicSchema = this.dynamicSchemaMap.get(operatorID);
 
     // do nothing if old & new schema are the same
@@ -182,12 +158,8 @@ export class DynamicSchemaService {
    * @param operator
    */
   private getInitialDynamicSchema(operator: OperatorPredicate): OperatorSchema {
-    let initialSchema = this.operatorMetadataService.getOperatorSchema(
-      operator.operatorType
-    );
-    this.initialSchemaTransformers.forEach(
-      (transformer) => (initialSchema = transformer(operator, initialSchema))
-    );
+    let initialSchema = this.operatorMetadataService.getOperatorSchema(operator.operatorType);
+    this.initialSchemaTransformers.forEach(transformer => (initialSchema = transformer(operator, initialSchema)));
 
     return initialSchema;
   }
@@ -202,10 +174,7 @@ export class DynamicSchemaService {
    */
   public static mutateProperty(
     jsonSchemaToChange: CustomJSONSchema7,
-    matchFunc: (
-      propertyName: string,
-      propertyValue: CustomJSONSchema7
-    ) => boolean,
+    matchFunc: (propertyName: string, propertyValue: CustomJSONSchema7) => boolean,
     mutationFunc: (propertyValue: CustomJSONSchema7) => CustomJSONSchema7
   ): CustomJSONSchema7 {
     // recursively walks the JSON schema property tree to find the property name
@@ -215,26 +184,20 @@ export class DynamicSchemaService {
       const schemaItems = jsonSchema.items;
 
       // nested JSON schema property can have 2 types: object or array
-      const mutateObjectProperty = (objectProperty: {
-        [key: string]: JSONSchema7Definition;
-      }) => {
-        Object.entries(objectProperty).forEach(
-          ([propertyName, propertyValue]) => {
-            if (typeof propertyValue === "boolean") {
-              return;
-            }
-            if (matchFunc(propertyName, propertyValue as CustomJSONSchema7)) {
-              objectProperty[propertyName] = mutationFunc(
-                propertyValue as CustomJSONSchema7
-              );
-            } else {
-              mutatePropertyRecurse(propertyValue);
-            }
+      const mutateObjectProperty = (objectProperty: { [key: string]: JSONSchema7Definition }) => {
+        Object.entries(objectProperty).forEach(([propertyName, propertyValue]) => {
+          if (typeof propertyValue === "boolean") {
+            return;
           }
-        );
+          if (matchFunc(propertyName, propertyValue as CustomJSONSchema7)) {
+            objectProperty[propertyName] = mutationFunc(propertyValue as CustomJSONSchema7);
+          } else {
+            mutatePropertyRecurse(propertyValue);
+          }
+        });
       };
       const mutateArrayProperty = (arrayProperty: JSONSchema7Definition[]) => {
-        arrayProperty.forEach((item) => {
+        arrayProperty.forEach(item => {
           if (typeof item !== "boolean") {
             mutatePropertyRecurse(item);
           }

--- a/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/mock-schema-propagation.data.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/mock-schema-propagation.data.ts
@@ -6,40 +6,37 @@ import { SchemaPropagationResponse } from "./schema-propagation.service";
 
 export const mockSchemaPropagationOperatorID = "2";
 
-export const mockSchemaPropagationResponse: Readonly<SchemaPropagationResponse> =
-  {
-    code: 0,
-    result: {
-      // [var] means using the variable value as key instead of variable name
-      [mockSchemaPropagationOperatorID]: [
-        [
-          { attributeName: "city", attributeType: "string" },
-          { attributeName: "user_screen_name", attributeType: "string" },
-          { attributeName: "user_name", attributeType: "string" },
-          { attributeName: "county", attributeType: "string" },
-          { attributeName: "tweet_link", attributeType: "string" },
-          { attributeName: "payload", attributeType: "string" },
-          { attributeName: "user_followers_count", attributeType: "integer" },
-          { attributeName: "user_link", attributeType: "string" },
-          { attributeName: "_id", attributeType: "string" },
-          { attributeName: "text", attributeType: "string" },
-          { attributeName: "state", attributeType: "string" },
-          { attributeName: "create_at", attributeType: "string" },
-          { attributeName: "user_description", attributeType: "string" },
-          { attributeName: "user_friends_count", attributeType: "integer" }
-        ]
-      ]
-    }
-  };
+export const mockSchemaPropagationResponse: Readonly<SchemaPropagationResponse> = {
+  code: 0,
+  result: {
+    // [var] means using the variable value as key instead of variable name
+    [mockSchemaPropagationOperatorID]: [
+      [
+        { attributeName: "city", attributeType: "string" },
+        { attributeName: "user_screen_name", attributeType: "string" },
+        { attributeName: "user_name", attributeType: "string" },
+        { attributeName: "county", attributeType: "string" },
+        { attributeName: "tweet_link", attributeType: "string" },
+        { attributeName: "payload", attributeType: "string" },
+        { attributeName: "user_followers_count", attributeType: "integer" },
+        { attributeName: "user_link", attributeType: "string" },
+        { attributeName: "_id", attributeType: "string" },
+        { attributeName: "text", attributeType: "string" },
+        { attributeName: "state", attributeType: "string" },
+        { attributeName: "create_at", attributeType: "string" },
+        { attributeName: "user_description", attributeType: "string" },
+        { attributeName: "user_friends_count", attributeType: "integer" },
+      ],
+    ],
+  },
+};
 
-export const mockEmptySchemaPropagationResponse: Readonly<SchemaPropagationResponse> =
-  {
-    code: 0,
-    result: {}
-  };
+export const mockEmptySchemaPropagationResponse: Readonly<SchemaPropagationResponse> = {
+  code: 0,
+  result: {},
+};
 
-export const mockAutocompleteAPIEmptyResponse: Readonly<SchemaPropagationResponse> =
-  {
-    code: 0,
-    result: {}
-  };
+export const mockAutocompleteAPIEmptyResponse: Readonly<SchemaPropagationResponse> = {
+  code: 0,
+  result: {},
+};

--- a/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.spec.ts
@@ -1,8 +1,5 @@
 import { HttpClient } from "@angular/common/http";
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from "@angular/common/http/testing";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
 import { fakeAsync, inject, TestBed, tick } from "@angular/core/testing";
 import { LoggerModule } from "ngx-logger";
 import { environment } from "../../../../../environments/environment";
@@ -12,7 +9,7 @@ import { JointUIService } from "../../joint-ui/joint-ui.service";
 import {
   mockAggregationSchema,
   mockKeywordSearchSchema,
-  mockNlpSentimentSchema
+  mockNlpSentimentSchema,
 } from "../../operator-metadata/mock-operator-metadata.data";
 import { OperatorMetadataService } from "../../operator-metadata/operator-metadata.service";
 
@@ -22,7 +19,7 @@ import {
   mockPoint,
   mockScanPredicate,
   mockScanSentimentLink,
-  mockSentimentPredicate
+  mockSentimentPredicate,
 } from "../../workflow-graph/model/mock-workflow-data";
 import { WorkflowActionService } from "../../workflow-graph/model/workflow-action.service";
 import { WorkflowUtilService } from "../../workflow-graph/util/workflow-util.service";
@@ -30,12 +27,12 @@ import { DynamicSchemaService } from "../dynamic-schema.service";
 import {
   mockEmptySchemaPropagationResponse,
   mockSchemaPropagationOperatorID,
-  mockSchemaPropagationResponse
+  mockSchemaPropagationResponse,
 } from "./mock-schema-propagation.data";
 import {
   SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS,
   SCHEMA_PROPAGATION_ENDPOINT,
-  SchemaPropagationService
+  SchemaPropagationService,
 } from "./schema-propagation.service";
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
@@ -49,15 +46,15 @@ describe("SchemaPropagationService", () => {
       providers: [
         {
           provide: OperatorMetadataService,
-          useClass: StubOperatorMetadataService
+          useClass: StubOperatorMetadataService,
         },
         JointUIService,
         WorkflowActionService,
         WorkflowUtilService,
         UndoRedoService,
         DynamicSchemaService,
-        SchemaPropagationService
-      ]
+        SchemaPropagationService,
+      ],
     });
 
     httpClient = TestBed.inject(HttpClient);
@@ -65,115 +62,80 @@ describe("SchemaPropagationService", () => {
     environment.schemaPropagationEnabled = true;
   });
 
-  it("should be created", inject(
-    [SchemaPropagationService],
-    (service: SchemaPropagationService) => {
-      expect(service).toBeTruthy();
-    }
-  ));
+  it("should be created", inject([SchemaPropagationService], (service: SchemaPropagationService) => {
+    expect(service).toBeTruthy();
+  }));
 
   it("should invoke schema propagation API on link changes, property changes, and disable status changes", fakeAsync(() => {
-    const workflowActionService: WorkflowActionService = TestBed.inject(
-      WorkflowActionService
-    );
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(
-      SchemaPropagationService
-    );
+    const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
     workflowActionService.addOperator(mockSentimentPredicate, mockPoint);
 
     // add link
     workflowActionService.addLink(mockScanSentimentLink);
-    httpTestingController.match(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     httpTestingController.verify();
 
     // delete link
     workflowActionService.deleteLinkWithID(mockScanSentimentLink.linkID);
-    httpTestingController.match(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     httpTestingController.verify();
 
     // add link again
     workflowActionService.addLink(mockScanSentimentLink);
-    httpTestingController.match(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     httpTestingController.verify();
 
     // disable opeator
-    workflowActionService
-      .getTexeraGraph()
-      .disableOperator(mockScanPredicate.operatorID);
-    httpTestingController.match(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    workflowActionService.getTexeraGraph().disableOperator(mockScanPredicate.operatorID);
+    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     httpTestingController.verify();
 
     // enable operator
-    workflowActionService
-      .getTexeraGraph()
-      .disableOperator(mockScanPredicate.operatorID);
-    httpTestingController.match(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    workflowActionService.getTexeraGraph().disableOperator(mockScanPredicate.operatorID);
+    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     httpTestingController.verify();
 
     // change operator property
     workflowActionService.setOperatorProperty(mockScanPredicate.operatorID, {
-      attribute: "mockChangedAttribute"
+      attribute: "mockChangedAttribute",
     });
     // verify debounce time: no request before debounce time ticks
     httpTestingController.verify();
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
     // reqeuest should be made after debounce time
-    httpTestingController.match(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     httpTestingController.verify();
   }));
 
   it("should invoke schema propagation API when a operator property is changed", fakeAsync(() => {
-    const workflowActionService: WorkflowActionService = TestBed.inject(
-      WorkflowActionService
-    );
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(
-      SchemaPropagationService
-    );
+    const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
 
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
     workflowActionService.setOperatorProperty(mockScanPredicate.operatorID, {
-      tableName: "test"
+      tableName: "test",
     });
 
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
-    const req1 = httpTestingController.expectOne(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     expect(req1.request.method).toEqual("POST");
     req1.flush(mockSchemaPropagationResponse);
     httpTestingController.verify();
   }));
 
   it("should handle error responses from server gracefully", fakeAsync(() => {
-    const workflowActionService: WorkflowActionService = TestBed.inject(
-      WorkflowActionService
-    );
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(
-      SchemaPropagationService
-    );
+    const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
 
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
     workflowActionService.setOperatorProperty(mockScanPredicate.operatorID, {
-      tableName: "test"
+      tableName: "test",
     });
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
 
-    const req1 = httpTestingController.expectOne(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     expect(req1.request.method).toEqual("POST");
 
     // return error response from server
@@ -182,48 +144,37 @@ describe("SchemaPropagationService", () => {
 
     // verify that after the error response, schema propagation service still reacts to events normally
     workflowActionService.setOperatorProperty(mockScanPredicate.operatorID, {
-      tableName: "newTable"
+      tableName: "newTable",
     });
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
 
-    const req2 = httpTestingController.expectOne(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    const req2 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     expect(req2.request.method).toEqual("POST");
     req2.flush(mockSchemaPropagationResponse);
     httpTestingController.verify();
   }));
 
   it("should modify `attribute` of operator schema", fakeAsync(() => {
-    const workflowActionService: WorkflowActionService = TestBed.inject(
-      WorkflowActionService
-    );
-    const dynamicSchemaService: DynamicSchemaService =
-      TestBed.inject(DynamicSchemaService);
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(
-      SchemaPropagationService
-    );
+    const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+    const dynamicSchemaService: DynamicSchemaService = TestBed.inject(DynamicSchemaService);
+    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
 
     const mockOperator = {
       ...mockSentimentPredicate,
-      operatorID: mockSchemaPropagationOperatorID
+      operatorID: mockSchemaPropagationOperatorID,
     };
 
     workflowActionService.addOperator(mockOperator, mockPoint);
     // change operator property to trigger invoking schema propagation API
     workflowActionService.setOperatorProperty(mockOperator.operatorID, {
-      testAttr: "test"
+      testAttr: "test",
     });
 
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
     // flush mock response
-    const req1 = httpTestingController.expectOne(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     expect(req1.request.method === "POST");
-    expect(req1.request.url).toEqual(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     req1.flush(mockSchemaPropagationResponse);
 
     // const req2 = httpTestingController.match(
@@ -234,51 +185,40 @@ describe("SchemaPropagationService", () => {
 
     httpTestingController.verify();
 
-    const schema = dynamicSchemaService.getDynamicSchema(
-      mockSentimentPredicate.operatorID
-    );
+    const schema = dynamicSchemaService.getDynamicSchema(mockSentimentPredicate.operatorID);
     const attributeInSchema = schema.jsonSchema!.properties!["attribute"];
-    const expectedEnum = mockSchemaPropagationResponse.result[
-      mockOperator.operatorID
-    ][0]?.map((attr) => attr.attributeName);
+    const expectedEnum = mockSchemaPropagationResponse.result[mockOperator.operatorID][0]?.map(
+      attr => attr.attributeName
+    );
 
     expect(attributeInSchema).toEqual({
       ...(mockNlpSentimentSchema.jsonSchema.properties!["attribute"] as object),
       enum: expectedEnum,
-      uniqueItems: true
+      uniqueItems: true,
     });
   }));
 
   it("should restore `attribute` to original schema if input attributes no longer exists", fakeAsync(() => {
-    const workflowActionService: WorkflowActionService = TestBed.inject(
-      WorkflowActionService
-    );
-    const dynamicSchemaService: DynamicSchemaService =
-      TestBed.inject(DynamicSchemaService);
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(
-      SchemaPropagationService
-    );
+    const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+    const dynamicSchemaService: DynamicSchemaService = TestBed.inject(DynamicSchemaService);
+    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
 
     const mockOperator = {
       ...mockSentimentPredicate,
-      operatorID: mockSchemaPropagationOperatorID
+      operatorID: mockSchemaPropagationOperatorID,
     };
 
     workflowActionService.addOperator(mockOperator, mockPoint);
     // change operator property to trigger invoking schema propagation API
     workflowActionService.setOperatorProperty(mockOperator.operatorID, {
-      testAttr: "test"
+      testAttr: "test",
     });
 
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
 
-    const req1 = httpTestingController.expectOne(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     expect(req1.request.method === "POST");
-    expect(req1.request.url).toEqual(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
 
     // flush mock response
     req1.flush(mockSchemaPropagationResponse);
@@ -291,33 +231,27 @@ describe("SchemaPropagationService", () => {
 
     httpTestingController.verify();
 
-    const schema = dynamicSchemaService.getDynamicSchema(
-      mockSentimentPredicate.operatorID
-    );
+    const schema = dynamicSchemaService.getDynamicSchema(mockSentimentPredicate.operatorID);
     const attributeInSchema = schema.jsonSchema!.properties!["attribute"];
-    const expectedEnum = mockSchemaPropagationResponse.result[
-      mockOperator.operatorID
-    ][0]?.map((attr) => attr.attributeName);
+    const expectedEnum = mockSchemaPropagationResponse.result[mockOperator.operatorID][0]?.map(
+      attr => attr.attributeName
+    );
 
     expect(attributeInSchema).toEqual({
       ...(mockNlpSentimentSchema.jsonSchema.properties!["attribute"] as object),
       enum: expectedEnum,
-      uniqueItems: true
+      uniqueItems: true,
     });
 
     // change operator property to trigger invoking schema propagation API
     workflowActionService.setOperatorProperty(mockOperator.operatorID, {
-      testAttr: "test"
+      testAttr: "test",
     });
 
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
-    const req3 = httpTestingController.expectOne(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    const req3 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     expect(req3.request.method === "POST");
-    expect(req3.request.url).toEqual(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    expect(req3.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
 
     // flush mock response, however, this time response is empty, which means input attrs no longer exists
     req3.flush(mockEmptySchemaPropagationResponse);
@@ -330,27 +264,19 @@ describe("SchemaPropagationService", () => {
 
     httpTestingController.verify();
     // verify that schema is restored to original value
-    const restoredSchema = dynamicSchemaService.getDynamicSchema(
-      mockSentimentPredicate.operatorID
-    );
-    const restoredAttributeInSchema =
-      restoredSchema.jsonSchema!.properties!["attribute"];
+    const restoredSchema = dynamicSchemaService.getDynamicSchema(mockSentimentPredicate.operatorID);
+    const restoredAttributeInSchema = restoredSchema.jsonSchema!.properties!["attribute"];
     expect(restoredAttributeInSchema).toEqual({
       ...(mockNlpSentimentSchema.jsonSchema.properties!["attribute"] as object),
       enum: undefined,
-      uniqueItems: undefined
+      uniqueItems: undefined,
     });
   }));
 
   it("should modify `attributes` of operator schema", fakeAsync(() => {
-    const workflowActionService: WorkflowActionService = TestBed.inject(
-      WorkflowActionService
-    );
-    const dynamicSchemaService: DynamicSchemaService =
-      TestBed.inject(DynamicSchemaService);
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(
-      SchemaPropagationService
-    );
+    const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+    const dynamicSchemaService: DynamicSchemaService = TestBed.inject(DynamicSchemaService);
+    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
 
     const mockKeywordSearchOperator: OperatorPredicate = {
       operatorID: mockSchemaPropagationOperatorID,
@@ -359,24 +285,17 @@ describe("SchemaPropagationService", () => {
       inputPorts: [],
       outputPorts: [],
       showAdvanced: true,
-      isDisabled: false
+      isDisabled: false,
     };
 
     workflowActionService.addOperator(mockKeywordSearchOperator, mockPoint);
     // change operator property to trigger invoking schema propagation API
-    workflowActionService.setOperatorProperty(
-      mockKeywordSearchOperator.operatorID,
-      { testAttr: "test" }
-    );
+    workflowActionService.setOperatorProperty(mockKeywordSearchOperator.operatorID, { testAttr: "test" });
 
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
-    const req1 = httpTestingController.expectOne(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     expect(req1.request.method === "POST");
-    expect(req1.request.url).toEqual(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     // flush mock response
     req1.flush(mockSchemaPropagationResponse);
 
@@ -388,13 +307,11 @@ describe("SchemaPropagationService", () => {
 
     httpTestingController.verify();
 
-    const schema = dynamicSchemaService.getDynamicSchema(
-      mockSentimentPredicate.operatorID
-    );
+    const schema = dynamicSchemaService.getDynamicSchema(mockSentimentPredicate.operatorID);
     const attributeInSchema = schema.jsonSchema!.properties!["attributes"];
-    const expectedEnum = mockSchemaPropagationResponse.result[
-      mockKeywordSearchOperator.operatorID
-    ][0]?.map((attr) => attr.attributeName);
+    const expectedEnum = mockSchemaPropagationResponse.result[mockKeywordSearchOperator.operatorID][0]?.map(
+      attr => attr.attributeName
+    );
 
     expect(attributeInSchema).toEqual({
       type: "array",
@@ -404,20 +321,15 @@ describe("SchemaPropagationService", () => {
       autofillAttributeOnPort: 0,
       items: {
         type: "string",
-        enum: expectedEnum
-      }
+        enum: expectedEnum,
+      },
     });
   }));
 
   it("should modify nested deep `attribute` of operator schema", fakeAsync(() => {
-    const workflowActionService: WorkflowActionService = TestBed.inject(
-      WorkflowActionService
-    );
-    const dynamicSchemaService: DynamicSchemaService =
-      TestBed.inject(DynamicSchemaService);
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(
-      SchemaPropagationService
-    );
+    const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+    const dynamicSchemaService: DynamicSchemaService = TestBed.inject(DynamicSchemaService);
+    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
 
     // to match the operator ID of mockSchemaPropagationResponse
     const mockAggregationPredicate: OperatorPredicate = {
@@ -427,24 +339,17 @@ describe("SchemaPropagationService", () => {
       inputPorts: [],
       outputPorts: [],
       showAdvanced: true,
-      isDisabled: false
+      isDisabled: false,
     };
 
     workflowActionService.addOperator(mockAggregationPredicate, mockPoint);
     // change operator property to trigger invoking schema propagation API
-    workflowActionService.setOperatorProperty(
-      mockAggregationPredicate.operatorID,
-      { testAttr: "test" }
-    );
+    workflowActionService.setOperatorProperty(mockAggregationPredicate.operatorID, { testAttr: "test" });
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
 
-    const req1 = httpTestingController.expectOne(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
     expect(req1.request.method === "POST");
-    expect(req1.request.url).toEqual(
-      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`
-    );
+    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
 
     // flush mock response
     req1.flush(mockSchemaPropagationResponse);
@@ -457,12 +362,10 @@ describe("SchemaPropagationService", () => {
 
     httpTestingController.verify();
 
-    const schema = dynamicSchemaService.getDynamicSchema(
-      mockSentimentPredicate.operatorID
+    const schema = dynamicSchemaService.getDynamicSchema(mockSentimentPredicate.operatorID);
+    const expectedEnum = mockSchemaPropagationResponse.result[mockAggregationPredicate.operatorID][0]?.map(
+      attr => attr.attributeName
     );
-    const expectedEnum = mockSchemaPropagationResponse.result[
-      mockAggregationPredicate.operatorID
-    ][0]?.map((attr) => attr.attributeName);
 
     expect(schema.jsonSchema!.properties).toEqual({
       listOfAggregations: {
@@ -477,18 +380,18 @@ describe("SchemaPropagationService", () => {
               autofill: "attributeName",
               autofillAttributeOnPort: 0,
               enum: expectedEnum,
-              uniqueItems: true
+              uniqueItems: true,
             },
             aggregator: {
               title: "aggregator",
               type: "string",
               enum: ["min", "max", "average", "sum", "count"],
-              uniqueItems: true
+              uniqueItems: true,
             },
-            resultAttribute: { type: "string", title: "result attribute" }
-          }
-        }
-      }
+            resultAttribute: { type: "string", title: "result attribute" },
+          },
+        },
+      },
     });
   }));
 });

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
@@ -1,13 +1,7 @@
-import {
-  ExecutionState,
-  LogicalPlan
-} from "../../types/execute-workflow.interface";
+import { ExecutionState, LogicalPlan } from "../../types/execute-workflow.interface";
 import { fakeAsync, flush, inject, TestBed, tick } from "@angular/core/testing";
 
-import {
-  ExecuteWorkflowService,
-  FORM_DEBOUNCE_TIME_MS
-} from "./execute-workflow.service";
+import { ExecuteWorkflowService, FORM_DEBOUNCE_TIME_MS } from "./execute-workflow.service";
 
 import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
 import { UndoRedoService } from "../undo-redo/undo-redo.service";
@@ -16,10 +10,7 @@ import { StubOperatorMetadataService } from "../operator-metadata/stub-operator-
 import { JointUIService } from "../joint-ui/joint-ui.service";
 import { Observable, of } from "rxjs";
 
-import {
-  mockLogicalPlan_scan_result,
-  mockWorkflowPlan_scan_result
-} from "./mock-workflow-plan";
+import { mockLogicalPlan_scan_result, mockWorkflowPlan_scan_result } from "./mock-workflow-plan";
 import { HttpClient } from "@angular/common/http";
 import { WorkflowGraph } from "../workflow-graph/model/workflow-graph";
 import { environment } from "../../../../environments/environment";
@@ -48,36 +39,29 @@ describe("ExecuteWorkflowService", () => {
         JointUIService,
         {
           provide: OperatorMetadataService,
-          useClass: StubOperatorMetadataService
+          useClass: StubOperatorMetadataService,
         },
-        { provide: HttpClient, useClass: StubHttpClient }
-      ]
+        { provide: HttpClient, useClass: StubHttpClient },
+      ],
     });
 
     service = TestBed.inject(ExecuteWorkflowService);
     environment.pauseResumeEnabled = true;
   });
 
-  it("should be created", inject(
-    [ExecuteWorkflowService],
-    (injectedService: ExecuteWorkflowService) => {
-      expect(injectedService).toBeTruthy();
-    }
-  ));
+  it("should be created", inject([ExecuteWorkflowService], (injectedService: ExecuteWorkflowService) => {
+    expect(injectedService).toBeTruthy();
+  }));
 
   it("should generate a logical plan request based on the workflow graph that is passed to the function", () => {
     const workflowGraph: WorkflowGraph = mockWorkflowPlan_scan_result;
-    const newLogicalPlan: LogicalPlan =
-      ExecuteWorkflowService.getLogicalPlanRequest(workflowGraph);
+    const newLogicalPlan: LogicalPlan = ExecuteWorkflowService.getLogicalPlanRequest(workflowGraph);
     expect(newLogicalPlan).toEqual(mockLogicalPlan_scan_result);
   });
 
   it("should msg backend when executing workflow", fakeAsync(() => {
     if (environment.amberEngineEnabled) {
-      const wsSendSpy = spyOn(
-        (service as any).workflowWebsocketService,
-        "send"
-      );
+      const wsSendSpy = spyOn((service as any).workflowWebsocketService, "send");
 
       service.executeWorkflow();
       tick(FORM_DEBOUNCE_TIME_MS + 1);
@@ -93,10 +77,7 @@ describe("ExecuteWorkflowService", () => {
     expect(function () {
       service.pauseWorkflow();
     }).toThrowError(
-      new RegExp(
-        "cannot pause workflow, current execution state is " +
-          (service as any).currentState.state
-      )
+      new RegExp("cannot pause workflow, current execution state is " + (service as any).currentState.state)
     );
   });
 
@@ -105,10 +86,7 @@ describe("ExecuteWorkflowService", () => {
     expect(function () {
       service.resumeWorkflow();
     }).toThrowError(
-      new RegExp(
-        "cannot resume workflow, current execution state is " +
-          (service as any).currentState.state
-      )
+      new RegExp("cannot resume workflow, current execution state is " + (service as any).currentState.state)
     );
   });
 });

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -8,28 +8,15 @@ import {
   ExecutionStateInfo,
   LogicalLink,
   LogicalOperator,
-  LogicalPlan
+  LogicalPlan,
 } from "../../types/execute-workflow.interface";
 import { environment } from "../../../../environments/environment";
 import { WorkflowWebsocketService } from "../workflow-websocket/workflow-websocket.service";
-import {
-  Breakpoint,
-  BreakpointRequest,
-  BreakpointTriggerInfo
-} from "../../types/workflow-common.interface";
-import {
-  OperatorCurrentTuples,
-  TexeraWebsocketEvent
-} from "../../types/workflow-websocket.interface";
+import { Breakpoint, BreakpointRequest, BreakpointTriggerInfo } from "../../types/workflow-common.interface";
+import { OperatorCurrentTuples, TexeraWebsocketEvent } from "../../types/workflow-websocket.interface";
 import { isEqual } from "lodash-es";
-import {
-  PAGINATION_INFO_STORAGE_KEY,
-  ResultPaginationInfo
-} from "../../types/result-table.interface";
-import {
-  sessionGetObject,
-  sessionSetObject
-} from "../../../common/util/storage";
+import { PAGINATION_INFO_STORAGE_KEY, ResultPaginationInfo } from "../../types/result-table.interface";
+import { sessionGetObject, sessionSetObject } from "../../../common/util/storage";
 
 // TODO: change this declaration
 export const FORM_DEBOUNCE_TIME_MS = 150;
@@ -60,11 +47,11 @@ export const EXECUTION_TIMEOUT = 3000;
  * @author Henry Chen
  */
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class ExecuteWorkflowService {
   private currentState: ExecutionStateInfo = {
-    state: ExecutionState.Uninitialized
+    state: ExecutionState.Uninitialized,
   };
   private executionStateStream = new Subject<{
     previous: ExecutionStateInfo;
@@ -79,7 +66,7 @@ export class ExecuteWorkflowService {
     private workflowWebsocketService: WorkflowWebsocketService
   ) {
     if (environment.amberEngineEnabled) {
-      workflowWebsocketService.websocketEvent().subscribe((event) => {
+      workflowWebsocketService.websocketEvent().subscribe(event => {
         // workflow status related event
         const newState = this.handleExecutionEvent(event);
         if (newState !== undefined) {
@@ -89,9 +76,7 @@ export class ExecuteWorkflowService {
     }
   }
 
-  public handleExecutionEvent(
-    event: TexeraWebsocketEvent
-  ): ExecutionStateInfo | undefined {
+  public handleExecutionEvent(event: TexeraWebsocketEvent): ExecutionStateInfo | undefined {
     switch (event.type) {
       case "WorkflowStartedEvent":
         return { state: ExecutionState.Running };
@@ -112,9 +97,7 @@ export class ExecuteWorkflowService {
         if (this.currentState.state === ExecutionState.BreakpointTriggered) {
           return this.currentState;
         }
-        let pausedCurrentTuples: Readonly<
-          Record<string, OperatorCurrentTuples>
-        >;
+        let pausedCurrentTuples: Readonly<Record<string, OperatorCurrentTuples>>;
         if (this.currentState.state === ExecutionState.Paused) {
           pausedCurrentTuples = this.currentState.currentTuples;
         } else {
@@ -124,11 +107,11 @@ export class ExecuteWorkflowService {
         currentTupleUpdate[event.operatorID] = event;
         const newCurrentTuples: Record<string, OperatorCurrentTuples> = {
           ...currentTupleUpdate,
-          ...pausedCurrentTuples
+          ...pausedCurrentTuples,
         };
         return {
           state: ExecutionState.Paused,
-          currentTuples: newCurrentTuples
+          currentTuples: newCurrentTuples,
         };
       case "WorkflowResumedEvent":
         return { state: ExecutionState.Running };
@@ -136,12 +119,10 @@ export class ExecuteWorkflowService {
         return { state: ExecutionState.BreakpointTriggered, breakpoint: event };
       case "WorkflowErrorEvent":
         const errorMessages: Record<string, string> = {};
-        Object.entries(event.operatorErrors).forEach((entry) => {
-          errorMessages[
-            entry[0]
-          ] = `${entry[1].propertyPath}: ${entry[1].message}`;
+        Object.entries(event.operatorErrors).forEach(entry => {
+          errorMessages[entry[0]] = `${entry[1].propertyPath}: ${entry[1].message}`;
         });
-        Object.entries(event.generalErrors).forEach((entry) => {
+        Object.entries(event.generalErrors).forEach(entry => {
           errorMessages[entry[0]] = entry[1];
         });
         return { state: ExecutionState.Failed, errorMessages: errorMessages };
@@ -149,7 +130,7 @@ export class ExecuteWorkflowService {
       case "WorkflowExecutionErrorEvent":
         return {
           state: ExecutionState.Failed,
-          errorMessages: { WorkflowExecutionError: event.message }
+          errorMessages: { WorkflowExecutionError: event.message },
         };
       default:
         return undefined;
@@ -184,31 +165,23 @@ export class ExecuteWorkflowService {
 
   public executeWorkflowAmberTexera(): void {
     // get the current workflow graph
-    const logicalPlan = ExecuteWorkflowService.getLogicalPlanRequest(
-      this.workflowActionService.getTexeraGraph()
-    );
+    const logicalPlan = ExecuteWorkflowService.getLogicalPlanRequest(this.workflowActionService.getTexeraGraph());
     console.log(logicalPlan);
     // wait for the form debounce to complete, then send
     window.setTimeout(() => {
       this.workflowWebsocketService.send("ExecuteWorkflowRequest", logicalPlan);
     }, FORM_DEBOUNCE_TIME_MS);
     this.updateExecutionState({ state: ExecutionState.WaitingToRun });
-    this.setExecutionTimeout(
-      "submit workflow timeout",
-      ExecutionState.Running,
-      ExecutionState.Failed
-    );
+    this.setExecutionTimeout("submit workflow timeout", ExecutionState.Running, ExecutionState.Failed);
 
     // add flag for new execution of workflow
     // so when next time the result panel is displayed, it will use new data
     // instead of those stored in the session storage
-    const resultPaginationInfo = sessionGetObject<ResultPaginationInfo>(
-      PAGINATION_INFO_STORAGE_KEY
-    );
+    const resultPaginationInfo = sessionGetObject<ResultPaginationInfo>(PAGINATION_INFO_STORAGE_KEY);
     if (resultPaginationInfo) {
       sessionSetObject(PAGINATION_INFO_STORAGE_KEY, {
         ...resultPaginationInfo,
-        newWorkflowExecuted: true
+        newWorkflowExecuted: true,
       });
     }
   }
@@ -217,22 +190,12 @@ export class ExecuteWorkflowService {
     if (!environment.pauseResumeEnabled || !environment.amberEngineEnabled) {
       return;
     }
-    if (
-      this.currentState === undefined ||
-      this.currentState.state !== ExecutionState.Running
-    ) {
-      throw new Error(
-        "cannot pause workflow, current execution state is " +
-          this.currentState?.state
-      );
+    if (this.currentState === undefined || this.currentState.state !== ExecutionState.Running) {
+      throw new Error("cannot pause workflow, current execution state is " + this.currentState?.state);
     }
     this.workflowWebsocketService.send("PauseWorkflowRequest", {});
     this.updateExecutionState({ state: ExecutionState.Pausing });
-    this.setExecutionTimeout(
-      "pause operation timeout",
-      ExecutionState.Paused,
-      ExecutionState.Failed
-    );
+    this.setExecutionTimeout("pause operation timeout", ExecutionState.Paused, ExecutionState.Failed);
   }
 
   public killWorkflow(): void {
@@ -243,10 +206,7 @@ export class ExecuteWorkflowService {
       this.currentState.state === ExecutionState.Uninitialized ||
       this.currentState.state === ExecutionState.Completed
     ) {
-      throw new Error(
-        "cannot kill workflow, current execution state is " +
-          this.currentState.state
-      );
+      throw new Error("cannot kill workflow, current execution state is " + this.currentState.state);
     }
     this.workflowWebsocketService.send("KillWorkflowRequest", {});
     this.updateExecutionState({ state: ExecutionState.Completed });
@@ -262,24 +222,14 @@ export class ExecuteWorkflowService {
         this.currentState.state === ExecutionState.BreakpointTriggered
       )
     ) {
-      throw new Error(
-        "cannot resume workflow, current execution state is " +
-          this.currentState.state
-      );
+      throw new Error("cannot resume workflow, current execution state is " + this.currentState.state);
     }
     this.workflowWebsocketService.send("ResumeWorkflowRequest", {});
     this.updateExecutionState({ state: ExecutionState.Resuming });
-    this.setExecutionTimeout(
-      "resume operation timeout",
-      ExecutionState.Running,
-      ExecutionState.Failed
-    );
+    this.setExecutionTimeout("resume operation timeout", ExecutionState.Running, ExecutionState.Failed);
   }
 
-  public addBreakpointRuntime(
-    linkID: string,
-    breakpointData: Breakpoint
-  ): void {
+  public addBreakpointRuntime(linkID: string, breakpointData: Breakpoint): void {
     if (!environment.amberEngineEnabled) {
       return;
     }
@@ -287,19 +237,12 @@ export class ExecuteWorkflowService {
       this.currentState.state !== ExecutionState.BreakpointTriggered &&
       this.currentState.state !== ExecutionState.Paused
     ) {
-      throw new Error(
-        "cannot add breakpoint at runtime, current execution state is " +
-          this.currentState.state
-      );
+      throw new Error("cannot add breakpoint at runtime, current execution state is " + this.currentState.state);
     }
     console.log("sending add breakpoint request");
     this.workflowWebsocketService.send(
       "AddBreakpointRequest",
-      ExecuteWorkflowService.transformBreakpoint(
-        this.workflowActionService.getTexeraGraph(),
-        linkID,
-        breakpointData
-      )
+      ExecuteWorkflowService.transformBreakpoint(this.workflowActionService.getTexeraGraph(), linkID, breakpointData)
     );
   }
 
@@ -308,15 +251,12 @@ export class ExecuteWorkflowService {
       return;
     }
     if (this.currentState.state !== ExecutionState.BreakpointTriggered) {
-      throw new Error(
-        "cannot skip tuples, current execution state is " +
-          this.currentState.state
-      );
+      throw new Error("cannot skip tuples, current execution state is " + this.currentState.state);
     }
-    this.currentState.breakpoint.report.forEach((fault) => {
+    this.currentState.breakpoint.report.forEach(fault => {
       this.workflowWebsocketService.send("SkipTupleRequest", {
         faultedTuple: fault.faultedTuple,
-        actorPath: fault.actorPath
+        actorPath: fault.actorPath,
       });
     });
   }
@@ -329,18 +269,13 @@ export class ExecuteWorkflowService {
       this.currentState.state !== ExecutionState.BreakpointTriggered &&
       this.currentState.state !== ExecutionState.Paused
     ) {
-      throw new Error(
-        "cannot modify logic, current execution state is " +
-          this.currentState.state
-      );
+      throw new Error("cannot modify logic, current execution state is " + this.currentState.state);
     }
-    const op = this.workflowActionService
-      .getTexeraGraph()
-      .getOperator(operatorID);
+    const op = this.workflowActionService.getTexeraGraph().getOperator(operatorID);
     const operator: LogicalOperator = {
       ...op.operatorProperties,
       operatorID: op.operatorID,
-      operatorType: op.operatorType
+      operatorType: op.operatorType,
     };
     this.workflowWebsocketService.send("ModifyLogicRequest", { operator });
   }
@@ -352,17 +287,14 @@ export class ExecuteWorkflowService {
     return this.executionStateStream.asObservable();
   }
 
-  private setExecutionTimeout(
-    message: string,
-    ...clearTimeoutState: ExecutionState[]
-  ) {
+  private setExecutionTimeout(message: string, ...clearTimeoutState: ExecutionState[]) {
     if (this.executionTimeoutID !== undefined) {
       this.clearExecutionTimeout();
     }
     this.executionTimeoutID = window.setTimeout(() => {
       this.updateExecutionState({
         state: ExecutionState.Failed,
-        errorMessages: { timeout: message }
+        errorMessages: { timeout: message },
       });
     }, EXECUTION_TIMEOUT);
     this.clearTimeoutState = clearTimeoutState;
@@ -390,7 +322,7 @@ export class ExecuteWorkflowService {
     // emit event
     this.executionStateStream.next({
       previous: previousState,
-      current: this.currentState
+      current: this.currentState,
     });
   }
 
@@ -429,62 +361,38 @@ export class ExecuteWorkflowService {
    *
    * @param workflowGraph
    */
-  public static getLogicalPlanRequest(
-    workflowGraph: WorkflowGraphReadonly
-  ): LogicalPlan {
-    const getInputPortOrdinal = (
-      operatorID: string,
-      inputPortID: string
-    ): number => {
-      return workflowGraph
-        .getOperator(operatorID)
-        .inputPorts.findIndex((port) => port.portID === inputPortID);
+  public static getLogicalPlanRequest(workflowGraph: WorkflowGraphReadonly): LogicalPlan {
+    const getInputPortOrdinal = (operatorID: string, inputPortID: string): number => {
+      return workflowGraph.getOperator(operatorID).inputPorts.findIndex(port => port.portID === inputPortID);
     };
-    const getOutputPortOrdinal = (
-      operatorID: string,
-      outputPortID: string
-    ): number => {
-      return workflowGraph
-        .getOperator(operatorID)
-        .outputPorts.findIndex((port) => port.portID === outputPortID);
+    const getOutputPortOrdinal = (operatorID: string, outputPortID: string): number => {
+      return workflowGraph.getOperator(operatorID).outputPorts.findIndex(port => port.portID === outputPortID);
     };
 
-    const operators: LogicalOperator[] = workflowGraph
-      .getAllEnabledOperators()
-      .map((op) => ({
-        ...op.operatorProperties,
-        operatorID: op.operatorID,
-        operatorType: op.operatorType
-      }));
+    const operators: LogicalOperator[] = workflowGraph.getAllEnabledOperators().map(op => ({
+      ...op.operatorProperties,
+      operatorID: op.operatorID,
+      operatorType: op.operatorType,
+    }));
 
-    const links: LogicalLink[] = workflowGraph
-      .getAllEnabledLinks()
-      .map((link) => ({
-        origin: {
-          operatorID: link.source.operatorID,
-          portOrdinal: getOutputPortOrdinal(
-            link.source.operatorID,
-            link.source.portID
-          )
-        },
-        destination: {
-          operatorID: link.target.operatorID,
-          portOrdinal: getInputPortOrdinal(
-            link.target.operatorID,
-            link.target.portID
-          )
-        }
-      }));
+    const links: LogicalLink[] = workflowGraph.getAllEnabledLinks().map(link => ({
+      origin: {
+        operatorID: link.source.operatorID,
+        portOrdinal: getOutputPortOrdinal(link.source.operatorID, link.source.portID),
+      },
+      destination: {
+        operatorID: link.target.operatorID,
+        portOrdinal: getInputPortOrdinal(link.target.operatorID, link.target.portID),
+      },
+    }));
 
-    const breakpoints: BreakpointInfo[] = Array.from(
-      workflowGraph.getAllEnabledLinkBreakpoints().entries()
-    ).map((e) =>
+    const breakpoints: BreakpointInfo[] = Array.from(workflowGraph.getAllEnabledLinkBreakpoints().entries()).map(e =>
       ExecuteWorkflowService.transformBreakpoint(workflowGraph, e[0], e[1])
     );
 
-    const cachedOperatorIds: string[] = Array.from(
-      workflowGraph.getCachedOperators()
-    ).filter((op) => !workflowGraph.isOperatorDisabled(op));
+    const cachedOperatorIds: string[] = Array.from(workflowGraph.getCachedOperators()).filter(
+      op => !workflowGraph.isOperatorDisabled(op)
+    );
 
     return { operators, links, breakpoints, cachedOperatorIds };
   }

--- a/core/new-gui/src/app/workspace/service/execute-workflow/mock-result-data.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/mock-result-data.ts
@@ -1,11 +1,5 @@
-import {
-  WebDataUpdate,
-  WebPaginationUpdate
-} from "../../types/execute-workflow.interface";
-import {
-  Point,
-  OperatorPredicate
-} from "../../types/workflow-common.interface";
+import { WebDataUpdate, WebPaginationUpdate } from "../../types/execute-workflow.interface";
+import { Point, OperatorPredicate } from "../../types/workflow-common.interface";
 import { PaginatedResultEvent } from "../../types/workflow-websocket.interface";
 
 export const mockData: Record<string, unknown>[] = [
@@ -13,59 +7,57 @@ export const mockData: Record<string, unknown>[] = [
     id: 1,
     layer: "Disk Space and I/O Managers",
     duty: "Manage space on disk (pages), including extents",
-    slides: "slide 2"
+    slides: "slide 2",
   },
   {
     id: 2,
     layer: "Buffer Manager",
     duty: "DB-oriented page replacement schemes",
-    slides: "slide 3"
+    slides: "slide 3",
   },
   {
     id: 3,
     layer: "System Catalog",
     duty: "Info about physical data, tables, indexes",
-    slides: "slides 4 and 5"
+    slides: "slides 4 and 5",
   },
   {
     id: 4,
     layer: "Access methods",
     duty: "Index structures for access based on field values.",
-    slides:
-      "B+ tree: slides 6 and 7. Hashing: slide 8. Indexing Performance: slide 9."
+    slides: "B+ tree: slides 6 and 7. Hashing: slide 8. Indexing Performance: slide 9.",
   },
   {
     id: 5,
     layer: "Plan Executor + Relational Operators",
     duty: "Runtime side of query processing",
-    slides:
-      "Sorting: slide 10. Selection+Projection: slide 11. Join: slide 12. Set operations: slide 13."
+    slides: "Sorting: slide 10. Selection+Projection: slide 11. Join: slide 12. Set operations: slide 13.",
   },
   {
     id: 6,
     layer: "Query Optimizer",
     duty: "Rewrite query logically. Perform cost-based optimization",
-    slides: "Cost estimation: slide 14. SystemR Optimizer: slide 15"
-  }
+    slides: "Cost estimation: slide 14. SystemR Optimizer: slide 15",
+  },
 ];
 
 export const mockResultSnapshotUpdate: WebDataUpdate = {
   mode: { type: "SetSnapshotMode" },
   chartType: undefined,
-  table: mockData
+  table: mockData,
 };
 
 export const mockResultPaginationUpdate: WebPaginationUpdate = {
   mode: { type: "PaginationMode" },
   dirtyPageIndices: [1],
-  totalNumTuples: mockData.length
+  totalNumTuples: mockData.length,
 };
 
 export const paginationResponse: PaginatedResultEvent = {
   requestID: "requestID",
   operatorID: "operator-sink",
   pageIndex: 1,
-  table: mockData
+  table: mockData,
 };
 
 export const mockResultOperator: OperatorPredicate = {
@@ -75,10 +67,10 @@ export const mockResultOperator: OperatorPredicate = {
   inputPorts: [],
   outputPorts: [],
   showAdvanced: false,
-  isDisabled: false
+  isDisabled: false,
 };
 
 export const mockResultPoint: Point = {
   x: 1,
-  y: 1
+  y: 1,
 };

--- a/core/new-gui/src/app/workspace/service/execute-workflow/mock-workflow-plan.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/mock-workflow-plan.ts
@@ -5,7 +5,7 @@ import {
   mockResultPredicate,
   mockScanResultLink,
   mockScanSentimentLink,
-  mockSentimentResultLink
+  mockSentimentResultLink,
 } from "../workflow-graph/model/mock-workflow-data";
 import { LogicalPlan } from "../../types/execute-workflow.interface";
 
@@ -19,67 +19,66 @@ export const mockLogicalPlan_scan_result: LogicalPlan = {
     {
       ...mockScanPredicate.operatorProperties,
       operatorID: mockScanPredicate.operatorID,
-      operatorType: mockScanPredicate.operatorType
+      operatorType: mockScanPredicate.operatorType,
     },
     {
       ...mockResultPredicate.operatorProperties,
       operatorID: mockResultPredicate.operatorID,
-      operatorType: mockResultPredicate.operatorType
-    }
+      operatorType: mockResultPredicate.operatorType,
+    },
   ],
   links: [
     {
       origin: { operatorID: mockScanPredicate.operatorID, portOrdinal: 0 },
       destination: {
         operatorID: mockResultPredicate.operatorID,
-        portOrdinal: 0
-      }
-    }
+        portOrdinal: 0,
+      },
+    },
   ],
   breakpoints: [],
-  cachedOperatorIds: []
+  cachedOperatorIds: [],
 };
 
-export const mockWorkflowPlan_scan_sentiment_result: WorkflowGraph =
-  new WorkflowGraph(
-    [mockScanPredicate, mockSentimentPredicate, mockResultPredicate],
-    [mockScanSentimentLink, mockSentimentResultLink]
-  );
+export const mockWorkflowPlan_scan_sentiment_result: WorkflowGraph = new WorkflowGraph(
+  [mockScanPredicate, mockSentimentPredicate, mockResultPredicate],
+  [mockScanSentimentLink, mockSentimentResultLink]
+);
 
 export const mockLogicalPlan_scan_sentiment_result: LogicalPlan = {
   operators: [
     {
       ...mockScanPredicate.operatorProperties,
       operatorID: mockScanPredicate.operatorID,
-      operatorType: mockScanPredicate.operatorType
+      operatorType: mockScanPredicate.operatorType,
     },
     {
       ...mockSentimentPredicate.operatorProperties,
       operatorID: mockSentimentPredicate.operatorID,
-      operatorType: mockSentimentPredicate.operatorType
+      operatorType: mockSentimentPredicate.operatorType,
     },
     {
       ...mockResultPredicate.operatorProperties,
       operatorID: mockResultPredicate.operatorID,
-      operatorType: mockResultPredicate.operatorType
-    }
+      operatorType: mockResultPredicate.operatorType,
+    },
   ],
   links: [
     {
       origin: { operatorID: mockScanPredicate.operatorID, portOrdinal: 0 },
       destination: {
         operatorID: mockSentimentPredicate.operatorID,
-        portOrdinal: 0
-      }
+        portOrdinal: 0,
+      },
     },
     {
       origin: { operatorID: mockSentimentPredicate.operatorID, portOrdinal: 0 },
       destination: {
         operatorID: mockResultPredicate.operatorID,
-        portOrdinal: 0
-      }
-    }
+        portOrdinal: 0,
+      },
+    },
   ],
   breakpoints: [],
-  cachedOperatorIds: []
+  cachedOperatorIds: [],
 };

--- a/core/new-gui/src/app/workspace/service/joint-ui/joint-ui.service.ts
+++ b/core/new-gui/src/app/workspace/service/joint-ui/joint-ui.service.ts
@@ -362,9 +362,7 @@ export class JointUIService {
     const cacheIcon = JointUIService.getOperatorCacheIcon(operator, cacheStatus);
 
     const cacheIndicatorText = cacheText === "" ? "" : "cache";
-    jointPaper
-      .getModelById(operator.operatorID)
-      .attr(`.${operatorCacheTextClass}/text`, cacheIndicatorText);
+    jointPaper.getModelById(operator.operatorID).attr(`.${operatorCacheTextClass}/text`, cacheIndicatorText);
     jointPaper.getModelById(operator.operatorID).attr(`.${operatorCacheIconClass}/xlink:href`, cacheIcon);
     jointPaper.getModelById(operator.operatorID).attr(`.${operatorCacheIconClass}/title`, cacheText);
   }
@@ -646,10 +644,7 @@ export class JointUIService {
         "y-alignment": "middle",
       },
       ".texera-operator-result-cache-text": {
-        text:
-          JointUIService.getOperatorCacheDisplayText(operator) === ""
-            ? ""
-            : "cache",
+        text: JointUIService.getOperatorCacheDisplayText(operator) === "" ? "" : "cache",
         fill: "#595959",
         "font-size": "14px",
         visible: true,

--- a/core/new-gui/src/app/workspace/service/joint-ui/joint-ui.service.ts
+++ b/core/new-gui/src/app/workspace/service/joint-ui/joint-ui.service.ts
@@ -3,19 +3,9 @@ import { OperatorMetadataService } from "../operator-metadata/operator-metadata.
 import { OperatorSchema } from "../../types/operator-schema.interface";
 
 import * as joint from "jointjs";
-import {
-  OperatorLink,
-  OperatorPredicate,
-  Point
-} from "../../types/workflow-common.interface";
-import {
-  Group,
-  GroupBoundingBox
-} from "../workflow-graph/model/operator-group";
-import {
-  OperatorState,
-  OperatorStatistics
-} from "../../types/execute-workflow.interface";
+import { OperatorLink, OperatorPredicate, Point } from "../../types/workflow-common.interface";
+import { Group, GroupBoundingBox } from "../workflow-graph/model/operator-group";
+import { OperatorState, OperatorStatistics } from "../../types/execute-workflow.interface";
 import { OperatorResultCacheStatus } from "../../types/workflow-websocket.interface";
 
 /**
@@ -143,7 +133,7 @@ class TexeraCustomGroupElement extends joint.shapes.devs.Model {
  * @author Zuozhi Wang
  */
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class JointUIService {
   public static readonly DEFAULT_OPERATOR_WIDTH = 60;
@@ -160,9 +150,7 @@ export class JointUIService {
   constructor(private operatorMetadataService: OperatorMetadataService) {
     // initialize the operator information
     // subscribe to operator metadata observable
-    this.operatorMetadataService
-      .getOperatorMetadata()
-      .subscribe((value) => (this.operatorSchemas = value.operators));
+    this.operatorMetadataService.getOperatorMetadata().subscribe(value => (this.operatorSchemas = value.operators));
   }
 
   /**
@@ -181,14 +169,9 @@ export class JointUIService {
    *
    * @returns JointJS Element
    */
-  public getJointOperatorElement(
-    operator: OperatorPredicate,
-    point: Point
-  ): joint.dia.Element {
+  public getJointOperatorElement(operator: OperatorPredicate, point: Point): joint.dia.Element {
     // check if the operatorType exists in the operator metadata
-    const operatorSchema = this.operatorSchemas.find(
-      (op) => op.operatorType === operator.operatorType
-    );
+    const operatorSchema = this.operatorSchemas.find(op => op.operatorType === operator.operatorType);
     if (operatorSchema === undefined) {
       throw new Error(`operator type ${operator.operatorType} doesn't exist`);
     }
@@ -199,46 +182,45 @@ export class JointUIService {
       position: point,
       size: {
         width: JointUIService.DEFAULT_OPERATOR_WIDTH,
-        height: JointUIService.DEFAULT_OPERATOR_HEIGHT
+        height: JointUIService.DEFAULT_OPERATOR_HEIGHT,
       },
       attrs: JointUIService.getCustomOperatorStyleAttrs(
         operator,
-        operator.customDisplayName ??
-          operatorSchema.additionalMetadata.userFriendlyName,
+        operator.customDisplayName ?? operatorSchema.additionalMetadata.userFriendlyName,
         operatorSchema.operatorType
       ),
       ports: {
         groups: {
           in: { attrs: JointUIService.getCustomPortStyleAttrs() },
-          out: { attrs: JointUIService.getCustomPortStyleAttrs() }
-        }
-      }
+          out: { attrs: JointUIService.getCustomPortStyleAttrs() },
+        },
+      },
     });
 
     // set operator element ID to be operator ID
     operatorElement.set("id", operator.operatorID);
 
     // set the input ports and output ports based on operator predicate
-    operator.inputPorts.forEach((port) =>
+    operator.inputPorts.forEach(port =>
       operatorElement.addPort({
         group: "in",
         id: port.portID,
         attrs: {
           ".port-label": {
-            text: port.displayName ?? ""
-          }
-        }
+            text: port.displayName ?? "",
+          },
+        },
       })
     );
-    operator.outputPorts.forEach((port) =>
+    operator.outputPorts.forEach(port =>
       operatorElement.addPort({
         group: "out",
         id: port.portID,
         attrs: {
           ".port-label": {
-            text: port.displayName ?? ""
-          }
-        }
+            text: port.displayName ?? "",
+          },
+        },
       })
     );
 
@@ -252,16 +234,10 @@ export class JointUIService {
   ): void {
     this.changeOperatorState(jointPaper, operatorID, statistics.operatorState);
 
-    const processedText =
-      "Processed: " + statistics.aggregatedInputRowCount.toLocaleString();
-    const outputText =
-      "Output:    " + statistics.aggregatedOutputRowCount.toLocaleString();
-    jointPaper
-      .getModelById(operatorID)
-      .attr(`.${operatorProcessedCountClass}/text`, processedText);
-    jointPaper
-      .getModelById(operatorID)
-      .attr(`.${operatorOutputCountClass}/text`, outputText);
+    const processedText = "Processed: " + statistics.aggregatedInputRowCount.toLocaleString();
+    const outputText = "Output:    " + statistics.aggregatedOutputRowCount.toLocaleString();
+    jointPaper.getModelById(operatorID).attr(`.${operatorProcessedCountClass}/text`, processedText);
+    jointPaper.getModelById(operatorID).attr(`.${operatorOutputCountClass}/text`, outputText);
   }
 
   /**
@@ -275,19 +251,14 @@ export class JointUIService {
    * @param topLeft the position of the operator (if there was one) that's in the top left corner of the group
    * @param bottomRight the position of the operator (if there was one) that's in the bottom right corner of the group
    */
-  public getJointGroupElement(
-    group: Group,
-    boundingBox: GroupBoundingBox
-  ): joint.dia.Element {
+  public getJointGroupElement(group: Group, boundingBox: GroupBoundingBox): joint.dia.Element {
     const { topLeft, bottomRight } = boundingBox;
 
     const groupElementPosition = {
       x: topLeft.x - JointUIService.DEFAULT_GROUP_MARGIN,
-      y: topLeft.y - JointUIService.DEFAULT_GROUP_MARGIN
+      y: topLeft.y - JointUIService.DEFAULT_GROUP_MARGIN,
     };
-    const widthMargin =
-      JointUIService.DEFAULT_OPERATOR_WIDTH +
-      2 * JointUIService.DEFAULT_GROUP_MARGIN;
+    const widthMargin = JointUIService.DEFAULT_OPERATOR_WIDTH + 2 * JointUIService.DEFAULT_GROUP_MARGIN;
     const heightMargin =
       JointUIService.DEFAULT_OPERATOR_HEIGHT +
       JointUIService.DEFAULT_GROUP_MARGIN +
@@ -297,22 +268,16 @@ export class JointUIService {
       position: groupElementPosition,
       size: {
         width: bottomRight.x - topLeft.x + widthMargin,
-        height: bottomRight.y - topLeft.y + heightMargin
+        height: bottomRight.y - topLeft.y + heightMargin,
       },
-      attrs: JointUIService.getCustomGroupStyleAttrs(
-        bottomRight.x - topLeft.x + widthMargin
-      )
+      attrs: JointUIService.getCustomGroupStyleAttrs(bottomRight.x - topLeft.x + widthMargin),
     });
 
     groupElement.set("id", group.groupID);
     return groupElement;
   }
 
-  public changeOperatorState(
-    jointPaper: joint.dia.Paper,
-    operatorID: string,
-    operatorState: OperatorState
-  ): void {
+  public changeOperatorState(jointPaper: joint.dia.Paper, operatorID: string, operatorState: OperatorState): void {
     let fillColor: string;
     switch (operatorState) {
       case OperatorState.Completed:
@@ -327,12 +292,8 @@ export class JointUIService {
         break;
     }
 
-    jointPaper
-      .getModelById(operatorID)
-      .attr(`.${operatorStateClass}/text`, operatorState.toString());
-    jointPaper
-      .getModelById(operatorID)
-      .attr(`.${operatorStateClass}/fill`, fillColor);
+    jointPaper.getModelById(operatorID).attr(`.${operatorStateClass}/text`, operatorState.toString());
+    jointPaper.getModelById(operatorID).attr(`.${operatorStateClass}/fill`, fillColor);
   }
 
   /**
@@ -342,10 +303,7 @@ export class JointUIService {
    * @param jointPaper
    * @param groupID
    */
-  public hideGroupExpandButton(
-    jointPaper: joint.dia.Paper,
-    groupID: string
-  ): void {
+  public hideGroupExpandButton(jointPaper: joint.dia.Paper, groupID: string): void {
     jointPaper.getModelById(groupID).attr(".expand-button/display", "none");
     jointPaper.getModelById(groupID).removeAttr(".collapse-button/display");
   }
@@ -357,10 +315,7 @@ export class JointUIService {
    * @param jointPaper
    * @param groupID
    */
-  public hideGroupCollapseButton(
-    jointPaper: joint.dia.Paper,
-    groupID: string
-  ): void {
+  public hideGroupCollapseButton(jointPaper: joint.dia.Paper, groupID: string): void {
     jointPaper.getModelById(groupID).attr(".collapse-button/display", "none");
     jointPaper.getModelById(groupID).removeAttr(".expand-button/display");
   }
@@ -373,14 +328,8 @@ export class JointUIService {
    * @param groupID
    * @param width
    */
-  public repositionGroupCollapseButton(
-    jointPaper: joint.dia.Paper,
-    groupID: string,
-    width: number
-  ): void {
-    jointPaper
-      .getModelById(groupID)
-      .attr(".collapse-button/x", `${width - 23}`);
+  public repositionGroupCollapseButton(jointPaper: joint.dia.Paper, groupID: string, width: number): void {
+    jointPaper.getModelById(groupID).attr(".collapse-button/x", `${width - 23}`);
   }
 
   /**
@@ -392,11 +341,7 @@ export class JointUIService {
    * @param operatorID
    * @param status
    */
-  public changeOperatorColor(
-    jointPaper: joint.dia.Paper,
-    operatorID: string,
-    isOperatorValid: boolean
-  ): void {
+  public changeOperatorColor(jointPaper: joint.dia.Paper, operatorID: string, isOperatorValid: boolean): void {
     if (isOperatorValid) {
       jointPaper.getModelById(operatorID).attr("rect/stroke", "#CFCFCF");
     } else {
@@ -404,13 +349,8 @@ export class JointUIService {
     }
   }
 
-  public changeOperatorDisableStatus(
-    jointPaper: joint.dia.Paper,
-    operator: OperatorPredicate
-  ): void {
-    jointPaper
-      .getModelById(operator.operatorID)
-      .attr("rect/fill", JointUIService.getOperatorFillColor(operator));
+  public changeOperatorDisableStatus(jointPaper: joint.dia.Paper, operator: OperatorPredicate): void {
+    jointPaper.getModelById(operator.operatorID).attr("rect/fill", JointUIService.getOperatorFillColor(operator));
   }
 
   public changeOperatorCacheStatus(
@@ -418,21 +358,11 @@ export class JointUIService {
     operator: OperatorPredicate,
     cacheStatus?: OperatorResultCacheStatus
   ): void {
-    const cacheText = JointUIService.getOperatorCacheDisplayText(
-      operator,
-      cacheStatus
-    );
-    const cacheIcon = JointUIService.getOperatorCacheIcon(
-      operator,
-      cacheStatus
-    );
+    const cacheText = JointUIService.getOperatorCacheDisplayText(operator, cacheStatus);
+    const cacheIcon = JointUIService.getOperatorCacheIcon(operator, cacheStatus);
 
-    jointPaper
-      .getModelById(operator.operatorID)
-      .attr(`.${operatorCacheIconClass}/xlink:href`, cacheIcon);
-    jointPaper
-      .getModelById(operator.operatorID)
-      .attr(`.${operatorCacheIconClass}/title`, cacheText);
+    jointPaper.getModelById(operator.operatorID).attr(`.${operatorCacheIconClass}/xlink:href`, cacheIcon);
+    jointPaper.getModelById(operator.operatorID).attr(`.${operatorCacheIconClass}/title`, cacheText);
   }
 
   public changeOperatorJointDisplayName(
@@ -440,9 +370,7 @@ export class JointUIService {
     jointPaper: joint.dia.Paper,
     displayName: string
   ): void {
-    jointPaper
-      .getModelById(operator.operatorID)
-      .attr(`.${operatorNameClass}/text`, displayName);
+    jointPaper.getModelById(operator.operatorID).attr(`.${operatorNameClass}/text`, displayName);
   }
 
   public getBreakpointButton(): new () => joint.linkTools.Button {
@@ -456,8 +384,8 @@ export class JointUIService {
             attributes: {
               r: 10,
               fill: "#001DFF",
-              cursor: "pointer"
-            }
+              cursor: "pointer",
+            },
           },
           {
             tagName: "path",
@@ -467,9 +395,9 @@ export class JointUIService {
               fill: "none",
               stroke: "#FFFFFF",
               "stroke-width": 2,
-              "pointer-events": "none"
-            }
-          }
+              "pointer-events": "none",
+            },
+          },
         ],
         distance: 60,
         offset: 0,
@@ -478,8 +406,8 @@ export class JointUIService {
           if (linkView.paper) {
             linkView.paper.trigger("tool:breakpoint", linkView, event);
           }
-        }
-      }
+        },
+      },
     });
   }
 
@@ -495,11 +423,11 @@ export class JointUIService {
     const jointLinkCell = JointUIService.getDefaultLinkCell();
     jointLinkCell.set("source", {
       id: link.source.operatorID,
-      port: link.source.portID
+      port: link.source.portID,
     });
     jointLinkCell.set("target", {
       id: link.target.operatorID,
-      port: link.target.portID
+      port: link.target.portID,
     });
     jointLinkCell.set("id", link.linkID);
     return jointLinkCell;
@@ -526,10 +454,10 @@ export class JointUIService {
   public static getDefaultLinkCell(): joint.dia.Link {
     const link = new joint.dia.Link({
       router: {
-        name: "manhattan"
+        name: "manhattan",
       },
       connector: {
-        name: "rounded"
+        name: "rounded",
       },
       toolMarkup: `<g class="link-tool">
           <g class="tool-remove" event="tool:remove">
@@ -543,38 +471,38 @@ export class JointUIService {
       attrs: {
         ".connection": {
           stroke: linkPathStrokeColor,
-          "stroke-width": "2px"
+          "stroke-width": "2px",
         },
         ".connection-wrap": {
-          "stroke-width": "0px"
+          "stroke-width": "0px",
           // 'display': 'inline'
         },
         ".marker-source": {
           d: sourceOperatorHandle,
           stroke: "none",
-          fill: "#919191"
+          fill: "#919191",
         },
         ".marker-arrowhead-group-source .marker-arrowhead": {
-          d: sourceOperatorHandle
+          d: sourceOperatorHandle,
         },
         ".marker-target": {
           d: targetOperatorHandle,
           stroke: "none",
-          fill: "#919191"
+          fill: "#919191",
         },
         ".marker-arrowhead-group-target .marker-arrowhead": {
-          d: targetOperatorHandle
+          d: targetOperatorHandle,
         },
         ".tool-remove": {
           fill: "#D8656A",
           width: 24,
-          display: "none"
+          display: "none",
         },
         ".tool-remove path": {
-          d: deleteButtonPath
+          d: deleteButtonPath,
         },
-        ".tool-remove circle": {}
-      }
+        ".tool-remove circle": {},
+      },
     });
     return link;
   }
@@ -590,9 +518,9 @@ export class JointUIService {
       ".port-body": {
         fill: "#A0A0A0",
         r: 5,
-        stroke: "none"
+        stroke: "none",
       },
-      ".port-label": {}
+      ".port-label": {},
     };
     return portStyleAttrs;
   }
@@ -604,7 +532,7 @@ export class JointUIService {
   public static getCustomOperatorStatusTooltipStyleAttrs(): joint.shapes.devs.ModelSelectors {
     const tooltipStyleAttrs = {
       "element-node": {
-        style: { "pointer-events": "none" }
+        style: { "pointer-events": "none" },
       },
       polygon: {
         fill: "#FFFFFF",
@@ -615,7 +543,7 @@ export class JointUIService {
         ry: "5px",
         refPoints: "0,30 150,30 150,120 85,120 75,150 65,120 0,120",
         display: "none",
-        style: { "pointer-events": "none" }
+        style: { "pointer-events": "none" },
       },
       "#operatorCount": {
         fill: "#595959",
@@ -626,8 +554,8 @@ export class JointUIService {
         "ref-x": 0.05,
         "ref-y": 0.2,
         display: "none",
-        style: { "pointer-events": "none" }
-      }
+        style: { "pointer-events": "none" },
+      },
     };
     return tooltipStyleAttrs;
   }
@@ -654,7 +582,7 @@ export class JointUIService {
         "ref-y": 100,
         ref: "rect",
         "y-alignment": "middle",
-        "x-alignment": "middle"
+        "x-alignment": "middle",
       },
       ".texera-operator-processed-count": {
         text: "",
@@ -665,7 +593,7 @@ export class JointUIService {
         "ref-y": -40,
         ref: "rect",
         "y-alignment": "middle",
-        "x-alignment": "middle"
+        "x-alignment": "middle",
       },
       ".texera-operator-output-count": {
         text: "",
@@ -676,7 +604,7 @@ export class JointUIService {
         "ref-y": -20,
         ref: "rect",
         "y-alignment": "middle",
-        "x-alignment": "middle"
+        "x-alignment": "middle",
       },
       rect: {
         fill: JointUIService.getOperatorFillColor(operator),
@@ -684,7 +612,7 @@ export class JointUIService {
         stroke: "red",
         "stroke-width": "2",
         rx: "5px",
-        ry: "5px"
+        ry: "5px",
       },
       ".texera-operator-name": {
         text: operatorDisplayName,
@@ -694,14 +622,14 @@ export class JointUIService {
         "ref-y": 80,
         ref: "rect",
         "y-alignment": "middle",
-        "x-alignment": "middle"
+        "x-alignment": "middle",
       },
       ".delete-button": {
         x: 60,
         y: -20,
         cursor: "pointer",
         fill: "#D8656A",
-        event: "element:delete"
+        event: "element:delete",
       },
       ".texera-operator-icon": {
         "xlink:href": "assets/operator_images/" + operatorType + ".png",
@@ -711,7 +639,7 @@ export class JointUIService {
         "ref-y": 0.5,
         ref: "rect",
         "x-alignment": "middle",
-        "y-alignment": "middle"
+        "y-alignment": "middle",
       },
       ".texera-operator-result-cache-text": {
         text: "cache",
@@ -722,7 +650,7 @@ export class JointUIService {
         "ref-y": 60,
         ref: "rect",
         "y-alignment": "middle",
-        "x-alignment": "middle"
+        "x-alignment": "middle",
       },
       ".texera-operator-result-cache-icon": {
         "xlink:href": JointUIService.getOperatorCacheIcon(operator),
@@ -733,8 +661,8 @@ export class JointUIService {
         "ref-y": 50,
         ref: "rect",
         "x-alignment": "middle",
-        "y-alignment": "middle"
-      }
+        "y-alignment": "middle",
+      },
     };
     return operatorStyleAttrs;
   }
@@ -755,10 +683,7 @@ export class JointUIService {
     return isCached ? "to be cached" : "";
   }
 
-  public static getOperatorCacheIcon(
-    operator: OperatorPredicate,
-    cacheStatus?: OperatorResultCacheStatus
-  ): string {
+  public static getOperatorCacheIcon(operator: OperatorPredicate, cacheStatus?: OperatorResultCacheStatus): string {
     if (cacheStatus && cacheStatus !== "cache not enabled") {
       if (cacheStatus === "cache valid") {
         return "assets/svg/operator-result-cache-successful.svg";
@@ -787,9 +712,7 @@ export class JointUIService {
    * @param width width of the group (used to position the collapse button)
    * @returns the custom attributes of the group
    */
-  public static getCustomGroupStyleAttrs(
-    width: number
-  ): joint.shapes.devs.ModelSelectors {
+  public static getCustomGroupStyleAttrs(width: number): joint.shapes.devs.ModelSelectors {
     const groupStyleAttrs = {
       rect: {
         fill: "#F2F4F5",
@@ -797,21 +720,21 @@ export class JointUIService {
         stroke: "#CED4D9",
         "stroke-width": "2",
         rx: "5px",
-        ry: "5px"
+        ry: "5px",
       },
       text: {
         fill: "#595959",
         "font-size": "16px",
         "ref-x": 15,
         "ref-y": 20,
-        ref: "rect"
+        ref: "rect",
       },
       ".collapse-button": {
         x: width - 23,
         y: 6,
         cursor: "pointer",
         fill: "#728393",
-        event: "element:collapse"
+        event: "element:collapse",
       },
       ".expand-button": {
         x: 147,
@@ -819,8 +742,8 @@ export class JointUIService {
         cursor: "pointer",
         fill: "#728393",
         event: "element:expand",
-        display: "none"
-      }
+        display: "none",
+      },
     };
     return groupStyleAttrs;
   }

--- a/core/new-gui/src/app/workspace/service/operator-metadata/mock-operator-metadata.data.ts
+++ b/core/new-gui/src/app/workspace/service/operator-metadata/mock-operator-metadata.data.ts
@@ -1,8 +1,4 @@
-import {
-  GroupInfo,
-  OperatorMetadata,
-  OperatorSchema
-} from "../../types/operator-schema.interface";
+import { GroupInfo, OperatorMetadata, OperatorSchema } from "../../types/operator-schema.interface";
 import { BreakpointSchema } from "../../types/workflow-common.interface";
 import { CustomJSONSchema7 } from "../../types/custom-json-schema.interface";
 
@@ -15,19 +11,19 @@ export const mockScanSourceSchema: OperatorSchema = {
     operatorDescription: "Read records from a table one by one",
     operatorGroupName: "Source",
     inputPorts: [],
-    outputPorts: [{}]
+    outputPorts: [{}],
   },
   jsonSchema: {
     properties: {
       tableName: {
         type: "string",
         description: "name of source table",
-        title: "table name"
-      }
+        title: "table name",
+      },
     },
     required: ["tableName"],
-    type: "object"
-  }
+    type: "object",
+  },
 };
 
 export const mockFileSourceSchema: OperatorSchema = {
@@ -35,17 +31,17 @@ export const mockFileSourceSchema: OperatorSchema = {
   jsonSchema: {
     type: "object",
     properties: {
-      fileName: { type: "string", title: "file name" }
+      fileName: { type: "string", title: "file name" },
     },
-    required: ["fileName"]
+    required: ["fileName"],
   },
   additionalMetadata: {
     userFriendlyName: "Source: File",
     operatorDescription: "Read the content of one file or multiple files",
     operatorGroupName: "Source",
     inputPorts: [],
-    outputPorts: [{}]
-  }
+    outputPorts: [{}],
+  },
 };
 
 export const mockNlpSentimentSchema: OperatorSchema = {
@@ -55,7 +51,7 @@ export const mockNlpSentimentSchema: OperatorSchema = {
     operatorDescription: "Sentiment analysis based on Stanford NLP package",
     operatorGroupName: "Analysis",
     inputPorts: [{}],
-    outputPorts: [{}]
+    outputPorts: [{}],
   },
   jsonSchema: {
     properties: {
@@ -63,13 +59,13 @@ export const mockNlpSentimentSchema: OperatorSchema = {
         type: "string",
         title: "attribute",
         autofill: "attributeName",
-        autofillAttributeOnPort: 0
+        autofillAttributeOnPort: 0,
       },
-      resultAttribute: { type: "string", title: "result attribute" }
+      resultAttribute: { type: "string", title: "result attribute" },
     },
     required: ["attribute", "resultAttribute"],
-    type: "object"
-  }
+    type: "object",
+  },
 };
 
 export const mockKeywordSourceSchema: OperatorSchema = {
@@ -83,21 +79,20 @@ export const mockKeywordSourceSchema: OperatorSchema = {
         items: { type: "string" },
         title: "attributes",
         autofill: "attributeNameList",
-        autofillAttributeOnPort: 0
+        autofillAttributeOnPort: 0,
       },
       tableName: { type: "string", title: "table name" },
-      spanListName: { type: "string", title: "span list name" }
+      spanListName: { type: "string", title: "span list name" },
     },
-    required: ["query", "attributes", "tableName"]
+    required: ["query", "attributes", "tableName"],
   },
   additionalMetadata: {
     userFriendlyName: "Source: Keyword",
-    operatorDescription:
-      "Perform an index-based search on a table using a keyword",
+    operatorDescription: "Perform an index-based search on a table using a keyword",
     operatorGroupName: "Analysis",
     inputPorts: [],
-    outputPorts: [{}]
-  }
+    outputPorts: [{}],
+  },
 };
 
 export const mockKeywordSearchSchema: OperatorSchema = {
@@ -111,19 +106,19 @@ export const mockKeywordSearchSchema: OperatorSchema = {
         items: { type: "string" },
         title: "attributes",
         autofill: "attributeNameList",
-        autofillAttributeOnPort: 0
+        autofillAttributeOnPort: 0,
       },
-      spanListName: { type: "string", title: "span list name" }
+      spanListName: { type: "string", title: "span list name" },
     },
-    required: ["query", "attributes"]
+    required: ["query", "attributes"],
   },
   additionalMetadata: {
     userFriendlyName: "Keyword Search",
     operatorDescription: "Search the documents using a keyword",
     operatorGroupName: "Analysis",
     inputPorts: [{}],
-    outputPorts: [{}]
-  }
+    outputPorts: [{}],
+  },
 };
 
 export const mockAggregationSchema: OperatorSchema = {
@@ -140,30 +135,29 @@ export const mockAggregationSchema: OperatorSchema = {
               type: "string",
               title: "attribute",
               autofill: "attributeName",
-              autofillAttributeOnPort: 0
+              autofillAttributeOnPort: 0,
             },
             aggregator: {
               type: "string",
               enum: ["min", "max", "average", "sum", "count"],
               uniqueItems: true,
-              title: "aggregator"
+              title: "aggregator",
             },
-            resultAttribute: { type: "string", title: "result attribute" }
-          }
+            resultAttribute: { type: "string", title: "result attribute" },
+          },
         },
-        title: "list of aggregations"
-      }
+        title: "list of aggregations",
+      },
     },
-    required: ["listOfAggregations"]
+    required: ["listOfAggregations"],
   },
   additionalMetadata: {
     userFriendlyName: "Aggregation",
-    operatorDescription:
-      "Aggregate one or more columns to find min, max, sum, average, count of the column",
+    operatorDescription: "Aggregate one or more columns to find min, max, sum, average, count of the column",
     operatorGroupName: "Analysis",
     inputPorts: [{}],
-    outputPorts: [{}]
-  }
+    outputPorts: [{}],
+  },
 };
 
 export const mockViewResultsSchema: OperatorSchema = {
@@ -173,53 +167,53 @@ export const mockViewResultsSchema: OperatorSchema = {
       limit: {
         default: 10,
         type: "integer",
-        title: "limit"
+        title: "limit",
       },
       offset: {
         default: 0,
         type: "integer",
-        title: "offset"
-      }
+        title: "offset",
+      },
     },
-    type: "object"
+    type: "object",
   },
   additionalMetadata: {
     userFriendlyName: "View Results",
     operatorDescription: "View the results of the workflow",
     operatorGroupName: "View Results",
     inputPorts: [{}],
-    outputPorts: []
-  }
+    outputPorts: [],
+  },
 };
 
 export const mockMultiInputOutputSchema: OperatorSchema = {
   operatorType: "MultiInputOutput",
   jsonSchema: {
     properties: {},
-    type: "object"
+    type: "object",
   },
   additionalMetadata: {
     userFriendlyName: "3-I/O Mock op",
     operatorDescription: "Mock operator with 3 inputs and 3 outputs",
     operatorGroupName: "Analysis",
     inputPorts: [{}, {}, {}],
-    outputPorts: [{}, {}, {}]
-  }
+    outputPorts: [{}, {}, {}],
+  },
 };
 
 export const mockUnionSchema: OperatorSchema = {
   operatorType: "Union",
   jsonSchema: {
     properties: {},
-    type: "object"
+    type: "object",
   },
   additionalMetadata: {
     userFriendlyName: "Union",
     operatorDescription: "Union multiple inputs",
     operatorGroupName: "Analysis",
     inputPorts: [{ allowMultiInputs: true }],
-    outputPorts: [{}]
-  }
+    outputPorts: [{}],
+  },
 };
 
 export const mockOperatorSchemaList: ReadonlyArray<OperatorSchema> = [
@@ -231,18 +225,18 @@ export const mockOperatorSchemaList: ReadonlyArray<OperatorSchema> = [
   mockAggregationSchema,
   mockViewResultsSchema,
   mockMultiInputOutputSchema,
-  mockUnionSchema
+  mockUnionSchema,
 ];
 
 export const mockOperatorGroup: ReadonlyArray<GroupInfo> = [
   { groupName: "Source", groupOrder: 1 },
   { groupName: "Analysis", groupOrder: 2 },
-  { groupName: "View Results", groupOrder: 3 }
+  { groupName: "View Results", groupOrder: 3 },
 ];
 
 export const mockOperatorMetaData: OperatorMetadata = {
   operators: mockOperatorSchemaList,
-  groups: mockOperatorGroup
+  groups: mockOperatorGroup,
 };
 
 export const testJsonSchema: CustomJSONSchema7 = {
@@ -251,15 +245,15 @@ export const testJsonSchema: CustomJSONSchema7 = {
       type: "string",
       title: "attribute",
       autofill: "attributeName",
-      autofillAttributeOnPort: 0
+      autofillAttributeOnPort: 0,
     },
     resultAttribute: {
       type: "string",
-      title: "result attribute"
-    }
+      title: "result attribute",
+    },
   },
   required: ["attribute", "resultAttribute"],
-  type: "object"
+  type: "object",
 };
 
 export const mockBreakpointSchema: BreakpointSchema = {
@@ -271,39 +265,30 @@ export const mockBreakpointSchema: BreakpointSchema = {
         properties: {
           column: {
             type: "string",
-            title: "column"
+            title: "column",
           },
           condition: {
             type: "string",
-            enum: [
-              "contains",
-              "does not contain",
-              "=",
-              ">",
-              ">=",
-              "<",
-              "<=",
-              "!="
-            ],
-            title: "condition"
+            enum: ["contains", "does not contain", "=", ">", ">=", "<", "<=", "!="],
+            title: "condition",
           },
           value: {
             type: "string",
-            title: "value"
-          }
+            title: "value",
+          },
         },
-        required: ["column", "condition", "value"]
+        required: ["column", "condition", "value"],
       },
       {
         title: "count",
         properties: {
           count: {
             type: "integer",
-            title: "count"
-          }
+            title: "count",
+          },
         },
-        required: ["count"]
-      }
-    ]
-  }
+        required: ["count"],
+      },
+    ],
+  },
 };

--- a/core/new-gui/src/app/workspace/service/operator-metadata/operator-metadata.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/operator-metadata/operator-metadata.service.spec.ts
@@ -1,14 +1,8 @@
 import { TestBed } from "@angular/core/testing";
 
 import { HttpClient } from "@angular/common/http";
-import {
-  HttpClientTestingModule,
-  HttpTestingController
-} from "@angular/common/http/testing";
-import {
-  EMPTY_OPERATOR_METADATA,
-  OperatorMetadataService
-} from "./operator-metadata.service";
+import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
+import { EMPTY_OPERATOR_METADATA, OperatorMetadataService } from "./operator-metadata.service";
 import { mockOperatorMetaData } from "./mock-operator-metadata.data";
 import { first, last } from "rxjs/operators";
 
@@ -20,7 +14,7 @@ describe("OperatorMetadataService", () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [OperatorMetadataService, HttpClient]
+      providers: [OperatorMetadataService, HttpClient],
     });
 
     httpClient = TestBed.get(HttpClient);
@@ -36,15 +30,15 @@ describe("OperatorMetadataService", () => {
     service
       .getOperatorMetadata()
       .pipe(first())
-      .subscribe((value) => expect(value).toEqual(EMPTY_OPERATOR_METADATA));
+      .subscribe(value => expect(value).toEqual(EMPTY_OPERATOR_METADATA));
   });
 
   it("should send http request once", () => {
     service
       .getOperatorMetadata()
       .pipe(last())
-      .subscribe((value) => expect(value).toBeTruthy());
-    httpTestingController.expectOne((request) => request.method === "GET");
+      .subscribe(value => expect(value).toBeTruthy());
+    httpTestingController.expectOne(request => request.method === "GET");
   });
 
   it("should check if operatorType exists correctly", () => {
@@ -55,9 +49,7 @@ describe("OperatorMetadataService", () => {
         expect(service.operatorTypeExists("ScanSource")).toBeTruthy();
         expect(service.operatorTypeExists("InvalidOperatorType")).toBeFalsy();
       });
-    const req = httpTestingController.match(
-      (request) => request.method === "GET"
-    );
+    const req = httpTestingController.match(request => request.method === "GET");
     req[0].flush(mockOperatorMetaData);
   });
 });

--- a/core/new-gui/src/app/workspace/service/operator-metadata/operator-metadata.service.ts
+++ b/core/new-gui/src/app/workspace/service/operator-metadata/operator-metadata.service.ts
@@ -2,10 +2,7 @@ import { HttpClient } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Observable } from "rxjs";
 import { AppSettings } from "../../../common/app-setting";
-import {
-  OperatorMetadata,
-  OperatorSchema
-} from "../../types/operator-schema.interface";
+import { OperatorMetadata, OperatorSchema } from "../../types/operator-schema.interface";
 import { BreakpointSchema } from "../../types/workflow-common.interface";
 import { mockBreakpointSchema } from "./mock-operator-metadata.data";
 import { shareReplay, startWith } from "rxjs/operators";
@@ -14,17 +11,14 @@ export const OPERATOR_METADATA_ENDPOINT = "resources/operator-metadata";
 
 export const EMPTY_OPERATOR_METADATA: OperatorMetadata = {
   operators: [],
-  groups: []
+  groups: [],
 };
 
 const addDictionaryAPIAddress = "/api/resources/dictionary/";
 const getDictionaryAPIAddress = "/api/upload/dictionary/";
 
 // interface only containing public methods
-export type IOperatorMetadataService = Pick<
-  OperatorMetadataService,
-  keyof OperatorMetadataService
->;
+export type IOperatorMetadataService = Pick<OperatorMetadataService, keyof OperatorMetadataService>;
 
 /**
  * OperatorMetadataService talks to the backend to fetch the operator metadata,
@@ -43,7 +37,7 @@ export type IOperatorMetadataService = Pick<
  *
  */
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class OperatorMetadataService {
   // holds the current version of operator metadata
@@ -51,13 +45,11 @@ export class OperatorMetadataService {
   private readonly currentBreakpointSchema: BreakpointSchema | undefined;
 
   private operatorMetadataObservable = this.httpClient
-    .get<OperatorMetadata>(
-      `${AppSettings.getApiEndpoint()}/${OPERATOR_METADATA_ENDPOINT}`
-    )
+    .get<OperatorMetadata>(`${AppSettings.getApiEndpoint()}/${OPERATOR_METADATA_ENDPOINT}`)
     .pipe(startWith(EMPTY_OPERATOR_METADATA), shareReplay(1));
 
   constructor(private httpClient: HttpClient) {
-    this.getOperatorMetadata().subscribe((data) => {
+    this.getOperatorMetadata().subscribe(data => {
       this.currentOperatorMetadata = data;
     });
     // At current design, all the links have one fixed breakpoint schema stored in the frontend
@@ -81,9 +73,7 @@ export class OperatorMetadataService {
     if (!this.currentOperatorMetadata) {
       throw new Error("operator metadata is undefined");
     }
-    const operatorSchema = this.currentOperatorMetadata.operators.find(
-      (schema) => schema.operatorType === operatorType
-    );
+    const operatorSchema = this.currentOperatorMetadata.operators.find(schema => schema.operatorType === operatorType);
     if (!operatorSchema) {
       throw new Error(`can\'t find operator schema of type ${operatorType}`);
     }
@@ -101,9 +91,7 @@ export class OperatorMetadataService {
     if (!this.currentOperatorMetadata) {
       return false;
     }
-    const operator = this.currentOperatorMetadata.operators.filter(
-      (op) => op.operatorType === operatorType
-    );
+    const operator = this.currentOperatorMetadata.operators.filter(op => op.operatorType === operatorType);
     if (operator.length === 0) {
       return false;
     }

--- a/core/new-gui/src/app/workspace/service/operator-metadata/stub-operator-metadata.service.ts
+++ b/core/new-gui/src/app/workspace/service/operator-metadata/stub-operator-metadata.service.ts
@@ -1,13 +1,7 @@
 import { Injectable } from "@angular/core";
 import { Observable, of } from "rxjs";
-import {
-  mockBreakpointSchema,
-  mockOperatorMetaData
-} from "./mock-operator-metadata.data";
-import {
-  OperatorMetadata,
-  OperatorSchema
-} from "../../types/operator-schema.interface";
+import { mockBreakpointSchema, mockOperatorMetaData } from "./mock-operator-metadata.data";
+import { OperatorMetadata, OperatorSchema } from "../../types/operator-schema.interface";
 import { IOperatorMetadataService } from "./operator-metadata.service";
 import { BreakpointSchema } from "../../types/workflow-common.interface";
 import { shareReplay } from "rxjs/operators";
@@ -15,16 +9,12 @@ import { shareReplay } from "rxjs/operators";
 @Injectable()
 export class StubOperatorMetadataService implements IOperatorMetadataService {
   private currentBreakpointSchema = mockBreakpointSchema;
-  private operatorMetadataObservable = of(mockOperatorMetaData).pipe(
-    shareReplay(1)
-  );
+  private operatorMetadataObservable = of(mockOperatorMetaData).pipe(shareReplay(1));
 
   constructor() {}
 
   public getOperatorSchema(operatorType: string): OperatorSchema {
-    const operatorSchema = mockOperatorMetaData.operators.find(
-      (schema) => schema.operatorType === operatorType
-    );
+    const operatorSchema = mockOperatorMetaData.operators.find(schema => schema.operatorType === operatorType);
     if (!operatorSchema) {
       throw new Error(`can\'t find operator schema of type ${operatorType}`);
     }
@@ -36,9 +26,7 @@ export class StubOperatorMetadataService implements IOperatorMetadataService {
   }
 
   public operatorTypeExists(operatorType: string): boolean {
-    const operator = mockOperatorMetaData.operators.filter(
-      (op) => op.operatorType === operatorType
-    );
+    const operator = mockOperatorMetaData.operators.filter(op => op.operatorType === operatorType);
     if (operator.length === 0) {
       return false;
     }

--- a/core/new-gui/src/app/workspace/service/result-panel-toggle/result-panel-toggle.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/result-panel-toggle/result-panel-toggle.service.spec.ts
@@ -8,38 +8,31 @@ describe("ResultPanelToggleService", () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [ResultPanelToggleService]
+      providers: [ResultPanelToggleService],
     });
 
     resultPanelToggleService = TestBed.inject(ResultPanelToggleService);
   });
 
-  it("should be created", inject(
-    [ResultPanelToggleService],
-    (injectedservice: ResultPanelToggleService) => {
-      expect(injectedservice).toBeTruthy();
-    }
-  ));
+  it("should be created", inject([ResultPanelToggleService], (injectedservice: ResultPanelToggleService) => {
+    expect(injectedservice).toBeTruthy();
+  }));
 
   it(
     `should receive 'true' from toggleDisplayChangeStream when toggleResultPanel
     is called when the current result panel status is hidden`,
-    marbles((m) => {
+    marbles(m => {
       (resultPanelToggleService as any).currentResultPanelStatus = false;
 
-      resultPanelToggleService
-        .getToggleChangeStream()
-        .subscribe((newToggleStatus) => {
-          expect(newToggleStatus).toBeTruthy();
-        });
+      resultPanelToggleService.getToggleChangeStream().subscribe(newToggleStatus => {
+        expect(newToggleStatus).toBeTruthy();
+      });
 
       const expectedStream = "-a-";
 
-      const toggleStream = resultPanelToggleService
-        .getToggleChangeStream()
-        .pipe(map((value) => "a"));
+      const toggleStream = resultPanelToggleService.getToggleChangeStream().pipe(map(value => "a"));
       m.hot("-a-")
-        .pipe(tap((event) => resultPanelToggleService.toggleResultPanel()))
+        .pipe(tap(event => resultPanelToggleService.toggleResultPanel()))
         .subscribe();
       m.expect(toggleStream).toBeObservable(expectedStream);
     })
@@ -48,22 +41,18 @@ describe("ResultPanelToggleService", () => {
   it(
     `should receive 'false' from toggleDisplayChangeStream when toggleResultPanel
     is called when the current result panel status is open`,
-    marbles((m) => {
+    marbles(m => {
       (resultPanelToggleService as any).currentResultPanelStatus = true;
 
-      resultPanelToggleService
-        .getToggleChangeStream()
-        .subscribe((newToggleStatus) => {
-          expect(newToggleStatus).toBeFalsy();
-        });
+      resultPanelToggleService.getToggleChangeStream().subscribe(newToggleStatus => {
+        expect(newToggleStatus).toBeFalsy();
+      });
 
       const expectedStream = "-a-";
 
-      const toggleStream = resultPanelToggleService
-        .getToggleChangeStream()
-        .pipe(map((value) => "a"));
+      const toggleStream = resultPanelToggleService.getToggleChangeStream().pipe(map(value => "a"));
       m.hot("-a-")
-        .pipe(tap((event) => resultPanelToggleService.toggleResultPanel()))
+        .pipe(tap(event => resultPanelToggleService.toggleResultPanel()))
         .subscribe();
       m.expect(toggleStream).toBeObservable(expectedStream);
     })

--- a/core/new-gui/src/app/workspace/service/result-panel-toggle/result-panel-toggle.service.ts
+++ b/core/new-gui/src/app/workspace/service/result-panel-toggle/result-panel-toggle.service.ts
@@ -10,7 +10,7 @@ import { Subject } from "rxjs";
  * @author Angela Wang
  */
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class ResultPanelToggleService {
   private currentResultPanelStatus: boolean = false;

--- a/core/new-gui/src/app/workspace/service/undo-redo/undo-redo.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/undo-redo/undo-redo.service.spec.ts
@@ -2,11 +2,7 @@ import { StubOperatorMetadataService } from "../operator-metadata/stub-operator-
 import { JointUIService } from "../joint-ui/joint-ui.service";
 import { OperatorMetadataService } from "../operator-metadata/operator-metadata.service";
 import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
-import {
-  mockScanPredicate,
-  mockResultPredicate,
-  mockPoint
-} from "../workflow-graph/model/mock-workflow-data";
+import { mockScanPredicate, mockResultPredicate, mockPoint } from "../workflow-graph/model/mock-workflow-data";
 import { TestBed, inject } from "@angular/core/testing";
 
 import { UndoRedoService } from "./undo-redo.service";
@@ -24,20 +20,17 @@ describe("UndoRedoService", () => {
         JointUIService,
         {
           provide: OperatorMetadataService,
-          useClass: StubOperatorMetadataService
-        }
-      ]
+          useClass: StubOperatorMetadataService,
+        },
+      ],
     });
     service = TestBed.get(UndoRedoService);
     workflowActionService = TestBed.get(WorkflowActionService);
   });
 
-  it("should be created", inject(
-    [UndoRedoService],
-    (injectedService: UndoRedoService) => {
-      expect(injectedService).toBeTruthy();
-    }
-  ));
+  it("should be created", inject([UndoRedoService], (injectedService: UndoRedoService) => {
+    expect(injectedService).toBeTruthy();
+  }));
 
   it("executing command should append to stack", () => {
     workflowActionService.addOperator(mockScanPredicate, mockPoint);

--- a/core/new-gui/src/app/workspace/service/undo-redo/undo-redo.service.ts
+++ b/core/new-gui/src/app/workspace/service/undo-redo/undo-redo.service.ts
@@ -9,7 +9,7 @@ import { Command } from "../workflow-graph/model/workflow-action.service";
 after a certain period of time so we don't undo one character at a time */
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class UndoRedoService {
   // lets us know whether to listen to the JointJS observables, most of the time we don't
@@ -40,13 +40,8 @@ export class UndoRedoService {
   public undoAction(): void {
     // We have a toggle to let our service know to add to the redo stack
     if (this.undoStack.length > 0) {
-      if (
-        !this.workFlowModificationEnabled &&
-        this.undoStack[this.undoStack.length - 1].modifiesWorkflow
-      ) {
-        console.error(
-          "attempted to undo a workflow-modifying command while workflow modification is disabled"
-        );
+      if (!this.workFlowModificationEnabled && this.undoStack[this.undoStack.length - 1].modifiesWorkflow) {
+        console.error("attempted to undo a workflow-modifying command while workflow modification is disabled");
         return;
       }
 
@@ -65,13 +60,8 @@ export class UndoRedoService {
   public redoAction(): void {
     // need to figure out what to keep on the stack and off
     if (this.redoStack.length > 0) {
-      if (
-        !this.workFlowModificationEnabled &&
-        this.redoStack[this.redoStack.length - 1].modifiesWorkflow
-      ) {
-        console.error(
-          "attempted to redo a workflow-modifying command while workflow modification is disabled"
-        );
+      if (!this.workFlowModificationEnabled && this.redoStack[this.redoStack.length - 1].modifiesWorkflow) {
+        console.error("attempted to redo a workflow-modifying command while workflow modification is disabled");
         return;
       }
       const command = this.redoStack.pop();
@@ -109,8 +99,7 @@ export class UndoRedoService {
   public canUndo(): boolean {
     return (
       this.undoStack.length > 0 &&
-      (this.workFlowModificationEnabled ||
-        !this.undoStack[this.undoStack.length - 1].modifiesWorkflow)
+      (this.workFlowModificationEnabled || !this.undoStack[this.undoStack.length - 1].modifiesWorkflow)
     );
   }
 
@@ -121,8 +110,7 @@ export class UndoRedoService {
   public canRedo(): boolean {
     return (
       this.redoStack.length > 0 &&
-      (this.workFlowModificationEnabled ||
-        !this.redoStack[this.redoStack.length - 1].modifiesWorkflow)
+      (this.workFlowModificationEnabled || !this.redoStack[this.redoStack.length - 1].modifiesWorkflow)
     );
   }
 

--- a/core/new-gui/src/app/workspace/service/validation/validation-workflow.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/validation/validation-workflow.service.spec.ts
@@ -4,7 +4,7 @@ import {
   mockPoint,
   mockResultPredicate,
   mockScanPredicate,
-  mockScanResultLink
+  mockScanResultLink,
 } from "../workflow-graph/model/mock-workflow-data";
 import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
 import { UndoRedoService } from "../undo-redo/undo-redo.service";
@@ -28,72 +28,54 @@ describe("ValidationWorkflowService", () => {
         JointUIService,
         {
           provide: OperatorMetadataService,
-          useClass: StubOperatorMetadataService
-        }
-      ]
+          useClass: StubOperatorMetadataService,
+        },
+      ],
     });
 
     validationWorkflowService = TestBed.get(ValidationWorkflowService);
     workflowActionservice = TestBed.get(WorkflowActionService);
   });
 
-  it("should be created", inject(
-    [ValidationWorkflowService],
-    (service: ValidationWorkflowService) => {
-      expect(service).toBeTruthy();
-    }
-  ));
+  it("should be created", inject([ValidationWorkflowService], (service: ValidationWorkflowService) => {
+    expect(service).toBeTruthy();
+  }));
 
   it("should receive true from validateOperator when operator box is connected and required properties are complete ", () => {
     workflowActionservice.addOperator(mockScanPredicate, mockPoint);
     workflowActionservice.addOperator(mockResultPredicate, mockPoint);
     workflowActionservice.addLink(mockScanResultLink);
     const newProperty = { tableName: "test-table" };
-    workflowActionservice.setOperatorProperty(
-      mockScanPredicate.operatorID,
-      newProperty
-    );
-    expect(
-      validationWorkflowService.validateOperator(mockResultPredicate.operatorID)
-        .isValid
-    ).toBeTruthy();
-    expect(
-      validationWorkflowService.validateOperator(mockScanPredicate.operatorID)
-        .isValid
-    ).toBeTruthy();
+    workflowActionservice.setOperatorProperty(mockScanPredicate.operatorID, newProperty);
+    expect(validationWorkflowService.validateOperator(mockResultPredicate.operatorID).isValid).toBeTruthy();
+    expect(validationWorkflowService.validateOperator(mockScanPredicate.operatorID).isValid).toBeTruthy();
   });
 
   it(
     "should subscribe the changes of validateOperatorStream when operator box is connected and required properties are complete ",
-    marbles((m) => {
+    marbles(m => {
       const testEvents = m.hot("-a-b-c----d-", {
-        a: () =>
-          workflowActionservice.addOperator(mockScanPredicate, mockPoint),
-        b: () =>
-          workflowActionservice.addOperator(mockResultPredicate, mockPoint),
+        a: () => workflowActionservice.addOperator(mockScanPredicate, mockPoint),
+        b: () => workflowActionservice.addOperator(mockResultPredicate, mockPoint),
         c: () => workflowActionservice.addLink(mockScanResultLink),
-        d: () =>
-          workflowActionservice.setOperatorProperty(
-            mockScanPredicate.operatorID,
-            { tableName: "test-table" }
-          )
+        d: () => workflowActionservice.setOperatorProperty(mockScanPredicate.operatorID, { tableName: "test-table" }),
       });
 
-      testEvents.subscribe((action) => action());
+      testEvents.subscribe(action => action());
 
       const expected = m.hot("-u-v-(yz)-m-", {
         u: { operatorID: "1", isValid: false },
         v: { operatorID: "3", isValid: false },
         y: { operatorID: "1", isValid: false },
         z: { operatorID: "3", isValid: true },
-        m: { operatorID: "1", isValid: true }
+        m: { operatorID: "1", isValid: true },
       });
 
       m.expect(
         validationWorkflowService.getOperatorValidationStream().pipe(
-          map((value) => ({
+          map(value => ({
             operatorID: value.operatorID,
-            isValid: value.validation.isValid
+            isValid: value.validation.isValid,
           }))
         )
       ).toBeObservable(expected);
@@ -104,35 +86,22 @@ describe("ValidationWorkflowService", () => {
     workflowActionservice.addOperator(mockScanPredicate, mockPoint);
     workflowActionservice.addOperator(mockResultPredicate, mockPoint);
     workflowActionservice.addLink(mockScanResultLink);
-    expect(
-      validationWorkflowService.validateOperator(mockResultPredicate.operatorID)
-        .isValid
-    ).toBeTruthy();
-    expect(
-      validationWorkflowService.validateOperator(mockScanPredicate.operatorID)
-        .isValid
-    ).toBeFalsy();
+    expect(validationWorkflowService.validateOperator(mockResultPredicate.operatorID).isValid).toBeTruthy();
+    expect(validationWorkflowService.validateOperator(mockScanPredicate.operatorID).isValid).toBeFalsy();
   });
 
   it(
     "should subscribe the changes of validateOperatorStream when one operator box is deleted after valid status ",
-    marbles((m) => {
+    marbles(m => {
       const testEvents = m.hot("-a-b-c----d-e-----", {
-        a: () =>
-          workflowActionservice.addOperator(mockScanPredicate, mockPoint),
-        b: () =>
-          workflowActionservice.addOperator(mockResultPredicate, mockPoint),
+        a: () => workflowActionservice.addOperator(mockScanPredicate, mockPoint),
+        b: () => workflowActionservice.addOperator(mockResultPredicate, mockPoint),
         c: () => workflowActionservice.addLink(mockScanResultLink),
-        d: () =>
-          workflowActionservice.setOperatorProperty(
-            mockScanPredicate.operatorID,
-            { tableName: "test-table" }
-          ),
-        e: () =>
-          workflowActionservice.deleteOperator(mockResultPredicate.operatorID)
+        d: () => workflowActionservice.setOperatorProperty(mockScanPredicate.operatorID, { tableName: "test-table" }),
+        e: () => workflowActionservice.deleteOperator(mockResultPredicate.operatorID),
       });
 
-      testEvents.subscribe((action) => action());
+      testEvents.subscribe(action => action());
 
       const expected = m.hot("-t-u-(vw)-x-(yz)-)", {
         t: { operatorID: "1", isValid: false },
@@ -141,14 +110,14 @@ describe("ValidationWorkflowService", () => {
         w: { operatorID: "3", isValid: true },
         x: { operatorID: "1", isValid: true },
         y: { operatorID: "1", isValid: false }, // If one of the oprator is deleted, the other one is invaild since it is isolated
-        z: { operatorID: "3", isValid: false }
+        z: { operatorID: "3", isValid: false },
       });
 
       m.expect(
         validationWorkflowService.getOperatorValidationStream().pipe(
-          map((value) => ({
+          map(value => ({
             operatorID: value.operatorID,
-            isValid: value.validation.isValid
+            isValid: value.validation.isValid,
           }))
         )
       ).toBeObservable(expected);
@@ -157,22 +126,16 @@ describe("ValidationWorkflowService", () => {
 
   it(
     "should subscribe the changes of validateOperatorStream when operator link is deleted after valid status ",
-    marbles((m) => {
+    marbles(m => {
       const testEvents = m.hot("-a-b-c----d-e----", {
-        a: () =>
-          workflowActionservice.addOperator(mockScanPredicate, mockPoint),
-        b: () =>
-          workflowActionservice.addOperator(mockResultPredicate, mockPoint),
+        a: () => workflowActionservice.addOperator(mockScanPredicate, mockPoint),
+        b: () => workflowActionservice.addOperator(mockResultPredicate, mockPoint),
         c: () => workflowActionservice.addLink(mockScanResultLink),
-        d: () =>
-          workflowActionservice.setOperatorProperty(
-            mockScanPredicate.operatorID,
-            { tableName: "test-table" }
-          ),
-        e: () => workflowActionservice.deleteLinkWithID("link-1")
+        d: () => workflowActionservice.setOperatorProperty(mockScanPredicate.operatorID, { tableName: "test-table" }),
+        e: () => workflowActionservice.deleteLinkWithID("link-1"),
       });
 
-      testEvents.subscribe((action) => action());
+      testEvents.subscribe(action => action());
 
       const expected = m.hot("-t-u-(vw)-x-(yz)-", {
         t: { operatorID: "1", isValid: false },
@@ -181,14 +144,14 @@ describe("ValidationWorkflowService", () => {
         w: { operatorID: "3", isValid: true },
         x: { operatorID: "1", isValid: true },
         y: { operatorID: "1", isValid: false }, // If the link is deleted, two operators are isolated and are invalid
-        z: { operatorID: "3", isValid: false }
+        z: { operatorID: "3", isValid: false },
       });
 
       m.expect(
         validationWorkflowService.getOperatorValidationStream().pipe(
-          map((value) => ({
+          map(value => ({
             operatorID: value.operatorID,
-            isValid: value.validation.isValid
+            isValid: value.validation.isValid,
           }))
         )
       ).toBeObservable(expected);
@@ -200,56 +163,38 @@ describe("ValidationWorkflowService", () => {
     workflowActionservice.addOperator(mockResultPredicate, mockPoint);
     workflowActionservice.addLink(mockScanResultLink);
     workflowActionservice.setOperatorProperty(mockScanPredicate.operatorID, {
-      tableName: "test-table"
+      tableName: "test-table",
     });
-    expect(
-      Object.entries(
-        validationWorkflowService.getCurrentWorkflowValidationError().errors
-      ).length
-    ).toEqual(0);
+    expect(Object.entries(validationWorkflowService.getCurrentWorkflowValidationError().errors).length).toEqual(0);
 
     const mockScanPredicate2 = {
       ...mockScanPredicate,
-      operatorID: "mockScan2"
+      operatorID: "mockScan2",
     };
     const mockResultPredicate2 = {
       ...mockResultPredicate,
-      operatorID: "mockResult2"
+      operatorID: "mockResult2",
     };
     const mockScanResultLink2 = {
       linkID: "mock-scan-result-link-2",
       source: {
         operatorID: mockScanPredicate2.operatorID,
-        portID: mockScanPredicate2.outputPorts[0].portID
+        portID: mockScanPredicate2.outputPorts[0].portID,
       },
       target: {
         operatorID: mockResultPredicate2.operatorID,
-        portID: mockResultPredicate2.inputPorts[0].portID
-      }
+        portID: mockResultPredicate2.inputPorts[0].portID,
+      },
     };
 
     workflowActionservice.addOperator(mockScanPredicate2, mockPoint);
     workflowActionservice.addOperator(mockResultPredicate2, mockPoint);
     workflowActionservice.addLink(mockScanResultLink2);
-    console.log(
-      validationWorkflowService.getCurrentWorkflowValidationError().errors
-    );
-    expect(
-      Object.entries(
-        validationWorkflowService.getCurrentWorkflowValidationError().errors
-      ).length
-    ).toEqual(1);
+    console.log(validationWorkflowService.getCurrentWorkflowValidationError().errors);
+    expect(Object.entries(validationWorkflowService.getCurrentWorkflowValidationError().errors).length).toEqual(1);
 
-    workflowActionservice
-      .getTexeraGraph()
-      .disableOperator(mockScanPredicate2.operatorID);
-    workflowActionservice
-      .getTexeraGraph()
-      .disableOperator(mockResultPredicate2.operatorID);
-    expect(
-      Object.entries(
-        validationWorkflowService.getCurrentWorkflowValidationError().errors
-      ).length
-    ).toEqual(0);
+    workflowActionservice.getTexeraGraph().disableOperator(mockScanPredicate2.operatorID);
+    workflowActionservice.getTexeraGraph().disableOperator(mockResultPredicate2.operatorID);
+    expect(Object.entries(validationWorkflowService.getCurrentWorkflowValidationError().errors).length).toEqual(0);
   });
 });

--- a/core/new-gui/src/app/workspace/service/validation/validation-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/validation/validation-workflow.service.ts
@@ -27,7 +27,7 @@ export type Validation = { isValid: true } | ValidationError;
  * @author Angela Wang
  */
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class ValidationWorkflowService {
   public static readonly VALIDATION_OPERATOR_INPUT_MESSAGE = "inputs";
@@ -61,8 +61,8 @@ export class ValidationWorkflowService {
     // fetch operator schema list
     this.operatorMetadataService
       .getOperatorMetadata()
-      .pipe(filter((metadata) => metadata.operators.length > 0))
-      .subscribe((metadata) => {
+      .pipe(filter(metadata => metadata.operators.length > 0))
+      .subscribe(metadata => {
         this.operatorSchemaList = metadata.operators;
         this.initializeValidation();
       });
@@ -99,18 +99,12 @@ export class ValidationWorkflowService {
   }
 
   public validateOperator(operatorID: string): Validation {
-    if (
-      this.workflowActionService.getTexeraGraph().isOperatorDisabled(operatorID)
-    ) {
+    if (this.workflowActionService.getTexeraGraph().isOperatorDisabled(operatorID)) {
       return { isValid: true };
     }
     const jsonSchemaValidation = this.validateJsonSchema(operatorID);
-    const operatorConnectionValidation =
-      this.validateOperatorConnection(operatorID);
-    return ValidationWorkflowService.combineValidation(
-      jsonSchemaValidation,
-      operatorConnectionValidation
-    );
+    const operatorConnectionValidation = this.validateOperatorConnection(operatorID);
+    return ValidationWorkflowService.combineValidation(jsonSchemaValidation, operatorConnectionValidation);
   }
 
   private updateValidationState(operatorID: string, validation: Validation) {
@@ -138,31 +132,23 @@ export class ValidationWorkflowService {
     this.workflowActionService
       .getTexeraGraph()
       .getAllOperators()
-      .forEach((operator) => {
-        this.updateValidationState(
-          operator.operatorID,
-          this.validateOperator(operator.operatorID)
-        );
+      .forEach(operator => {
+        this.updateValidationState(operator.operatorID, this.validateOperator(operator.operatorID));
       });
 
     // Capture the operator add event and validate the newly added operator
     this.workflowActionService
       .getTexeraGraph()
       .getOperatorAddStream()
-      .subscribe((operator) =>
-        this.updateValidationState(
-          operator.operatorID,
-          this.validateOperator(operator.operatorID)
-        )
+      .subscribe(operator =>
+        this.updateValidationState(operator.operatorID, this.validateOperator(operator.operatorID))
       );
 
     // Capture the operator delete event but not validate the deleted operator
     this.workflowActionService
       .getTexeraGraph()
       .getOperatorDeleteStream()
-      .subscribe((operator) =>
-        this.updateValidationStateOnDelete(operator.deletedOperator.operatorID)
-      );
+      .subscribe(operator => this.updateValidationStateOnDelete(operator.deletedOperator.operatorID));
 
     // Capture the link add and delete event and validate the source and target operators for this link
     merge(
@@ -170,61 +156,42 @@ export class ValidationWorkflowService {
       this.workflowActionService
         .getTexeraGraph()
         .getLinkDeleteStream()
-        .pipe(map((link) => link.deletedLink))
-    ).subscribe((link) => {
-      this.updateValidationState(
-        link.source.operatorID,
-        this.validateOperator(link.source.operatorID)
-      );
-      this.updateValidationState(
-        link.target.operatorID,
-        this.validateOperator(link.target.operatorID)
-      );
+        .pipe(map(link => link.deletedLink))
+    ).subscribe(link => {
+      this.updateValidationState(link.source.operatorID, this.validateOperator(link.source.operatorID));
+      this.updateValidationState(link.target.operatorID, this.validateOperator(link.target.operatorID));
     });
 
     // Capture the operator property change event and validate the current operator being changed
     this.workflowActionService
       .getTexeraGraph()
       .getOperatorPropertyChangeStream()
-      .subscribe((value) =>
-        this.updateValidationState(
-          value.operator.operatorID,
-          this.validateOperator(value.operator.operatorID)
-        )
+      .subscribe(value =>
+        this.updateValidationState(value.operator.operatorID, this.validateOperator(value.operator.operatorID))
       );
 
     // on enable / disable operator - re-validate the changed operators
     this.workflowActionService
       .getTexeraGraph()
       .getDisabledOperatorsChangedStream()
-      .subscribe((event) => {
+      .subscribe(event => {
         const operatorsToRevalidate = new Set<string>();
 
         // for every changed operator:
-        event.newDisabled.concat(event.newEnabled).forEach((op) => {
+        event.newDisabled.concat(event.newEnabled).forEach(op => {
           // revalidate itself
           operatorsToRevalidate.add(op);
 
           // revalidate all its input operators
-          const inputs = this.workflowActionService
-            .getTexeraGraph()
-            .getInputLinksByOperatorId(op);
-          inputs.forEach((link) =>
-            operatorsToRevalidate.add(link.source.operatorID)
-          );
+          const inputs = this.workflowActionService.getTexeraGraph().getInputLinksByOperatorId(op);
+          inputs.forEach(link => operatorsToRevalidate.add(link.source.operatorID));
 
           // revliadate all its output operators
-          const outputs = this.workflowActionService
-            .getTexeraGraph()
-            .getOutputLinksByOperatorId(op);
-          outputs.forEach((link) =>
-            operatorsToRevalidate.add(link.target.operatorID)
-          );
+          const outputs = this.workflowActionService.getTexeraGraph().getOutputLinksByOperatorId(op);
+          outputs.forEach(link => operatorsToRevalidate.add(link.target.operatorID));
         });
 
-        operatorsToRevalidate.forEach((op) =>
-          this.updateValidationState(op, this.validateOperator(op))
-        );
+        operatorsToRevalidate.forEach(op => this.updateValidationState(op, this.validateOperator(op)));
       });
   }
 
@@ -233,23 +200,16 @@ export class ValidationWorkflowService {
    *  If completed correctly, the operator is valid.
    */
   private validateJsonSchema(operatorID: string): Validation {
-    const operator = this.workflowActionService
-      .getTexeraGraph()
-      .getOperator(operatorID);
+    const operator = this.workflowActionService.getTexeraGraph().getOperator(operatorID);
     if (operator === undefined) {
       throw new Error(`operator with ID ${operatorID} doesn't exist`);
     }
-    const operatorSchema = this.operatorSchemaList.find(
-      (schema) => schema.operatorType === operator.operatorType
-    );
+    const operatorSchema = this.operatorSchemaList.find(schema => schema.operatorType === operator.operatorType);
     if (operatorSchema === undefined) {
       throw new Error("operatorSchema doesn't exist");
     }
 
-    const isValid = this.ajv.validate(
-      operatorSchema.jsonSchema,
-      operator.operatorProperties
-    );
+    const isValid = this.ajv.validate(operatorSchema.jsonSchema, operator.operatorProperties);
     if (isValid) {
       return { isValid: true };
     }
@@ -257,10 +217,7 @@ export class ValidationWorkflowService {
     const errors = this.ajv.errors;
     const validationError: Record<string, string> = {};
     if (errors) {
-      errors.forEach(
-        (error) =>
-          (validationError[error.keyword] = error.message ? error.message : "")
-      );
+      errors.forEach(error => (validationError[error.keyword] = error.message ? error.message : ""));
     }
     return { isValid: false, messages: validationError };
   }
@@ -270,16 +227,12 @@ export class ValidationWorkflowService {
    *  if all ports of the operator are connected, the operator is valid.
    */
   private validateOperatorConnection(operatorID: string): Validation {
-    const operator = this.workflowActionService
-      .getTexeraGraph()
-      .getOperator(operatorID);
+    const operator = this.workflowActionService.getTexeraGraph().getOperator(operatorID);
     if (operator === undefined) {
       throw new Error(`operator with ID ${operatorID} doesn't exist`);
     }
 
-    const operatorSchema = this.operatorSchemaList.find(
-      (schema) => schema.operatorType === operator.operatorType
-    );
+    const operatorSchema = this.operatorSchemaList.find(schema => schema.operatorType === operator.operatorType);
     if (operatorSchema === undefined) {
       throw new Error("operatorSchema doesn't exist");
     }
@@ -288,7 +241,7 @@ export class ValidationWorkflowService {
 
     // check if input links satisfy the requirement
     const numInputLinksByPort = new Map<string, number>();
-    texeraGraph.getInputLinksByOperatorId(operatorID).forEach((inLink) => {
+    texeraGraph.getInputLinksByOperatorId(operatorID).forEach(inLink => {
       if (texeraGraph.isLinkEnabled(inLink.linkID)) {
         const portID = inLink.target.portID;
         const num = numInputLinksByPort.get(portID) ?? 0;
@@ -300,8 +253,7 @@ export class ValidationWorkflowService {
     let inputPortsViolationMessage = "";
     for (let i = 0; i < operator.inputPorts.length; i++) {
       const portInfo = operatorSchema.additionalMetadata.inputPorts[i];
-      const portNumInputs =
-        numInputLinksByPort.get(operator.inputPorts[i].portID) ?? 0;
+      const portNumInputs = numInputLinksByPort.get(operator.inputPorts[i].portID) ?? 0;
       if (portInfo.allowMultiInputs) {
         if (portNumInputs < 1) {
           satisfyInput = false;
@@ -312,9 +264,7 @@ export class ValidationWorkflowService {
       } else {
         if (portNumInputs !== 1) {
           satisfyInput = false;
-          inputPortsViolationMessage += `${
-            portInfo.displayName ?? ""
-          } requires 1 input, has ${portNumInputs}`;
+          inputPortsViolationMessage += `${portInfo.displayName ?? ""} requires 1 input, has ${portNumInputs}`;
         }
       }
     }
@@ -323,12 +273,12 @@ export class ValidationWorkflowService {
     const requiredOutputNum = operator.outputPorts.length;
     const actualOutputNum = texeraGraph
       .getOutputLinksByOperatorId(operatorID)
-      .filter((link) => texeraGraph.isLinkEnabled(link.linkID)).length;
+      .filter(link => texeraGraph.isLinkEnabled(link.linkID)).length;
 
     // If the operator is the sink operator, the actual output number must be equal to required number.
     const satisyOutput =
-      this.operatorMetadataService.getOperatorSchema(operator.operatorType)
-        .additionalMetadata.operatorGroupName === "View Results"
+      this.operatorMetadataService.getOperatorSchema(operator.operatorType).additionalMetadata.operatorGroupName ===
+      "View Results"
         ? requiredOutputNum === actualOutputNum
         : requiredOutputNum <= actualOutputNum;
 
@@ -341,12 +291,10 @@ export class ValidationWorkflowService {
     } else {
       const messages: Record<string, string> = {};
       if (!satisfyInput) {
-        messages[ValidationWorkflowService.VALIDATION_OPERATOR_INPUT_MESSAGE] =
-          inputPortsViolationMessage;
+        messages[ValidationWorkflowService.VALIDATION_OPERATOR_INPUT_MESSAGE] = inputPortsViolationMessage;
       }
       if (!satisyOutput) {
-        messages[ValidationWorkflowService.VALIDATION_OPERATOR_OUTPUT_MESSAGE] =
-          outputPortsViolationMessage;
+        messages[ValidationWorkflowService.VALIDATION_OPERATOR_OUTPUT_MESSAGE] = outputPortsViolationMessage;
       }
       return { isValid: false, messages: messages };
     }
@@ -355,7 +303,7 @@ export class ValidationWorkflowService {
   public static combineValidation(...validations: Validation[]): Validation {
     let isValid = true;
     let messages = {};
-    validations.forEach((validation) => {
+    validations.forEach(validation => {
       isValid = isValid && validation.isValid;
       if (!validation.isValid) {
         messages = { ...messages, ...validation.messages };

--- a/core/new-gui/src/app/workspace/service/workflow-cache/workflow-cache.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-cache/workflow-cache.service.ts
@@ -1,13 +1,9 @@
 import { Injectable } from "@angular/core";
 import { Workflow } from "../../../common/type/workflow";
-import {
-  localGetObject,
-  localRemoveObject,
-  localSetObject
-} from "../../../common/util/storage";
+import { localGetObject, localRemoveObject, localSetObject } from "../../../common/util/storage";
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class WorkflowCacheService {
   private static readonly WORKFLOW_KEY: string = "workflow";

--- a/core/new-gui/src/app/workspace/service/workflow-console/workflow-console.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-console/workflow-console.service.ts
@@ -8,7 +8,7 @@ import { RingBuffer } from "ring-buffer-ts";
 export const CONSOLE_BUFFER_SIZE = 100;
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class WorkflowConsoleService {
   private consoleMessages: Map<string, RingBuffer<string>> = new Map();
@@ -24,25 +24,17 @@ export class WorkflowConsoleService {
       .subscribeToEvent("PythonPrintTriggeredEvent")
       .subscribe((pythonPrintTriggerInfo: PythonPrintTriggerInfo) => {
         const operatorID = pythonPrintTriggerInfo.operatorID;
-        const messages =
-          this.consoleMessages.get(operatorID) ||
-          new RingBuffer<string>(CONSOLE_BUFFER_SIZE);
-        messages.add(
-          ...pythonPrintTriggerInfo.message
-            .split("\n")
-            .filter((msg) => msg !== "")
-        );
+        const messages = this.consoleMessages.get(operatorID) || new RingBuffer<string>(CONSOLE_BUFFER_SIZE);
+        messages.add(...pythonPrintTriggerInfo.message.split("\n").filter(msg => msg !== ""));
         this.consoleMessages.set(operatorID, messages);
         this.consoleMessagesUpdateStream.next();
       });
   }
 
   registerAutoClearConsoleMessages() {
-    this.workflowWebsocketService
-      .subscribeToEvent("WorkflowStartedEvent")
-      .subscribe((_) => {
-        this.consoleMessages.clear();
-      });
+    this.workflowWebsocketService.subscribeToEvent("WorkflowStartedEvent").subscribe(_ => {
+      this.consoleMessages.clear();
+    });
   }
 
   getConsoleMessages(operatorID: string): ReadonlyArray<string> | undefined {

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.spec.ts
@@ -12,7 +12,7 @@ import {
   mockScanResultLink,
   mockScanSentimentLink,
   mockSentimentPredicate,
-  mockSentimentResultLink
+  mockSentimentResultLink,
 } from "./mock-workflow-data";
 import * as joint from "jointjs";
 import { StubOperatorMetadataService } from "../../operator-metadata/stub-operator-metadata.service";
@@ -34,9 +34,9 @@ describe("JointGraphWrapperService", () => {
         UndoRedoService,
         {
           provide: OperatorMetadataService,
-          useClass: StubOperatorMetadataService
-        }
-      ]
+          useClass: StubOperatorMetadataService,
+        },
+      ],
     });
     jointGraph = new joint.dia.Graph();
     jointGraphWrapper = new JointGraphWrapper(jointGraph);
@@ -45,20 +45,14 @@ describe("JointGraphWrapperService", () => {
 
   it(
     "should emit operator delete event correctly when operator is deleted by JointJS",
-    marbles((m) => {
-      jointGraph.addCell(
-        jointUIService.getJointOperatorElement(mockScanPredicate, mockPoint)
-      );
+    marbles(m => {
+      jointGraph.addCell(jointUIService.getJointOperatorElement(mockScanPredicate, mockPoint));
 
       m.hot("-e-")
-        .pipe(
-          tap(() => jointGraph.getCell(mockScanPredicate.operatorID).remove())
-        )
+        .pipe(tap(() => jointGraph.getCell(mockScanPredicate.operatorID).remove()))
         .subscribe();
 
-      const jointOperatorDeleteStream = jointGraphWrapper
-        .getJointElementCellDeleteStream()
-        .pipe(map(() => "e"));
+      const jointOperatorDeleteStream = jointGraphWrapper.getJointElementCellDeleteStream().pipe(map(() => "e"));
       const expectedStream = m.hot("-e-");
 
       m.expect(jointOperatorDeleteStream).toBeObservable(expectedStream);
@@ -67,24 +61,17 @@ describe("JointGraphWrapperService", () => {
 
   it(
     "should emit link add event correctly when a link is connected by JointJS",
-    marbles((m) => {
-      jointGraph.addCell(
-        jointUIService.getJointOperatorElement(mockScanPredicate, mockPoint)
-      );
-      jointGraph.addCell(
-        jointUIService.getJointOperatorElement(mockResultPredicate, mockPoint)
-      );
+    marbles(m => {
+      jointGraph.addCell(jointUIService.getJointOperatorElement(mockScanPredicate, mockPoint));
+      jointGraph.addCell(jointUIService.getJointOperatorElement(mockResultPredicate, mockPoint));
 
-      const mockScanResultLinkCell =
-        JointUIService.getJointLinkCell(mockScanResultLink);
+      const mockScanResultLinkCell = JointUIService.getJointLinkCell(mockScanResultLink);
 
       m.hot("-e-")
         .pipe(tap(() => jointGraph.addCell(mockScanResultLinkCell)))
         .subscribe();
 
-      const jointLinkAddStream = jointGraphWrapper
-        .getJointLinkCellAddStream()
-        .pipe(map(() => "e"));
+      const jointLinkAddStream = jointGraphWrapper.getJointLinkCellAddStream().pipe(map(() => "e"));
       const expectedStream = m.hot("-e-");
 
       m.expect(jointLinkAddStream).toBeObservable(expectedStream);
@@ -93,25 +80,18 @@ describe("JointGraphWrapperService", () => {
 
   it(
     "should emit link delete event correctly when a link is deleted by JointJS",
-    marbles((m) => {
-      jointGraph.addCell(
-        jointUIService.getJointOperatorElement(mockScanPredicate, mockPoint)
-      );
-      jointGraph.addCell(
-        jointUIService.getJointOperatorElement(mockResultPredicate, mockPoint)
-      );
+    marbles(m => {
+      jointGraph.addCell(jointUIService.getJointOperatorElement(mockScanPredicate, mockPoint));
+      jointGraph.addCell(jointUIService.getJointOperatorElement(mockResultPredicate, mockPoint));
 
-      const mockScanResultLinkCell =
-        JointUIService.getJointLinkCell(mockScanResultLink);
+      const mockScanResultLinkCell = JointUIService.getJointLinkCell(mockScanResultLink);
       jointGraph.addCell(mockScanResultLinkCell);
 
       m.hot("---e-")
         .pipe(tap(() => jointGraph.getCell(mockScanResultLink.linkID).remove()))
         .subscribe();
 
-      const jointLinkDeleteStream = jointGraphWrapper
-        .getJointLinkCellDeleteStream()
-        .pipe(map(() => "e"));
+      const jointLinkDeleteStream = jointGraphWrapper.getJointLinkCellDeleteStream().pipe(map(() => "e"));
       const expectedStream = m.hot("---e-");
 
       m.expect(jointLinkDeleteStream).toBeObservable(expectedStream);
@@ -128,30 +108,19 @@ describe("JointGraphWrapperService", () => {
   it(
     `should emit operator delete event and link delete event correctly
           when an operator along with one connected link are deleted by JointJS`,
-    marbles((m) => {
-      jointGraph.addCell(
-        jointUIService.getJointOperatorElement(mockScanPredicate, mockPoint)
-      );
-      jointGraph.addCell(
-        jointUIService.getJointOperatorElement(mockResultPredicate, mockPoint)
-      );
+    marbles(m => {
+      jointGraph.addCell(jointUIService.getJointOperatorElement(mockScanPredicate, mockPoint));
+      jointGraph.addCell(jointUIService.getJointOperatorElement(mockResultPredicate, mockPoint));
 
-      const mockScanResultLinkCell =
-        JointUIService.getJointLinkCell(mockScanResultLink);
+      const mockScanResultLinkCell = JointUIService.getJointLinkCell(mockScanResultLink);
       jointGraph.addCell(mockScanResultLinkCell);
 
       m.hot("-e-")
-        .pipe(
-          tap(() => jointGraph.getCell(mockScanPredicate.operatorID).remove())
-        )
+        .pipe(tap(() => jointGraph.getCell(mockScanPredicate.operatorID).remove()))
         .subscribe();
 
-      const jointOperatorDeleteStream = jointGraphWrapper
-        .getJointElementCellDeleteStream()
-        .pipe(map(() => "e"));
-      const jointLinkDeleteStream = jointGraphWrapper
-        .getJointLinkCellDeleteStream()
-        .pipe(map(() => "e"));
+      const jointOperatorDeleteStream = jointGraphWrapper.getJointElementCellDeleteStream().pipe(map(() => "e"));
+      const jointLinkDeleteStream = jointGraphWrapper.getJointLinkCellDeleteStream().pipe(map(() => "e"));
 
       const expectedStream = "-e-";
 
@@ -169,43 +138,22 @@ describe("JointGraphWrapperService", () => {
   it(
     `should emit operator delete event and link delete event correctly when
         an operator along with multiple links are deleted by JointJS`,
-    marbles((m) => {
-      jointGraph.addCell(
-        jointUIService.getJointOperatorElement(mockScanPredicate, mockPoint)
-      );
-      jointGraph.addCell(
-        jointUIService.getJointOperatorElement(
-          mockSentimentPredicate,
-          mockPoint
-        )
-      );
-      jointGraph.addCell(
-        jointUIService.getJointOperatorElement(mockResultPredicate, mockPoint)
-      );
+    marbles(m => {
+      jointGraph.addCell(jointUIService.getJointOperatorElement(mockScanPredicate, mockPoint));
+      jointGraph.addCell(jointUIService.getJointOperatorElement(mockSentimentPredicate, mockPoint));
+      jointGraph.addCell(jointUIService.getJointOperatorElement(mockResultPredicate, mockPoint));
 
-      const mockScanSentimentLinkCell = JointUIService.getJointLinkCell(
-        mockScanSentimentLink
-      );
-      const mockSentimentResultLinkCell = JointUIService.getJointLinkCell(
-        mockSentimentResultLink
-      );
+      const mockScanSentimentLinkCell = JointUIService.getJointLinkCell(mockScanSentimentLink);
+      const mockSentimentResultLinkCell = JointUIService.getJointLinkCell(mockSentimentResultLink);
       jointGraph.addCell(mockScanSentimentLinkCell);
       jointGraph.addCell(mockSentimentResultLinkCell);
 
       m.hot("-e--")
-        .pipe(
-          tap(() =>
-            jointGraph.getCell(mockSentimentPredicate.operatorID).remove()
-          )
-        )
+        .pipe(tap(() => jointGraph.getCell(mockSentimentPredicate.operatorID).remove()))
         .subscribe();
 
-      const jointOperatorDeleteStream = jointGraphWrapper
-        .getJointElementCellDeleteStream()
-        .pipe(map(() => "e"));
-      const jointLinkDeleteStream = jointGraphWrapper
-        .getJointLinkCellDeleteStream()
-        .pipe(map(() => "e"));
+      const jointOperatorDeleteStream = jointGraphWrapper.getJointElementCellDeleteStream().pipe(map(() => "e"));
+      const jointLinkDeleteStream = jointGraphWrapper.getJointLinkCellDeleteStream().pipe(map(() => "e"));
 
       const expectedStream = "-e--";
       const expectedMultiStream = "-(ee)--";
@@ -217,399 +165,301 @@ describe("JointGraphWrapperService", () => {
 
   it(
     "should emit a highlight event correctly when an operator is highlighted",
-    marbles((m) => {
-      const workflowActionService: WorkflowActionService = TestBed.inject(
-        WorkflowActionService
-      );
-      const localJointGraphWrapper =
-        workflowActionService.getJointGraphWrapper();
+    marbles(m => {
+      const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+      const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
       // add one operator, it should be automatically highlighted
       workflowActionService.addOperator(mockScanPredicate, mockPoint);
-      expect(
-        workflowActionService
-          .getJointGraphWrapper()
-          .getCurrentHighlightedOperatorIDs()
-      ).toEqual([mockScanPredicate.operatorID]);
+      expect(workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()).toEqual([
+        mockScanPredicate.operatorID,
+      ]);
       // unhighlight the current operator
-      workflowActionService
-        .getJointGraphWrapper()
-        .unhighlightOperators(mockScanPredicate.operatorID);
-      expect(
-        workflowActionService
-          .getJointGraphWrapper()
-          .getCurrentHighlightedOperatorIDs()
-      ).toEqual([]);
+      workflowActionService.getJointGraphWrapper().unhighlightOperators(mockScanPredicate.operatorID);
+      expect(workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()).toEqual([]);
 
       // prepare marble operation for highlighting an operator
-      const highlightActionMarbleEvent = m
-        .hot("-a-|", { a: mockScanPredicate.operatorID })
-        .pipe(share());
+      const highlightActionMarbleEvent = m.hot("-a-|", { a: mockScanPredicate.operatorID }).pipe(share());
 
       // highlight that operator at events
-      highlightActionMarbleEvent.subscribe((value) =>
-        localJointGraphWrapper.highlightOperators(value)
-      );
+      highlightActionMarbleEvent.subscribe(value => localJointGraphWrapper.highlightOperators(value));
 
       // prepare expected output highlight event stream
       const expectedHighlightEventStream = m.hot("-a-", {
-        a: [mockScanPredicate.operatorID]
+        a: [mockScanPredicate.operatorID],
       });
 
       // expect the output event stream is correct
-      m.expect(
-        localJointGraphWrapper.getJointOperatorHighlightStream()
-      ).toBeObservable(expectedHighlightEventStream);
+      m.expect(localJointGraphWrapper.getJointOperatorHighlightStream()).toBeObservable(expectedHighlightEventStream);
 
       // expect the current highlighted operator is correct
       highlightActionMarbleEvent.subscribe({
         complete: () => {
-          expect(
-            localJointGraphWrapper.getCurrentHighlightedOperatorIDs()
-          ).toEqual([mockScanPredicate.operatorID]);
-        }
+          expect(localJointGraphWrapper.getCurrentHighlightedOperatorIDs()).toEqual([mockScanPredicate.operatorID]);
+        },
       });
     })
   );
 
   it(
     "should emit a highlight event correctly when multiple operators are highlighted",
-    marbles((m) => {
-      const workflowActionService: WorkflowActionService = TestBed.inject(
-        WorkflowActionService
-      );
-      const localJointGraphWrapper =
-        workflowActionService.getJointGraphWrapper();
+    marbles(m => {
+      const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+      const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
       // add two operators, they should be automatically highlighted
       workflowActionService.addOperatorsAndLinks(
         [
           { op: mockScanPredicate, pos: mockPoint },
-          { op: mockResultPredicate, pos: mockPoint }
+          { op: mockResultPredicate, pos: mockPoint },
         ],
         []
       );
-      expect(
-        workflowActionService
-          .getJointGraphWrapper()
-          .getCurrentHighlightedOperatorIDs()
-      ).toEqual([mockScanPredicate.operatorID, mockResultPredicate.operatorID]);
+      expect(workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()).toEqual([
+        mockScanPredicate.operatorID,
+        mockResultPredicate.operatorID,
+      ]);
 
       // unhighlight current operators
       workflowActionService
         .getJointGraphWrapper()
-        .unhighlightOperators(
-          ...mockScanPredicate.operatorID,
-          mockResultPredicate.operatorID
-        );
-      expect(
-        workflowActionService
-          .getJointGraphWrapper()
-          .getCurrentHighlightedOperatorIDs()
-      ).toEqual([]);
+        .unhighlightOperators(...mockScanPredicate.operatorID, mockResultPredicate.operatorID);
+      expect(workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()).toEqual([]);
 
       // prepare marble operation for highlighting two operators
       const highlightActionMarbleEvent = m
         .hot("-a-|", {
-          a: [mockScanPredicate.operatorID, mockResultPredicate.operatorID]
+          a: [mockScanPredicate.operatorID, mockResultPredicate.operatorID],
         })
         .pipe(share());
 
       // highlight those operators at events
-      highlightActionMarbleEvent.subscribe((value) =>
-        localJointGraphWrapper.highlightOperators(...value)
-      );
+      highlightActionMarbleEvent.subscribe(value => localJointGraphWrapper.highlightOperators(...value));
 
       // prepare expected output highlight event stream
       const expectedHighlightEventStream = m.hot("-a-", {
-        a: [mockScanPredicate.operatorID, mockResultPredicate.operatorID]
+        a: [mockScanPredicate.operatorID, mockResultPredicate.operatorID],
       });
 
       // expect the output event stream is correct
-      m.expect(
-        localJointGraphWrapper.getJointOperatorHighlightStream()
-      ).toBeObservable(expectedHighlightEventStream);
+      m.expect(localJointGraphWrapper.getJointOperatorHighlightStream()).toBeObservable(expectedHighlightEventStream);
 
       // expect the current highlighted operators are correct
       highlightActionMarbleEvent.subscribe({
         complete: () => {
-          expect(
-            localJointGraphWrapper.getCurrentHighlightedOperatorIDs()
-          ).toEqual([
+          expect(localJointGraphWrapper.getCurrentHighlightedOperatorIDs()).toEqual([
             mockScanPredicate.operatorID,
-            mockResultPredicate.operatorID
+            mockResultPredicate.operatorID,
           ]);
-        }
+        },
       });
     })
   );
 
   it(
     "should emit an unhighlight event correctly when an operator is unhighlighted",
-    marbles((m) => {
-      const workflowActionService: WorkflowActionService = TestBed.inject(
-        WorkflowActionService
-      );
-      const localJointGraphWrapper =
-        workflowActionService.getJointGraphWrapper();
+    marbles(m => {
+      const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+      const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
       // add and highlight an operator
       workflowActionService.addOperator(mockScanPredicate, mockPoint);
-      workflowActionService
-        .getJointGraphWrapper()
-        .highlightOperators(mockScanPredicate.operatorID);
+      workflowActionService.getJointGraphWrapper().highlightOperators(mockScanPredicate.operatorID);
 
       // prepare marble operation for unhighlighting an operator
       const unhighlightActionMarbleEvent = m.hot("-a-|").pipe(share());
 
       // unhighlight that operator at events
       unhighlightActionMarbleEvent.subscribe(() =>
-        localJointGraphWrapper.unhighlightOperators(
-          mockScanPredicate.operatorID
-        )
+        localJointGraphWrapper.unhighlightOperators(mockScanPredicate.operatorID)
       );
 
       // prepare expected output unhighlight event stream
       const expectedUnhighlightEventStream = m.hot("-a-", {
-        a: [mockScanPredicate.operatorID]
+        a: [mockScanPredicate.operatorID],
       });
 
       // expect the output event stream is correct
-      m.expect(
-        localJointGraphWrapper.getJointOperatorUnhighlightStream()
-      ).toBeObservable(expectedUnhighlightEventStream);
+      m.expect(localJointGraphWrapper.getJointOperatorUnhighlightStream()).toBeObservable(
+        expectedUnhighlightEventStream
+      );
 
       // expect no operator is currently highlighted
       unhighlightActionMarbleEvent.subscribe({
         complete: () => {
-          expect(
-            localJointGraphWrapper.getCurrentHighlightedOperatorIDs()
-          ).toEqual([]);
-        }
+          expect(localJointGraphWrapper.getCurrentHighlightedOperatorIDs()).toEqual([]);
+        },
       });
     })
   );
 
   it(
     "should emit an unhighlight event correctly when multiple operators are unhighlighted",
-    marbles((m) => {
-      const workflowActionService: WorkflowActionService = TestBed.inject(
-        WorkflowActionService
-      );
-      const localJointGraphWrapper =
-        workflowActionService.getJointGraphWrapper();
+    marbles(m => {
+      const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+      const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
       // add and highlight two operators
       workflowActionService.addOperatorsAndLinks(
         [
           { op: mockScanPredicate, pos: mockPoint },
-          { op: mockResultPredicate, pos: mockPoint }
+          { op: mockResultPredicate, pos: mockPoint },
         ],
         []
       );
       workflowActionService
         .getJointGraphWrapper()
-        .highlightOperators(
-          ...mockScanPredicate.operatorID,
-          mockResultPredicate.operatorID
-        );
+        .highlightOperators(...mockScanPredicate.operatorID, mockResultPredicate.operatorID);
 
       // prepare marble operation for unhighlighting two operators
       const unhighlightActionMarbleEvent = m.hot("-a-|").pipe(share());
 
       // unhighlight those operators at events
       unhighlightActionMarbleEvent.subscribe(() =>
-        localJointGraphWrapper.unhighlightOperators(
-          ...mockScanPredicate.operatorID,
-          mockResultPredicate.operatorID
-        )
+        localJointGraphWrapper.unhighlightOperators(...mockScanPredicate.operatorID, mockResultPredicate.operatorID)
       );
 
       // prepare expected output unhighlight event stream
       const expectedUnhighlightEventStream = m.hot("-a-", {
-        a: [mockScanPredicate.operatorID, mockResultPredicate.operatorID]
+        a: [mockScanPredicate.operatorID, mockResultPredicate.operatorID],
       });
 
       // expect the output event stream is correct
-      m.expect(
-        localJointGraphWrapper.getJointOperatorUnhighlightStream()
-      ).toBeObservable(expectedUnhighlightEventStream);
+      m.expect(localJointGraphWrapper.getJointOperatorUnhighlightStream()).toBeObservable(
+        expectedUnhighlightEventStream
+      );
 
       // expect no operator is currently highlighted
       unhighlightActionMarbleEvent.subscribe({
         complete: () => {
-          expect(
-            localJointGraphWrapper.getCurrentHighlightedOperatorIDs()
-          ).toEqual([]);
-        }
+          expect(localJointGraphWrapper.getCurrentHighlightedOperatorIDs()).toEqual([]);
+        },
       });
     })
   );
 
   it(
     "should unhighlight previous highlighted operator if a new operator is highlighted",
-    marbles((m) => {
-      const workflowActionService: WorkflowActionService = TestBed.inject(
-        WorkflowActionService
-      );
-      const localJointGraphWrapper =
-        workflowActionService.getJointGraphWrapper();
+    marbles(m => {
+      const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+      const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
       workflowActionService.addOperator(mockScanPredicate, mockPoint);
       workflowActionService.addOperator(mockResultPredicate, mockPoint);
 
       // unhighlight the last operator in case of automatic highlight
-      workflowActionService
-        .getJointGraphWrapper()
-        .unhighlightOperators(mockResultPredicate.operatorID);
+      workflowActionService.getJointGraphWrapper().unhighlightOperators(mockResultPredicate.operatorID);
 
       // prepare marble operation for highlighting one operator, then highlight another
       const highlightActionMarbleEvent = m
         .hot("-a-b-|", {
           a: mockScanPredicate.operatorID,
-          b: mockResultPredicate.operatorID
+          b: mockResultPredicate.operatorID,
         })
         .pipe(share());
 
       // highlight that operator at events
-      highlightActionMarbleEvent.subscribe((value) =>
-        localJointGraphWrapper.highlightOperators(value)
-      );
+      highlightActionMarbleEvent.subscribe(value => localJointGraphWrapper.highlightOperators(value));
 
       // prepare expected output highlight event stream
       const expectedHighlightEventStream = m.hot("-a-b-", {
         a: [mockScanPredicate.operatorID],
-        b: [mockResultPredicate.operatorID]
+        b: [mockResultPredicate.operatorID],
       });
 
       // expect the output event stream is correct
-      m.expect(
-        localJointGraphWrapper.getJointOperatorHighlightStream()
-      ).toBeObservable(expectedHighlightEventStream);
+      m.expect(localJointGraphWrapper.getJointOperatorHighlightStream()).toBeObservable(expectedHighlightEventStream);
 
       // expect the current highlighted operator is correct
       highlightActionMarbleEvent.subscribe({
         complete: () => {
-          expect(
-            localJointGraphWrapper.getCurrentHighlightedOperatorIDs()
-          ).toEqual([mockResultPredicate.operatorID]);
-        }
+          expect(localJointGraphWrapper.getCurrentHighlightedOperatorIDs()).toEqual([mockResultPredicate.operatorID]);
+        },
       });
     })
   );
 
   it(
     "should ignore the action if trying to highlight the same currently highlighted operator",
-    marbles((m) => {
-      const workflowActionService: WorkflowActionService = TestBed.inject(
-        WorkflowActionService
-      );
-      const localJointGraphWrapper =
-        workflowActionService.getJointGraphWrapper();
+    marbles(m => {
+      const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+      const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
       // add an operator, it should be automatically highlighted
       workflowActionService.addOperator(mockScanPredicate, mockPoint);
       // unhighlight it
-      workflowActionService
-        .getJointGraphWrapper()
-        .unhighlightOperators(mockScanPredicate.operatorID);
+      workflowActionService.getJointGraphWrapper().unhighlightOperators(mockScanPredicate.operatorID);
 
       // prepare marble operation for highlighting the same operator twice
       const highlightActionMarbleEvent = m
         .hot("-a-b-|", {
           a: mockScanPredicate.operatorID,
-          b: mockScanPredicate.operatorID
+          b: mockScanPredicate.operatorID,
         })
         .pipe(share());
 
       // highlight that operator at events
-      highlightActionMarbleEvent.subscribe((value) =>
-        localJointGraphWrapper.highlightOperators(value)
-      );
+      highlightActionMarbleEvent.subscribe(value => localJointGraphWrapper.highlightOperators(value));
 
       // prepare expected output highlight event stream: the second highlight is ignored
       const expectedHighlightEventStream = m.hot("-a---", {
-        a: [mockScanPredicate.operatorID]
+        a: [mockScanPredicate.operatorID],
       });
 
       // expect the output event stream is correct
-      m.expect(
-        localJointGraphWrapper.getJointOperatorHighlightStream()
-      ).toBeObservable(expectedHighlightEventStream);
+      m.expect(localJointGraphWrapper.getJointOperatorHighlightStream()).toBeObservable(expectedHighlightEventStream);
     })
   );
 
   it(
     "should unhighlight the currently highlighted operator if it is deleted",
-    marbles((m) => {
-      const workflowActionService: WorkflowActionService = TestBed.inject(
-        WorkflowActionService
-      );
-      const localJointGraphWrapper =
-        workflowActionService.getJointGraphWrapper();
+    marbles(m => {
+      const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+      const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
       // add and highlight the operator
       workflowActionService.addOperator(mockScanPredicate, mockPoint);
       localJointGraphWrapper.highlightOperators(mockScanPredicate.operatorID);
 
-      expect(localJointGraphWrapper.getCurrentHighlightedOperatorIDs()).toEqual(
-        [mockScanPredicate.operatorID]
-      );
+      expect(localJointGraphWrapper.getCurrentHighlightedOperatorIDs()).toEqual([mockScanPredicate.operatorID]);
 
       // prepare the delete operator action marble test
       const deleteOperatorActionMarble = m.hot("-a-").pipe(share());
-      deleteOperatorActionMarble.subscribe(() =>
-        workflowActionService.deleteOperator(mockScanPredicate.operatorID)
-      );
+      deleteOperatorActionMarble.subscribe(() => workflowActionService.deleteOperator(mockScanPredicate.operatorID));
 
       // expect that the unhighlight event stream is triggered
       const expectedEventStream = m.hot("-a-", {
-        a: [mockScanPredicate.operatorID]
+        a: [mockScanPredicate.operatorID],
       });
-      m.expect(
-        localJointGraphWrapper.getJointOperatorUnhighlightStream()
-      ).toBeObservable(expectedEventStream);
+      m.expect(localJointGraphWrapper.getJointOperatorUnhighlightStream()).toBeObservable(expectedEventStream);
 
       // expect that the current highlighted operator is undefined
       deleteOperatorActionMarble.subscribe({
-        complete: () =>
-          expect(
-            localJointGraphWrapper.getCurrentHighlightedOperatorIDs()
-          ).toEqual([])
+        complete: () => expect(localJointGraphWrapper.getCurrentHighlightedOperatorIDs()).toEqual([]),
       });
     })
   );
 
   it("should get operator position successfully if the operator exists in the paper", () => {
-    const workflowActionService: WorkflowActionService = TestBed.inject(
-      WorkflowActionService
-    );
+    const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
     const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
 
-    expect(
-      localJointGraphWrapper.getElementPosition(mockScanPredicate.operatorID)
-    ).toEqual(mockPoint);
+    expect(localJointGraphWrapper.getElementPosition(mockScanPredicate.operatorID)).toEqual(mockPoint);
   });
 
   it("should throw an error if operator does not exist in the paper when calling 'getElementPosition()'", () => {
-    const workflowActionService: WorkflowActionService = TestBed.inject(
-      WorkflowActionService
-    );
+    const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
     const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
     expect(function () {
       localJointGraphWrapper.getElementPosition(mockScanPredicate.operatorID);
-    }).toThrowError(
-      `element with ID ${mockScanPredicate.operatorID} doesn't exist`
-    );
+    }).toThrowError(`element with ID ${mockScanPredicate.operatorID} doesn't exist`);
   });
 
   it("should throw an error if the id we are using is linkID when calling 'getElementPosition()'", () => {
-    const workflowActionService: WorkflowActionService = TestBed.inject(
-      WorkflowActionService
-    );
+    const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
     const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
@@ -622,23 +472,15 @@ describe("JointGraphWrapperService", () => {
   });
 
   it("should repositions the operator successfully if the operator exists in the paper", () => {
-    const workflowActionService: WorkflowActionService = TestBed.inject(
-      WorkflowActionService
-    );
+    const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
     const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
     // changes the operator's position
-    localJointGraphWrapper.setElementPosition(
-      mockScanPredicate.operatorID,
-      10,
-      10
-    );
+    localJointGraphWrapper.setElementPosition(mockScanPredicate.operatorID, 10, 10);
 
     const expectedPosition = { x: mockPoint.x + 10, y: mockPoint.y + 10 };
-    expect(
-      localJointGraphWrapper.getElementPosition(mockScanPredicate.operatorID)
-    ).toEqual(expectedPosition);
+    expect(localJointGraphWrapper.getElementPosition(mockScanPredicate.operatorID)).toEqual(expectedPosition);
   });
 
   it("should successfully set a new zoom property", () => {
@@ -654,17 +496,13 @@ describe("JointGraphWrapperService", () => {
 
   it(
     "should triggle getWorkflowEditorZoomStream when new zoom ratio is set",
-    marbles((m) => {
+    marbles(m => {
       const mockNewZoomProperty = 0.5;
 
       m.hot("-e-")
-        .pipe(
-          tap((event) => jointGraphWrapper.setZoomProperty(mockNewZoomProperty))
-        )
+        .pipe(tap(event => jointGraphWrapper.setZoomProperty(mockNewZoomProperty)))
         .subscribe();
-      const zoomStream = jointGraphWrapper
-        .getWorkflowEditorZoomStream()
-        .pipe(map((value) => "e"));
+      const zoomStream = jointGraphWrapper.getWorkflowEditorZoomStream().pipe(map(value => "e"));
       const expectedStream = "-e-";
 
       m.expect(zoomStream).toBeObservable(expectedStream);
@@ -673,13 +511,11 @@ describe("JointGraphWrapperService", () => {
 
   it(
     "should trigger getRestorePaperOffsetStream when resumeDefaultZoomAndOffset is called",
-    marbles((m) => {
+    marbles(m => {
       m.hot("-e-")
         .pipe(tap(() => jointGraphWrapper.restoreDefaultZoomAndOffset()))
         .subscribe();
-      const restoreStream = jointGraphWrapper
-        .getRestorePaperOffsetStream()
-        .pipe(map((value) => "e"));
+      const restoreStream = jointGraphWrapper.getRestorePaperOffsetStream().pipe(map(value => "e"));
       const expectedStream = "-e-";
 
       m.expect(restoreStream).toBeObservable(expectedStream);
@@ -687,40 +523,27 @@ describe("JointGraphWrapperService", () => {
   );
 
   it("should move all highlighted operators together when any one of them is moved", () => {
-    const workflowActionService: WorkflowActionService = TestBed.inject(
-      WorkflowActionService
-    );
+    const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
     const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
     // add and highlight two operators
     workflowActionService.addOperatorsAndLinks(
       [
         { op: mockScanPredicate, pos: mockPoint },
-        { op: mockResultPredicate, pos: mockPoint }
+        { op: mockResultPredicate, pos: mockPoint },
       ],
       []
     );
-    localJointGraphWrapper.highlightOperators(
-      ...mockScanPredicate.operatorID,
-      mockResultPredicate.operatorID
-    );
+    localJointGraphWrapper.highlightOperators(...mockScanPredicate.operatorID, mockResultPredicate.operatorID);
 
     // change one operator's position
-    localJointGraphWrapper.setElementPosition(
-      mockScanPredicate.operatorID,
-      10,
-      10
-    );
+    localJointGraphWrapper.setElementPosition(mockScanPredicate.operatorID, 10, 10);
 
     const expectedPosition = { x: mockPoint.x + 10, y: mockPoint.y + 10 };
 
     // expect both operators to be in the new position
-    expect(
-      localJointGraphWrapper.getElementPosition(mockScanPredicate.operatorID)
-    ).toEqual(expectedPosition);
-    expect(
-      localJointGraphWrapper.getElementPosition(mockResultPredicate.operatorID)
-    ).toEqual(expectedPosition);
+    expect(localJointGraphWrapper.getElementPosition(mockScanPredicate.operatorID)).toEqual(expectedPosition);
+    expect(localJointGraphWrapper.getElementPosition(mockResultPredicate.operatorID)).toEqual(expectedPosition);
   });
 
   describe("when linkBreakpoint is enabled", () => {
@@ -734,54 +557,42 @@ describe("JointGraphWrapperService", () => {
 
     it(
       "should emit link highlight event correctly when a link is selected",
-      marbles((m) => {
-        const workflowActionService: WorkflowActionService = TestBed.inject(
-          WorkflowActionService
-        );
-        const localJointGraphWrapper =
-          workflowActionService.getJointGraphWrapper();
+      marbles(m => {
+        const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+        const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
         workflowActionService.addOperator(mockScanPredicate, mockPoint);
         workflowActionService.addOperator(mockResultPredicate, mockPoint);
         workflowActionService.addLink(mockScanResultLink);
 
         // prepare marble operation for highlighting one link, then highlight an operator
-        const highlightActionMarbleEvent = m
-          .hot("-a-|", { a: mockScanResultLink.linkID })
-          .pipe(share());
+        const highlightActionMarbleEvent = m.hot("-a-|", { a: mockScanResultLink.linkID }).pipe(share());
 
         // highlight at events
-        highlightActionMarbleEvent.subscribe((value) => {
+        highlightActionMarbleEvent.subscribe(value => {
           localJointGraphWrapper.highlightLink(value);
         });
 
         // prepare expected output highlight event stream
         const expectedLinkHighlightEventStream = m.hot("-a-", {
-          a: [mockScanResultLink.linkID]
+          a: [mockScanResultLink.linkID],
         });
-        m.expect(
-          localJointGraphWrapper.getLinkHighlightStream()
-        ).toBeObservable(expectedLinkHighlightEventStream);
+        m.expect(localJointGraphWrapper.getLinkHighlightStream()).toBeObservable(expectedLinkHighlightEventStream);
 
         // expect the current highlighted link to be correct
         highlightActionMarbleEvent.subscribe({
           complete: () => {
-            expect(
-              localJointGraphWrapper.getCurrentHighlightedLinkIDs()
-            ).toEqual([mockScanResultLink.linkID]);
-          }
+            expect(localJointGraphWrapper.getCurrentHighlightedLinkIDs()).toEqual([mockScanResultLink.linkID]);
+          },
         });
       })
     );
 
     it(
       "should emit an unhighlight event correctly when an link is unhighlighted",
-      marbles((m) => {
-        const workflowActionService: WorkflowActionService = TestBed.inject(
-          WorkflowActionService
-        );
-        const localJointGraphWrapper =
-          workflowActionService.getJointGraphWrapper();
+      marbles(m => {
+        const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+        const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
         // add one operator
         workflowActionService.addOperator(mockScanPredicate, mockPoint);
@@ -794,39 +605,30 @@ describe("JointGraphWrapperService", () => {
         const unhighlightActionMarbleEvent = m.hot("-a-|").pipe(share());
 
         // unhighlight that operator at events
-        unhighlightActionMarbleEvent.subscribe(() =>
-          localJointGraphWrapper.unhighlightLink(mockScanResultLink.linkID)
-        );
+        unhighlightActionMarbleEvent.subscribe(() => localJointGraphWrapper.unhighlightLink(mockScanResultLink.linkID));
 
         // prepare expected output highlight event stream
         const expectedUnhighlightEventStream = m.hot("-a-", {
-          a: [mockScanResultLink.linkID]
+          a: [mockScanResultLink.linkID],
         });
 
         // expect the output event stream is correct
-        m.expect(
-          localJointGraphWrapper.getLinkUnhighlightStream()
-        ).toBeObservable(expectedUnhighlightEventStream);
+        m.expect(localJointGraphWrapper.getLinkUnhighlightStream()).toBeObservable(expectedUnhighlightEventStream);
 
         // expect the current highlighted operator is correct
         unhighlightActionMarbleEvent.subscribe({
           complete: () => {
-            expect(
-              localJointGraphWrapper.getCurrentHighlightedLinkIDs()
-            ).toEqual([]);
-          }
+            expect(localJointGraphWrapper.getCurrentHighlightedLinkIDs()).toEqual([]);
+          },
         });
       })
     );
 
     it(
       "should emit an unhighlight event correctly when an highlighted link is deleted",
-      marbles((m) => {
-        const workflowActionService: WorkflowActionService = TestBed.inject(
-          WorkflowActionService
-        );
-        const localJointGraphWrapper =
-          workflowActionService.getJointGraphWrapper();
+      marbles(m => {
+        const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+        const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
         // add one operator
         workflowActionService.addOperator(mockScanPredicate, mockPoint);
@@ -839,39 +641,30 @@ describe("JointGraphWrapperService", () => {
         const deleteActionMarbleEvent = m.hot("-a-|").pipe(share());
 
         // unhighlight that operator at events
-        deleteActionMarbleEvent.subscribe(() =>
-          workflowActionService.deleteLinkWithID(mockScanResultLink.linkID)
-        );
+        deleteActionMarbleEvent.subscribe(() => workflowActionService.deleteLinkWithID(mockScanResultLink.linkID));
 
         // prepare expected output highlight event stream
         const expectedUnhighlightEventStream = m.hot("-a-", {
-          a: [mockScanResultLink.linkID]
+          a: [mockScanResultLink.linkID],
         });
 
         // expect the output event stream is correct
-        m.expect(
-          localJointGraphWrapper.getLinkUnhighlightStream()
-        ).toBeObservable(expectedUnhighlightEventStream);
+        m.expect(localJointGraphWrapper.getLinkUnhighlightStream()).toBeObservable(expectedUnhighlightEventStream);
 
         // expect the current highlighted operator is correct
         deleteActionMarbleEvent.subscribe({
           complete: () => {
-            expect(
-              localJointGraphWrapper.getCurrentHighlightedLinkIDs()
-            ).toEqual([]);
-          }
+            expect(localJointGraphWrapper.getCurrentHighlightedLinkIDs()).toEqual([]);
+          },
         });
       })
     );
 
     it(
       "should unhighlight previous highlighted link if another link is selected/highlighted",
-      marbles((m) => {
-        const workflowActionService: WorkflowActionService = TestBed.inject(
-          WorkflowActionService
-        );
-        const localJointGraphWrapper =
-          workflowActionService.getJointGraphWrapper();
+      marbles(m => {
+        const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+        const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
         workflowActionService.addOperator(mockScanPredicate, mockPoint);
         workflowActionService.addOperator(mockSentimentPredicate, mockPoint);
@@ -883,51 +676,42 @@ describe("JointGraphWrapperService", () => {
         const highlightActionMarbleEvent = m
           .hot("-a-b-|", {
             a: mockScanSentimentLink.linkID,
-            b: mockSentimentResultLink.linkID
+            b: mockSentimentResultLink.linkID,
           })
           .pipe(share());
 
         // highlight at events
-        highlightActionMarbleEvent.subscribe((value) => {
+        highlightActionMarbleEvent.subscribe(value => {
           localJointGraphWrapper.highlightLink(value);
         });
 
         // prepare expected output highlight event stream
         const expectedLinkHighlightEventStream = m.hot("-a-b-", {
           a: [mockScanSentimentLink.linkID],
-          b: [mockSentimentResultLink.linkID]
+          b: [mockSentimentResultLink.linkID],
         });
-        m.expect(
-          localJointGraphWrapper.getLinkHighlightStream()
-        ).toBeObservable(expectedLinkHighlightEventStream);
+        m.expect(localJointGraphWrapper.getLinkHighlightStream()).toBeObservable(expectedLinkHighlightEventStream);
 
         // prepare expected output unhighlight event stream
         const expectedLinUnhighlightEventStream = m.hot("---a-", {
-          a: [mockScanSentimentLink.linkID]
+          a: [mockScanSentimentLink.linkID],
         });
-        m.expect(
-          localJointGraphWrapper.getLinkUnhighlightStream()
-        ).toBeObservable(expectedLinUnhighlightEventStream);
+        m.expect(localJointGraphWrapper.getLinkUnhighlightStream()).toBeObservable(expectedLinUnhighlightEventStream);
 
         // expect the current highlighted link to be correct
         highlightActionMarbleEvent.subscribe({
           complete: () => {
-            expect(
-              localJointGraphWrapper.getCurrentHighlightedLinkIDs()
-            ).toEqual([mockSentimentResultLink.linkID]);
-          }
+            expect(localJointGraphWrapper.getCurrentHighlightedLinkIDs()).toEqual([mockSentimentResultLink.linkID]);
+          },
         });
       })
     );
 
     it(
       "should unhighlight previous highlighted links if an operator is highlighted",
-      marbles((m) => {
-        const workflowActionService: WorkflowActionService = TestBed.inject(
-          WorkflowActionService
-        );
-        const localJointGraphWrapper =
-          workflowActionService.getJointGraphWrapper();
+      marbles(m => {
+        const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+        const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
         workflowActionService.addOperator(mockScanPredicate, mockPoint);
         workflowActionService.addOperator(mockResultPredicate, mockPoint);
@@ -937,12 +721,12 @@ describe("JointGraphWrapperService", () => {
         const highlightActionMarbleEvent = m
           .hot("-a-b-|", {
             a: mockScanResultLink.linkID,
-            b: mockResultPredicate.operatorID
+            b: mockResultPredicate.operatorID,
           })
           .pipe(share());
 
         // highlight at events
-        highlightActionMarbleEvent.subscribe((value) => {
+        highlightActionMarbleEvent.subscribe(value => {
           if (value === mockResultPredicate.operatorID) {
             localJointGraphWrapper.highlightOperators(value);
           } else {
@@ -952,48 +736,39 @@ describe("JointGraphWrapperService", () => {
 
         // prepare expected output highlight event stream
         const expectedLinkHighlightEventStream = m.hot("-a---", {
-          a: [mockScanResultLink.linkID]
+          a: [mockScanResultLink.linkID],
         });
 
         const expectedOperatorHighlightEventStream = m.hot("---b-", {
-          b: [mockResultPredicate.operatorID]
+          b: [mockResultPredicate.operatorID],
         });
 
         // prepare expected output highlight event stream
         const expectedLinkUnhighlightEventStream = m.hot("---c-", {
-          c: [mockScanResultLink.linkID]
+          c: [mockScanResultLink.linkID],
         });
 
         // expect the output event stream is correct
-        m.expect(
-          localJointGraphWrapper.getLinkHighlightStream()
-        ).toBeObservable(expectedLinkHighlightEventStream);
-        m.expect(
-          localJointGraphWrapper.getJointOperatorHighlightStream()
-        ).toBeObservable(expectedOperatorHighlightEventStream);
-        m.expect(
-          localJointGraphWrapper.getLinkUnhighlightStream()
-        ).toBeObservable(expectedLinkUnhighlightEventStream);
+        m.expect(localJointGraphWrapper.getLinkHighlightStream()).toBeObservable(expectedLinkHighlightEventStream);
+        m.expect(localJointGraphWrapper.getJointOperatorHighlightStream()).toBeObservable(
+          expectedOperatorHighlightEventStream
+        );
+        m.expect(localJointGraphWrapper.getLinkUnhighlightStream()).toBeObservable(expectedLinkUnhighlightEventStream);
 
         // expect the current highlighted operator is correct
         highlightActionMarbleEvent.subscribe({
           complete: () => {
-            expect(
-              localJointGraphWrapper.getCurrentHighlightedOperatorIDs()
-            ).toEqual([mockResultPredicate.operatorID]);
-          }
+            expect(localJointGraphWrapper.getCurrentHighlightedOperatorIDs()).toEqual([mockResultPredicate.operatorID]);
+          },
         });
       })
     );
 
     it(
       "should emit an show breakpoint event correctly when adding a breakpoint to a link",
-      marbles((m) => {
-        const workflowActionService: WorkflowActionService = TestBed.inject(
-          WorkflowActionService
-        );
-        const localJointGraphWrapper =
-          workflowActionService.getJointGraphWrapper();
+      marbles(m => {
+        const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+        const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
         // add one link
         workflowActionService.addOperator(mockScanPredicate, mockPoint);
@@ -1008,41 +783,33 @@ describe("JointGraphWrapperService", () => {
         const mockBreakpoint = { count: 100 };
         // add breakpoint to the link at events
         ActionMarbleEvent.subscribe(() =>
-          workflowActionService.setLinkBreakpoint(
-            mockScanResultLink.linkID,
-            mockBreakpoint
-          )
+          workflowActionService.setLinkBreakpoint(mockScanResultLink.linkID, mockBreakpoint)
         );
 
         // prepare expected output event stream
         const expectedbreakpointShowEventStream = m.hot("-a-", {
-          a: { linkID: mockScanResultLink.linkID }
+          a: { linkID: mockScanResultLink.linkID },
         });
 
         // expect the output event stream is correct
-        m.expect(
-          localJointGraphWrapper.getLinkBreakpointShowStream()
-        ).toBeObservable(expectedbreakpointShowEventStream);
+        m.expect(localJointGraphWrapper.getLinkBreakpointShowStream()).toBeObservable(
+          expectedbreakpointShowEventStream
+        );
 
         // expect the current highlighted operator is correct
         ActionMarbleEvent.subscribe({
           complete: () => {
-            expect(localJointGraphWrapper.getLinkIDsWithBreakpoint()).toEqual([
-              mockScanResultLink.linkID
-            ]);
-          }
+            expect(localJointGraphWrapper.getLinkIDsWithBreakpoint()).toEqual([mockScanResultLink.linkID]);
+          },
         });
       })
     );
 
     it(
       "should emit an hide breakpoint event correctly when removing a breakpoint",
-      marbles((m) => {
-        const workflowActionService: WorkflowActionService = TestBed.inject(
-          WorkflowActionService
-        );
-        const localJointGraphWrapper =
-          workflowActionService.getJointGraphWrapper();
+      marbles(m => {
+        const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
+        const localJointGraphWrapper = workflowActionService.getJointGraphWrapper();
 
         // add one link
         workflowActionService.addOperator(mockScanPredicate, mockPoint);
@@ -1051,36 +818,29 @@ describe("JointGraphWrapperService", () => {
         // add breakpoint
         const mockBreakpoint = { count: 100 };
         localJointGraphWrapper.highlightLink(mockScanResultLink.linkID);
-        workflowActionService.setLinkBreakpoint(
-          mockScanResultLink.linkID,
-          mockBreakpoint
-        );
+        workflowActionService.setLinkBreakpoint(mockScanResultLink.linkID, mockBreakpoint);
 
         // prepare marble operation for removing a breakpoint
         const ActionMarbleEvent = m.hot("-a-|").pipe(share());
 
         // remove breakpoint at events
-        ActionMarbleEvent.subscribe(() =>
-          workflowActionService.removeLinkBreakpoint(mockScanResultLink.linkID)
-        );
+        ActionMarbleEvent.subscribe(() => workflowActionService.removeLinkBreakpoint(mockScanResultLink.linkID));
 
         // prepare expected output highlight event stream
         const expectedBreakpointHideEventStream = m.hot("-a-", {
-          a: { linkID: mockScanResultLink.linkID }
+          a: { linkID: mockScanResultLink.linkID },
         });
 
         // expect the output event stream is correct
-        m.expect(
-          localJointGraphWrapper.getLinkBreakpointHideStream()
-        ).toBeObservable(expectedBreakpointHideEventStream);
+        m.expect(localJointGraphWrapper.getLinkBreakpointHideStream()).toBeObservable(
+          expectedBreakpointHideEventStream
+        );
 
         // expect the current link with breakpoint to be correct
         ActionMarbleEvent.subscribe({
           complete: () => {
-            expect(localJointGraphWrapper.getLinkIDsWithBreakpoint()).toEqual(
-              []
-            );
-          }
+            expect(localJointGraphWrapper.getLinkIDsWithBreakpoint()).toEqual([]);
+          },
         });
       })
     );

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
@@ -23,17 +23,9 @@ type JointModelEventInfo = {
 // which is a 3-element tuple:
 // 1. the JointJS model (Cell) of the event
 // 2 and 3. additional information of the event
-type JointModelEvent = [
-  joint.dia.Cell,
-  { graph: joint.dia.Graph; models: joint.dia.Cell[] },
-  JointModelEventInfo
-];
+type JointModelEvent = [joint.dia.Cell, { graph: joint.dia.Graph; models: joint.dia.Cell[] }, JointModelEventInfo];
 
-type JointLinkChangeEvent = [
-  joint.dia.Link,
-  { x: number; y: number },
-  { ui: boolean; updateConnectionOnly: boolean }
-];
+type JointLinkChangeEvent = [joint.dia.Link, { x: number; y: number }, { ui: boolean; updateConnectionOnly: boolean }];
 
 type JointPositionChangeEvent = [joint.dia.Element, { x: number; y: number }];
 
@@ -77,18 +69,13 @@ export class JointGraphWrapper {
   public static readonly ZOOM_MINIMUM: number = 0.7;
   public static readonly ZOOM_MAXIMUM: number = 1.3;
 
-  public navigatorMoveDelta: Subject<{ deltaX: number; deltaY: number }> =
-    new Subject();
+  public navigatorMoveDelta: Subject<{ deltaX: number; deltaY: number }> = new Subject();
 
   private mainJointPaper: joint.dia.Paper | undefined;
-  private mainJointPaperAttachedStream: Subject<joint.dia.Paper> =
-    new ReplaySubject(1);
+  private mainJointPaperAttachedStream: Subject<joint.dia.Paper> = new ReplaySubject(1);
   private miniMapPaper: joint.dia.Paper | undefined;
 
-  private elementPositions: Map<string, PositionInfo> = new Map<
-    string,
-    PositionInfo
-  >();
+  private elementPositions: Map<string, PositionInfo> = new Map<string, PositionInfo>();
   private listenPositionChange: boolean = true;
 
   // flag that indicates whether multiselect mode is on
@@ -97,7 +84,7 @@ export class JointGraphWrapper {
   private currentHighlights: JointHighlights = {
     operators: [],
     groups: [],
-    links: []
+    links: [],
   };
 
   // the currently highlighted operators' IDs
@@ -138,48 +125,37 @@ export class JointGraphWrapper {
    * This will capture all events in JointJS
    *  involving the 'add' operation
    */
-  private jointCellAddStream = fromEvent<JointModelEvent>(
-    this.jointGraph,
-    "add"
-  ).pipe(map((value) => value[0]));
+  private jointCellAddStream = fromEvent<JointModelEvent>(this.jointGraph, "add").pipe(map(value => value[0]));
 
   /**
    * This will capture all events in JointJS
    *  involving the 'change position' operation
    */
-  private jointCellDragStream = fromEvent<JointModelEvent>(
-    this.jointGraph,
-    "change:position"
-  ).pipe(map((value) => value[0]));
+  private jointCellDragStream = fromEvent<JointModelEvent>(this.jointGraph, "change:position").pipe(
+    map(value => value[0])
+  );
 
   /**
    * This will capture all events in JointJS
    *  involving the 'remove' operation
    */
-  private jointCellDeleteStream = fromEvent<JointModelEvent>(
-    this.jointGraph,
-    "remove"
-  ).pipe(map((value) => value[0]));
+  private jointCellDeleteStream = fromEvent<JointModelEvent>(this.jointGraph, "remove").pipe(map(value => value[0]));
 
   constructor(public jointGraph: joint.dia.Graph) {
     // handle if the currently highlighted operator/group/link is deleted, it should be unhighlighted
     this.handleElementDeleteUnhighlight();
 
-    this.jointCellAddStream
-      .pipe(filter((cell) => cell.isElement()))
-      .subscribe((element) => {
-        const initPosition = {
-          currPos: (element as joint.dia.Element).position(),
-          lastPos: undefined
-        };
-        this.elementPositions.set(element.id.toString(), initPosition);
-      });
+    this.jointCellAddStream.pipe(filter(cell => cell.isElement())).subscribe(element => {
+      const initPosition = {
+        currPos: (element as joint.dia.Element).position(),
+        lastPos: undefined,
+      };
+      this.elementPositions.set(element.id.toString(), initPosition);
+    });
 
     this.jointCellDeleteStream
-      .pipe(filter((cell) => cell.isElement()))
-      .subscribe((element) =>
-        this.elementPositions.delete(element.id.toString())
-      );
+      .pipe(filter(cell => cell.isElement()))
+      .subscribe(element => this.elementPositions.delete(element.id.toString()));
   }
 
   /**
@@ -190,9 +166,7 @@ export class JointGraphWrapper {
    *
    * @param paperOptions JointJS paper options
    */
-  public attachMainJointPaper(
-    paperOptions: joint.dia.Paper.Options
-  ): joint.dia.Paper {
+  public attachMainJointPaper(paperOptions: joint.dia.Paper.Options): joint.dia.Paper {
     paperOptions.model = this.jointGraph;
     const paper = new joint.dia.Paper(paperOptions);
     this.mainJointPaper = paper;
@@ -208,9 +182,7 @@ export class JointGraphWrapper {
     return this.mainJointPaperAttachedStream;
   }
 
-  public attachMiniMapJointPaper(
-    paperOptions: joint.dia.Paper.Options
-  ): joint.dia.Paper {
+  public attachMiniMapJointPaper(paperOptions: joint.dia.Paper.Options): joint.dia.Paper {
     paperOptions.model = this.jointGraph;
     const paper = new joint.dia.Paper(paperOptions);
     this.miniMapPaper = paper;
@@ -273,7 +245,7 @@ export class JointGraphWrapper {
     return {
       operators: this.currentHighlightedOperators,
       groups: this.currentHighlightedGroups,
-      links: this.currentHighlightedLinks
+      links: this.currentHighlightedLinks,
     };
   }
 
@@ -290,18 +262,13 @@ export class JointGraphWrapper {
     oldPosition: Point;
     newPosition: Point;
   }> {
-    return fromEvent<JointPositionChangeEvent>(
-      this.jointGraph,
-      "change:position"
-    ).pipe(
-      map((e) => {
+    return fromEvent<JointPositionChangeEvent>(this.jointGraph, "change:position").pipe(
+      map(e => {
         const elementID = e[0].id.toString();
         const oldPosition = this.elementPositions.get(elementID);
         const newPosition = { x: e[1].x, y: e[1].y };
         if (!oldPosition) {
-          throw new Error(
-            `internal error: cannot find element position for ${elementID}`
-          );
+          throw new Error(`internal error: cannot find element position for ${elementID}`);
         }
         if (
           !oldPosition.lastPos ||
@@ -312,12 +279,12 @@ export class JointGraphWrapper {
         }
         this.elementPositions.set(elementID, {
           currPos: newPosition,
-          lastPos: oldPosition.lastPos
+          lastPos: oldPosition.lastPos,
         });
         return {
           elementID: elementID,
           oldPosition: oldPosition.lastPos,
-          newPosition: newPosition
+          newPosition: newPosition,
         };
       })
     );
@@ -335,10 +302,10 @@ export class JointGraphWrapper {
     newLayer: number;
   }> {
     return fromEvent<JointLayerChangeEvent>(this.jointGraph, "change:z").pipe(
-      map((e) => {
+      map(e => {
         return {
           cellID: e[0].id.toString(),
-          newLayer: e[1]
+          newLayer: e[1],
         };
       })
     );
@@ -366,12 +333,8 @@ export class JointGraphWrapper {
    */
   public highlightOperators(...operatorIDs: string[]): void {
     const highlightedOperatorIDs: string[] = [];
-    operatorIDs.forEach((operatorID) =>
-      this.highlightElement(
-        operatorID,
-        this.currentHighlightedOperators,
-        highlightedOperatorIDs
-      )
+    operatorIDs.forEach(operatorID =>
+      this.highlightElement(operatorID, this.currentHighlightedOperators, highlightedOperatorIDs)
     );
     if (highlightedOperatorIDs.length > 0) {
       this.jointOperatorHighlightStream.next(highlightedOperatorIDs);
@@ -388,12 +351,8 @@ export class JointGraphWrapper {
    */
   public unhighlightOperators(...operatorIDs: string[]): void {
     const unhighlightedOperatorIDs: string[] = [];
-    operatorIDs.forEach((operatorID) =>
-      this.unhighlightElement(
-        operatorID,
-        this.currentHighlightedOperators,
-        unhighlightedOperatorIDs
-      )
+    operatorIDs.forEach(operatorID =>
+      this.unhighlightElement(operatorID, this.currentHighlightedOperators, unhighlightedOperatorIDs)
     );
     if (unhighlightedOperatorIDs.length > 0) {
       this.jointOperatorUnhighlightStream.next(unhighlightedOperatorIDs);
@@ -410,13 +369,7 @@ export class JointGraphWrapper {
    */
   public highlightGroups(...groupIDs: string[]): void {
     const highlightedGroupIDs: string[] = [];
-    groupIDs.forEach((groupID) =>
-      this.highlightElement(
-        groupID,
-        this.currentHighlightedGroups,
-        highlightedGroupIDs
-      )
-    );
+    groupIDs.forEach(groupID => this.highlightElement(groupID, this.currentHighlightedGroups, highlightedGroupIDs));
     if (highlightedGroupIDs.length > 0) {
       this.jointGroupHighlightStream.next(highlightedGroupIDs);
     }
@@ -432,13 +385,7 @@ export class JointGraphWrapper {
    */
   public unhighlightGroups(...groupIDs: string[]): void {
     const unhighlightedGroupIDs: string[] = [];
-    groupIDs.forEach((groupID) =>
-      this.unhighlightElement(
-        groupID,
-        this.currentHighlightedGroups,
-        unhighlightedGroupIDs
-      )
-    );
+    groupIDs.forEach(groupID => this.unhighlightElement(groupID, this.currentHighlightedGroups, unhighlightedGroupIDs));
     if (unhighlightedGroupIDs.length > 0) {
       this.jointGroupUnhighlightStream.next(unhighlightedGroupIDs);
     }
@@ -451,13 +398,7 @@ export class JointGraphWrapper {
    */
   public highlightLinks(...linkIDs: string[]): void {
     const highlightedLinkIDs: string[] = [];
-    linkIDs.forEach((linkID) =>
-      this.highlightElement(
-        linkID,
-        this.currentHighlightedLinks,
-        highlightedLinkIDs
-      )
-    );
+    linkIDs.forEach(linkID => this.highlightElement(linkID, this.currentHighlightedLinks, highlightedLinkIDs));
     if (highlightedLinkIDs.length > 0) {
       this.jointLinkHighlightStream.next(highlightedLinkIDs);
     }
@@ -470,13 +411,7 @@ export class JointGraphWrapper {
    */
   public unhighlightLinks(...linkIDs: string[]): void {
     const unhighlightedLinkIDs: string[] = [];
-    linkIDs.forEach((linkID) =>
-      this.unhighlightElement(
-        linkID,
-        this.currentHighlightedLinks,
-        unhighlightedLinkIDs
-      )
-    );
+    linkIDs.forEach(linkID => this.unhighlightElement(linkID, this.currentHighlightedLinks, unhighlightedLinkIDs));
     if (unhighlightedLinkIDs.length > 0) {
       this.jointLinkUnhighlightStream.next(unhighlightedLinkIDs);
     }
@@ -552,8 +487,8 @@ export class JointGraphWrapper {
    */
   public getJointElementCellDragStream(): Observable<joint.dia.Element> {
     const jointElementDragStream = this.jointCellDragStream.pipe(
-      filter((cell) => cell.isElement()),
-      map((cell) => <joint.dia.Element>cell)
+      filter(cell => cell.isElement()),
+      map(cell => <joint.dia.Element>cell)
     );
     return jointElementDragStream;
   }
@@ -564,8 +499,8 @@ export class JointGraphWrapper {
    */
   public getJointElementCellDeleteStream(): Observable<joint.dia.Element> {
     const jointElementDeleteStream = this.jointCellDeleteStream.pipe(
-      filter((cell) => cell.isElement()),
-      map((cell) => <joint.dia.Element>cell)
+      filter(cell => cell.isElement()),
+      map(cell => <joint.dia.Element>cell)
     );
     return jointElementDeleteStream;
   }
@@ -580,8 +515,8 @@ export class JointGraphWrapper {
    */
   public getJointLinkCellAddStream(): Observable<joint.dia.Link> {
     const jointLinkAddStream = this.jointCellAddStream.pipe(
-      filter((cell) => cell.isLink()),
-      map((cell) => <joint.dia.Link>cell)
+      filter(cell => cell.isLink()),
+      map(cell => <joint.dia.Link>cell)
     );
 
     return jointLinkAddStream;
@@ -597,8 +532,8 @@ export class JointGraphWrapper {
    */
   public getJointLinkCellDeleteStream(): Observable<joint.dia.Link> {
     const jointLinkDeleteStream = this.jointCellDeleteStream.pipe(
-      filter((cell) => cell.isLink()),
-      map((cell) => <joint.dia.Link>cell)
+      filter(cell => cell.isLink()),
+      map(cell => <joint.dia.Link>cell)
     );
 
     return jointLinkDeleteStream;
@@ -653,7 +588,7 @@ export class JointGraphWrapper {
       rankSep: 80,
       ranker: "tight-tree",
       rankDir: "LR",
-      resizeClusters: true
+      resizeClusters: true,
     });
   }
 
@@ -683,10 +618,9 @@ export class JointGraphWrapper {
    *  - one end of the link is moved from one point to another point in the paper
    */
   public getJointLinkCellChangeStream(): Observable<joint.dia.Link> {
-    const jointLinkChangeStream = fromEvent<JointLinkChangeEvent>(
-      this.jointGraph,
-      "change:source change:target"
-    ).pipe(map((value) => value[0]));
+    const jointLinkChangeStream = fromEvent<JointLinkChangeEvent>(this.jointGraph, "change:source change:target").pipe(
+      map(value => value[0])
+    );
 
     return jointLinkChangeStream;
   }
@@ -712,11 +646,7 @@ export class JointGraphWrapper {
    * This method repositions the element according to given offsets.
    * An element can be an operator or a group.
    */
-  public setElementPosition(
-    elementID: string,
-    offsetX: number,
-    offsetY: number
-  ): void {
+  public setElementPosition(elementID: string, offsetX: number, offsetY: number): void {
     const cell: joint.dia.Cell | undefined = this.jointGraph.getCell(elementID);
     if (!cell) {
       throw new Error(`element with ID ${elementID} doesn't exist`);
@@ -732,11 +662,7 @@ export class JointGraphWrapper {
    * This method repositions the element according to given absolute positions.
    * An element can be an operator or a group.
    */
-  public setAbsolutePosition(
-    elementID: string,
-    posX: number,
-    poY: number
-  ): void {
+  public setAbsolutePosition(elementID: string, posX: number, poY: number): void {
     const cell: joint.dia.Cell | undefined = this.jointGraph.getCell(elementID);
     if (!cell) {
       throw new Error(`element with ID ${elementID} doesn't exist`);
@@ -769,13 +695,9 @@ export class JointGraphWrapper {
     // only allow one link highlighted at a time
     if (this.currentHighlightedLinks.length > 0) {
       const highlightedLinks = Object.assign([], this.currentHighlightedLinks);
-      highlightedLinks.forEach((highlightedLink) =>
-        this.unhighlightLink(highlightedLink)
-      );
+      highlightedLinks.forEach(highlightedLink => this.unhighlightLink(highlightedLink));
     }
-    this.getCurrentHighlightedOperatorIDs().forEach((operatorID) =>
-      this.unhighlightOperators(operatorID)
-    );
+    this.getCurrentHighlightedOperatorIDs().forEach(operatorID => this.unhighlightOperators(operatorID));
     this.currentHighlightedLinks.push(linkID);
     this.jointLinkHighlightStream.next([linkID]);
   }
@@ -824,11 +746,7 @@ export class JointGraphWrapper {
    * This method resizes the element according to given width and height.
    * An element can be an operator or a group.
    */
-  public setElementSize(
-    elementID: string,
-    width: number,
-    height: number
-  ): void {
+  public setElementSize(elementID: string, width: number, height: number): void {
     const cell: joint.dia.Cell | undefined = this.jointGraph.getCell(elementID);
     if (!cell) {
       throw new Error(`element with ID ${elementID} doesn't exist`);
@@ -926,10 +844,7 @@ export class JointGraphWrapper {
     if (!currentHighlightedElements.includes(elementID)) {
       return;
     }
-    currentHighlightedElements.splice(
-      currentHighlightedElements.indexOf(elementID),
-      1
-    );
+    currentHighlightedElements.splice(currentHighlightedElements.indexOf(elementID), 1);
     unhighlightedElements.push(elementID);
   }
 
@@ -939,7 +854,7 @@ export class JointGraphWrapper {
    *  and unhighlight it if it is.
    */
   private handleElementDeleteUnhighlight(): void {
-    this.jointCellDeleteStream.subscribe((deletedCell) => {
+    this.jointCellDeleteStream.subscribe(deletedCell => {
       const deletedCellID = deletedCell.id.toString();
       if (this.currentHighlightedOperators.includes(deletedCellID)) {
         this.unhighlightOperators(deletedCellID);

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/mock-workflow-data.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/mock-workflow-data.ts
@@ -1,8 +1,4 @@
-import {
-  OperatorLink,
-  OperatorPredicate,
-  Point
-} from "../../../types/workflow-common.interface";
+import { OperatorLink, OperatorPredicate, Point } from "../../../types/workflow-common.interface";
 
 /**
  * Provides mock data related operators and links:
@@ -26,7 +22,7 @@ import {
 
 export const mockPoint: Point = {
   x: 100,
-  y: 100
+  y: 100,
 };
 
 export const mockScanPredicate: OperatorPredicate = {
@@ -36,7 +32,7 @@ export const mockScanPredicate: OperatorPredicate = {
   inputPorts: [],
   outputPorts: [{ portID: "output-0" }],
   showAdvanced: true,
-  isDisabled: false
+  isDisabled: false,
 };
 
 export const mockSentimentPredicate: OperatorPredicate = {
@@ -46,7 +42,7 @@ export const mockSentimentPredicate: OperatorPredicate = {
   inputPorts: [{ portID: "input-0" }],
   outputPorts: [{ portID: "output-0" }],
   showAdvanced: true,
-  isDisabled: false
+  isDisabled: false,
 };
 
 export const mockResultPredicate: OperatorPredicate = {
@@ -56,83 +52,75 @@ export const mockResultPredicate: OperatorPredicate = {
   inputPorts: [{ portID: "input-0" }],
   outputPorts: [],
   showAdvanced: true,
-  isDisabled: false
+  isDisabled: false,
 };
 
 export const mockMultiInputOutputPredicate: OperatorPredicate = {
   operatorID: "4",
   operatorType: "MultiInputOutput",
   operatorProperties: {},
-  inputPorts: [
-    { portID: "input-0" },
-    { portID: "input-1" },
-    { portID: "input-2" }
-  ],
-  outputPorts: [
-    { portID: "output-0" },
-    { portID: "output-1" },
-    { portID: "output-2" }
-  ],
+  inputPorts: [{ portID: "input-0" }, { portID: "input-1" }, { portID: "input-2" }],
+  outputPorts: [{ portID: "output-0" }, { portID: "output-1" }, { portID: "output-2" }],
   showAdvanced: true,
-  isDisabled: false
+  isDisabled: false,
 };
 
 export const mockScanResultLink: OperatorLink = {
   linkID: "link-1",
   source: {
     operatorID: mockScanPredicate.operatorID,
-    portID: mockScanPredicate.outputPorts[0].portID
+    portID: mockScanPredicate.outputPorts[0].portID,
   },
   target: {
     operatorID: mockResultPredicate.operatorID,
-    portID: mockResultPredicate.inputPorts[0].portID
-  }
+    portID: mockResultPredicate.inputPorts[0].portID,
+  },
 };
 
 export const mockScanSentimentLink: OperatorLink = {
   linkID: "link-2",
   source: {
     operatorID: mockScanPredicate.operatorID,
-    portID: mockScanPredicate.outputPorts[0].portID
+    portID: mockScanPredicate.outputPorts[0].portID,
   },
   target: {
     operatorID: mockSentimentPredicate.operatorID,
-    portID: mockSentimentPredicate.inputPorts[0].portID
-  }
+    portID: mockSentimentPredicate.inputPorts[0].portID,
+  },
 };
 
 export const mockSentimentResultLink: OperatorLink = {
   linkID: "link-3",
   source: {
     operatorID: mockSentimentPredicate.operatorID,
-    portID: mockSentimentPredicate.outputPorts[0].portID
+    portID: mockSentimentPredicate.outputPorts[0].portID,
   },
   target: {
     operatorID: mockResultPredicate.operatorID,
-    portID: mockResultPredicate.inputPorts[0].portID
-  }
+    portID: mockResultPredicate.inputPorts[0].portID,
+  },
 };
 
 export const mockFalseResultSentimentLink: OperatorLink = {
   linkID: "link-4",
   source: {
     operatorID: mockResultPredicate.operatorID,
-    portID: undefined as any
+    portID: undefined as any,
   },
   target: {
     operatorID: mockSentimentPredicate.operatorID,
-    portID: mockSentimentPredicate.inputPorts[0].portID
-  }
+    portID: mockSentimentPredicate.inputPorts[0].portID,
+  },
 };
 
 export const mockFalseSentimentScanLink: OperatorLink = {
   linkID: "link-5",
   source: {
     operatorID: mockSentimentPredicate.operatorID,
-    portID: mockSentimentPredicate.outputPorts[0].portID
+    portID: mockSentimentPredicate.outputPorts[0].portID,
   },
   target: {
     operatorID: mockScanPredicate.operatorID,
-    portID: undefined as any
-  }
+    portID: undefined as any,
+  },
 };

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/operator-group.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/operator-group.ts
@@ -1,11 +1,7 @@
 import { Subject } from "rxjs";
 import { Observable } from "rxjs";
 import { WorkflowUtilService } from "../util/workflow-util.service";
-import {
-  Point,
-  OperatorPredicate,
-  OperatorLink
-} from "../../../types/workflow-common.interface";
+import { Point, OperatorPredicate, OperatorLink } from "../../../types/workflow-common.interface";
 import { WorkflowGraph } from "./workflow-graph";
 import { JointGraphWrapper } from "./joint-graph-wrapper";
 import { JointUIService } from "../../joint-ui/joint-ui.service";
@@ -173,10 +169,7 @@ export class OperatorGroup {
     const operatorLayer = this.jointGraphWrapper.getCellLayer(operatorID);
     const groupLayer = this.jointGraphWrapper.getCellLayer(groupID);
     if (operatorLayer <= groupLayer) {
-      this.jointGraphWrapper.setCellLayer(
-        operatorID,
-        groupLayer + operatorLayer
-      );
+      this.jointGraphWrapper.setCellLayer(operatorID, groupLayer + operatorLayer);
     }
 
     const position = this.jointGraphWrapper.getElementPosition(operatorID);
@@ -185,8 +178,8 @@ export class OperatorGroup {
 
     this.texeraGraph
       .getAllLinks()
-      .filter((link) => link.source.operatorID === operatorID)
-      .forEach((link) => {
+      .filter(link => link.source.operatorID === operatorID)
+      .forEach(link => {
         if (group.operators.has(link.target.operatorID)) {
           group.inLinks.splice(group.inLinks.indexOf(link.linkID), 1);
           this.addLinkToGroup(link.linkID, groupID);
@@ -197,8 +190,8 @@ export class OperatorGroup {
 
     this.texeraGraph
       .getAllLinks()
-      .filter((link) => link.target.operatorID === operatorID)
-      .forEach((link) => {
+      .filter(link => link.target.operatorID === operatorID)
+      .forEach(link => {
         if (group.operators.has(link.source.operatorID)) {
           group.outLinks.splice(group.outLinks.indexOf(link.linkID), 1);
           this.addLinkToGroup(link.linkID, groupID);
@@ -233,20 +226,11 @@ export class OperatorGroup {
     const link = this.texeraGraph.getLinkWithID(linkID);
     const group = this.getGroup(groupID);
 
-    if (
-      this.getGroupByLink(linkID) ||
-      this.getGroupByInLink(linkID) ||
-      this.getGroupByOutLink(linkID)
-    ) {
+    if (this.getGroupByLink(linkID) || this.getGroupByInLink(linkID) || this.getGroupByOutLink(linkID)) {
       throw Error(`link with ID ${linkID} already exists in a group`);
     }
-    if (
-      !group.operators.has(link.source.operatorID) ||
-      !group.operators.has(link.target.operatorID)
-    ) {
-      throw Error(
-        `link ${linkID} doesn't qualify as a link of group ${groupID}`
-      );
+    if (!group.operators.has(link.source.operatorID) || !group.operators.has(link.target.operatorID)) {
+      throw Error(`link ${linkID} doesn't qualify as a link of group ${groupID}`);
     }
 
     if (this.jointGraph.getCell(linkID)) {
@@ -288,13 +272,8 @@ export class OperatorGroup {
     if (this.getGroupByLink(linkID) || this.getGroupByInLink(linkID)) {
       throw Error(`link with ID ${linkID} already exists in a group`);
     }
-    if (
-      group.operators.has(link.source.operatorID) ||
-      !group.operators.has(link.target.operatorID)
-    ) {
-      throw Error(
-        `link ${linkID} doesn't qualify as an in-link of group ${groupID}`
-      );
+    if (group.operators.has(link.source.operatorID) || !group.operators.has(link.target.operatorID)) {
+      throw Error(`link ${linkID} doesn't qualify as an in-link of group ${groupID}`);
     }
 
     const linkLayer = this.jointGraphWrapper.getCellLayer(linkID);
@@ -332,13 +311,8 @@ export class OperatorGroup {
     if (this.getGroupByLink(linkID) || this.getGroupByOutLink(linkID)) {
       throw Error(`link with ID ${linkID} already exists in a group`);
     }
-    if (
-      !group.operators.has(link.source.operatorID) ||
-      group.operators.has(link.target.operatorID)
-    ) {
-      throw Error(
-        `link ${linkID} doesn't qualify as an out-link of group ${groupID}`
-      );
+    if (!group.operators.has(link.source.operatorID) || group.operators.has(link.target.operatorID)) {
+      throw Error(`link ${linkID} doesn't qualify as an out-link of group ${groupID}`);
     }
 
     const linkLayer = this.jointGraphWrapper.getCellLayer(linkID);
@@ -608,9 +582,7 @@ export class OperatorGroup {
       if (operatorInfo) {
         return operatorInfo.position;
       } else {
-        throw Error(
-          `Internal error: can't find operator ${operatorID} in group ${group.groupID}`
-        );
+        throw Error(`Internal error: can't find operator ${operatorID} in group ${group.groupID}`);
       }
     } else {
       return this.jointGraphWrapper.getElementPosition(operatorID);
@@ -633,9 +605,7 @@ export class OperatorGroup {
       if (operatorInfo) {
         return operatorInfo.layer;
       } else {
-        throw Error(
-          `Internal error: can't find operator ${operatorID} in group ${group.groupID}`
-        );
+        throw Error(`Internal error: can't find operator ${operatorID} in group ${group.groupID}`);
       }
     } else {
       return this.jointGraphWrapper.getCellLayer(operatorID);
@@ -658,9 +628,7 @@ export class OperatorGroup {
       if (linkInfo) {
         return linkInfo.layer;
       } else {
-        throw Error(
-          `Internal error: can't find link ${linkID} in group ${group.groupID}`
-        );
+        throw Error(`Internal error: can't find link ${linkID} in group ${group.groupID}`);
       }
     } else {
       return this.jointGraphWrapper.getCellLayer(linkID);
@@ -690,7 +658,7 @@ export class OperatorGroup {
     }
 
     const operators = new Map<string, OperatorInfo>();
-    operatorIDs.forEach((operatorID) => {
+    operatorIDs.forEach(operatorID => {
       const operator = this.texeraGraph.getOperator(operatorID);
       const position = this.jointGraphWrapper.getElementPosition(operatorID);
       const layer = this.jointGraphWrapper.getCellLayer(operatorID);
@@ -700,32 +668,20 @@ export class OperatorGroup {
     const links = new Map<string, LinkInfo>();
     this.texeraGraph
       .getAllLinks()
-      .filter(
-        (link) =>
-          operators.has(link.source.operatorID) &&
-          operators.has(link.target.operatorID)
-      )
-      .forEach((link) => {
+      .filter(link => operators.has(link.source.operatorID) && operators.has(link.target.operatorID))
+      .forEach(link => {
         const layer = this.jointGraphWrapper.getCellLayer(link.linkID);
         links.set(link.linkID, { link, layer });
       });
 
     const inLinks = this.texeraGraph
       .getAllLinks()
-      .filter(
-        (link) =>
-          !operators.has(link.source.operatorID) &&
-          operators.has(link.target.operatorID)
-      )
-      .map((link) => link.linkID);
+      .filter(link => !operators.has(link.source.operatorID) && operators.has(link.target.operatorID))
+      .map(link => link.linkID);
     const outLinks = this.texeraGraph
       .getAllLinks()
-      .filter(
-        (link) =>
-          operators.has(link.source.operatorID) &&
-          !operators.has(link.target.operatorID)
-      )
-      .map((link) => link.linkID);
+      .filter(link => operators.has(link.source.operatorID) && !operators.has(link.target.operatorID))
+      .map(link => link.linkID);
 
     return { groupID, operators, links, inLinks, outLinks, collapsed: false };
   }
@@ -742,25 +698,21 @@ export class OperatorGroup {
    * @param group
    */
   public getGroupBoundingBox(group: Group): GroupBoundingBox {
-    const randomOperator = group.operators.get(
-      Array.from(group.operators.keys())[0]
-    );
+    const randomOperator = group.operators.get(Array.from(group.operators.keys())[0]);
     if (!randomOperator) {
-      throw new Error(
-        `Internal error: group with ID ${group.groupID} is invalid`
-      );
+      throw new Error(`Internal error: group with ID ${group.groupID} is invalid`);
     }
 
     const topLeft = {
       x: randomOperator.position.x,
-      y: randomOperator.position.y
+      y: randomOperator.position.y,
     };
     const bottomRight = {
       x: randomOperator.position.x,
-      y: randomOperator.position.y
+      y: randomOperator.position.y,
     };
 
-    group.operators.forEach((operatorInfo) => {
+    group.operators.forEach(operatorInfo => {
       if (operatorInfo.position.x < topLeft.x) {
         topLeft.x = operatorInfo.position.x;
       }
@@ -784,13 +736,13 @@ export class OperatorGroup {
   public getHighestLayer(): number {
     let highestLayer = 0;
 
-    this.texeraGraph.getAllOperators().forEach((operator) => {
+    this.texeraGraph.getAllOperators().forEach(operator => {
       const layer = this.getOperatorLayerByGroup(operator.operatorID);
       if (layer > highestLayer) {
         highestLayer = layer;
       }
     });
-    this.texeraGraph.getAllLinks().forEach((link) => {
+    this.texeraGraph.getAllLinks().forEach(link => {
       const layer = this.getLinkLayerByGroup(link.linkID);
       if (layer > highestLayer) {
         highestLayer = layer;
@@ -811,30 +763,24 @@ export class OperatorGroup {
   public moveGroupToLayer(group: Group, groupLayer: number): void {
     group.operators.forEach((operatorInfo, operatorID) => {
       if (!group.collapsed) {
-        this.jointGraphWrapper.setCellLayer(
-          operatorID,
-          operatorInfo.layer + groupLayer
-        );
+        this.jointGraphWrapper.setCellLayer(operatorID, operatorInfo.layer + groupLayer);
       }
       operatorInfo.layer += groupLayer;
     });
 
     group.links.forEach((linkInfo, linkID) => {
       if (!group.collapsed) {
-        this.jointGraphWrapper.setCellLayer(
-          linkID,
-          linkInfo.layer + groupLayer
-        );
+        this.jointGraphWrapper.setCellLayer(linkID, linkInfo.layer + groupLayer);
       }
       linkInfo.layer += groupLayer;
     });
 
-    group.inLinks.forEach((linkID) => {
+    group.inLinks.forEach(linkID => {
       const layer = this.jointGraphWrapper.getCellLayer(linkID);
       this.jointGraphWrapper.setCellLayer(linkID, layer + groupLayer);
     });
 
-    group.outLinks.forEach((linkID) => {
+    group.outLinks.forEach(linkID => {
       const layer = this.jointGraphWrapper.getCellLayer(linkID);
       this.jointGraphWrapper.setCellLayer(linkID, layer + groupLayer);
     });
@@ -850,20 +796,13 @@ export class OperatorGroup {
     const { topLeft, bottomRight } = this.getGroupBoundingBox(group);
 
     // calculate group's new position
-    const originalPosition = this.jointGraphWrapper.getElementPosition(
-      group.groupID
-    );
-    const offsetX =
-      topLeft.x - JointUIService.DEFAULT_GROUP_MARGIN - originalPosition.x;
-    const offsetY =
-      topLeft.y - JointUIService.DEFAULT_GROUP_MARGIN - originalPosition.y;
+    const originalPosition = this.jointGraphWrapper.getElementPosition(group.groupID);
+    const offsetX = topLeft.x - JointUIService.DEFAULT_GROUP_MARGIN - originalPosition.x;
+    const offsetY = topLeft.y - JointUIService.DEFAULT_GROUP_MARGIN - originalPosition.y;
 
     // calculate group's new height & width
     const width =
-      bottomRight.x -
-      topLeft.x +
-      JointUIService.DEFAULT_OPERATOR_WIDTH +
-      2 * JointUIService.DEFAULT_GROUP_MARGIN;
+      bottomRight.x - topLeft.x + JointUIService.DEFAULT_OPERATOR_WIDTH + 2 * JointUIService.DEFAULT_GROUP_MARGIN;
     const height =
       bottomRight.y -
       topLeft.y +
@@ -872,8 +811,7 @@ export class OperatorGroup {
       JointUIService.DEFAULT_GROUP_MARGIN_BOTTOM;
 
     // reposition the group according to the new position
-    const listenPositionChange =
-      this.jointGraphWrapper.getListenPositionChange();
+    const listenPositionChange = this.jointGraphWrapper.getListenPositionChange();
     this.setSyncOperatorGroup(false);
     this.jointGraphWrapper.setListenPositionChange(false);
     this.jointGraphWrapper.setElementPosition(group.groupID, offsetX, offsetY);
@@ -885,7 +823,7 @@ export class OperatorGroup {
     this.groupResizeStream.next({
       groupID: group.groupID,
       height: height,
-      width: width
+      width: width,
     });
   }
 
@@ -901,16 +839,14 @@ export class OperatorGroup {
   public hideOperatorsAndLinks(group: Group): void {
     this.setSyncTexeraGraph(false);
 
-    group.links.forEach((linkInfo, linkID) =>
-      this.jointGraph.getCell(linkID).remove()
-    );
+    group.links.forEach((linkInfo, linkID) => this.jointGraph.getCell(linkID).remove());
 
-    group.inLinks.forEach((linkID) => {
+    group.inLinks.forEach(linkID => {
       const jointLinkCell = <joint.dia.Link>this.jointGraph.getCell(linkID);
       jointLinkCell.set("target", { id: group.groupID });
     });
 
-    group.outLinks.forEach((linkID) => {
+    group.outLinks.forEach(linkID => {
       const jointLinkCell = <joint.dia.Link>this.jointGraph.getCell(linkID);
       jointLinkCell.set("source", { id: group.groupID });
     });
@@ -949,21 +885,21 @@ export class OperatorGroup {
       this.jointGraphWrapper.setCellLayer(linkID, linkInfo.layer);
     });
 
-    group.inLinks.forEach((linkID) => {
+    group.inLinks.forEach(linkID => {
       const link = this.texeraGraph.getLinkWithID(linkID);
       const jointLinkCell = <joint.dia.Link>this.jointGraph.getCell(linkID);
       jointLinkCell.set("target", {
         id: link.target.operatorID,
-        port: link.target.portID
+        port: link.target.portID,
       });
     });
 
-    group.outLinks.forEach((linkID) => {
+    group.outLinks.forEach(linkID => {
       const link = this.texeraGraph.getLinkWithID(linkID);
       const jointLinkCell = <joint.dia.Link>this.jointGraph.getCell(linkID);
       jointLinkCell.set("source", {
         id: link.source.operatorID,
-        port: link.source.portID
+        port: link.source.portID,
       });
     });
 

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/sync-operator-group.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/sync-operator-group.ts
@@ -29,11 +29,9 @@ export class SyncOperatorGroup {
   private handleTexeraGraphOperatorDelete(): void {
     this.texeraGraph
       .getOperatorDeleteStream()
-      .pipe(map((operator) => operator.deletedOperator))
-      .subscribe((deletedOperator) => {
-        const group = this.operatorGroup.getGroupByOperator(
-          deletedOperator.operatorID
-        );
+      .pipe(map(operator => operator.deletedOperator))
+      .subscribe(deletedOperator => {
+        const group = this.operatorGroup.getGroupByOperator(deletedOperator.operatorID);
         if (group && !group.collapsed && group.operators.size > 1) {
           group.operators.delete(deletedOperator.operatorID);
           this.operatorGroup.repositionGroup(group);
@@ -49,22 +47,13 @@ export class SyncOperatorGroup {
    * link to the group as a link, in-link, or out-link.
    */
   private handleTexeraGraphLinkAdd(): void {
-    this.texeraGraph.getLinkAddStream().subscribe((link) => {
-      this.operatorGroup.getAllGroups().forEach((group) => {
-        if (
-          group.operators.has(link.source.operatorID) &&
-          group.operators.has(link.target.operatorID)
-        ) {
+    this.texeraGraph.getLinkAddStream().subscribe(link => {
+      this.operatorGroup.getAllGroups().forEach(group => {
+        if (group.operators.has(link.source.operatorID) && group.operators.has(link.target.operatorID)) {
           this.operatorGroup.addLinkToGroup(link.linkID, group.groupID);
-        } else if (
-          !group.operators.has(link.source.operatorID) &&
-          group.operators.has(link.target.operatorID)
-        ) {
+        } else if (!group.operators.has(link.source.operatorID) && group.operators.has(link.target.operatorID)) {
           this.operatorGroup.addInLinkToGroup(link.linkID, group.groupID);
-        } else if (
-          group.operators.has(link.source.operatorID) &&
-          !group.operators.has(link.target.operatorID)
-        ) {
+        } else if (group.operators.has(link.source.operatorID) && !group.operators.has(link.target.operatorID)) {
           this.operatorGroup.addOutLinkToGroup(link.linkID, group.groupID);
         }
       });
@@ -78,18 +67,15 @@ export class SyncOperatorGroup {
   private handleTexeraGraphLinkDelete(): void {
     this.texeraGraph
       .getLinkDeleteStream()
-      .pipe(map((link) => link.deletedLink))
-      .subscribe((deletedLink) => {
-        this.operatorGroup.getAllGroups().forEach((group) => {
+      .pipe(map(link => link.deletedLink))
+      .subscribe(deletedLink => {
+        this.operatorGroup.getAllGroups().forEach(group => {
           if (group.links.has(deletedLink.linkID)) {
             group.links.delete(deletedLink.linkID);
           } else if (group.inLinks.includes(deletedLink.linkID)) {
             group.inLinks.splice(group.inLinks.indexOf(deletedLink.linkID), 1);
           } else if (group.outLinks.includes(deletedLink.linkID)) {
-            group.outLinks.splice(
-              group.outLinks.indexOf(deletedLink.linkID),
-              1
-            );
+            group.outLinks.splice(group.outLinks.indexOf(deletedLink.linkID), 1);
           }
         });
       });
@@ -106,12 +92,10 @@ export class SyncOperatorGroup {
       .getElementPositionChangeEvent()
       .pipe(
         filter(() => this.operatorGroup.getSyncOperatorGroup()),
-        filter((movedElement) =>
-          this.texeraGraph.hasOperator(movedElement.elementID)
-        )
+        filter(movedElement => this.texeraGraph.hasOperator(movedElement.elementID))
       )
-      .subscribe((movedOperator) => {
-        this.operatorGroup.getAllGroups().forEach((group) => {
+      .subscribe(movedOperator => {
+        this.operatorGroup.getAllGroups().forEach(group => {
           const operatorInfo = group.operators.get(movedOperator.elementID);
           if (operatorInfo) {
             operatorInfo.position = movedOperator.newPosition;
@@ -132,33 +116,24 @@ export class SyncOperatorGroup {
       .getElementPositionChangeEvent()
       .pipe(
         filter(() => this.operatorGroup.getSyncOperatorGroup()),
-        filter((movedElement) =>
-          this.operatorGroup.hasGroup(movedElement.elementID)
-        )
+        filter(movedElement => this.operatorGroup.hasGroup(movedElement.elementID))
       )
-      .subscribe((movedGroup) => {
+      .subscribe(movedGroup => {
         const group = this.operatorGroup.getGroup(movedGroup.elementID);
         const offsetX = movedGroup.newPosition.x - movedGroup.oldPosition.x;
         const offsetY = movedGroup.newPosition.y - movedGroup.oldPosition.y;
         group.operators.forEach((operatorInfo, operatorID) => {
           operatorInfo.position = {
             x: operatorInfo.position.x + offsetX,
-            y: operatorInfo.position.y + offsetY
+            y: operatorInfo.position.y + offsetY,
           };
           if (!group.collapsed) {
-            const listenPositionChange =
-              this.jointGraphWrapper.getListenPositionChange();
+            const listenPositionChange = this.jointGraphWrapper.getListenPositionChange();
             this.operatorGroup.setSyncOperatorGroup(false);
             this.jointGraphWrapper.setListenPositionChange(false);
-            this.jointGraphWrapper.setElementPosition(
-              operatorID,
-              offsetX,
-              offsetY
-            );
+            this.jointGraphWrapper.setElementPosition(operatorID, offsetX, offsetY);
             this.operatorGroup.setSyncOperatorGroup(true);
-            this.jointGraphWrapper.setListenPositionChange(
-              listenPositionChange
-            );
+            this.jointGraphWrapper.setListenPositionChange(listenPositionChange);
           }
         });
       });
@@ -171,13 +146,9 @@ export class SyncOperatorGroup {
   private handleOperatorLayerChange(): void {
     this.jointGraphWrapper
       .getCellLayerChangeEvent()
-      .pipe(
-        filter((movedOperator) =>
-          this.texeraGraph.hasOperator(movedOperator.cellID)
-        )
-      )
-      .subscribe((movedOperator) => {
-        this.operatorGroup.getAllGroups().forEach((group) => {
+      .pipe(filter(movedOperator => this.texeraGraph.hasOperator(movedOperator.cellID)))
+      .subscribe(movedOperator => {
+        this.operatorGroup.getAllGroups().forEach(group => {
           const operatorInfo = group.operators.get(movedOperator.cellID);
           if (operatorInfo) {
             operatorInfo.layer = movedOperator.newLayer;
@@ -193,11 +164,9 @@ export class SyncOperatorGroup {
   private handleLinkLayerChange(): void {
     this.jointGraphWrapper
       .getCellLayerChangeEvent()
-      .pipe(
-        filter((movedLink) => this.texeraGraph.hasLinkWithID(movedLink.cellID))
-      )
-      .subscribe((movedLink) => {
-        this.operatorGroup.getAllGroups().forEach((group) => {
+      .pipe(filter(movedLink => this.texeraGraph.hasLinkWithID(movedLink.cellID)))
+      .subscribe(movedLink => {
+        this.operatorGroup.getAllGroups().forEach(group => {
           const linkInfo = group.links.get(movedLink.cellID);
           if (linkInfo) {
             linkInfo.layer = movedLink.newLayer;

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/sync-texera-model.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/sync-texera-model.spec.ts
@@ -9,7 +9,7 @@ import {
   mockScanResultLink,
   mockScanSentimentLink,
   mockSentimentPredicate,
-  mockSentimentResultLink
+  mockSentimentResultLink,
 } from "./mock-workflow-data";
 import { TestBed } from "@angular/core/testing";
 import { marbles } from "rxjs-marbles";
@@ -33,7 +33,7 @@ describe("SyncTexeraModel", () => {
    */
   function getJointOperatorValue(operatorID: string): joint.dia.Element {
     return {
-      id: operatorID
+      id: operatorID,
     } as joint.dia.Element;
   }
 
@@ -50,8 +50,8 @@ describe("SyncTexeraModel", () => {
       id: link.linkID,
       attributes: {
         source: { id: link.source.operatorID, port: link.source.portID },
-        target: { id: link.target.operatorID, port: link.target.portID }
-      }
+        target: { id: link.target.operatorID, port: link.target.portID },
+      },
       // getSourceElement: () => ({ id: link.source.operatorID }),
       // getTargetElement: () => ({ id: link.target.operatorID }),
       // get: (port: string) => {
@@ -88,11 +88,9 @@ describe("SyncTexeraModel", () => {
         } else if (port === "target") {
           return null;
         } else {
-          throw new Error(
-            "getJointLinkValue: mock is inconsistent with implementation"
-          );
+          throw new Error("getJointLinkValue: mock is inconsistent with implementation");
         }
-      }
+      },
     } as joint.dia.Link;
   }
 
@@ -104,9 +102,9 @@ describe("SyncTexeraModel", () => {
         JointUIService,
         {
           provide: OperatorMetadataService,
-          useClass: StubOperatorMetadataService
-        }
-      ]
+          useClass: StubOperatorMetadataService,
+        },
+      ],
     });
 
     texeraGraph = new WorkflowGraph();
@@ -129,19 +127,18 @@ describe("SyncTexeraModel", () => {
    */
   it(
     "should delete an operator when the delete operator event happens from JointJS",
-    marbles((m) => {
+    marbles(m => {
       // add operators
       texeraGraph.addOperator(mockScanPredicate);
 
       // prepare delete operator event stream
       const deleteOpMarbleString = "---d-|";
       const deleteOpMarbleValues = {
-        d: getJointOperatorValue(mockScanPredicate.operatorID)
+        d: getJointOperatorValue(mockScanPredicate.operatorID),
       };
-      spyOn(
-        jointGraphWrapper,
-        "getJointElementCellDeleteStream"
-      ).and.returnValue(m.hot(deleteOpMarbleString, deleteOpMarbleValues));
+      spyOn(jointGraphWrapper, "getJointElementCellDeleteStream").and.returnValue(
+        m.hot(deleteOpMarbleString, deleteOpMarbleValues)
+      );
 
       // construct the texera sync model with spied dependencies
       const syncTexeraModel = new SyncTexeraModel(
@@ -159,11 +156,9 @@ describe("SyncTexeraModel", () => {
       // assert workflow graph
       jointGraphWrapper.getJointElementCellDeleteStream().subscribe({
         complete: () => {
-          expect(
-            texeraGraph.hasOperator(mockScanPredicate.operatorID)
-          ).toBeFalsy();
+          expect(texeraGraph.hasOperator(mockScanPredicate.operatorID)).toBeFalsy();
           expect(texeraGraph.getAllOperators().length).toEqual(0);
-        }
+        },
       });
     })
   );
@@ -183,7 +178,7 @@ describe("SyncTexeraModel", () => {
    */
   it(
     "should delete an operator and not touch other operators when the delete operator event happens from JointJS",
-    marbles((m) => {
+    marbles(m => {
       // add operators
       texeraGraph.addOperator(mockScanPredicate);
       texeraGraph.addOperator(mockResultPredicate);
@@ -191,12 +186,11 @@ describe("SyncTexeraModel", () => {
       // prepare delete operator
       const deleteOpMarbleString = "-----d-|";
       const deleteOpMarbleValues = {
-        d: getJointOperatorValue(mockScanPredicate.operatorID)
+        d: getJointOperatorValue(mockScanPredicate.operatorID),
       };
-      spyOn(
-        jointGraphWrapper,
-        "getJointElementCellDeleteStream"
-      ).and.returnValue(m.hot(deleteOpMarbleString, deleteOpMarbleValues));
+      spyOn(jointGraphWrapper, "getJointElementCellDeleteStream").and.returnValue(
+        m.hot(deleteOpMarbleString, deleteOpMarbleValues)
+      );
 
       // construct the texera sync model with spied dependencies
       // construct the texera sync model with spied dependencies
@@ -214,15 +208,11 @@ describe("SyncTexeraModel", () => {
 
       jointGraphWrapper.getJointElementCellDeleteStream().subscribe({
         complete: () => {
-          expect(
-            texeraGraph.hasOperator(mockScanPredicate.operatorID)
-          ).toBeFalsy();
-          expect(
-            texeraGraph.hasOperator(mockResultPredicate.operatorID)
-          ).toBeTruthy();
+          expect(texeraGraph.hasOperator(mockScanPredicate.operatorID)).toBeFalsy();
+          expect(texeraGraph.hasOperator(mockResultPredicate.operatorID)).toBeTruthy();
           expect(texeraGraph.getAllOperators().length).toEqual(1);
           expect(texeraGraph.getAllLinks().length).toEqual(0);
-        }
+        },
       });
     })
   );
@@ -242,7 +232,7 @@ describe("SyncTexeraModel", () => {
    */
   it(
     "should explicitly throw an error if the JointJS operator delete event deletes a nonexist operator",
-    marbles((m) => {
+    marbles(m => {
       // add operators
       texeraGraph.addOperator(mockScanPredicate);
       texeraGraph.addOperator(mockResultPredicate);
@@ -252,14 +242,13 @@ describe("SyncTexeraModel", () => {
       // prepare delete operator
       const deleteOpMarbleString = "-----d-|";
       const deleteOpMarbleValues = {
-        d: getJointOperatorValue(mockScanPredicate.operatorID)
+        d: getJointOperatorValue(mockScanPredicate.operatorID),
       };
       // mock delete the operator operation at the same time frame of jointJS deleting it
       //  but executed before the handler
-      spyOn(
-        jointGraphWrapper,
-        "getJointElementCellDeleteStream"
-      ).and.returnValue(m.hot(deleteOpMarbleString, deleteOpMarbleValues));
+      spyOn(jointGraphWrapper, "getJointElementCellDeleteStream").and.returnValue(
+        m.hot(deleteOpMarbleString, deleteOpMarbleValues)
+      );
 
       // construct the texera sync model with spied dependencies
 
@@ -287,7 +276,7 @@ describe("SyncTexeraModel", () => {
    */
   it(
     "should add a link when link add event happen from JointJS",
-    marbles((m) => {
+    marbles(m => {
       // add operators
       texeraGraph.addOperator(mockScanPredicate);
       texeraGraph.addOperator(mockResultPredicate);
@@ -295,7 +284,7 @@ describe("SyncTexeraModel", () => {
       // prepare add link
       const addLinkMarbleString = "-----p-|";
       const addLinkMarbleValues = {
-        p: getJointLinkValue(mockScanResultLink)
+        p: getJointLinkValue(mockScanResultLink),
       };
       spyOn(jointGraphWrapper, "getJointLinkCellAddStream").and.returnValue(
         m.hot(addLinkMarbleString, addLinkMarbleValues)
@@ -319,19 +308,10 @@ describe("SyncTexeraModel", () => {
         complete: () => {
           expect(texeraGraph.getAllOperators().length).toEqual(2);
           expect(texeraGraph.getAllLinks().length).toEqual(1);
-          expect(
-            texeraGraph.hasLinkWithID(mockScanResultLink.linkID)
-          ).toBeTruthy();
-          expect(texeraGraph.getLinkWithID(mockScanResultLink.linkID)).toEqual(
-            mockScanResultLink
-          );
-          expect(
-            texeraGraph.hasLink(
-              mockScanResultLink.source,
-              mockScanResultLink.target
-            )
-          ).toBeTruthy();
-        }
+          expect(texeraGraph.hasLinkWithID(mockScanResultLink.linkID)).toBeTruthy();
+          expect(texeraGraph.getLinkWithID(mockScanResultLink.linkID)).toEqual(mockScanResultLink);
+          expect(texeraGraph.hasLink(mockScanResultLink.source, mockScanResultLink.target)).toBeTruthy();
+        },
       });
     })
   );
@@ -354,7 +334,7 @@ describe("SyncTexeraModel", () => {
    */
   it(
     "should not create a link when an incomplete link is added in JointJS",
-    marbles((m) => {
+    marbles(m => {
       // add operators
       texeraGraph.addOperator(mockScanPredicate);
       texeraGraph.addOperator(mockResultPredicate);
@@ -362,7 +342,7 @@ describe("SyncTexeraModel", () => {
       // prepare add link (incomplete link)
       const addLinkMarbleString = "-----q-|";
       const addLinkMarbleValues = {
-        q: getIncompleteJointLink(mockScanResultLink)
+        q: getIncompleteJointLink(mockScanResultLink),
       };
       spyOn(jointGraphWrapper, "getJointLinkCellAddStream").and.returnValue(
         m.hot(addLinkMarbleString, addLinkMarbleValues)
@@ -385,7 +365,7 @@ describe("SyncTexeraModel", () => {
       jointGraphWrapper.getJointLinkCellDeleteStream().subscribe({
         complete: () => {
           expect(texeraGraph.getAllLinks().length).toEqual(0);
-        }
+        },
       });
     })
   );
@@ -404,7 +384,7 @@ describe("SyncTexeraModel", () => {
    */
   it(
     "should delete a link when link delete event happens from JointJS",
-    marbles((m) => {
+    marbles(m => {
       // add operators
       texeraGraph.addOperator(mockScanPredicate);
       texeraGraph.addOperator(mockResultPredicate);
@@ -415,7 +395,7 @@ describe("SyncTexeraModel", () => {
       // prepare delete link
       const deleteLinkMarbleString = "-------r-|";
       const deleteLinkMarbleValues = {
-        r: getJointLinkValue(mockScanResultLink)
+        r: getJointLinkValue(mockScanResultLink),
       };
       spyOn(jointGraphWrapper, "getJointLinkCellDeleteStream").and.returnValue(
         m.hot(deleteLinkMarbleString, deleteLinkMarbleValues)
@@ -438,7 +418,7 @@ describe("SyncTexeraModel", () => {
       jointGraphWrapper.getJointLinkCellDeleteStream().subscribe({
         complete: () => {
           expect(texeraGraph.getAllLinks().length).toEqual(0);
-        }
+        },
       });
     })
   );
@@ -464,7 +444,7 @@ describe("SyncTexeraModel", () => {
    */
   it(
     "should ignore JointJS link delete event of an incomplete link",
-    marbles((m) => {
+    marbles(m => {
       // add operators
       texeraGraph.addOperator(mockScanPredicate);
       texeraGraph.addOperator(mockResultPredicate);
@@ -472,7 +452,7 @@ describe("SyncTexeraModel", () => {
       // prepare add link (incomplete link)
       const addLinkMarbleString = "-----q-|";
       const addLinkMarbleValues = {
-        q: getIncompleteJointLink(mockScanResultLink)
+        q: getIncompleteJointLink(mockScanResultLink),
       };
       spyOn(jointGraphWrapper, "getJointLinkCellAddStream").and.returnValue(
         m.hot(addLinkMarbleString, addLinkMarbleValues)
@@ -481,7 +461,7 @@ describe("SyncTexeraModel", () => {
       // prepare delete link (incomplete link)
       const deleteLinkMarbleString = "-------r-|";
       const deleteLinkMarbleValues = {
-        r: getIncompleteJointLink(mockScanResultLink)
+        r: getIncompleteJointLink(mockScanResultLink),
       };
       spyOn(jointGraphWrapper, "getJointLinkCellDeleteStream").and.returnValue(
         m.hot(deleteLinkMarbleString, deleteLinkMarbleValues)
@@ -503,7 +483,7 @@ describe("SyncTexeraModel", () => {
       jointGraphWrapper.getJointLinkCellAddStream().subscribe({
         complete: () => {
           expect(texeraGraph.getAllLinks().length).toEqual(0);
-        }
+        },
       });
     })
   );
@@ -525,7 +505,7 @@ describe("SyncTexeraModel", () => {
    */
   it(
     "should delete the link when a link is detached from the target port",
-    marbles((m) => {
+    marbles(m => {
       // add operators
       texeraGraph.addOperator(mockScanPredicate);
       texeraGraph.addOperator(mockResultPredicate);
@@ -536,7 +516,7 @@ describe("SyncTexeraModel", () => {
       // prepare change link (link detached from target port)
       const changeLinkMarbleString = "-------q-|";
       const changeLinkMarbleValues = {
-        q: getIncompleteJointLink(mockScanResultLink)
+        q: getIncompleteJointLink(mockScanResultLink),
       };
       spyOn(jointGraphWrapper, "getJointLinkCellChangeStream").and.returnValue(
         m.hot(changeLinkMarbleString, changeLinkMarbleValues)
@@ -558,7 +538,7 @@ describe("SyncTexeraModel", () => {
       jointGraphWrapper.getJointLinkCellChangeStream().subscribe({
         complete: () => {
           expect(texeraGraph.getAllLinks().length).toEqual(0);
-        }
+        },
       });
     })
   );
@@ -584,7 +564,7 @@ describe("SyncTexeraModel", () => {
    */
   it(
     "should delete and then re-add the link if link target is changed from one port to another",
-    marbles((m) => {
+    marbles(m => {
       // add operators
       texeraGraph.addOperator(mockScanPredicate);
       texeraGraph.addOperator(mockSentimentPredicate);
@@ -593,7 +573,7 @@ describe("SyncTexeraModel", () => {
       // prepare add link
       const addLinkMarbleString = "-------p-|";
       const addLinkMarbleValues = {
-        p: getJointLinkValue(mockScanResultLink)
+        p: getJointLinkValue(mockScanResultLink),
       };
       spyOn(jointGraphWrapper, "getJointLinkCellAddStream").and.returnValue(
         m.hot(addLinkMarbleString, addLinkMarbleValues)
@@ -603,13 +583,13 @@ describe("SyncTexeraModel", () => {
       // but the link ID remains the same
       const mockChangedLink = {
         ...mockScanSentimentLink,
-        linkID: mockScanResultLink.linkID
+        linkID: mockScanResultLink.linkID,
       };
 
       // prepare change link (link detached from target port)
       const changeLinkMarbleString = "---------t-|";
       const changeLinkMarbleValues = {
-        t: getJointLinkValue(mockChangedLink)
+        t: getJointLinkValue(mockChangedLink),
       };
       spyOn(jointGraphWrapper, "getJointLinkCellChangeStream").and.returnValue(
         m.hot(changeLinkMarbleString, changeLinkMarbleValues)
@@ -631,22 +611,11 @@ describe("SyncTexeraModel", () => {
       jointGraphWrapper.getJointLinkCellChangeStream().subscribe({
         complete: () => {
           expect(texeraGraph.getAllLinks().length).toEqual(1);
-          expect(
-            texeraGraph.hasLinkWithID(mockChangedLink.linkID)
-          ).toBeTruthy();
-          expect(texeraGraph.getLinkWithID(mockChangedLink.linkID)).toEqual(
-            mockChangedLink
-          );
-          expect(
-            texeraGraph.hasLink(
-              mockScanResultLink.source,
-              mockScanResultLink.target
-            )
-          ).toBeFalsy();
-          expect(
-            texeraGraph.hasLink(mockChangedLink.source, mockChangedLink.target)
-          ).toBeTruthy();
-        }
+          expect(texeraGraph.hasLinkWithID(mockChangedLink.linkID)).toBeTruthy();
+          expect(texeraGraph.getLinkWithID(mockChangedLink.linkID)).toEqual(mockChangedLink);
+          expect(texeraGraph.hasLink(mockScanResultLink.source, mockScanResultLink.target)).toBeFalsy();
+          expect(texeraGraph.hasLink(mockChangedLink.source, mockChangedLink.target)).toBeTruthy();
+        },
       });
     })
   );
@@ -671,7 +640,7 @@ describe("SyncTexeraModel", () => {
    */
   it(
     "should remove then add link if link target port is detached then dragged around then re-attached",
-    marbles((m) => {
+    marbles(m => {
       // add operators
       texeraGraph.addOperator(mockScanPredicate);
       texeraGraph.addOperator(mockSentimentPredicate);
@@ -684,7 +653,7 @@ describe("SyncTexeraModel", () => {
       // but the link ID remains the same
       const mockChangedLink = {
         ...mockScanSentimentLink,
-        linkID: mockScanResultLink.linkID
+        linkID: mockScanResultLink.linkID,
       };
 
       // prepare change link (link detached from target port)
@@ -693,7 +662,7 @@ describe("SyncTexeraModel", () => {
         q: getIncompleteJointLink(mockScanResultLink),
         r: getIncompleteJointLink(mockScanResultLink),
         s: getIncompleteJointLink(mockScanResultLink),
-        t: getJointLinkValue(mockChangedLink)
+        t: getJointLinkValue(mockChangedLink),
       };
       spyOn(jointGraphWrapper, "getJointLinkCellChangeStream").and.returnValue(
         m.hot(changeLinkMarbleString, changeLinkMarbleValues)
@@ -715,23 +684,21 @@ describe("SyncTexeraModel", () => {
       jointGraphWrapper.getJointLinkCellChangeStream().subscribe({
         complete: () => {
           expect(texeraGraph.getAllLinks().length).toEqual(1);
-          expect(
-            texeraGraph.hasLink(mockChangedLink.source, mockChangedLink.target)
-          ).toBeTruthy();
-        }
+          expect(texeraGraph.hasLink(mockChangedLink.source, mockChangedLink.target)).toBeTruthy();
+        },
       });
 
       // assert link delete stream: delete original link
       const linkDeleteStream = texeraGraph.getLinkDeleteStream();
       const expectedDeleteStream = m.hot("---------q---", {
-        q: { deletedLink: mockScanResultLink }
+        q: { deletedLink: mockScanResultLink },
       });
       m.expect(linkDeleteStream).toBeObservable(expectedDeleteStream);
 
       // assert link add stream: changed link after its re-attached (original link is added synchronously in the begining)
       const linkAddStream = texeraGraph.getLinkAddStream();
       const expectedAddStream = m.hot("---------------t-", {
-        t: mockChangedLink
+        t: mockChangedLink,
       });
       m.expect(linkAddStream).toBeObservable(expectedAddStream);
     })
@@ -757,7 +724,7 @@ describe("SyncTexeraModel", () => {
    */
   it(
     "should remove an operator and its connected links when that operator is deleted from jointJS",
-    marbles((m) => {
+    marbles(m => {
       // add operators
       texeraGraph.addOperator(mockScanPredicate);
       texeraGraph.addOperator(mockSentimentPredicate);
@@ -770,12 +737,11 @@ describe("SyncTexeraModel", () => {
       // prepare the delete oprator event
       const deleteOperatorString = "---------d-|";
       const deleteOperatorValue = {
-        d: getJointOperatorValue(mockSentimentPredicate.operatorID)
+        d: getJointOperatorValue(mockSentimentPredicate.operatorID),
       };
-      spyOn(
-        jointGraphWrapper,
-        "getJointElementCellDeleteStream"
-      ).and.returnValue(m.hot(deleteOperatorString, deleteOperatorValue));
+      spyOn(jointGraphWrapper, "getJointElementCellDeleteStream").and.returnValue(
+        m.hot(deleteOperatorString, deleteOperatorValue)
+      );
 
       /**
        * once the operator is deleted, JointJS will automatically delete connected links
@@ -784,7 +750,7 @@ describe("SyncTexeraModel", () => {
       const deleteLinkString = "---------(gh)-|";
       const deleteLinkValue = {
         g: getJointLinkValue(mockScanSentimentLink),
-        h: getJointLinkValue(mockSentimentResultLink)
+        h: getJointLinkValue(mockSentimentResultLink),
       };
 
       spyOn(jointGraphWrapper, "getJointLinkCellDeleteStream").and.returnValue(
@@ -805,24 +771,14 @@ describe("SyncTexeraModel", () => {
       );
       jointGraphWrapper.getJointElementCellDeleteStream().subscribe({
         complete: () => {
-          expect(
-            texeraGraph.hasOperator(mockSentimentPredicate.operatorID)
-          ).toBeFalsy();
-          expect(
-            texeraGraph.hasOperator(mockScanPredicate.operatorID)
-          ).toBeTruthy();
-          expect(
-            texeraGraph.hasOperator(mockResultPredicate.operatorID)
-          ).toBeTruthy();
+          expect(texeraGraph.hasOperator(mockSentimentPredicate.operatorID)).toBeFalsy();
+          expect(texeraGraph.hasOperator(mockScanPredicate.operatorID)).toBeTruthy();
+          expect(texeraGraph.hasOperator(mockResultPredicate.operatorID)).toBeTruthy();
           expect(texeraGraph.getAllOperators().length).toEqual(2);
-          expect(
-            texeraGraph.hasLinkWithID(mockScanSentimentLink.linkID)
-          ).toBeFalsy();
-          expect(
-            texeraGraph.hasLinkWithID(mockSentimentResultLink.linkID)
-          ).toBeFalsy();
+          expect(texeraGraph.hasLinkWithID(mockScanSentimentLink.linkID)).toBeFalsy();
+          expect(texeraGraph.hasLinkWithID(mockSentimentResultLink.linkID)).toBeFalsy();
           expect(texeraGraph.getAllLinks().length).toEqual(0);
-        }
+        },
       });
     })
   );

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/sync-texera-model.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/sync-texera-model.ts
@@ -41,14 +41,10 @@ export class SyncTexeraModel {
     this.jointGraphWrapper
       .getJointElementCellDeleteStream()
       .pipe(
-        map((element) => element.id.toString()),
-        filter(
-          (elementID) =>
-            this.texeraGraph.hasOperator(elementID) &&
-            this.operatorGroup.getSyncTexeraGraph()
-        )
+        map(element => element.id.toString()),
+        filter(elementID => this.texeraGraph.hasOperator(elementID) && this.operatorGroup.getSyncTexeraGraph())
       )
-      .subscribe((elementID) => this.texeraGraph.deleteOperator(elementID));
+      .subscribe(elementID => this.texeraGraph.deleteOperator(elementID));
   }
 
   /**
@@ -79,14 +75,10 @@ export class SyncTexeraModel {
     this.jointGraphWrapper
       .getJointLinkCellAddStream()
       .pipe(
-        filter(
-          (link) =>
-            this.isValidJointLink(link) &&
-            this.operatorGroup.getSyncTexeraGraph()
-        ),
-        map((link) => SyncTexeraModel.getOperatorLink(link))
+        filter(link => this.isValidJointLink(link) && this.operatorGroup.getSyncTexeraGraph()),
+        map(link => SyncTexeraModel.getOperatorLink(link))
       )
-      .subscribe((link) => this.texeraGraph.addLink(link));
+      .subscribe(link => this.texeraGraph.addLink(link));
 
     /**
      * on link cell delete:
@@ -96,14 +88,10 @@ export class SyncTexeraModel {
     this.jointGraphWrapper
       .getJointLinkCellDeleteStream()
       .pipe(
-        filter(
-          (link) =>
-            this.isValidJointLink(link) &&
-            this.operatorGroup.getSyncTexeraGraph()
-        ),
-        map((link) => SyncTexeraModel.getOperatorLink(link))
+        filter(link => this.isValidJointLink(link) && this.operatorGroup.getSyncTexeraGraph()),
+        map(link => SyncTexeraModel.getOperatorLink(link))
       )
-      .subscribe((link) => this.texeraGraph.deleteLinkWithID(link.linkID));
+      .subscribe(link => this.texeraGraph.deleteLinkWithID(link.linkID));
 
     /**
      * on link cell change:
@@ -115,16 +103,16 @@ export class SyncTexeraModel {
       .pipe(
         filter(() => this.operatorGroup.getSyncTexeraGraph()),
         // we intentionally want the side effect (delete the link) to happen **before** other operations in the chain
-        tap((link) => {
+        tap(link => {
           const linkID = link.id.toString();
           if (this.texeraGraph.hasLinkWithID(linkID)) {
             this.texeraGraph.deleteLinkWithID(linkID);
           }
         }),
-        filter((link) => this.isValidJointLink(link)),
-        map((link) => SyncTexeraModel.getOperatorLink(link))
+        filter(link => this.isValidJointLink(link)),
+        map(link => SyncTexeraModel.getOperatorLink(link))
       )
-      .subscribe((link) => {
+      .subscribe(link => {
         this.texeraGraph.addLink(link);
       });
   }
@@ -142,27 +130,13 @@ export class SyncTexeraModel {
       jointLink.attributes.source &&
       jointLink.attributes.target &&
       jointLink.attributes.source.id &&
-      (jointLink.attributes.source.port ||
-        this.operatorGroup.hasGroup(
-          jointLink.attributes.source.id.toString()
-        )) &&
+      (jointLink.attributes.source.port || this.operatorGroup.hasGroup(jointLink.attributes.source.id.toString())) &&
       jointLink.attributes.target.id &&
-      (jointLink.attributes.target.port ||
-        this.operatorGroup.hasGroup(
-          jointLink.attributes.target.id.toString()
-        )) &&
-      (this.texeraGraph.hasOperator(
-        jointLink.attributes.source.id.toString()
-      ) ||
-        this.texeraGraph.hasOperator(
-          jointLink.attributes.target.id.toString()
-        ) ||
-        (this.operatorGroup.hasGroup(
-          jointLink.attributes.source.id.toString()
-        ) &&
-          this.operatorGroup.hasGroup(
-            jointLink.attributes.source.id.toString()
-          )))
+      (jointLink.attributes.target.port || this.operatorGroup.hasGroup(jointLink.attributes.target.id.toString())) &&
+      (this.texeraGraph.hasOperator(jointLink.attributes.source.id.toString()) ||
+        this.texeraGraph.hasOperator(jointLink.attributes.target.id.toString()) ||
+        (this.operatorGroup.hasGroup(jointLink.attributes.source.id.toString()) &&
+          this.operatorGroup.hasGroup(jointLink.attributes.source.id.toString())))
     );
     // the above two lines are causing unit test fail in sync-texera-model.spec.ts
     // since if operator is deleted first the link will become invalid and thus undeletable.
@@ -174,17 +148,12 @@ export class SyncTexeraModel {
    * @param jointLink
    */
   static getOperatorLink(jointLink: joint.dia.Link): OperatorLink {
-    type jointLinkEndpointType =
-      | { id: string; port: string }
-      | null
-      | undefined;
+    type jointLinkEndpointType = { id: string; port: string } | null | undefined;
 
     // the link should be a valid link (both source and target are connected to an operator)
     // isValidLink function is not reused because of Typescript strict null checking
-    const jointSourceElement: jointLinkEndpointType =
-      jointLink.attributes.source;
-    const jointTargetElement: jointLinkEndpointType =
-      jointLink.attributes.target;
+    const jointSourceElement: jointLinkEndpointType = jointLink.attributes.source;
+    const jointTargetElement: jointLinkEndpointType = jointLink.attributes.target;
 
     if (!jointSourceElement) {
       throw new Error("Invalid JointJS Link: no source element");
@@ -198,12 +167,12 @@ export class SyncTexeraModel {
       linkID: jointLink.id.toString(),
       source: {
         operatorID: jointSourceElement.id,
-        portID: jointSourceElement.port
+        portID: jointSourceElement.port,
       },
       target: {
         operatorID: jointTargetElement.id,
-        portID: jointTargetElement.port
-      }
+        portID: jointTargetElement.port,
+      },
     };
   }
 }

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.spec.ts
@@ -12,15 +12,12 @@ import {
   mockSentimentResultLink,
   mockFalseResultSentimentLink,
   mockFalseSentimentScanLink,
-  mockPoint
+  mockPoint,
 } from "./mock-workflow-data";
 import { TestBed, inject } from "@angular/core/testing";
 
 import { WorkflowActionService } from "./workflow-action.service";
-import {
-  OperatorPredicate,
-  Point
-} from "../../../types/workflow-common.interface";
+import { OperatorPredicate, Point } from "../../../types/workflow-common.interface";
 import { g } from "jointjs";
 import { environment } from "./../../../../../environments/environment";
 import { WorkflowUtilService } from "../util/workflow-util.service";
@@ -40,10 +37,10 @@ describe("WorkflowActionService", () => {
         UndoRedoService,
         {
           provide: OperatorMetadataService,
-          useClass: StubOperatorMetadataService
-        }
+          useClass: StubOperatorMetadataService,
+        },
       ],
-      imports: []
+      imports: [],
     });
     service = TestBed.inject(WorkflowActionService);
     undoRedo = TestBed.inject(UndoRedoService);
@@ -51,12 +48,9 @@ describe("WorkflowActionService", () => {
     jointGraph = (service as any).jointGraph;
   });
 
-  it("should be created", inject(
-    [WorkflowActionService],
-    (injectedService: WorkflowActionService) => {
-      expect(injectedService).toBeTruthy();
-    }
-  ));
+  it("should be created", inject([WorkflowActionService], (injectedService: WorkflowActionService) => {
+    expect(injectedService).toBeTruthy();
+  }));
 
   it("should add an operator to both jointjs and texera graph correctly", () => {
     service.addOperator(mockScanPredicate, mockPoint);
@@ -76,7 +70,7 @@ describe("WorkflowActionService", () => {
   it("should throw an error when adding an operator with invalid operator type", () => {
     const invalidOperator: OperatorPredicate = {
       ...mockScanPredicate,
-      operatorType: "invalidOperatorTypeForTesting"
+      operatorType: "invalidOperatorTypeForTesting",
     };
 
     expect(() => {
@@ -105,9 +99,7 @@ describe("WorkflowActionService", () => {
 
     service.addLink(mockScanResultLink);
 
-    expect(
-      texeraGraph.hasLink(mockScanResultLink.source, mockScanResultLink.target)
-    ).toBeTruthy();
+    expect(texeraGraph.hasLink(mockScanResultLink.source, mockScanResultLink.target)).toBeTruthy();
     expect(texeraGraph.hasLinkWithID(mockScanResultLink.linkID)).toBeTruthy();
     expect(jointGraph.getCell(mockScanResultLink.linkID)).toBeTruthy();
   });
@@ -124,7 +116,7 @@ describe("WorkflowActionService", () => {
 
     const sameLinkDifferentID = {
       ...mockScanResultLink,
-      linkID: "link-2"
+      linkID: "link-2",
     };
 
     // same link but different id already exist
@@ -165,9 +157,7 @@ describe("WorkflowActionService", () => {
     // test delete by link ID
     service.deleteLinkWithID(mockScanResultLink.linkID);
 
-    expect(
-      texeraGraph.hasLink(mockScanResultLink.source, mockScanResultLink.target)
-    ).toBeFalsy();
+    expect(texeraGraph.hasLink(mockScanResultLink.source, mockScanResultLink.target)).toBeFalsy();
     expect(texeraGraph.hasLinkWithID(mockScanResultLink.linkID)).toBeFalsy();
     expect(jointGraph.getCell(mockScanResultLink.linkID)).toBeFalsy();
   });
@@ -180,9 +170,7 @@ describe("WorkflowActionService", () => {
     // test delete by link source and target
     service.deleteLink(mockScanResultLink.source, mockScanResultLink.target);
 
-    expect(
-      texeraGraph.hasLink(mockScanResultLink.source, mockScanResultLink.target)
-    ).toBeFalsy();
+    expect(texeraGraph.hasLink(mockScanResultLink.source, mockScanResultLink.target)).toBeFalsy();
     expect(texeraGraph.hasLinkWithID(mockScanResultLink.linkID)).toBeFalsy();
     expect(jointGraph.getCell(mockScanResultLink.linkID)).toBeFalsy();
   });
@@ -247,12 +235,8 @@ describe("WorkflowActionService", () => {
     service.autoLayoutWorkflow();
 
     // test it's actually reformated
-    let sentimentOpPos = service
-      .getJointGraphWrapper()
-      .getElementPosition(mockSentimentPredicate.operatorID);
-    let resultOpPos = service
-      .getJointGraphWrapper()
-      .getElementPosition(mockResultPredicate.operatorID);
+    let sentimentOpPos = service.getJointGraphWrapper().getElementPosition(mockSentimentPredicate.operatorID);
+    let resultOpPos = service.getJointGraphWrapper().getElementPosition(mockResultPredicate.operatorID);
 
     expect(sentimentOpPos).not.toEqual(mockPoint);
     expect(resultOpPos).not.toEqual(mockPoint);
@@ -261,12 +245,8 @@ describe("WorkflowActionService", () => {
     expect(undoRedo.canUndo()).toBeTruthy();
 
     undoRedo.undoAction();
-    sentimentOpPos = service
-      .getJointGraphWrapper()
-      .getElementPosition(mockSentimentPredicate.operatorID);
-    resultOpPos = service
-      .getJointGraphWrapper()
-      .getElementPosition(mockResultPredicate.operatorID);
+    sentimentOpPos = service.getJointGraphWrapper().getElementPosition(mockSentimentPredicate.operatorID);
+    resultOpPos = service.getJointGraphWrapper().getElementPosition(mockResultPredicate.operatorID);
 
     expect(sentimentOpPos).toEqual(mockPoint);
     expect(resultOpPos).toEqual(mockPoint);
@@ -287,14 +267,10 @@ describe("WorkflowActionService", () => {
       service.addLink(mockScanResultLink);
       const mockBreakpoint = { count: 100 };
       service.setLinkBreakpoint(mockScanResultLink.linkID, mockBreakpoint);
-      expect(texeraGraph.getLinkBreakpoint(mockScanResultLink.linkID)).toEqual(
-        mockBreakpoint
-      );
+      expect(texeraGraph.getLinkBreakpoint(mockScanResultLink.linkID)).toEqual(mockBreakpoint);
 
       service.removeLinkBreakpoint(mockScanResultLink.linkID);
-      expect(
-        texeraGraph.getLinkBreakpoint(mockScanResultLink.linkID)
-      ).toBeUndefined();
+      expect(texeraGraph.getLinkBreakpoint(mockScanResultLink.linkID)).toBeUndefined();
     });
   });
 

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
@@ -11,7 +11,7 @@ import {
   OperatorLink,
   OperatorPort,
   OperatorPredicate,
-  Point
+  Point,
 } from "../../../types/workflow-common.interface";
 import { JointUIService } from "../../joint-ui/joint-ui.service";
 import { OperatorMetadataService } from "../../operator-metadata/operator-metadata.service";
@@ -59,7 +59,7 @@ type GroupInfo = {
  */
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class WorkflowActionService {
   private static readonly DEFAULT_WORKFLOW_NAME = "Untitled Workflow";
@@ -67,7 +67,7 @@ export class WorkflowActionService {
     name: WorkflowActionService.DEFAULT_WORKFLOW_NAME,
     wid: undefined,
     creationTime: undefined,
-    lastModifiedTime: undefined
+    lastModifiedTime: undefined,
   };
 
   private readonly texeraGraph: WorkflowGraph;
@@ -99,16 +99,8 @@ export class WorkflowActionService {
       this.workflowUtilService,
       this.jointUIService
     );
-    this.syncTexeraModel = new SyncTexeraModel(
-      this.texeraGraph,
-      this.jointGraphWrapper,
-      this.operatorGroup
-    );
-    this.syncOperatorGroup = new SyncOperatorGroup(
-      this.texeraGraph,
-      this.jointGraphWrapper,
-      this.operatorGroup
-    );
+    this.syncTexeraModel = new SyncTexeraModel(this.texeraGraph, this.jointGraphWrapper, this.operatorGroup);
+    this.syncOperatorGroup = new SyncOperatorGroup(this.texeraGraph, this.jointGraphWrapper, this.operatorGroup);
     this.workflowMetadata = WorkflowActionService.DEFAULT_WORKFLOW;
 
     this.handleJointLinkAdd();
@@ -141,12 +133,12 @@ export class WorkflowActionService {
     this.texeraGraph
       .getLinkAddStream()
       .pipe(filter(() => this.undoRedoService.listenJointCommand))
-      .subscribe((link) => {
+      .subscribe(link => {
         const command: Command = {
           modifiesWorkflow: true,
           execute: () => {},
           undo: () => this.deleteLinkWithIDInternal(link.linkID),
-          redo: () => this.addLinkInternal(link)
+          redo: () => this.addLinkInternal(link),
         };
         this.executeAndStoreCommand(command);
       });
@@ -167,7 +159,7 @@ export class WorkflowActionService {
         filter(() => !gotOldPosition),
         filter(() => this.undoRedoService.listenJointCommand)
       )
-      .subscribe((event) => {
+      .subscribe(event => {
         oldPosition = event.oldPosition;
         gotOldPosition = true;
         dragRoot = event.elementID;
@@ -178,91 +170,57 @@ export class WorkflowActionService {
       .getElementPositionChangeEvent()
       .pipe(
         filter(() => this.undoRedoService.listenJointCommand),
-        filter((value) => value.elementID === dragRoot),
+        filter(value => value.elementID === dragRoot),
         debounceTime(100) // emit only when no further events have occurred in 100ms
       )
-      .subscribe((event) => {
+      .subscribe(event => {
         gotOldPosition = false;
         const offsetX = event.newPosition.x - oldPosition.x;
         const offsetY = event.newPosition.y - oldPosition.y;
         // remember currently highlighted operators and groups
-        const currentHighlightedOperators = new Set(
-          this.jointGraphWrapper.getCurrentHighlightedOperatorIDs().slice()
-        );
-        const currentHighlightedGroups = this.jointGraphWrapper
-          .getCurrentHighlightedGroupIDs()
-          .slice();
+        const currentHighlightedOperators = new Set(this.jointGraphWrapper.getCurrentHighlightedOperatorIDs().slice());
+        const currentHighlightedGroups = this.jointGraphWrapper.getCurrentHighlightedGroupIDs().slice();
 
         // un-remember child operators of groups (they will move with the group's movement, so we must avoid moving them twice)
-        currentHighlightedGroups.forEach((groupID) => {
-          this.operatorGroup
-            .getGroup(groupID)
-            .operators.forEach((operatorInfo, operatorID) => {
-              currentHighlightedOperators.delete(operatorID);
-            });
+        currentHighlightedGroups.forEach(groupID => {
+          this.operatorGroup.getGroup(groupID).operators.forEach((operatorInfo, operatorID) => {
+            currentHighlightedOperators.delete(operatorID);
+          });
         });
 
         const command: Command = {
           modifiesWorkflow: false,
           execute: () => {},
           undo: () => {
-            this.jointGraphWrapper.unhighlightOperators(
-              ...this.jointGraphWrapper.getCurrentHighlightedOperatorIDs()
-            );
-            this.jointGraphWrapper.unhighlightGroups(
-              ...this.jointGraphWrapper.getCurrentHighlightedGroupIDs()
-            );
+            this.jointGraphWrapper.unhighlightOperators(...this.jointGraphWrapper.getCurrentHighlightedOperatorIDs());
+            this.jointGraphWrapper.unhighlightGroups(...this.jointGraphWrapper.getCurrentHighlightedGroupIDs());
             this.jointGraphWrapper.setMultiSelectMode(
-              currentHighlightedOperators.size +
-                currentHighlightedGroups.length >
-                1
+              currentHighlightedOperators.size + currentHighlightedGroups.length > 1
             );
-            currentHighlightedOperators.forEach((operatorID) => {
+            currentHighlightedOperators.forEach(operatorID => {
               this.jointGraphWrapper.highlightOperators(operatorID);
-              this.jointGraphWrapper.setElementPosition(
-                operatorID,
-                -offsetX,
-                -offsetY
-              );
+              this.jointGraphWrapper.setElementPosition(operatorID, -offsetX, -offsetY);
             });
-            currentHighlightedGroups.forEach((groupID) => {
+            currentHighlightedGroups.forEach(groupID => {
               this.jointGraphWrapper.highlightGroups(groupID);
-              this.jointGraphWrapper.setElementPosition(
-                groupID,
-                -offsetX,
-                -offsetY
-              );
+              this.jointGraphWrapper.setElementPosition(groupID, -offsetX, -offsetY);
             });
           },
           redo: () => {
-            this.jointGraphWrapper.unhighlightOperators(
-              ...this.jointGraphWrapper.getCurrentHighlightedOperatorIDs()
-            );
-            this.jointGraphWrapper.unhighlightGroups(
-              ...this.jointGraphWrapper.getCurrentHighlightedGroupIDs()
-            );
+            this.jointGraphWrapper.unhighlightOperators(...this.jointGraphWrapper.getCurrentHighlightedOperatorIDs());
+            this.jointGraphWrapper.unhighlightGroups(...this.jointGraphWrapper.getCurrentHighlightedGroupIDs());
             this.jointGraphWrapper.setMultiSelectMode(
-              currentHighlightedOperators.size +
-                currentHighlightedGroups.length >
-                1
+              currentHighlightedOperators.size + currentHighlightedGroups.length > 1
             );
-            currentHighlightedOperators.forEach((operatorID) => {
+            currentHighlightedOperators.forEach(operatorID => {
               this.jointGraphWrapper.highlightOperators(operatorID);
-              this.jointGraphWrapper.setElementPosition(
-                operatorID,
-                offsetX,
-                offsetY
-              );
+              this.jointGraphWrapper.setElementPosition(operatorID, offsetX, offsetY);
             });
-            currentHighlightedGroups.forEach((groupID) => {
+            currentHighlightedGroups.forEach(groupID => {
               this.jointGraphWrapper.highlightGroups(groupID);
-              this.jointGraphWrapper.setElementPosition(
-                groupID,
-                offsetX,
-                offsetY
-              );
+              this.jointGraphWrapper.setElementPosition(groupID, offsetX, offsetY);
             });
-          }
+          },
         };
         this.executeAndStoreCommand(command);
       });
@@ -286,60 +244,34 @@ export class WorkflowActionService {
         filter(() => this.jointGraphWrapper.getListenPositionChange()),
         filter(() => this.undoRedoService.listenJointCommand),
         filter(
-          (movedElement) =>
-            this.jointGraphWrapper
-              .getCurrentHighlightedOperatorIDs()
-              .includes(movedElement.elementID) ||
-            this.jointGraphWrapper
-              .getCurrentHighlightedGroupIDs()
-              .includes(movedElement.elementID)
+          movedElement =>
+            this.jointGraphWrapper.getCurrentHighlightedOperatorIDs().includes(movedElement.elementID) ||
+            this.jointGraphWrapper.getCurrentHighlightedGroupIDs().includes(movedElement.elementID)
         )
       )
-      .subscribe((movedElement) => {
-        const selectedElements = this.jointGraphWrapper
-          .getCurrentHighlightedGroupIDs()
-          .slice(); // operators added to this list later
-        const movedGroup = this.operatorGroup.getGroupByOperator(
-          movedElement.elementID
-        );
+      .subscribe(movedElement => {
+        const selectedElements = this.jointGraphWrapper.getCurrentHighlightedGroupIDs().slice(); // operators added to this list later
+        const movedGroup = this.operatorGroup.getGroupByOperator(movedElement.elementID);
 
         if (movedGroup && selectedElements.includes(movedGroup.groupID)) {
-          movedGroup.operators.forEach((operatorInfo, operatorID) =>
-            selectedElements.push(operatorID)
-          );
-          selectedElements.splice(
-            selectedElements.indexOf(movedGroup.groupID),
-            1
-          );
+          movedGroup.operators.forEach((operatorInfo, operatorID) => selectedElements.push(operatorID));
+          selectedElements.splice(selectedElements.indexOf(movedGroup.groupID), 1);
         }
-        this.jointGraphWrapper
-          .getCurrentHighlightedOperatorIDs()
-          .forEach((operatorID) => {
-            const group = this.operatorGroup.getGroupByOperator(operatorID);
-            // operators move with their groups,
-            // do not add elements that are in a group that will also be moved
-            if (
-              !group ||
-              !this.jointGraphWrapper
-                .getCurrentHighlightedGroupIDs()
-                .includes(group.groupID)
-            ) {
-              selectedElements.push(operatorID);
-            }
-          });
+        this.jointGraphWrapper.getCurrentHighlightedOperatorIDs().forEach(operatorID => {
+          const group = this.operatorGroup.getGroupByOperator(operatorID);
+          // operators move with their groups,
+          // do not add elements that are in a group that will also be moved
+          if (!group || !this.jointGraphWrapper.getCurrentHighlightedGroupIDs().includes(group.groupID)) {
+            selectedElements.push(operatorID);
+          }
+        });
         const offsetX = movedElement.newPosition.x - movedElement.oldPosition.x;
         const offsetY = movedElement.newPosition.y - movedElement.oldPosition.y;
         this.jointGraphWrapper.setListenPositionChange(false);
         this.undoRedoService.setListenJointCommand(false);
         selectedElements
-          .filter((elementID) => elementID !== movedElement.elementID)
-          .forEach((elementID) =>
-            this.jointGraphWrapper.setElementPosition(
-              elementID,
-              offsetX,
-              offsetY
-            )
-          );
+          .filter(elementID => elementID !== movedElement.elementID)
+          .forEach(elementID => this.jointGraphWrapper.setElementPosition(elementID, offsetX, offsetY));
         this.jointGraphWrapper.setListenPositionChange(true);
         this.undoRedoService.setListenJointCommand(true);
       });
@@ -401,17 +333,12 @@ export class WorkflowActionService {
         // remove the operator from JointJS
         this.deleteOperatorInternal(operator.operatorID);
         // restore previous highlights
-        this.jointGraphWrapper.unhighlightElements(
-          this.jointGraphWrapper.getCurrentHighlights()
-        );
+        this.jointGraphWrapper.unhighlightElements(this.jointGraphWrapper.getCurrentHighlights());
         this.jointGraphWrapper.setMultiSelectMode(
-          currentHighlights.operators.length +
-            currentHighlights.groups.length +
-            currentHighlights.links.length >
-            1
+          currentHighlights.operators.length + currentHighlights.groups.length + currentHighlights.links.length > 1
         );
         this.jointGraphWrapper.highlightElements(currentHighlights);
-      }
+      },
     };
     this.executeAndStoreCommand(command);
   }
@@ -423,43 +350,24 @@ export class WorkflowActionService {
    */
   public deleteOperator(operatorID: string): void {
     const operator = this.getTexeraGraph().getOperator(operatorID);
-    const position =
-      this.getOperatorGroup().getOperatorPositionByGroup(operatorID);
+    const position = this.getOperatorGroup().getOperatorPositionByGroup(operatorID);
     const layer = this.getOperatorGroup().getOperatorLayerByGroup(operatorID);
 
     const linksToDelete = new Map<OperatorLink, number>();
     this.getTexeraGraph()
       .getAllLinks()
-      .filter(
-        (link) =>
-          link.source.operatorID === operatorID ||
-          link.target.operatorID === operatorID
-      )
-      .forEach((link) =>
-        linksToDelete.set(
-          link,
-          this.getOperatorGroup().getLinkLayerByGroup(link.linkID)
-        )
-      );
+      .filter(link => link.source.operatorID === operatorID || link.target.operatorID === operatorID)
+      .forEach(link => linksToDelete.set(link, this.getOperatorGroup().getLinkLayerByGroup(link.linkID)));
 
-    const group = cloneDeep(
-      this.getOperatorGroup().getGroupByOperator(operatorID)
-    );
-    const groupLayer = group
-      ? this.getJointGraphWrapper().getCellLayer(group.groupID)
-      : undefined;
+    const group = cloneDeep(this.getOperatorGroup().getGroupByOperator(operatorID));
+    const groupLayer = group ? this.getJointGraphWrapper().getCellLayer(group.groupID) : undefined;
 
     const command: Command = {
       modifiesWorkflow: true,
       execute: () => {
-        linksToDelete.forEach((linkLayer, link) =>
-          this.deleteLinkWithIDInternal(link.linkID)
-        );
+        linksToDelete.forEach((linkLayer, link) => this.deleteLinkWithIDInternal(link.linkID));
         this.deleteOperatorInternal(operatorID);
-        if (
-          group &&
-          this.getOperatorGroup().getGroup(group.groupID).operators.size < 2
-        ) {
+        if (group && this.getOperatorGroup().getGroup(group.groupID).operators.size < 2) {
           this.unGroupInternal(group.groupID);
         }
       },
@@ -481,7 +389,7 @@ export class WorkflowActionService {
           this.getJointGraphWrapper().setMultiSelectMode(false);
           this.getJointGraphWrapper().highlightOperators(operatorID);
         }
-      }
+      },
     };
     this.executeAndStoreCommand(command);
   }
@@ -505,66 +413,50 @@ export class WorkflowActionService {
       execute: () => {
         // unhighlight previous highlights
         this.jointGraphWrapper.unhighlightElements(currentHighlights);
-        this.jointGraphWrapper.setMultiSelectMode(
-          operatorsAndPositions.length > 1
-        );
-        operatorsAndPositions.forEach((o) => {
+        this.jointGraphWrapper.setMultiSelectMode(operatorsAndPositions.length > 1);
+        operatorsAndPositions.forEach(o => {
           this.addOperatorInternal(o.op, o.pos);
           this.jointGraphWrapper.highlightOperators(o.op.operatorID);
         });
         if (links) {
-          links.forEach((l) => this.addLinkInternal(l));
+          links.forEach(l => this.addLinkInternal(l));
           if (breakpoints !== undefined) {
-            breakpoints.forEach((breakpoint, linkID) =>
-              this.setLinkBreakpointInternal(linkID, breakpoint)
-            );
+            breakpoints.forEach((breakpoint, linkID) => this.setLinkBreakpointInternal(linkID, breakpoint));
           }
         }
 
         if (groups) {
-          groups.forEach((group) => {
+          groups.forEach(group => {
             // make a copy, because groups can be mutated after being given to operatorGroup (deletion for example)
             const groupCopy = cloneDeep(group);
             this.addGroupInternal(groupCopy);
-            this.operatorGroup.moveGroupToLayer(
-              groupCopy,
-              this.operatorGroup.getHighestLayer() + 1
-            );
+            this.operatorGroup.moveGroupToLayer(groupCopy, this.operatorGroup.getHighestLayer() + 1);
           });
         }
       },
       undo: () => {
         if (groups) {
-          groups.forEach((group) => {
+          groups.forEach(group => {
             this.unGroupInternal(group.groupID);
           });
         }
 
         // remove links
         if (links) {
-          links.forEach((l) => this.deleteLinkWithIDInternal(l.linkID));
+          links.forEach(l => this.deleteLinkWithIDInternal(l.linkID));
         }
         // remove the operators from JointJS
-        operatorsAndPositions.forEach((o) =>
-          this.deleteOperatorInternal(o.op.operatorID)
-        );
+        operatorsAndPositions.forEach(o => this.deleteOperatorInternal(o.op.operatorID));
         if (breakpoints !== undefined) {
-          breakpoints.forEach((breakpoint, linkID) =>
-            this.setLinkBreakpointInternal(linkID, undefined)
-          );
+          breakpoints.forEach((breakpoint, linkID) => this.setLinkBreakpointInternal(linkID, undefined));
         }
         // restore previous highlights
-        this.jointGraphWrapper.unhighlightElements(
-          this.jointGraphWrapper.getCurrentHighlights()
-        );
+        this.jointGraphWrapper.unhighlightElements(this.jointGraphWrapper.getCurrentHighlights());
         this.jointGraphWrapper.setMultiSelectMode(
-          currentHighlights.operators.length +
-            currentHighlights.groups.length +
-            currentHighlights.links.length >
-            1
+          currentHighlights.operators.length + currentHighlights.groups.length + currentHighlights.links.length > 1
         );
         this.jointGraphWrapper.highlightElements(currentHighlights);
-      }
+      },
     };
     this.executeAndStoreCommand(command);
   }
@@ -583,26 +475,22 @@ export class WorkflowActionService {
     const operatorIDsCopy = Array.from(
       new Set(
         operatorIDs.concat(
-          (groupIDs ?? []).flatMap((groupID) =>
-            Array.from(
-              this.operatorGroup.getGroup(groupID).operators.values()
-            ).map((operatorInfo) => operatorInfo.operator.operatorID)
+          (groupIDs ?? []).flatMap(groupID =>
+            Array.from(this.operatorGroup.getGroup(groupID).operators.values()).map(
+              operatorInfo => operatorInfo.operator.operatorID
+            )
           )
         )
       )
     );
 
     // save operators to be deleted and their current positions
-    const operatorsAndPositions = new Map<
-      OperatorPredicate,
-      OperatorPosition
-    >();
+    const operatorsAndPositions = new Map<OperatorPredicate, OperatorPosition>();
 
-    operatorIDsCopy.forEach((operatorID) =>
+    operatorIDsCopy.forEach(operatorID =>
       operatorsAndPositions.set(this.getTexeraGraph().getOperator(operatorID), {
-        position:
-          this.getOperatorGroup().getOperatorPositionByGroup(operatorID),
-        layer: this.getOperatorGroup().getOperatorLayerByGroup(operatorID)
+        position: this.getOperatorGroup().getOperatorPositionByGroup(operatorID),
+        layer: this.getOperatorGroup().getOperatorLayerByGroup(operatorID),
       })
     );
 
@@ -610,38 +498,24 @@ export class WorkflowActionService {
     const linksToDelete = new Map<OperatorLink, number>();
     // delete links required by this command
     linkIDs
-      .map((linkID) => this.getTexeraGraph().getLinkWithID(linkID))
-      .forEach((link) =>
-        linksToDelete.set(
-          link,
-          this.getOperatorGroup().getLinkLayerByGroup(link.linkID)
-        )
-      );
+      .map(linkID => this.getTexeraGraph().getLinkWithID(linkID))
+      .forEach(link => linksToDelete.set(link, this.getOperatorGroup().getLinkLayerByGroup(link.linkID)));
     // delete links related to the deleted operator
     this.getTexeraGraph()
       .getAllLinks()
       .filter(
-        (link) =>
-          operatorIDsCopy.includes(link.source.operatorID) ||
-          operatorIDsCopy.includes(link.target.operatorID)
+        link => operatorIDsCopy.includes(link.source.operatorID) || operatorIDsCopy.includes(link.target.operatorID)
       )
-      .forEach((link) =>
-        linksToDelete.set(
-          link,
-          this.getOperatorGroup().getLinkLayerByGroup(link.linkID)
-        )
-      );
+      .forEach(link => linksToDelete.set(link, this.getOperatorGroup().getLinkLayerByGroup(link.linkID)));
 
     // save groups that deleted operators reside in
     const groups = new Map<string, GroupInfo>();
-    operatorIDsCopy.forEach((operatorID) => {
-      const group = cloneDeep(
-        this.getOperatorGroup().getGroupByOperator(operatorID)
-      );
+    operatorIDsCopy.forEach(operatorID => {
+      const group = cloneDeep(this.getOperatorGroup().getGroupByOperator(operatorID));
       if (group) {
         groups.set(operatorID, {
           group,
-          layer: this.getJointGraphWrapper().getCellLayer(group.groupID)
+          layer: this.getJointGraphWrapper().getCellLayer(group.groupID),
         });
       }
     });
@@ -652,21 +526,18 @@ export class WorkflowActionService {
     const command: Command = {
       modifiesWorkflow: true,
       execute: () => {
-        (groupIDs ?? []).forEach((groupID) => {
+        (groupIDs ?? []).forEach(groupID => {
           this.unGroupInternal(groupID);
         });
-        linksToDelete.forEach((layer, link) =>
-          this.deleteLinkWithIDInternal(link.linkID)
-        );
-        operatorIDsCopy.forEach((operatorID) => {
+        linksToDelete.forEach((layer, link) => this.deleteLinkWithIDInternal(link.linkID));
+        operatorIDsCopy.forEach(operatorID => {
           this.deleteOperatorInternal(operatorID);
           // if the group has less than 2 operators left, delete the group
           const groupInfo = groups.get(operatorID);
           if (
             groupInfo &&
             this.getOperatorGroup().hasGroup(groupInfo.group.groupID) &&
-            this.getOperatorGroup().getGroup(groupInfo.group.groupID).operators
-              .size < 2
+            this.getOperatorGroup().getGroup(groupInfo.group.groupID).operators.size < 2
           ) {
             this.unGroupInternal(groupInfo.group.groupID);
           }
@@ -675,20 +546,11 @@ export class WorkflowActionService {
       undo: () => {
         operatorsAndPositions.forEach((pos, operator) => {
           this.addOperatorInternal(operator, pos.position);
-          this.getJointGraphWrapper().setCellLayer(
-            operator.operatorID,
-            pos.layer
-          );
+          this.getJointGraphWrapper().setCellLayer(operator.operatorID, pos.layer);
           // if the group still exists, add the operator back to the group
           const groupInfo = groups.get(operator.operatorID);
-          if (
-            groupInfo &&
-            this.getOperatorGroup().hasGroup(groupInfo.group.groupID)
-          ) {
-            this.getOperatorGroup().addOperatorToGroup(
-              operator.operatorID,
-              groupInfo.group.groupID
-            );
+          if (groupInfo && this.getOperatorGroup().hasGroup(groupInfo.group.groupID)) {
+            this.getOperatorGroup().addOperatorToGroup(operator.operatorID, groupInfo.group.groupID);
           }
         });
         linksToDelete.forEach((layer, link) => {
@@ -705,27 +567,19 @@ export class WorkflowActionService {
           }
         });
         // add back groups that were deleted when deleting operators
-        groups.forEach((groupInfo) => {
+        groups.forEach(groupInfo => {
           if (!this.getOperatorGroup().hasGroup(groupInfo.group.groupID)) {
             this.addGroupInternal(cloneDeep(groupInfo.group));
-            this.getJointGraphWrapper().setCellLayer(
-              groupInfo.group.groupID,
-              groupInfo.layer
-            );
+            this.getJointGraphWrapper().setCellLayer(groupInfo.group.groupID, groupInfo.layer);
           }
         });
         // restore previous highlights
-        this.jointGraphWrapper.unhighlightElements(
-          this.jointGraphWrapper.getCurrentHighlights()
-        );
+        this.jointGraphWrapper.unhighlightElements(this.jointGraphWrapper.getCurrentHighlights());
         this.jointGraphWrapper.setMultiSelectMode(
-          currentHighlights.operators.length +
-            currentHighlights.groups.length +
-            currentHighlights.links.length >
-            1
+          currentHighlights.operators.length + currentHighlights.groups.length + currentHighlights.links.length > 1
         );
         this.jointGraphWrapper.highlightElements(currentHighlights);
-      }
+      },
     };
 
     this.executeAndStoreCommand(command);
@@ -743,9 +597,7 @@ export class WorkflowActionService {
     this.texeraGraph
       .getAllOperators()
       .forEach(
-        (op) =>
-          (operatorPositions[op.operatorID] =
-            this.getJointGraphWrapper().getElementPosition(op.operatorID))
+        op => (operatorPositions[op.operatorID] = this.getJointGraphWrapper().getElementPosition(op.operatorID))
       );
     const command: Command = {
       modifiesWorkflow: false,
@@ -753,14 +605,10 @@ export class WorkflowActionService {
         this.jointGraphWrapper.autoLayoutJoint();
       },
       undo: () => {
-        Object.entries(operatorPositions).forEach((opPosition) => {
-          this.jointGraphWrapper.setAbsolutePosition(
-            opPosition[0],
-            opPosition[1].x,
-            opPosition[1].y
-          );
+        Object.entries(operatorPositions).forEach(opPosition => {
+          this.jointGraphWrapper.setAbsolutePosition(opPosition[0], opPosition[1].x, opPosition[1].y);
         });
-      }
+      },
     };
     this.executeAndStoreCommand(command);
   }
@@ -774,7 +622,7 @@ export class WorkflowActionService {
     const command: Command = {
       modifiesWorkflow: true,
       execute: () => this.addLinkInternal(link),
-      undo: () => this.deleteLinkWithIDInternal(link.linkID)
+      undo: () => this.deleteLinkWithIDInternal(link.linkID),
     };
     this.executeAndStoreCommand(command);
   }
@@ -801,7 +649,7 @@ export class WorkflowActionService {
         } else {
           this.getJointGraphWrapper().setCellLayer(linkID, layer);
         }
-      }
+      },
     };
     this.executeAndStoreCommand(command);
   }
@@ -819,21 +667,18 @@ export class WorkflowActionService {
     const command: Command = {
       modifiesWorkflow: false,
       execute: () => {
-        groups.forEach((group) => {
+        groups.forEach(group => {
           // make a copy, because groups can be mutated after being given to operatorGroup (deletion for example)
           const groupCopy = cloneDeep(group);
           this.addGroupInternal(groupCopy);
-          this.operatorGroup.moveGroupToLayer(
-            groupCopy,
-            this.operatorGroup.getHighestLayer() + 1
-          );
+          this.operatorGroup.moveGroupToLayer(groupCopy, this.operatorGroup.getHighestLayer() + 1);
         });
       },
       undo: () => {
-        groups.forEach((group) => {
+        groups.forEach(group => {
           this.unGroupInternal(group.groupID);
         });
-      }
+      },
     };
     this.executeAndStoreCommand(command);
   }
@@ -843,25 +688,19 @@ export class WorkflowActionService {
    * @param groupIDs
    */
   public unGroupGroups(...groupIDs: readonly string[]): void {
-    const groups = groupIDs.map((groupID) =>
-      cloneDeep(this.operatorGroup.getGroup(groupID))
-    );
+    const groups = groupIDs.map(groupID => cloneDeep(this.operatorGroup.getGroup(groupID)));
 
     const command: Command = {
       modifiesWorkflow: false,
-      execute: () =>
-        groupIDs.forEach((groupID) => this.unGroupInternal(groupID)),
+      execute: () => groupIDs.forEach(groupID => this.unGroupInternal(groupID)),
       undo: () => {
-        groups.forEach((group) => {
+        groups.forEach(group => {
           // make a copy, because groups can be mutated after being given to operatorGroup (deletion for example)
           const groupCopy = cloneDeep(group);
           this.addGroupInternal(groupCopy);
-          this.operatorGroup.moveGroupToLayer(
-            groupCopy,
-            this.operatorGroup.getHighestLayer() + 1
-          );
+          this.operatorGroup.moveGroupToLayer(groupCopy, this.operatorGroup.getHighestLayer() + 1);
         });
-      }
+      },
     };
     this.executeAndStoreCommand(command);
   }
@@ -873,10 +712,8 @@ export class WorkflowActionService {
   public collapseGroups(...groupIDs: readonly string[]): void {
     const command: Command = {
       modifiesWorkflow: false,
-      execute: () =>
-        groupIDs.forEach((groupID) => this.collapseGroupInternal(groupID)),
-      undo: () =>
-        groupIDs.forEach((groupID) => this.expandGroupInternal(groupID))
+      execute: () => groupIDs.forEach(groupID => this.collapseGroupInternal(groupID)),
+      undo: () => groupIDs.forEach(groupID => this.expandGroupInternal(groupID)),
     };
     this.executeAndStoreCommand(command);
   }
@@ -888,10 +725,8 @@ export class WorkflowActionService {
   public expandGroups(...groupIDs: string[]): void {
     const command: Command = {
       modifiesWorkflow: false,
-      execute: () =>
-        groupIDs.forEach((groupID) => this.expandGroupInternal(groupID)),
-      undo: () =>
-        groupIDs.forEach((groupID) => this.collapseGroupInternal(groupID))
+      execute: () => groupIDs.forEach(groupID => this.expandGroupInternal(groupID)),
+      undo: () => groupIDs.forEach(groupID => this.collapseGroupInternal(groupID)),
     };
     this.executeAndStoreCommand(command);
   }
@@ -904,69 +739,43 @@ export class WorkflowActionService {
     // save all explicitly deleted group operators and links
     // this is necessary because deleteGroupAndOperatorsInternal deletes operators and links,
     // trying to add back a group whose operators are gone will cause an error (referencing a deleted operator)
-    const operators = groupIDs.map((groupID) =>
-      Array.from(this.operatorGroup.getGroup(groupID).operators.values())
+    const operators = groupIDs.map(groupID => Array.from(this.operatorGroup.getGroup(groupID).operators.values()));
+    const links = groupIDs.map(groupID => Array.from(this.operatorGroup.getGroup(groupID).links.values()));
+    const inLinks = groupIDs.map(groupID =>
+      this.operatorGroup.getGroup(groupID).inLinks.map(linkID => this.texeraGraph.getLinkWithID(linkID))
     );
-    const links = groupIDs.map((groupID) =>
-      Array.from(this.operatorGroup.getGroup(groupID).links.values())
-    );
-    const inLinks = groupIDs.map((groupID) =>
-      this.operatorGroup
-        .getGroup(groupID)
-        .inLinks.map((linkID) => this.texeraGraph.getLinkWithID(linkID))
-    );
-    const outLinks = groupIDs.map((groupID) =>
-      this.operatorGroup
-        .getGroup(groupID)
-        .outLinks.map((linkID) => this.texeraGraph.getLinkWithID(linkID))
+    const outLinks = groupIDs.map(groupID =>
+      this.operatorGroup.getGroup(groupID).outLinks.map(linkID => this.texeraGraph.getLinkWithID(linkID))
     );
 
     const command: Command = {
       modifiesWorkflow: true,
-      execute: () =>
-        groupIDs.forEach((groupID) =>
-          this.deleteGroupAndOperatorsInternal(groupID)
-        ),
+      execute: () => groupIDs.forEach(groupID => this.deleteGroupAndOperatorsInternal(groupID)),
       undo: () => {
         for (let i = 0; i < groupIDs.length; i++) {
           // add back operators and links of deleted groups
-          operators[i].forEach((operatorInfo) =>
-            this.addOperatorInternal(
-              operatorInfo.operator,
-              operatorInfo.position
-            )
-          );
-          links[i].forEach((linkInfo) => this.addLinkInternal(linkInfo.link));
-          inLinks[i].forEach((operatorLink) =>
-            this.addLinkInternal(operatorLink)
-          );
-          outLinks[i].forEach((operatorLink) =>
-            this.addLinkInternal(operatorLink)
-          );
+          operators[i].forEach(operatorInfo => this.addOperatorInternal(operatorInfo.operator, operatorInfo.position));
+          links[i].forEach(linkInfo => this.addLinkInternal(linkInfo.link));
+          inLinks[i].forEach(operatorLink => this.addLinkInternal(operatorLink));
+          outLinks[i].forEach(operatorLink => this.addLinkInternal(operatorLink));
 
           // re-create group with same operators and ID
           const recreatedGroup = this.operatorGroup.getNewGroup(
-            operators[i].map(
-              (operatorInfo) => operatorInfo.operator.operatorID
-            ),
+            operators[i].map(operatorInfo => operatorInfo.operator.operatorID),
             groupIDs[i]
           );
 
           // add back group as if normal
           this.addGroupInternal(recreatedGroup);
-          this.operatorGroup.moveGroupToLayer(
-            recreatedGroup,
-            this.operatorGroup.getHighestLayer() + 1
-          );
+          this.operatorGroup.moveGroupToLayer(recreatedGroup, this.operatorGroup.getHighestLayer() + 1);
         }
-      }
+      },
     };
     this.executeAndStoreCommand(command);
   }
 
   public setOperatorProperty(operatorID: string, newProperty: object): void {
-    const prevProperty =
-      this.getTexeraGraph().getOperator(operatorID).operatorProperties;
+    const prevProperty = this.getTexeraGraph().getOperator(operatorID).operatorProperties;
     const group = this.getOperatorGroup().getGroupByOperator(operatorID);
     const command: Command = {
       modifiesWorkflow: true,
@@ -974,54 +783,30 @@ export class WorkflowActionService {
         this.setOperatorPropertyInternal(operatorID, newProperty);
 
         // unhighlight everything but the operator being modified
-        const currentHighlightedOperators = <string[]>(
-          this.jointGraphWrapper.getCurrentHighlightedOperatorIDs().slice()
-        );
-        if (
-          (!group || !group.collapsed) &&
-          !currentHighlightedOperators.includes(operatorID)
-        ) {
+        const currentHighlightedOperators = <string[]>this.jointGraphWrapper.getCurrentHighlightedOperatorIDs().slice();
+        if ((!group || !group.collapsed) && !currentHighlightedOperators.includes(operatorID)) {
           this.jointGraphWrapper.setMultiSelectMode(false);
           this.jointGraphWrapper.highlightOperators(operatorID);
         } else if (!group || !group.collapsed) {
-          currentHighlightedOperators.splice(
-            currentHighlightedOperators.indexOf(operatorID),
-            1
-          );
-          this.jointGraphWrapper.unhighlightOperators(
-            ...currentHighlightedOperators
-          );
-          this.jointGraphWrapper.unhighlightGroups(
-            ...this.jointGraphWrapper.getCurrentHighlightedGroupIDs()
-          );
+          currentHighlightedOperators.splice(currentHighlightedOperators.indexOf(operatorID), 1);
+          this.jointGraphWrapper.unhighlightOperators(...currentHighlightedOperators);
+          this.jointGraphWrapper.unhighlightGroups(...this.jointGraphWrapper.getCurrentHighlightedGroupIDs());
         }
       },
       undo: () => {
         this.setOperatorPropertyInternal(operatorID, prevProperty);
 
         // unhighlight everything but the operator being modified
-        const currentHighlightedOperators = <string[]>(
-          this.jointGraphWrapper.getCurrentHighlightedOperatorIDs().slice()
-        );
-        if (
-          (!group || !group.collapsed) &&
-          !currentHighlightedOperators.includes(operatorID)
-        ) {
+        const currentHighlightedOperators = <string[]>this.jointGraphWrapper.getCurrentHighlightedOperatorIDs().slice();
+        if ((!group || !group.collapsed) && !currentHighlightedOperators.includes(operatorID)) {
           this.jointGraphWrapper.setMultiSelectMode(false);
           this.jointGraphWrapper.highlightOperators(operatorID);
         } else if (!group || !group.collapsed) {
-          currentHighlightedOperators.splice(
-            currentHighlightedOperators.indexOf(operatorID),
-            1
-          );
-          this.jointGraphWrapper.unhighlightOperators(
-            ...currentHighlightedOperators
-          );
-          this.jointGraphWrapper.unhighlightGroups(
-            ...this.jointGraphWrapper.getCurrentHighlightedGroupIDs()
-          );
+          currentHighlightedOperators.splice(currentHighlightedOperators.indexOf(operatorID), 1);
+          this.jointGraphWrapper.unhighlightOperators(...currentHighlightedOperators);
+          this.jointGraphWrapper.unhighlightGroups(...this.jointGraphWrapper.getCurrentHighlightedGroupIDs());
         }
-      }
+      },
     };
     this.executeAndStoreCommand(command);
   }
@@ -1029,10 +814,7 @@ export class WorkflowActionService {
   /**
    * set a given link's breakpoint properties to specific values
    */
-  public setLinkBreakpoint(
-    linkID: string,
-    newBreakpoint: Breakpoint | undefined
-  ): void {
+  public setLinkBreakpoint(linkID: string, newBreakpoint: Breakpoint | undefined): void {
     const prevBreakpoint = this.getTexeraGraph().getLinkBreakpoint(linkID);
     const command: Command = {
       modifiesWorkflow: true,
@@ -1041,7 +823,7 @@ export class WorkflowActionService {
       },
       undo: () => {
         this.setLinkBreakpointInternal(linkID, prevBreakpoint);
-      }
+      },
     };
     this.executeAndStoreCommand(command);
   }
@@ -1064,7 +846,7 @@ export class WorkflowActionService {
     this.deleteOperatorsAndLinks(
       this.getTexeraGraph()
         .getAllOperators()
-        .map((op) => op.operatorID),
+        .map(op => op.operatorID),
       []
     );
 
@@ -1075,7 +857,7 @@ export class WorkflowActionService {
     const workflowContent: WorkflowContent = workflow.content;
 
     const operatorsAndPositions: { op: OperatorPredicate; pos: Point }[] = [];
-    workflowContent.operators.forEach((op) => {
+    workflowContent.operators.forEach(op => {
       const opPosition = workflowContent.operatorPositions[op.operatorID];
       if (!opPosition) {
         throw new Error("position error");
@@ -1085,31 +867,24 @@ export class WorkflowActionService {
 
     const links: OperatorLink[] = workflowContent.links;
 
-    const groups: readonly Group[] = workflowContent.groups.map((group) => {
+    const groups: readonly Group[] = workflowContent.groups.map(group => {
       return {
         groupID: group.groupID,
         operators: recordToMap(group.operators),
         links: recordToMap(group.links),
         inLinks: group.inLinks,
         outLinks: group.outLinks,
-        collapsed: group.collapsed
+        collapsed: group.collapsed,
       };
     });
 
     const breakpoints = new Map(Object.entries(workflowContent.breakpoints));
 
-    this.addOperatorsAndLinks(
-      operatorsAndPositions,
-      links,
-      groups,
-      breakpoints
-    );
+    this.addOperatorsAndLinks(operatorsAndPositions, links, groups, breakpoints);
 
     // operators shouldn't be highlighted during page reload
     const jointGraphWrapper = this.getJointGraphWrapper();
-    jointGraphWrapper.unhighlightOperators(
-      ...jointGraphWrapper.getCurrentHighlightedOperatorIDs()
-    );
+    jointGraphWrapper.unhighlightOperators(...jointGraphWrapper.getCurrentHighlightedOperatorIDs());
     // restore the view point
     this.getJointGraphWrapper().restoreDefaultZoomAndOffset();
   }
@@ -1137,13 +912,8 @@ export class WorkflowActionService {
     return this.workflowMetadataChangeSubject.asObservable();
   }
 
-  public setWorkflowMetadata(
-    workflowMetaData: WorkflowMetadata | undefined
-  ): void {
-    this.workflowMetadata =
-      workflowMetaData === undefined
-        ? WorkflowActionService.DEFAULT_WORKFLOW
-        : workflowMetaData;
+  public setWorkflowMetadata(workflowMetaData: WorkflowMetadata | undefined): void {
+    this.workflowMetadata = workflowMetaData === undefined ? WorkflowActionService.DEFAULT_WORKFLOW : workflowMetaData;
     this.workflowMetadataChangeSubject.next();
   }
 
@@ -1160,14 +930,14 @@ export class WorkflowActionService {
 
     const groups = this.getOperatorGroup()
       .getAllGroups()
-      .map((group) => {
+      .map(group => {
         return {
           groupID: group.groupID,
           operators: mapToRecord(group.operators),
           links: mapToRecord(group.links),
           inLinks: group.inLinks,
           outLinks: group.outLinks,
-          collapsed: group.collapsed
+          collapsed: group.collapsed,
         };
       });
     const breakpointsMap = texeraGraph.getAllLinkBreakpoints();
@@ -1176,9 +946,7 @@ export class WorkflowActionService {
     texeraGraph
       .getAllOperators()
       .forEach(
-        (op) =>
-          (operatorPositions[op.operatorID] =
-            this.getJointGraphWrapper().getElementPosition(op.operatorID))
+        op => (operatorPositions[op.operatorID] = this.getJointGraphWrapper().getElementPosition(op.operatorID))
       );
 
     const workflowContent: WorkflowContent = {
@@ -1186,7 +954,7 @@ export class WorkflowActionService {
       operatorPositions,
       links,
       groups,
-      breakpoints
+      breakpoints,
     };
     return workflowContent;
   }
@@ -1194,15 +962,12 @@ export class WorkflowActionService {
   public getWorkflow(): Workflow {
     return {
       ...this.workflowMetadata,
-      ...{ content: this.getWorkflowContent() }
+      ...{ content: this.getWorkflowContent() },
     };
   }
 
   public setWorkflowName(name: string): void {
-    this.workflowMetadata.name =
-      name.trim().length > 0
-        ? name
-        : WorkflowActionService.DEFAULT_WORKFLOW_NAME;
+    this.workflowMetadata.name = name.trim().length > 0 ? name : WorkflowActionService.DEFAULT_WORKFLOW_NAME;
     this.workflowMetadataChangeSubject.next();
   }
 
@@ -1216,24 +981,16 @@ export class WorkflowActionService {
     // check that the operator doesn't exist
     this.texeraGraph.assertOperatorNotExists(operator.operatorID);
     // check that the operator type exists
-    if (
-      !this.operatorMetadataService.operatorTypeExists(operator.operatorType)
-    ) {
+    if (!this.operatorMetadataService.operatorTypeExists(operator.operatorType)) {
       throw new Error(`operator type ${operator.operatorType} is invalid`);
     }
     // get the JointJS UI element for operator
-    const operatorJointElement = this.jointUIService.getJointOperatorElement(
-      operator,
-      point
-    );
+    const operatorJointElement = this.jointUIService.getJointOperatorElement(operator, point);
 
     // add operator to joint graph first
     // if jointJS throws an error, it won't cause the inconsistency in texera graph
     this.jointGraph.addCell(operatorJointElement);
-    this.jointGraphWrapper.setCellLayer(
-      operator.operatorID,
-      this.operatorGroup.getHighestLayer() + 1
-    );
+    this.jointGraphWrapper.setCellLayer(operator.operatorID, this.operatorGroup.getHighestLayer() + 1);
 
     // add operator to texera graph
     this.texeraGraph.addOperator(operator);
@@ -1255,19 +1012,10 @@ export class WorkflowActionService {
     this.texeraGraph.assertLinkNotExists(link);
     this.texeraGraph.assertLinkIsValid(link);
 
-    const sourceGroup = this.operatorGroup.getGroupByOperator(
-      link.source.operatorID
-    );
-    const targetGroup = this.operatorGroup.getGroupByOperator(
-      link.target.operatorID
-    );
+    const sourceGroup = this.operatorGroup.getGroupByOperator(link.source.operatorID);
+    const targetGroup = this.operatorGroup.getGroupByOperator(link.target.operatorID);
 
-    if (
-      sourceGroup &&
-      targetGroup &&
-      sourceGroup.groupID === targetGroup.groupID &&
-      sourceGroup.collapsed
-    ) {
+    if (sourceGroup && targetGroup && sourceGroup.groupID === targetGroup.groupID && sourceGroup.collapsed) {
       this.texeraGraph.addLink(link);
     } else {
       // if a group is collapsed, jointjs target is the group not the operator
@@ -1282,10 +1030,7 @@ export class WorkflowActionService {
       // manually add a link element (normally automatic when syncTexeraGraph = true)
       this.operatorGroup.setSyncTexeraGraph(false);
       this.jointGraph.addCell(jointLinkCell);
-      this.jointGraphWrapper.setCellLayer(
-        link.linkID,
-        this.operatorGroup.getHighestLayer() + 1
-      );
+      this.jointGraphWrapper.setCellLayer(link.linkID, this.operatorGroup.getHighestLayer() + 1);
       this.operatorGroup.setSyncTexeraGraph(true);
 
       this.texeraGraph.addLink(link);
@@ -1368,14 +1113,10 @@ export class WorkflowActionService {
   private deleteGroupAndOperatorsInternal(groupID: string): void {
     const group = this.operatorGroup.getGroup(groupID);
     // delete operators and links from the group
-    group.links.forEach((linkInfo, linkID) =>
-      this.deleteLinkWithIDInternal(linkID)
-    );
-    group.inLinks.forEach((linkID) => this.deleteLinkWithIDInternal(linkID));
-    group.outLinks.forEach((linkID) => this.deleteLinkWithIDInternal(linkID));
-    group.operators.forEach((operatorInfo, operatorID) =>
-      this.deleteOperatorInternal(operatorID)
-    );
+    group.links.forEach((linkInfo, linkID) => this.deleteLinkWithIDInternal(linkID));
+    group.inLinks.forEach(linkID => this.deleteLinkWithIDInternal(linkID));
+    group.outLinks.forEach(linkID => this.deleteLinkWithIDInternal(linkID));
+    group.operators.forEach((operatorInfo, operatorID) => this.deleteOperatorInternal(operatorID));
     // delete the group from joint graph and group ID map
     this.jointGraph.getCell(groupID).remove();
     this.operatorGroup.unGroup(groupID);
@@ -1390,9 +1131,7 @@ export class WorkflowActionService {
     // if command would modify workflow (adding link, operator, changing operator properties), throw an error
     // non-modifying commands include dragging an operator.
     if (command.modifiesWorkflow && !this.workflowModificationEnabled) {
-      console.error(
-        "attempted to execute workflow action when workflow service is disabled"
-      );
+      console.error("attempted to execute workflow action when workflow service is disabled");
       return;
     }
 
@@ -1402,15 +1141,9 @@ export class WorkflowActionService {
     this.undoRedoService.setListenJointCommand(true);
   }
 
-  private setLinkBreakpointInternal(
-    linkID: string,
-    newBreakpoint: Breakpoint | undefined
-  ): void {
+  private setLinkBreakpointInternal(linkID: string, newBreakpoint: Breakpoint | undefined): void {
     this.texeraGraph.setLinkBreakpoint(linkID, newBreakpoint);
-    if (
-      newBreakpoint === undefined ||
-      Object.keys(newBreakpoint).length === 0
-    ) {
+    if (newBreakpoint === undefined || Object.keys(newBreakpoint).length === 0) {
       this.getJointGraphWrapper().hideLinkBreakpoint(linkID);
     } else {
       this.getJointGraphWrapper().showLinkBreakpoint(linkID);

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.spec.ts
@@ -4,7 +4,7 @@ import {
   mockScanResultLink,
   mockScanSentimentLink,
   mockSentimentPredicate,
-  mockSentimentResultLink
+  mockSentimentResultLink,
 } from "./mock-workflow-data";
 import { WorkflowGraph } from "./workflow-graph";
 import { environment } from "../../../../../environments/environment";
@@ -32,9 +32,7 @@ describe("WorkflowGraph", () => {
 
   it("should add an operator and get it properly", () => {
     workflowGraph.addOperator(mockScanPredicate);
-    expect(
-      workflowGraph.getOperator(mockScanPredicate.operatorID)
-    ).toBeTruthy();
+    expect(workflowGraph.getOperator(mockScanPredicate.operatorID)).toBeTruthy();
     expect(workflowGraph.getAllOperators().length).toEqual(1);
     expect(workflowGraph.getAllOperators()[0]).toEqual(mockScanPredicate);
   });
@@ -69,15 +67,8 @@ describe("WorkflowGraph", () => {
     workflowGraph.addOperator(mockResultPredicate);
     workflowGraph.addLink(mockScanResultLink);
 
-    expect(workflowGraph.getLinkWithID(mockScanResultLink.linkID)).toEqual(
-      mockScanResultLink
-    );
-    expect(
-      workflowGraph.getLink(
-        mockScanResultLink.source,
-        mockScanResultLink.target
-      )
-    ).toEqual(mockScanResultLink);
+    expect(workflowGraph.getLinkWithID(mockScanResultLink.linkID)).toEqual(mockScanResultLink);
+    expect(workflowGraph.getLink(mockScanResultLink.source, mockScanResultLink.target)).toEqual(mockScanResultLink);
     expect(workflowGraph.getAllLinks().length).toEqual(1);
   });
 
@@ -92,8 +83,8 @@ describe("WorkflowGraph", () => {
       ...mockScanResultLink,
       target: {
         operatorID: mockSentimentPredicate.operatorID,
-        portID: mockSentimentPredicate.inputPorts[0].portID
-      }
+        portID: mockSentimentPredicate.inputPorts[0].portID,
+      },
     };
 
     expect(() => {
@@ -110,7 +101,7 @@ describe("WorkflowGraph", () => {
     // create a mock link with modified ID
     const mockLink = {
       ...mockScanResultLink,
-      linkID: "new-link-id"
+      linkID: "new-link-id",
     };
 
     expect(() => {
@@ -146,10 +137,7 @@ describe("WorkflowGraph", () => {
     workflowGraph.addOperator(mockScanPredicate);
     workflowGraph.addOperator(mockResultPredicate);
     workflowGraph.addLink(mockScanResultLink);
-    workflowGraph.deleteLink(
-      mockScanResultLink.source,
-      mockScanResultLink.target
-    );
+    workflowGraph.deleteLink(mockScanResultLink.source, mockScanResultLink.target);
 
     expect(workflowGraph.getAllLinks().length).toEqual(0);
   });
@@ -173,10 +161,7 @@ describe("WorkflowGraph", () => {
     workflowGraph.addOperator(mockScanPredicate);
 
     const testProperty = { tableName: "testTable" };
-    workflowGraph.setOperatorProperty(
-      mockScanPredicate.operatorID,
-      testProperty
-    );
+    workflowGraph.setOperatorProperty(mockScanPredicate.operatorID, testProperty);
 
     const operator = workflowGraph.getOperator(mockScanPredicate.operatorID);
     if (!operator) {
@@ -188,10 +173,7 @@ describe("WorkflowGraph", () => {
   it("should throw an error when trying to set the property of an nonexist operator", () => {
     expect(() => {
       const testProperty = { tableName: "testTable" };
-      workflowGraph.setOperatorProperty(
-        mockScanPredicate.operatorID,
-        testProperty
-      );
+      workflowGraph.setOperatorProperty(mockScanPredicate.operatorID, testProperty);
     }).toThrowError(new RegExp("doesn't exist"));
   });
 
@@ -214,18 +196,12 @@ describe("WorkflowGraph", () => {
     workflowGraph.addOperator(mockResultPredicate);
     workflowGraph.disableOperator(mockScanPredicate.operatorID);
 
-    expect(
-      workflowGraph.isOperatorDisabled(mockScanPredicate.operatorID)
-    ).toBeTrue();
-    expect(
-      workflowGraph.isOperatorDisabled(mockResultPredicate.operatorID)
-    ).toBeFalse();
+    expect(workflowGraph.isOperatorDisabled(mockScanPredicate.operatorID)).toBeTrue();
+    expect(workflowGraph.isOperatorDisabled(mockResultPredicate.operatorID)).toBeFalse();
     expect(workflowGraph.getDisabledOperators().size).toEqual(1);
 
     workflowGraph.enableOperator(mockScanPredicate.operatorID);
-    expect(
-      workflowGraph.isOperatorDisabled(mockScanPredicate.operatorID)
-    ).toBeFalse();
+    expect(workflowGraph.isOperatorDisabled(mockScanPredicate.operatorID)).toBeFalse();
     expect(workflowGraph.getDisabledOperators().size).toEqual(0);
   });
 
@@ -253,13 +229,8 @@ describe("WorkflowGraph", () => {
       workflowGraph.addOperator(mockResultPredicate);
       workflowGraph.addLink(mockScanResultLink);
       const mockBreakpoint = { count: 100 };
-      workflowGraph.setLinkBreakpoint(
-        mockScanResultLink.linkID,
-        mockBreakpoint
-      );
-      expect(
-        workflowGraph.getLinkBreakpoint(mockScanResultLink.linkID)
-      ).toEqual(mockBreakpoint);
+      workflowGraph.setLinkBreakpoint(mockScanResultLink.linkID, mockBreakpoint);
+      expect(workflowGraph.getLinkBreakpoint(mockScanResultLink.linkID)).toEqual(mockBreakpoint);
     });
   });
 });

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.spec.ts
@@ -220,18 +220,12 @@ describe("WorkflowGraph", () => {
     workflowGraph.addOperator(mockResultPredicate);
     workflowGraph.cacheOperator(mockScanPredicate.operatorID);
 
-    expect(
-      workflowGraph.isOperatorCached(mockScanPredicate.operatorID)
-    ).toBeTrue();
-    expect(
-      workflowGraph.isOperatorCached(mockResultPredicate.operatorID)
-    ).toBeFalse();
+    expect(workflowGraph.isOperatorCached(mockScanPredicate.operatorID)).toBeTrue();
+    expect(workflowGraph.isOperatorCached(mockResultPredicate.operatorID)).toBeFalse();
     expect(workflowGraph.getCachedOperators().size).toEqual(1);
 
     workflowGraph.unCacheOperator(mockScanPredicate.operatorID);
-    expect(
-      workflowGraph.isOperatorCached(mockScanPredicate.operatorID)
-    ).toBeFalse();
+    expect(workflowGraph.isOperatorCached(mockScanPredicate.operatorID)).toBeFalse();
     expect(workflowGraph.getDisabledOperators().size).toEqual(0);
   });
 
@@ -240,18 +234,12 @@ describe("WorkflowGraph", () => {
     workflowGraph.addOperator(mockResultPredicate);
     workflowGraph.cacheOperator(mockResultPredicate.operatorID);
 
-    expect(
-      workflowGraph.isOperatorCached(mockScanPredicate.operatorID)
-    ).toBeFalse();
-    expect(
-      workflowGraph.isOperatorCached(mockResultPredicate.operatorID)
-    ).toBeFalse();
+    expect(workflowGraph.isOperatorCached(mockScanPredicate.operatorID)).toBeFalse();
+    expect(workflowGraph.isOperatorCached(mockResultPredicate.operatorID)).toBeFalse();
     expect(workflowGraph.getCachedOperators().size).toEqual(0);
 
     workflowGraph.unCacheOperator(mockResultPredicate.operatorID);
-    expect(
-      workflowGraph.isOperatorCached(mockResultPredicate.operatorID)
-    ).toBeFalse();
+    expect(workflowGraph.isOperatorCached(mockResultPredicate.operatorID)).toBeFalse();
     expect(workflowGraph.getCachedOperators().size).toEqual(0);
   });
 

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
@@ -1,10 +1,5 @@
 import { Observable, Subject } from "rxjs";
-import {
-  Breakpoint,
-  OperatorLink,
-  OperatorPort,
-  OperatorPredicate
-} from "../../../types/workflow-common.interface";
+import { Breakpoint, OperatorLink, OperatorPort, OperatorPredicate } from "../../../types/workflow-common.interface";
 import { isEqual } from "lodash-es";
 
 // define the restricted methods that could change the graph
@@ -66,16 +61,9 @@ export class WorkflowGraph {
     linkID: string;
   }>();
 
-  constructor(
-    operatorPredicates: OperatorPredicate[] = [],
-    operatorLinks: OperatorLink[] = []
-  ) {
-    operatorPredicates.forEach((op) =>
-      this.operatorIDMap.set(op.operatorID, op)
-    );
-    operatorLinks.forEach((link) =>
-      this.operatorLinkMap.set(link.linkID, link)
-    );
+  constructor(operatorPredicates: OperatorPredicate[] = [], operatorLinks: OperatorLink[] = []) {
+    operatorPredicates.forEach(op => this.operatorIDMap.set(op.operatorID, op));
+    operatorLinks.forEach(link => this.operatorLinkMap.set(link.linkID, link));
   }
 
   /**
@@ -114,7 +102,7 @@ export class WorkflowGraph {
     this.operatorIDMap.set(operatorID, { ...operator, isDisabled: true });
     this.disabledOperatorChangedSubject.next({
       newDisabled: [operatorID],
-      newEnabled: []
+      newEnabled: [],
     });
   }
 
@@ -129,21 +117,18 @@ export class WorkflowGraph {
     this.operatorIDMap.set(operatorID, { ...operator, isDisabled: false });
     this.disabledOperatorChangedSubject.next({
       newDisabled: [],
-      newEnabled: [operatorID]
+      newEnabled: [operatorID],
     });
   }
 
-  public changeOperatorDisplayName(
-    operatorID: string,
-    newDisplayName: string
-  ): void {
+  public changeOperatorDisplayName(operatorID: string, newDisplayName: string): void {
     const operator = this.getOperator(operatorID);
     if (operator.customDisplayName === newDisplayName) {
       return;
     }
     this.operatorIDMap.set(operatorID, {
       ...operator,
-      customDisplayName: newDisplayName
+      customDisplayName: newDisplayName,
     });
     this.operatorDisplayNameChangedSubject.next({ operatorID, newDisplayName });
   }
@@ -157,11 +142,7 @@ export class WorkflowGraph {
   }
 
   public getDisabledOperators(): ReadonlySet<string> {
-    return new Set(
-      Array.from(this.operatorIDMap.keys()).filter((op) =>
-        this.isOperatorDisabled(op)
-      )
-    );
+    return new Set(Array.from(this.operatorIDMap.keys()).filter(op => this.isOperatorDisabled(op)));
   }
 
   public cacheOperator(operatorID: string): void {
@@ -175,7 +156,7 @@ export class WorkflowGraph {
     this.operatorIDMap.set(operatorID, { ...operator, isCached: true });
     this.cachedOperatorChangedSubject.next({
       newCached: [operatorID],
-      newUnCached: []
+      newUnCached: [],
     });
   }
 
@@ -190,7 +171,7 @@ export class WorkflowGraph {
     this.operatorIDMap.set(operatorID, { ...operator, isCached: false });
     this.cachedOperatorChangedSubject.next({
       newCached: [],
-      newUnCached: [operatorID]
+      newUnCached: [operatorID],
     });
   }
 
@@ -203,11 +184,7 @@ export class WorkflowGraph {
   }
 
   public getCachedOperators(): ReadonlySet<string> {
-    return new Set(
-      Array.from(this.operatorIDMap.keys()).filter((op) =>
-        this.isOperatorCached(op)
-      )
-    );
+    return new Set(Array.from(this.operatorIDMap.keys()).filter(op => this.isOperatorCached(op)));
   }
 
   /**
@@ -239,9 +216,7 @@ export class WorkflowGraph {
   }
 
   public getAllEnabledOperators(): ReadonlyArray<OperatorPredicate> {
-    return Array.from(this.operatorIDMap.values()).filter(
-      (op) => !this.isOperatorDisabled(op.operatorID)
-    );
+    return Array.from(this.operatorIDMap.values()).filter(op => !this.isOperatorDisabled(op.operatorID));
   }
 
   /**
@@ -316,10 +291,7 @@ export class WorkflowGraph {
 
   public isLinkEnabled(linkID: string): boolean {
     const link = this.getLinkWithID(linkID);
-    return (
-      !this.isOperatorDisabled(link.source.operatorID) &&
-      !this.isOperatorDisabled(link.target.operatorID)
-    );
+    return !this.isOperatorDisabled(link.source.operatorID) && !this.isOperatorDisabled(link.target.operatorID);
   }
 
   /**
@@ -342,18 +314,12 @@ export class WorkflowGraph {
    * @param target target operator and port of the link
    */
   public getLink(source: OperatorPort, target: OperatorPort): OperatorLink {
-    const links = this.getAllLinks().filter(
-      (value) => isEqual(value.source, source) && isEqual(value.target, target)
-    );
+    const links = this.getAllLinks().filter(value => isEqual(value.source, source) && isEqual(value.target, target));
     if (links.length === 0) {
-      throw new Error(
-        `link with source ${source} and target ${target} does not exist`
-      );
+      throw new Error(`link with source ${source} and target ${target} does not exist`);
     }
     if (links.length > 1) {
-      throw new Error(
-        "WorkflowGraph inconsistency: find duplicate links with same source and target"
-      );
+      throw new Error("WorkflowGraph inconsistency: find duplicate links with same source and target");
     }
     return links[0];
   }
@@ -366,9 +332,7 @@ export class WorkflowGraph {
   }
 
   public getAllEnabledLinks(): ReadonlyArray<OperatorLink> {
-    return Array.from(this.operatorLinkMap.values()).filter((link) =>
-      this.isLinkEnabled(link.linkID)
-    );
+    return Array.from(this.operatorLinkMap.values()).filter(link => this.isLinkEnabled(link.linkID));
   }
 
   /**
@@ -376,9 +340,7 @@ export class WorkflowGraph {
    * @param operatorID
    */
   public getInputLinksByOperatorId(operatorID: string): OperatorLink[] {
-    return this.getAllLinks().filter(
-      (link) => link.target.operatorID === operatorID
-    );
+    return this.getAllLinks().filter(link => link.target.operatorID === operatorID);
   }
 
   /**
@@ -386,9 +348,7 @@ export class WorkflowGraph {
    * @param operatorID
    */
   public getOutputLinksByOperatorId(operatorID: string): OperatorLink[] {
-    return this.getAllLinks().filter(
-      (link) => link.source.operatorID === operatorID
-    );
+    return this.getAllLinks().filter(link => link.source.operatorID === operatorID);
   }
 
   /**
@@ -408,7 +368,7 @@ export class WorkflowGraph {
     // constructor a new copy with new operatorProperty and all other original attributes
     const operator = {
       ...originalOperatorData,
-      operatorProperties: newProperty
+      operatorProperties: newProperty,
     };
     // set the new copy back to the operator ID map
     this.operatorIDMap.set(operatorID, operator);
@@ -423,10 +383,7 @@ export class WorkflowGraph {
    * @param linkID linkID
    * @param breakpoint
    */
-  public setLinkBreakpoint(
-    linkID: string,
-    breakpoint: Breakpoint | undefined
-  ): void {
+  public setLinkBreakpoint(linkID: string, breakpoint: Breakpoint | undefined): void {
     this.assertLinkWithIDExists(linkID);
     const oldBreakpoint = this.linkBreakpointMap.get(linkID);
     if (breakpoint === undefined || Object.keys(breakpoint).length === 0) {
@@ -601,31 +558,19 @@ export class WorkflowGraph {
   public assertLinkIsValid(link: OperatorLink): void {
     const sourceOperator = this.getOperator(link.source.operatorID);
     if (!sourceOperator) {
-      throw new Error(
-        `link's source operator ${link.source.operatorID} doesn't exist`
-      );
+      throw new Error(`link's source operator ${link.source.operatorID} doesn't exist`);
     }
 
     const targetOperator = this.getOperator(link.target.operatorID);
     if (!targetOperator) {
-      throw new Error(
-        `link's target operator ${link.target.operatorID} doesn't exist`
-      );
+      throw new Error(`link's target operator ${link.target.operatorID} doesn't exist`);
     }
 
-    if (
-      sourceOperator.outputPorts.find(
-        (port) => port.portID === link.source.portID
-      ) === undefined
-    ) {
+    if (sourceOperator.outputPorts.find(port => port.portID === link.source.portID) === undefined) {
       throw new Error(`link's source port ${link.source.portID} doesn't exist
           on output ports of the source operator ${link.source.operatorID}`);
     }
-    if (
-      targetOperator.inputPorts.find(
-        (port) => port.portID === link.target.portID
-      ) === undefined
-    ) {
+    if (targetOperator.inputPorts.find(port => port.portID === link.target.portID) === undefined) {
       throw new Error(`link's target port ${link.target.portID} doesn't exist
           on input ports of the target operator ${link.target.operatorID}`);
     }

--- a/core/new-gui/src/app/workspace/service/workflow-graph/util/workflow-util.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/util/workflow-util.service.spec.ts
@@ -14,43 +14,30 @@ describe("WorkflowUtilService", () => {
         WorkflowUtilService,
         {
           provide: OperatorMetadataService,
-          useClass: StubOperatorMetadataService
-        }
-      ]
+          useClass: StubOperatorMetadataService,
+        },
+      ],
     });
     workflowUtilService = TestBed.get(WorkflowUtilService);
   });
 
-  it("should be created", inject(
-    [WorkflowUtilService],
-    (service: WorkflowUtilService) => {
-      expect(service).toBeTruthy();
-    }
-  ));
+  it("should be created", inject([WorkflowUtilService], (service: WorkflowUtilService) => {
+    expect(service).toBeTruthy();
+  }));
 
   it("should be able to generate an operator predicate properly given a valid operator type", () => {
     const operatorSchema = mockScanSourceSchema;
-    const operatorPredicate = workflowUtilService.getNewOperatorPredicate(
-      operatorSchema.operatorType
-    );
+    const operatorPredicate = workflowUtilService.getNewOperatorPredicate(operatorSchema.operatorType);
 
     // assert predicate itself and operator type are correct
     expect(operatorPredicate).toBeTruthy();
     expect(operatorPredicate.operatorType).toEqual(operatorSchema.operatorType);
     // assert num of input ports and output ports are correct
-    expect(operatorPredicate.inputPorts.length).toEqual(
-      operatorSchema.additionalMetadata.inputPorts.length
-    );
-    expect(operatorPredicate.outputPorts.length).toEqual(
-      operatorSchema.additionalMetadata.outputPorts.length
-    );
+    expect(operatorPredicate.inputPorts.length).toEqual(operatorSchema.additionalMetadata.inputPorts.length);
+    expect(operatorPredicate.outputPorts.length).toEqual(operatorSchema.additionalMetadata.outputPorts.length);
     // asssert that the portID of input and output ports are all distinct
-    expect(new Set(operatorPredicate.inputPorts).size).toEqual(
-      operatorPredicate.inputPorts.length
-    );
-    expect(new Set(operatorPredicate.outputPorts).size).toEqual(
-      operatorPredicate.outputPorts.length
-    );
+    expect(new Set(operatorPredicate.inputPorts).size).toEqual(operatorPredicate.inputPorts.length);
+    expect(new Set(operatorPredicate.outputPorts).size).toEqual(operatorPredicate.outputPorts.length);
 
     // assert that it creates the operator property to be an empty object
     expect(operatorPredicate.operatorProperties).toEqual({});
@@ -88,10 +75,7 @@ describe("WorkflowUtilService", () => {
     const repeat = 100;
 
     for (let i = 0; i < repeat; i++) {
-      idSet.add(
-        workflowUtilService.getNewOperatorPredicate(operatorSchema.operatorType)
-          .operatorID
-      );
+      idSet.add(workflowUtilService.getNewOperatorPredicate(operatorSchema.operatorType).operatorID);
     }
     // assert all IDs are distinct
     expect(idSet.size).toEqual(repeat);

--- a/core/new-gui/src/app/workspace/service/workflow-graph/util/workflow-util.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/util/workflow-util.service.ts
@@ -11,7 +11,7 @@ import { Observable, Subject } from "rxjs";
  * WorkflowUtilService provide utilities related to dealing with operator data.
  */
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class WorkflowUtilService {
   private operatorSchemaList: ReadonlyArray<OperatorSchema> = [];
@@ -19,11 +19,10 @@ export class WorkflowUtilService {
   // used to fetch default values in json schema to initialize new operator
   private ajv = new Ajv({ useDefaults: true });
 
-  private operatorSchemaListCreatedSubject: Subject<boolean> =
-    new Subject<boolean>();
+  private operatorSchemaListCreatedSubject: Subject<boolean> = new Subject<boolean>();
 
   constructor(private operatorMetadataService: OperatorMetadataService) {
-    this.operatorMetadataService.getOperatorMetadata().subscribe((value) => {
+    this.operatorMetadataService.getOperatorMetadata().subscribe(value => {
       this.operatorSchemaList = value.operators;
       this.operatorSchemaListCreatedSubject.next(true);
     });
@@ -69,17 +68,12 @@ export class WorkflowUtilService {
    * @returns a new OperatorPredicate of the operatorType
    */
   public getNewOperatorPredicate(operatorType: string): OperatorPredicate {
-    const operatorSchema = this.operatorSchemaList.find(
-      (schema) => schema.operatorType === operatorType
-    );
+    const operatorSchema = this.operatorSchemaList.find(schema => schema.operatorType === operatorType);
     if (operatorSchema === undefined) {
-      throw new Error(
-        `operatorType ${operatorType} doesn't exist in operator metadata`
-      );
+      throw new Error(`operatorType ${operatorType} doesn't exist in operator metadata`);
     }
 
-    const operatorID =
-      operatorSchema.operatorType + "-" + this.getOperatorRandomUUID();
+    const operatorID = operatorSchema.operatorType + "-" + this.getOperatorRandomUUID();
     const operatorProperties = {};
 
     // Remove the ID field for the schema to prevent warning messages from Ajv
@@ -99,28 +93,17 @@ export class WorkflowUtilService {
     const isDisabled = false;
 
     // by default, the operator name is the user friendly name
-    const customDisplayName =
-      operatorSchema.additionalMetadata.userFriendlyName;
+    const customDisplayName = operatorSchema.additionalMetadata.userFriendlyName;
 
-    for (
-      let i = 0;
-      i < operatorSchema.additionalMetadata.inputPorts.length;
-      i++
-    ) {
+    for (let i = 0; i < operatorSchema.additionalMetadata.inputPorts.length; i++) {
       const portID = "input-" + i.toString();
-      const displayName =
-        operatorSchema.additionalMetadata.inputPorts[i].displayName;
+      const displayName = operatorSchema.additionalMetadata.inputPorts[i].displayName;
       inputPorts.push({ portID, displayName });
     }
 
-    for (
-      let i = 0;
-      i < operatorSchema.additionalMetadata.outputPorts.length;
-      i++
-    ) {
+    for (let i = 0; i < operatorSchema.additionalMetadata.outputPorts.length; i++) {
       const portID = "output-" + i.toString();
-      const displayName =
-        operatorSchema.additionalMetadata.outputPorts[i].displayName;
+      const displayName = operatorSchema.additionalMetadata.outputPorts[i].displayName;
       outputPorts.push({ portID, displayName });
     }
 
@@ -132,7 +115,7 @@ export class WorkflowUtilService {
       outputPorts,
       showAdvanced,
       isDisabled,
-      customDisplayName
+      customDisplayName,
     };
   }
 }

--- a/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.spec.ts
@@ -8,7 +8,7 @@ describe("WorkflowResultExportService", () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule]
+      imports: [HttpClientTestingModule],
     });
     service = TestBed.inject(WorkflowResultExportService);
   });

--- a/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
@@ -10,12 +10,11 @@ import { ExecutionState } from "../../types/execute-workflow.interface";
 import { filter } from "rxjs/operators";
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class WorkflowResultExportService {
   hasResultToExport: boolean = false;
-  exportExecutionResultEnabled: boolean =
-    environment.exportExecutionResultEnabled;
+  exportExecutionResultEnabled: boolean = environment.exportExecutionResultEnabled;
 
   constructor(
     private workflowWebsocketService: WorkflowWebsocketService,
@@ -43,26 +42,16 @@ export class WorkflowResultExportService {
     merge(
       this.executeWorkflowService
         .getExecutionStateStream()
-        .pipe(
-          filter(
-            ({ previous, current }) =>
-              current.state === ExecutionState.Completed
-          )
-        ),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointOperatorHighlightStream(),
-      this.workflowActionService
-        .getJointGraphWrapper()
-        .getJointOperatorUnhighlightStream()
+        .pipe(filter(({ previous, current }) => current.state === ExecutionState.Completed)),
+      this.workflowActionService.getJointGraphWrapper().getJointOperatorHighlightStream(),
+      this.workflowActionService.getJointGraphWrapper().getJointOperatorUnhighlightStream()
     ).subscribe(() => {
       this.hasResultToExport =
-        this.executeWorkflowService.getExecutionState().state ===
-          ExecutionState.Completed &&
+        this.executeWorkflowService.getExecutionState().state === ExecutionState.Completed &&
         this.workflowActionService
           .getJointGraphWrapper()
           .getCurrentHighlightedOperatorIDs()
-          .filter((operatorId) =>
+          .filter(operatorId =>
             this.workflowActionService
               .getTexeraGraph()
               .getOperator(operatorId)
@@ -75,10 +64,7 @@ export class WorkflowResultExportService {
   /**
    * export the workflow execution result according the export type
    */
-  exportWorkflowExecutionResult(
-    exportType: string,
-    workflowName: string
-  ): void {
+  exportWorkflowExecutionResult(exportType: string, workflowName: string): void {
     if (!environment.exportExecutionResultEnabled || !this.hasResultToExport) {
       return;
     }
@@ -87,18 +73,14 @@ export class WorkflowResultExportService {
     this.workflowActionService
       .getJointGraphWrapper()
       .getCurrentHighlightedOperatorIDs()
-      .filter((operatorId) =>
-        this.workflowActionService
-          .getTexeraGraph()
-          .getOperator(operatorId)
-          .operatorType.toLowerCase()
-          .includes("sink")
+      .filter(operatorId =>
+        this.workflowActionService.getTexeraGraph().getOperator(operatorId).operatorType.toLowerCase().includes("sink")
       )
-      .forEach((operatorId) => {
+      .forEach(operatorId => {
         this.workflowWebsocketService.send("ResultExportRequest", {
           exportType,
           workflowName,
-          operatorId
+          operatorId,
         });
       });
   }

--- a/core/new-gui/src/app/workspace/service/workflow-status/operator-cache-status.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-status/operator-cache-status.service.spec.ts
@@ -12,9 +12,9 @@ xdescribe("OperatorCacheStatusService", () => {
       providers: [
         {
           provide: OperatorMetadataService,
-          useClass: StubOperatorMetadataService
-        }
-      ]
+          useClass: StubOperatorMetadataService,
+        },
+      ],
     });
     service = TestBed.inject(OperatorCacheStatusService);
   });

--- a/core/new-gui/src/app/workspace/service/workflow-status/operator-cache-status.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-status/operator-cache-status.service.ts
@@ -9,7 +9,7 @@ import { JointUIService } from "../joint-ui/joint-ui.service";
 import { environment } from "src/environments/environment";
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class OperatorCacheStatusService {
   constructor(
@@ -36,16 +36,10 @@ export class OperatorCacheStatusService {
         .getTexeraGraph()
         .getOperatorPropertyChangeStream()
         .pipe(debounceTime(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS)),
-      this.workflowActionService
-        .getTexeraGraph()
-        .getDisabledOperatorsChangedStream(),
-      this.workflowActionService
-        .getTexeraGraph()
-        .getCachedOperatorsChangedStream()
+      this.workflowActionService.getTexeraGraph().getDisabledOperatorsChangedStream(),
+      this.workflowActionService.getTexeraGraph().getCachedOperatorsChangedStream()
     ).subscribe(() => {
-      const workflow = ExecuteWorkflowService.getLogicalPlanRequest(
-        this.workflowActionService.getTexeraGraph()
-      );
+      const workflow = ExecuteWorkflowService.getLogicalPlanRequest(this.workflowActionService.getTexeraGraph());
       this.workflowWebsocketService.send("CacheStatusUpdateRequest", workflow);
     });
   }
@@ -57,41 +51,27 @@ export class OperatorCacheStatusService {
     this.workflowActionService
       .getTexeraGraph()
       .getCachedOperatorsChangedStream()
-      .subscribe((event) => {
-        const mainJointPaper = this.workflowActionService
-          .getJointGraphWrapper()
-          .getMainJointPaper();
+      .subscribe(event => {
+        const mainJointPaper = this.workflowActionService.getJointGraphWrapper().getMainJointPaper();
         if (!mainJointPaper) {
           return;
         }
 
-        event.newCached.concat(event.newUnCached).forEach((opID) => {
-          const op = this.workflowActionService
-            .getTexeraGraph()
-            .getOperator(opID);
+        event.newCached.concat(event.newUnCached).forEach(opID => {
+          const op = this.workflowActionService.getTexeraGraph().getOperator(opID);
 
           this.jointUIService.changeOperatorCacheStatus(mainJointPaper, op);
         });
       });
-    this.workflowWebsocketService
-      .subscribeToEvent("CacheStatusUpdateEvent")
-      .subscribe((event) => {
-        const mainJointPaper = this.workflowActionService
-          .getJointGraphWrapper()
-          .getMainJointPaper();
-        if (!mainJointPaper) {
-          return;
-        }
-        Object.entries(event.cacheStatusMap).forEach(([opID, cacheStatus]) => {
-          const op = this.workflowActionService
-            .getTexeraGraph()
-            .getOperator(opID);
-          this.jointUIService.changeOperatorCacheStatus(
-            mainJointPaper,
-            op,
-            cacheStatus
-          );
-        });
+    this.workflowWebsocketService.subscribeToEvent("CacheStatusUpdateEvent").subscribe(event => {
+      const mainJointPaper = this.workflowActionService.getJointGraphWrapper().getMainJointPaper();
+      if (!mainJointPaper) {
+        return;
+      }
+      Object.entries(event.cacheStatusMap).forEach(([opID, cacheStatus]) => {
+        const op = this.workflowActionService.getTexeraGraph().getOperator(opID);
+        this.jointUIService.changeOperatorCacheStatus(mainJointPaper, op, cacheStatus);
       });
+    });
   }
 }

--- a/core/new-gui/src/app/workspace/service/workflow-status/workflow-status.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-status/workflow-status.service.ts
@@ -6,7 +6,7 @@ import { WorkflowActionService } from "../workflow-graph/model/workflow-action.s
 import { WorkflowWebsocketService } from "../workflow-websocket/workflow-websocket.service";
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class WorkflowStatusService {
   // status is responsible for passing websocket responses to other components
@@ -20,11 +20,9 @@ export class WorkflowStatusService {
     if (!environment.executionStatusEnabled) {
       return;
     }
-    this.getStatusUpdateStream().subscribe(
-      (event) => (this.currentStatus = event)
-    );
+    this.getStatusUpdateStream().subscribe(event => (this.currentStatus = event));
 
-    this.workflowWebsocketService.websocketEvent().subscribe((event) => {
+    this.workflowWebsocketService.websocketEvent().subscribe(event => {
       if (event.type !== "WebWorkflowStatusUpdateEvent") {
         return;
       }
@@ -32,9 +30,7 @@ export class WorkflowStatusService {
     });
   }
 
-  public getStatusUpdateStream(): Observable<
-    Record<string, OperatorStatistics>
-  > {
+  public getStatusUpdateStream(): Observable<Record<string, OperatorStatistics>> {
     return this.statusSubject.asObservable();
   }
 

--- a/core/new-gui/src/app/workspace/service/workflow-websocket/workflow-websocket.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-websocket/workflow-websocket.service.ts
@@ -7,7 +7,7 @@ import {
   TexeraWebsocketEventTypes,
   TexeraWebsocketRequest,
   TexeraWebsocketRequestTypeMap,
-  TexeraWebsocketRequestTypes
+  TexeraWebsocketRequestTypes,
 } from "../../types/workflow-websocket.interface";
 import { delayWhen, filter, map, retryWhen, tap } from "rxjs/operators";
 
@@ -15,19 +15,15 @@ export const WS_HEARTBEAT_INTERVAL_MS = 10000;
 export const WS_RECONNECT_INTERVAL_MS = 3000;
 
 @Injectable({
-  providedIn: "root"
+  providedIn: "root",
 })
 export class WorkflowWebsocketService {
-  private static readonly TEXERA_WEBSOCKET_ENDPOINT =
-    "wsapi/workflow-websocket";
+  private static readonly TEXERA_WEBSOCKET_ENDPOINT = "wsapi/workflow-websocket";
 
   public isConnected: boolean = false;
 
-  private readonly websocket: WebSocketSubject<
-    TexeraWebsocketEvent | TexeraWebsocketRequest
-  >;
-  private readonly webSocketResponseSubject: Subject<TexeraWebsocketEvent> =
-    new Subject();
+  private readonly websocket: WebSocketSubject<TexeraWebsocketEvent | TexeraWebsocketRequest>;
+  private readonly webSocketResponseSubject: Subject<TexeraWebsocketEvent> = new Subject();
 
   constructor() {
     this.websocket = webSocket<TexeraWebsocketEvent | TexeraWebsocketRequest>(
@@ -36,36 +32,28 @@ export class WorkflowWebsocketService {
 
     // setup reconnection logic
     const wsWithReconnect = this.websocket.pipe(
-      retryWhen((error) =>
+      retryWhen(error =>
         error.pipe(
-          tap((_) => (this.isConnected = false)), // update connection status
-          tap((_) =>
-            console.log(
-              `websocket connection lost, reconnecting in ${
-                WS_RECONNECT_INTERVAL_MS / 1000
-              } seconds`
-            )
+          tap(_ => (this.isConnected = false)), // update connection status
+          tap(_ =>
+            console.log(`websocket connection lost, reconnecting in ${WS_RECONNECT_INTERVAL_MS / 1000} seconds`)
           ),
-          delayWhen((_) => timer(WS_RECONNECT_INTERVAL_MS)), // reconnect after delay
+          delayWhen(_ => timer(WS_RECONNECT_INTERVAL_MS)), // reconnect after delay
           tap(
-            (_) => this.send("HeartBeatRequest", {}) // try to send heartbeat immediately after reconnect
+            _ => this.send("HeartBeatRequest", {}) // try to send heartbeat immediately after reconnect
           )
         )
       )
     );
 
     // set up heartbeat
-    interval(WS_HEARTBEAT_INTERVAL_MS).subscribe((_) =>
-      this.send("HeartBeatRequest", {})
-    );
+    interval(WS_HEARTBEAT_INTERVAL_MS).subscribe(_ => this.send("HeartBeatRequest", {}));
 
     // refresh connection status
-    this.websocketEvent().subscribe((_) => (this.isConnected = true));
+    this.websocketEvent().subscribe(_ => (this.isConnected = true));
 
     // set up event listener on re-connectable websocket observable
-    wsWithReconnect.subscribe((event) =>
-      this.webSocketResponseSubject.next(event as TexeraWebsocketEvent)
-    );
+    wsWithReconnect.subscribe(event => this.webSocketResponseSubject.next(event as TexeraWebsocketEvent));
 
     // send hello world
     this.send("HelloWorldRequest", { message: "Texera on Amber" });
@@ -82,27 +70,21 @@ export class WorkflowWebsocketService {
     type: T
   ): Observable<{ type: T } & TexeraWebsocketEventTypeMap[T]> {
     return this.websocketEvent().pipe(
-      filter((event) => event.type === type),
-      map((event) => event as { type: T } & TexeraWebsocketEventTypeMap[T])
+      filter(event => event.type === type),
+      map(event => event as { type: T } & TexeraWebsocketEventTypeMap[T])
     );
   }
 
-  public send<T extends TexeraWebsocketRequestTypes>(
-    type: T,
-    payload: TexeraWebsocketRequestTypeMap[T]
-  ): void {
+  public send<T extends TexeraWebsocketRequestTypes>(type: T, payload: TexeraWebsocketRequestTypeMap[T]): void {
     const request = {
       type,
-      ...payload
+      ...payload,
     } as any as TexeraWebsocketRequest;
     this.websocket.next(request);
   }
 
   public static getWorkflowWebsocketUrl(): string {
-    const websocketUrl = new URL(
-      WorkflowWebsocketService.TEXERA_WEBSOCKET_ENDPOINT,
-      document.baseURI
-    );
+    const websocketUrl = new URL(WorkflowWebsocketService.TEXERA_WEBSOCKET_ENDPOINT, document.baseURI);
     // replace protocol, so that http -> ws, https -> wss
     websocketUrl.protocol = websocketUrl.protocol.replace("http", "ws");
     return websocketUrl.toString();

--- a/core/new-gui/src/app/workspace/types/execute-workflow.interface.ts
+++ b/core/new-gui/src/app/workspace/types/execute-workflow.interface.ts
@@ -5,10 +5,7 @@
  */
 
 import { ChartType } from "./visualization.interface";
-import {
-  BreakpointRequest,
-  BreakpointTriggerInfo
-} from "./workflow-common.interface";
+import { BreakpointRequest, BreakpointTriggerInfo } from "./workflow-common.interface";
 import { OperatorCurrentTuples } from "./workflow-websocket.interface";
 
 export interface LogicalLink
@@ -23,11 +20,7 @@ export interface LogicalOperator
     operatorType: string;
     // reason for not using `any` in this case is to
     //  prevent types such as `undefined` or `null`
-    [uniqueAttributes: string]:
-      | string
-      | number
-      | boolean
-      | Record<string, unknown>;
+    [uniqueAttributes: string]: string | number | boolean | Record<string, unknown>;
   }> {}
 
 export interface BreakpointInfo
@@ -69,7 +62,7 @@ export enum OperatorState {
   Paused = "Paused",
   Resuming = "Resuming",
   Completed = "Completed",
-  Recovering = "Recovering"
+  Recovering = "Recovering",
 }
 
 export interface OperatorStatistics
@@ -115,19 +108,12 @@ export interface WorkflowResultUpdateEvent
 // user-defined type guards to check the type of the result update
 // because TypeScript can't do Tagged Unions on nested data types https://github.com/microsoft/TypeScript/issues/18758
 // and the unions have to be defined as nested because of JSON serialization options
-export function isWebPaginationUpdate(
-  update: WebResultUpdate
-): update is WebPaginationUpdate {
+export function isWebPaginationUpdate(update: WebResultUpdate): update is WebPaginationUpdate {
   return update !== undefined && update.mode.type === "PaginationMode";
 }
 
-export function isWebDataUpdate(
-  update: WebResultUpdate
-): update is WebDataUpdate {
-  return (
-    (update !== undefined && update.mode.type === "SetSnapshotMode") ||
-    update.mode.type === "SetDeltaMode"
-  );
+export function isWebDataUpdate(update: WebResultUpdate): update is WebDataUpdate {
+  return (update !== undefined && update.mode.type === "SetSnapshotMode") || update.mode.type === "SetDeltaMode";
 }
 
 export enum ExecutionState {
@@ -140,7 +126,7 @@ export enum ExecutionState {
   Recovering = "Recovering",
   BreakpointTriggered = "BreakpointTriggered",
   Completed = "Completed",
-  Failed = "Failed"
+  Failed = "Failed",
 }
 
 export type ExecutionStateInfo = Readonly<

--- a/core/new-gui/src/app/workspace/types/result-table.interface.ts
+++ b/core/new-gui/src/app/workspace/types/result-table.interface.ts
@@ -19,9 +19,7 @@ export interface IndexableObject
  *  retreiving each attribute from each result row.
  * Given a row, extract the cell value of each column.
  */
-type TableCellMethod = (
-  row: IndexableObject
-) => object | string | number | boolean;
+type TableCellMethod = (row: IndexableObject) => object | string | number | boolean;
 
 /**
  * TableColumn specifies the information about each column.

--- a/core/new-gui/src/app/workspace/types/visualization.interface.ts
+++ b/core/new-gui/src/app/workspace/types/visualization.interface.ts
@@ -15,7 +15,7 @@ export enum ChartType {
   SPLINE = "spline",
   HTML_VIZ = "HTML visualizer",
   SIMPLE_SCATTERPLOT = "scatter",
-  SPATIAL_SCATTERPLOT = "spatial scatterplot"
+  SPATIAL_SCATTERPLOT = "spatial scatterplot",
 }
 
 /**

--- a/core/new-gui/src/app/workspace/types/workflow-common.interface.ts
+++ b/core/new-gui/src/app/workspace/types/workflow-common.interface.ts
@@ -44,15 +44,7 @@ export interface BreakpointSchema
 
 type ConditionBreakpoint = Readonly<{
   column: number;
-  condition:
-    | "="
-    | ">"
-    | ">="
-    | "<"
-    | "<="
-    | "!="
-    | "contains"
-    | "does not contain";
+  condition: "=" | ">" | ">=" | "<" | "<=" | "!=" | "contains" | "does not contain";
   value: string;
 }>;
 

--- a/core/new-gui/src/app/workspace/types/workflow-websocket.interface.ts
+++ b/core/new-gui/src/app/workspace/types/workflow-websocket.interface.ts
@@ -4,13 +4,9 @@ import {
   LogicalPlan,
   WebOutputMode,
   WorkflowResultUpdateEvent,
-  WorkflowStatusUpdate
+  WorkflowStatusUpdate,
 } from "./execute-workflow.interface";
-import {
-  BreakpointFaultedTuple,
-  BreakpointTriggerInfo,
-  PythonPrintTriggerInfo
-} from "./workflow-common.interface";
+import { BreakpointFaultedTuple, BreakpointTriggerInfo, PythonPrintTriggerInfo } from "./workflow-common.interface";
 
 /**
  *  @fileOverview Type Definitions of WebSocket (Ws) API
@@ -100,10 +96,7 @@ export type WorkflowAvailableResultEvent = Readonly<{
   availableOperators: ReadonlyArray<OperatorAvailableResult>;
 }>;
 
-export type OperatorResultCacheStatus =
-  | "cache invalid"
-  | "cache valid"
-  | "cache not enabled";
+export type OperatorResultCacheStatus = "cache invalid" | "cache valid" | "cache not enabled";
 export interface CacheStatusUpdateEvent
   extends Readonly<{
     cacheStatusMap: Record<string, OperatorResultCacheStatus>;
@@ -157,8 +150,7 @@ type CustomUnionType<T> = ValueOf<
 >;
 
 export type TexeraWebsocketRequestTypes = keyof TexeraWebsocketRequestTypeMap;
-export type TexeraWebsocketRequest =
-  CustomUnionType<TexeraWebsocketRequestTypeMap>;
+export type TexeraWebsocketRequest = CustomUnionType<TexeraWebsocketRequestTypeMap>;
 
 export type TexeraWebsocketEventTypes = keyof TexeraWebsocketEventTypeMap;
 export type TexeraWebsocketEvent = CustomUnionType<TexeraWebsocketEventTypeMap>;

--- a/core/new-gui/src/environments/environment.default.ts
+++ b/core/new-gui/src/environments/environment.default.ts
@@ -54,15 +54,15 @@ export const defaultEnvironment = {
    * the access code for mapbox
    */
   mapbox: {
-    accessToken: ""
+    accessToken: "",
   },
 
   /**
    * all google-related configs
    */
   google: {
-    clientID: ""
-  }
+    clientID: "",
+  },
 };
 
 export type AppEnv = typeof defaultEnvironment;

--- a/core/new-gui/src/environments/environment.prod.ts
+++ b/core/new-gui/src/environments/environment.prod.ts
@@ -2,5 +2,5 @@ import { AppEnv, defaultEnvironment } from "./environment.default";
 
 export const environment: AppEnv = {
   ...defaultEnvironment,
-  production: true
+  production: true,
 };

--- a/core/new-gui/src/environments/environment.test.ts
+++ b/core/new-gui/src/environments/environment.test.ts
@@ -2,5 +2,5 @@ import { AppEnv, defaultEnvironment } from "./environment.default";
 
 export const environment: AppEnv = {
   ...defaultEnvironment,
-  userSystemEnabled: true
+  userSystemEnabled: true,
 };

--- a/core/new-gui/src/environments/environment.ts
+++ b/core/new-gui/src/environments/environment.ts
@@ -6,5 +6,5 @@
 import { AppEnv, defaultEnvironment } from "./environment.default";
 
 export const environment: AppEnv = {
-  ...defaultEnvironment
+  ...defaultEnvironment,
 };

--- a/core/new-gui/src/index.html
+++ b/core/new-gui/src/index.html
@@ -6,30 +6,13 @@
     <base href="/" />
 
     <meta content="width=device-width, initial-scale=1" name="viewport" />
-    <link
-      href="assets/logos/apple-touch-icon.png?v=1"
-      rel="apple-touch-icon"
-      sizes="180x180"
-    />
-    <link
-      href="assets/logos/favicon-32x32.png?v=1"
-      rel="icon"
-      sizes="32x32"
-      type="image/png"
-    />
-    <link
-      href="assets/logos/favicon-16x16.png?v=1"
-      rel="icon"
-      sizes="16x16"
-      type="image/png"
-    />
+    <link href="assets/logos/apple-touch-icon.png?v=1" rel="apple-touch-icon" sizes="180x180" />
+    <link href="assets/logos/favicon-32x32.png?v=1" rel="icon" sizes="32x32" type="image/png" />
+    <link href="assets/logos/favicon-16x16.png?v=1" rel="icon" sizes="16x16" type="image/png" />
     <link href="assets/logos/site.webmanifest?v=1" rel="manifest" />
 
     <!-- Add Angular Material Fonts -->
-    <link
-      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500"
-      rel="stylesheet"
-    />
+    <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet" />
   </head>
   <body>
     <texera-root></texera-root>

--- a/core/new-gui/src/main.ts
+++ b/core/new-gui/src/main.ts
@@ -10,4 +10,4 @@ if (environment.production) {
 
 platformBrowserDynamic()
   .bootstrapModule(AppModule)
-  .catch((err) => console.log(err));
+  .catch(err => console.log(err));

--- a/core/new-gui/src/material-custom-theme.scss
+++ b/core/new-gui/src/material-custom-theme.scss
@@ -23,7 +23,7 @@ $fontConfig: (
   body-1: mat-typography-level(14px, 20px, 400, "Roboto", 0.0179em),
   button: mat-typography-level(14px, 14px, 500, "Roboto", 0.0893em),
   caption: mat-typography-level(12px, 20px, 400, "Roboto", 0.0333em),
-  input: mat-typography-level(inherit, 1.125, 400, "Roboto", 1.5px)
+  input: mat-typography-level(inherit, 1.125, 400, "Roboto", 1.5px),
 );
 
 // Foreground Elements
@@ -52,7 +52,7 @@ $mat-light-theme-foreground: (
   text: $dark-primary-text,
   slider-min: $dark-primary-text,
   slider-off: rgba($dark-text, 0.26),
-  slider-off-active: $dark-disabled-text
+  slider-off-active: $dark-disabled-text,
 );
 
 // Dark Theme text
@@ -79,7 +79,7 @@ $mat-dark-theme-foreground: (
   text: $light-text,
   slider-min: $light-text,
   slider-off: rgba($light-text, 0.3),
-  slider-off-active: rgba($light-text, 0.3)
+  slider-off-active: rgba($light-text, 0.3),
 );
 
 // Background config
@@ -107,7 +107,7 @@ $mat-light-theme-background: (
   selected-disabled-button: $light-bg-darker-30,
   disabled-button-toggle: $light-bg-darker-10,
   unselected-chip: $light-bg-darker-10,
-  disabled-list-option: $light-bg-darker-10
+  disabled-list-option: $light-bg-darker-10,
 );
 
 // Dark bg
@@ -134,7 +134,7 @@ $mat-dark-theme-background: (
   selected-disabled-button: $dark-bg-lighter-30,
   disabled-button-toggle: $dark-bg-lighter-10,
   unselected-chip: $dark-bg-lighter-20,
-  disabled-list-option: $dark-bg-lighter-10
+  disabled-list-option: $dark-bg-lighter-10,
 );
 
 // Compute font config
@@ -161,8 +161,8 @@ $mat-primary: (
     (
       main: $light-primary-text,
       lighter: $dark-primary-text,
-      darker: $light-primary-text
-    )
+      darker: $light-primary-text,
+    ),
 );
 $theme-primary: mat-palette($mat-primary, main, lighter, darker);
 
@@ -185,8 +185,8 @@ $mat-accent: (
     (
       main: $light-primary-text,
       lighter: $dark-primary-text,
-      darker: $light-primary-text
-    )
+      darker: $light-primary-text,
+    ),
 );
 $theme-accent: mat-palette($mat-accent, main, lighter, darker);
 
@@ -209,8 +209,8 @@ $mat-warn: (
     (
       main: $light-primary-text,
       lighter: $dark-primary-text,
-      darker: $light-primary-text
-    )
+      darker: $light-primary-text,
+    ),
 );
 $theme-warn: mat-palette($mat-warn, main, lighter, darker);
 

--- a/core/new-gui/src/test.ts
+++ b/core/new-gui/src/test.ts
@@ -2,18 +2,12 @@
 
 import "zone.js/dist/zone-testing";
 import { getTestBed } from "@angular/core/testing";
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting
-} from "@angular/platform-browser-dynamic/testing";
+import { BrowserDynamicTestingModule, platformBrowserDynamicTesting } from "@angular/platform-browser-dynamic/testing";
 
 declare const require: any;
 
 // First, initialize the Angular testing environment.
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting()
-);
+getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 // Then we find all the tests.
 const context = require.context("./", true, /\.spec\.ts$/);
 // And load the modules.

--- a/core/new-gui/src/theme.less
+++ b/core/new-gui/src/theme.less
@@ -21,21 +21,15 @@
 
 // Color used by default to control hover and active backgrounds and for
 // alert info backgrounds.
-@primary-1: color(
-  ~`colorPalette("@{primary-color}", 1) `
-); // replace tint(@primary-color, 90%)
-@primary-2: color(
-  ~`colorPalette("@{primary-color}", 2) `
-); // replace tint(@primary-color, 80%)
+@primary-1: color(~`colorPalette("@{primary-color}", 1) `); // replace tint(@primary-color, 90%)
+@primary-2: color(~`colorPalette("@{primary-color}", 2) `); // replace tint(@primary-color, 80%)
 @primary-3: color(~`colorPalette("@{primary-color}", 3) `); // unused
 @primary-4: color(~`colorPalette("@{primary-color}", 4) `); // unused
 @primary-5: color(
   ~`colorPalette("@{primary-color}", 5) `
 ); // color used to control the text color in many active and hover states, replace tint(@primary-color, 20%)
 @primary-6: @primary-color; // color used to control the text color of active buttons, don't use, use @primary-color
-@primary-7: color(
-  ~`colorPalette("@{primary-color}", 7) `
-); // replace shade(@primary-color, 5%)
+@primary-7: color(~`colorPalette("@{primary-color}", 7) `); // replace shade(@primary-color, 5%)
 @primary-8: color(~`colorPalette("@{primary-color}", 8) `); // unused
 @primary-9: color(~`colorPalette("@{primary-color}", 9) `); // unused
 @primary-10: color(~`colorPalette("@{primary-color}", 10) `); // unused
@@ -50,11 +44,9 @@
 // Popover background color
 @popover-background: @component-background;
 @popover-customize-border-color: @border-color-split;
-@font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
-  "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji",
-  "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
-@code-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier,
-  monospace;
+@font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif,
+  "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+@code-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, Courier, monospace;
 @text-color: fade(@black, 85%);
 @text-color-secondary: fade(@black, 45%);
 @text-color-inverse: @white;
@@ -148,11 +140,7 @@
 @outline-color: @primary-color;
 @outline-fade: 20%;
 
-@background-color-light: hsv(
-  0,
-  0,
-  98%
-); // background of header and selected item
+@background-color-light: hsv(0, 0, 98%); // background of header and selected item
 @background-color-base: hsv(0, 0, 96%); // Default grey background color
 
 // Disabled states
@@ -164,16 +152,15 @@
 @shadow-color: rgba(0, 0, 0, 0.15);
 @shadow-color-inverse: @component-background;
 @box-shadow-base: @shadow-2;
-@shadow-1-up: 0 -6px 16px -8px rgba(0, 0, 0, 0.08),
-  0 -9px 28px 0 rgba(0, 0, 0, 0.05), 0 -12px 48px 16px rgba(0, 0, 0, 0.03);
-@shadow-1-down: 0 6px 16px -8px rgba(0, 0, 0, 0.08),
-  0 9px 28px 0 rgba(0, 0, 0, 0.05), 0 12px 48px 16px rgba(0, 0, 0, 0.03);
-@shadow-1-left: -6px 0 16px -8px rgba(0, 0, 0, 0.08),
-  -9px 0 28px 0 rgba(0, 0, 0, 0.05), -12px 0 48px 16px rgba(0, 0, 0, 0.03);
-@shadow-1-right: 6px 0 16px -8px rgba(0, 0, 0, 0.08),
-  9px 0 28px 0 rgba(0, 0, 0, 0.05), 12px 0 48px 16px rgba(0, 0, 0, 0.03);
-@shadow-2: 0 3px 6px -4px rgba(0, 0, 0, 0.12), 0 6px 16px 0 rgba(0, 0, 0, 0.08),
-  0 9px 28px 8px rgba(0, 0, 0, 0.05);
+@shadow-1-up: 0 -6px 16px -8px rgba(0, 0, 0, 0.08), 0 -9px 28px 0 rgba(0, 0, 0, 0.05),
+  0 -12px 48px 16px rgba(0, 0, 0, 0.03);
+@shadow-1-down: 0 6px 16px -8px rgba(0, 0, 0, 0.08), 0 9px 28px 0 rgba(0, 0, 0, 0.05),
+  0 12px 48px 16px rgba(0, 0, 0, 0.03);
+@shadow-1-left: -6px 0 16px -8px rgba(0, 0, 0, 0.08), -9px 0 28px 0 rgba(0, 0, 0, 0.05),
+  -12px 0 48px 16px rgba(0, 0, 0, 0.03);
+@shadow-1-right: 6px 0 16px -8px rgba(0, 0, 0, 0.08), 9px 0 28px 0 rgba(0, 0, 0, 0.05),
+  12px 0 48px 16px rgba(0, 0, 0, 0.03);
+@shadow-2: 0 3px 6px -4px rgba(0, 0, 0, 0.12), 0 6px 16px 0 rgba(0, 0, 0, 0.08), 0 9px 28px 8px rgba(0, 0, 0, 0.05);
 
 // Buttons
 @btn-font-weight: 400;
@@ -393,18 +380,15 @@
 @input-padding-horizontal-sm: @control-padding-horizontal-sm - 1px;
 @input-padding-horizontal-lg: @input-padding-horizontal;
 @input-padding-vertical-base: max(
-  round((@input-height-base - @font-size-base * @line-height-base) / 2 * 10) /
-    10 - @border-width-base,
+  round((@input-height-base - @font-size-base * @line-height-base) / 2 * 10) / 10 - @border-width-base,
   3px
 );
 @input-padding-vertical-sm: max(
-  round((@input-height-sm - @font-size-base * @line-height-base) / 2 * 10) / 10 -
-    @border-width-base,
+  round((@input-height-sm - @font-size-base * @line-height-base) / 2 * 10) / 10 - @border-width-base,
   0
 );
-@input-padding-vertical-lg: ceil(
-    (@input-height-lg - @font-size-lg * @line-height-base) / 2 * 10
-  ) / 10 - @border-width-base;
+@input-padding-vertical-lg: ceil((@input-height-lg - @font-size-lg * @line-height-base) / 2 * 10) / 10 -
+  @border-width-base;
 @input-placeholder-color: hsv(0, 0, 75%);
 @input-color: @text-color;
 @input-icon-color: @input-color;
@@ -444,8 +428,7 @@
 @select-selection-item-bg: @background-color-base;
 @select-selection-item-border-color: @border-color-split;
 @select-single-item-height-lg: 40px;
-@select-multiple-item-height: @input-height-base - @input-padding-vertical-base *
-  2; // Normal 24px
+@select-multiple-item-height: @input-height-base - @input-padding-vertical-base * 2; // Normal 24px
 @select-multiple-item-height-lg: 32px;
 @select-multiple-item-spacing-half: ceil(@input-padding-vertical-base / 2);
 @select-multiple-disabled-background: @input-disabled-bg;
@@ -515,8 +498,7 @@
 @modal-header-padding-horizontal: @padding-lg;
 @modal-body-padding: @padding-lg;
 @modal-header-bg: @component-background;
-@modal-header-padding: @modal-header-padding-vertical
-  @modal-header-padding-horizontal;
+@modal-header-padding: @modal-header-padding-vertical @modal-header-padding-horizontal;
 @modal-header-border-width: @border-width-base;
 @modal-header-border-style: @border-style-base;
 @modal-header-title-line-height: 22px;
@@ -701,8 +683,7 @@
 @card-actions-li-margin: 12px 0;
 @card-skeleton-bg: #cfd8dc;
 @card-background: @component-background;
-@card-shadow: 0 1px 2px -2px rgba(0, 0, 0, 0.16),
-  0 3px 6px 0 rgba(0, 0, 0, 0.12), 0 5px 12px 4px rgba(0, 0, 0, 0.09);
+@card-shadow: 0 1px 2px -2px rgba(0, 0, 0, 0.16), 0 3px 6px 0 rgba(0, 0, 0, 0.12), 0 5px 12px 4px rgba(0, 0, 0, 0.09);
 @card-radius: @border-radius-base;
 @card-head-tabs-margin-bottom: -17px;
 @card-head-extra-color: @text-color;
@@ -727,9 +708,8 @@
 @tabs-card-head-background: @background-color-light;
 @tabs-card-height: 40px;
 @tabs-card-active-color: @primary-color;
-@tabs-card-horizontal-padding: (
-    @tabs-card-height - floor(@font-size-base * @line-height-base)
-  ) / 2 - @border-width-base @padding-md;
+@tabs-card-horizontal-padding: (@tabs-card-height - floor(@font-size-base * @line-height-base)) / 2 - @border-width-base
+  @padding-md;
 @tabs-card-horizontal-padding-sm: 6px @padding-md;
 @tabs-card-horizontal-padding-lg: 7px @padding-md 6px;
 @tabs-title-font-size: @font-size-base;
@@ -916,11 +896,9 @@
 @alert-with-description-no-icon-padding-vertical: @padding-md - 1px;
 @alert-with-description-padding-vertical: @padding-md - 1px;
 @alert-with-description-padding: @alert-with-description-padding-vertical 15px
-  @alert-with-description-no-icon-padding-vertical
-  @alert-with-description-icon-size * 2 +
+  @alert-with-description-no-icon-padding-vertical @alert-with-description-icon-size * 2 +
   @alert-with-description-padding-vertical;
-@alert-icon-top: 8px + @font-size-base * @line-height-base / 2 - @font-size-base /
-  2;
+@alert-icon-top: 8px + @font-size-base * @line-height-base / 2 - @font-size-base / 2;
 @alert-with-description-icon-size: 24px;
 @alert-with-description-icon-top: @alert-with-description-padding-vertical;
 
@@ -1018,7 +996,4 @@
 @image-color: #fff;
 @image-preview-operation-size: 18px;
 @image-preview-operation-color: @text-color-dark;
-@image-preview-operation-disabled-color: fade(
-  @image-preview-operation-color,
-  45%
-);
+@image-preview-operation-disabled-color: fade(@image-preview-operation-color, 45%);


### PR DESCRIPTION
This PR changes some configs of the frontend formatter (`Prettier`):

- `printWidth`: 80 -> 120,
- `trailingComma`: "none" ->  "es5",
- `arrowParens`: "aways" -> "avoid",