### PR TITLE
Operator Cache: Un-allow cache for view result operator. Opitmize cache text display on operator.

### DIFF
--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -17,6 +17,7 @@ import { merge } from "rxjs";
 import { WorkflowResultExportService } from "../../service/workflow-result-export/workflow-result-export.service";
 import { debounceTime } from "rxjs/operators";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { VIEW_RESULT_OP_TYPE } from "../../service/workflow-graph/model/workflow-graph";
 
 /**
  * NavigationComponent is the top level navigation bar that shows
@@ -383,12 +384,21 @@ export class NavigationComponent {
   }
 
   public onClickCacheOperators(): void {
+    const effectiveHighlightedOperators =
+      this.effectivelyHighlightedOperators();
+    const effectiveHighlightedOperatorsExcludeSink =
+      effectiveHighlightedOperators.filter(
+        (op) =>
+          this.workflowActionService.getTexeraGraph().getOperator(op)
+            .operatorType !== VIEW_RESULT_OP_TYPE
+      );
+
     if (this.isCacheOperator) {
-      this.effectivelyHighlightedOperators().forEach((op) => {
+      effectiveHighlightedOperatorsExcludeSink.forEach((op) => {
         this.workflowActionService.getTexeraGraph().cacheOperator(op);
       });
     } else {
-      this.effectivelyHighlightedOperators().forEach((op) => {
+      effectiveHighlightedOperatorsExcludeSink.forEach((op) => {
         this.workflowActionService.getTexeraGraph().unCacheOperator(op);
       });
     }
@@ -522,13 +532,20 @@ export class NavigationComponent {
       .subscribe((event) => {
         const effectiveHighlightedOperators =
           this.effectivelyHighlightedOperators();
-        const allCached = this.effectivelyHighlightedOperators().every((op) =>
+        const effectiveHighlightedOperatorsExcludeSink =
+          effectiveHighlightedOperators.filter(
+            (op) =>
+              this.workflowActionService.getTexeraGraph().getOperator(op)
+                .operatorType !== VIEW_RESULT_OP_TYPE
+          );
+
+        const allCached = effectiveHighlightedOperatorsExcludeSink.every((op) =>
           this.workflowActionService.getTexeraGraph().isOperatorCached(op)
         );
 
         this.isCacheOperator = !allCached;
         this.isCacheOperatorClickable =
-          effectiveHighlightedOperators.length !== 0;
+          effectiveHighlightedOperatorsExcludeSink.length !== 0;
       });
   }
 

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -1,5 +1,5 @@
 import { DatePipe, Location } from "@angular/common";
-import { Component, ElementRef, Input, OnInit, ViewChild } from "@angular/core";
+import { Component, ElementRef, Input, ViewChild } from "@angular/core";
 import { TourService } from "ngx-tour-ng-bootstrap";
 import { environment } from "../../../../environments/environment";
 import { UserService } from "../../../common/service/user/user.service";

--- a/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/drag-drop/drag-drop.service.spec.ts
@@ -21,6 +21,7 @@ import {
   OperatorPredicate
 } from "../../types/workflow-common.interface";
 import { map } from "rxjs/operators";
+import { VIEW_RESULT_OP_TYPE } from "../workflow-graph/model/workflow-graph";
 
 describe("DragDropService", () => {
   let dragDropService: DragDropService;
@@ -135,9 +136,12 @@ describe("DragDropService", () => {
     const input1 = workflowUtilService.getNewOperatorPredicate("ScanSource");
     const input2 = workflowUtilService.getNewOperatorPredicate("ScanSource");
     const input3 = workflowUtilService.getNewOperatorPredicate("ScanSource");
-    const output1 = workflowUtilService.getNewOperatorPredicate("ViewResults");
-    const output2 = workflowUtilService.getNewOperatorPredicate("ViewResults");
-    const output3 = workflowUtilService.getNewOperatorPredicate("ViewResults");
+    const output1 =
+      workflowUtilService.getNewOperatorPredicate(VIEW_RESULT_OP_TYPE);
+    const output2 =
+      workflowUtilService.getNewOperatorPredicate(VIEW_RESULT_OP_TYPE);
+    const output3 =
+      workflowUtilService.getNewOperatorPredicate(VIEW_RESULT_OP_TYPE);
     const [inputOps, outputOps] = (dragDropService as any).findClosestOperators(
       { x: 50, y: 0 },
       mockMultiInputOutputPredicate
@@ -244,11 +248,11 @@ describe("DragDropService", () => {
       const input2 = workflowUtilService.getNewOperatorPredicate("ScanSource");
       const input3 = workflowUtilService.getNewOperatorPredicate("ScanSource");
       const output1 =
-        workflowUtilService.getNewOperatorPredicate("ViewResults");
+        workflowUtilService.getNewOperatorPredicate(VIEW_RESULT_OP_TYPE);
       const output2 =
-        workflowUtilService.getNewOperatorPredicate("ViewResults");
+        workflowUtilService.getNewOperatorPredicate(VIEW_RESULT_OP_TYPE);
       const output3 =
-        workflowUtilService.getNewOperatorPredicate("ViewResults");
+        workflowUtilService.getNewOperatorPredicate(VIEW_RESULT_OP_TYPE);
       const heightSortedInputs: OperatorPredicate[] = [input1, input2, input3];
       const heightSortedOutputs: OperatorPredicate[] = [
         output1,

--- a/core/new-gui/src/app/workspace/service/joint-ui/joint-ui.service.ts
+++ b/core/new-gui/src/app/workspace/service/joint-ui/joint-ui.service.ts
@@ -427,6 +427,10 @@ export class JointUIService {
       cacheStatus
     );
 
+    const cacheIndicatorText = cacheText === "" ? "" : "cache";
+    jointPaper
+      .getModelById(operator.operatorID)
+      .attr(`.${operatorCacheTextClass}/text`, cacheIndicatorText);
     jointPaper
       .getModelById(operator.operatorID)
       .attr(`.${operatorCacheIconClass}/xlink:href`, cacheIcon);
@@ -714,7 +718,10 @@ export class JointUIService {
         "y-alignment": "middle"
       },
       ".texera-operator-result-cache-text": {
-        text: "cache",
+        text:
+          JointUIService.getOperatorCacheDisplayText(operator) === ""
+            ? ""
+            : "cache",
         fill: "#595959",
         "font-size": "14px",
         visible: true,

--- a/core/new-gui/src/app/workspace/service/operator-metadata/mock-operator-metadata.data.ts
+++ b/core/new-gui/src/app/workspace/service/operator-metadata/mock-operator-metadata.data.ts
@@ -5,6 +5,7 @@ import {
 } from "../../types/operator-schema.interface";
 import { BreakpointSchema } from "../../types/workflow-common.interface";
 import { CustomJSONSchema7 } from "../../types/custom-json-schema.interface";
+import { VIEW_RESULT_OP_TYPE } from "../workflow-graph/model/workflow-graph";
 
 // Exports constants related to operator schema and operator metadata for testing purposes.
 
@@ -167,7 +168,7 @@ export const mockAggregationSchema: OperatorSchema = {
 };
 
 export const mockViewResultsSchema: OperatorSchema = {
-  operatorType: "ViewResults",
+  operatorType: VIEW_RESULT_OP_TYPE,
   jsonSchema: {
     properties: {
       limit: {

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/mock-workflow-data.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/mock-workflow-data.ts
@@ -3,6 +3,7 @@ import {
   OperatorPredicate,
   Point
 } from "../../../types/workflow-common.interface";
+import { VIEW_RESULT_OP_TYPE } from "./workflow-graph";
 
 /**
  * Provides mock data related operators and links:
@@ -51,7 +52,7 @@ export const mockSentimentPredicate: OperatorPredicate = {
 
 export const mockResultPredicate: OperatorPredicate = {
   operatorID: "3",
-  operatorType: "ViewResults",
+  operatorType: VIEW_RESULT_OP_TYPE,
   operatorProperties: {},
   inputPorts: [{ portID: "input-0" }],
   outputPorts: [],

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.spec.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.spec.ts
@@ -239,6 +239,46 @@ describe("WorkflowGraph", () => {
     expect(workflowGraph.getAllEnabledLinks().length).toEqual(0);
   });
 
+  it("should cache and un-cache an operator", () => {
+    workflowGraph.addOperator(mockScanPredicate);
+    workflowGraph.addOperator(mockResultPredicate);
+    workflowGraph.cacheOperator(mockScanPredicate.operatorID);
+
+    expect(
+      workflowGraph.isOperatorCached(mockScanPredicate.operatorID)
+    ).toBeTrue();
+    expect(
+      workflowGraph.isOperatorCached(mockResultPredicate.operatorID)
+    ).toBeFalse();
+    expect(workflowGraph.getCachedOperators().size).toEqual(1);
+
+    workflowGraph.unCacheOperator(mockScanPredicate.operatorID);
+    expect(
+      workflowGraph.isOperatorCached(mockScanPredicate.operatorID)
+    ).toBeFalse();
+    expect(workflowGraph.getDisabledOperators().size).toEqual(0);
+  });
+
+  it("should ignore cache the view result operator", () => {
+    workflowGraph.addOperator(mockScanPredicate);
+    workflowGraph.addOperator(mockResultPredicate);
+    workflowGraph.cacheOperator(mockResultPredicate.operatorID);
+
+    expect(
+      workflowGraph.isOperatorCached(mockScanPredicate.operatorID)
+    ).toBeFalse();
+    expect(
+      workflowGraph.isOperatorCached(mockResultPredicate.operatorID)
+    ).toBeFalse();
+    expect(workflowGraph.getCachedOperators().size).toEqual(0);
+
+    workflowGraph.unCacheOperator(mockResultPredicate.operatorID);
+    expect(
+      workflowGraph.isOperatorCached(mockResultPredicate.operatorID)
+    ).toBeFalse();
+    expect(workflowGraph.getCachedOperators().size).toEqual(0);
+  });
+
   describe("when linkBreakpoint is enabled", () => {
     beforeAll(() => {
       environment.linkBreakpointEnabled = true;

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
@@ -25,6 +25,9 @@ type restrictedMethods =
  */
 export type WorkflowGraphReadonly = Omit<WorkflowGraph, restrictedMethods>;
 
+export const VIEW_RESULT_OP_TYPE = "SimpleSink";
+export const VIEW_RESULT_OP_NAME = "View Results";
+
 /**
  * WorkflowGraph represents the Texera's logical WorkflowGraph,
  *  it's a graph consisted of operators <OperatorPredicate> and links <OpreatorLink>,
@@ -168,6 +171,9 @@ export class WorkflowGraph {
     const operator = this.getOperator(operatorID);
     if (!operator) {
       throw new Error(`operator with ID ${operatorID} doesn't exist`);
+    }
+    if (operator.operatorType === VIEW_RESULT_OP_TYPE) {
+      return;
     }
     if (this.isOperatorCached(operatorID)) {
       return;

--- a/core/new-gui/src/environments/environment.default.ts
+++ b/core/new-gui/src/environments/environment.default.ts
@@ -48,7 +48,7 @@ export const defaultEnvironment = {
   /**
    * whether operator caching is enabled
    */
-  operatorCacheEnabled: false,
+  operatorCacheEnabled: true,
 
   /**
    * the access code for mapbox

--- a/core/new-gui/src/environments/environment.default.ts
+++ b/core/new-gui/src/environments/environment.default.ts
@@ -48,7 +48,7 @@ export const defaultEnvironment = {
   /**
    * whether operator caching is enabled
    */
-  operatorCacheEnabled: true,
+  operatorCacheEnabled: false,
 
   /**
    * the access code for mapbox


### PR DESCRIPTION
This PR optimizes the frontend implementation on opeator caching:
1. view result operator cannot be cached, the frontend excludes the view result operator for cache-related operations
2. optmizes the text on operator cache display, it now only shows up when cache is enabled for an operator

Screenshot of cache display of different states: 
- Source: to be cached,
- Top projection: cache valid,
- Bottom projection: cache invalid,
- other opeators: cache not enabled

![image](https://user-images.githubusercontent.com/12578068/132928414-ce9f85d2-5146-4c73-a5ee-75a70cd7d170.png)