### PR TITLE
Reconnect frontend to the workflow execution upon reopening the tab

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/Utils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/Utils.scala
@@ -73,6 +73,12 @@ object Utils {
     }
   }
 
+  def runIfOptionNonEmpty[T](opt: Option[T])(fn: T => Unit): Unit = {
+    if (opt.nonEmpty) {
+      fn(opt.get)
+    }
+  }
+
   private def isAmberHomePath(path: Path): Boolean = {
     path.toRealPath().endsWith(AMBER_HOME_FOLDER_NAME)
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/WebsocketLogStorage.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/WebsocketLogStorage.scala
@@ -1,0 +1,63 @@
+package edu.uci.ics.texera.web
+
+import edu.uci.ics.texera.web.model.event.{
+  FrameSynchronization,
+  StateSynchronization,
+  TexeraWebSocketEvent
+}
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+object WebsocketLogStorage {
+  class SocketMessageLog {
+    private var seqNumber = 0
+    private val statelessEvents = new mutable.HashMap[String, (Int, TexeraWebSocketEvent)]
+    private val statefulEvents =
+      new mutable.HashMap[String, mutable.ArrayBuffer[(Int, TexeraWebSocketEvent)]]
+    def logEvent(evt: TexeraWebSocketEvent): Unit = {
+      evt match {
+        case _: FrameSynchronization =>
+          val name = evt.getClass.getSimpleName
+          if (!statefulEvents.contains(name)) {
+            statefulEvents(name) = ArrayBuffer((seqNumber, evt))
+          } else {
+            statefulEvents(name).append((seqNumber, evt))
+          }
+          seqNumber += 1
+        case _: StateSynchronization =>
+          val name = evt.getClass.getSimpleName
+          statelessEvents(name) = (seqNumber, evt)
+          seqNumber += 1
+        case _ =>
+        //skip
+      }
+    }
+
+    def retrieveEvents(): Seq[TexeraWebSocketEvent] = {
+      (statelessEvents.values ++ statefulEvents.values.flatten).toList.sortBy(_._1).map(_._2)
+    }
+  }
+
+  private val idToLogs = new mutable.HashMap[String, SocketMessageLog]
+
+  def logMarkedEvent(id: String, evt: TexeraWebSocketEvent): Unit = {
+    if (!idToLogs.contains(id)) {
+      idToLogs(id) = new SocketMessageLog()
+    }
+    idToLogs(id).logEvent(evt)
+  }
+
+  def getLoggedEvents(id: String): Seq[TexeraWebSocketEvent] = {
+    if (!idToLogs.contains(id)) {
+      Seq.empty
+    } else {
+      idToLogs(id).retrieveEvents()
+    }
+  }
+
+  def clearLoggedEvents(id: String): Unit = {
+    idToLogs.remove(id)
+  }
+
+}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/PaginatedResultEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/PaginatedResultEvent.scala
@@ -16,6 +16,7 @@ case class PaginatedResultEvent(
     pageIndex: Int,
     table: List[ObjectNode]
 ) extends TexeraWebSocketEvent
+    with FrameSynchronization
 
 case class OperatorAvailableResult(
     cacheValid: Boolean,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/RegisterWIdResponse.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/RegisterWIdResponse.scala
@@ -1,5 +1,5 @@
 package edu.uci.ics.texera.web.model.event
 
-case class HelloWorldResponse(message: String) extends TexeraWebSocketEvent
+case class RegisterWIdResponse(message: String) extends TexeraWebSocketEvent
 
 case class HeartBeatResponse() extends TexeraWebSocketEvent

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/TexeraWebSocketEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/TexeraWebSocketEvent.scala
@@ -6,12 +6,13 @@ import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes(
   Array(
-    new Type(value = classOf[HelloWorldResponse]),
+    new Type(value = classOf[RegisterWIdResponse]),
     new Type(value = classOf[HeartBeatResponse]),
     new Type(value = classOf[WorkflowErrorEvent]),
     new Type(value = classOf[WorkflowStartedEvent]),
     new Type(value = classOf[WorkflowCompletedEvent]),
     new Type(value = classOf[WebWorkflowStatusUpdateEvent]),
+    new Type(value = classOf[WebResultUpdateEvent]),
     new Type(value = classOf[WorkflowPausedEvent]),
     new Type(value = classOf[WorkflowResumedEvent]),
     new Type(value = classOf[RecoveryStartedEvent]),
@@ -23,3 +24,7 @@ import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
   )
 )
 trait TexeraWebSocketEvent {}
+
+trait StateSynchronization
+
+trait FrameSynchronization

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WebResultUpdateEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WebResultUpdateEvent.scala
@@ -1,0 +1,7 @@
+package edu.uci.ics.texera.web.model.event
+
+import edu.uci.ics.texera.web.resource.WorkflowResultService.WebResultUpdate
+
+case class WebResultUpdateEvent(updates: Map[String, WebResultUpdate])
+    extends TexeraWebSocketEvent
+    with FrameSynchronization

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WebWorkflowStatusUpdateEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WebWorkflowStatusUpdateEvent.scala
@@ -15,3 +15,4 @@ object WebWorkflowStatusUpdateEvent {
 
 case class WebWorkflowStatusUpdateEvent(operatorStatistics: Map[String, OperatorStatistics])
     extends TexeraWebSocketEvent
+    with StateSynchronization

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowCompletedEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowCompletedEvent.scala
@@ -1,3 +1,3 @@
 package edu.uci.ics.texera.web.model.event
 
-case class WorkflowCompletedEvent() extends TexeraWebSocketEvent
+case class WorkflowCompletedEvent() extends TexeraWebSocketEvent with StateSynchronization

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowPausedEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowPausedEvent.scala
@@ -1,3 +1,3 @@
 package edu.uci.ics.texera.web.model.event
 
-case class WorkflowPausedEvent() extends TexeraWebSocketEvent
+case class WorkflowPausedEvent() extends TexeraWebSocketEvent with StateSynchronization

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStartedEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/event/WorkflowStartedEvent.scala
@@ -1,3 +1,3 @@
 package edu.uci.ics.texera.web.model.event
 
-case class WorkflowStartedEvent() extends TexeraWebSocketEvent
+case class WorkflowStartedEvent() extends TexeraWebSocketEvent with StateSynchronization

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/request/HelloWorldRequest.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/request/HelloWorldRequest.scala
@@ -1,5 +1,0 @@
-package edu.uci.ics.texera.web.model.request
-
-case class HelloWorldRequest(message: String) extends TexeraWebSocketRequest
-
-case class HeartBeatRequest() extends TexeraWebSocketRequest

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/request/RegisterWIdRequest.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/request/RegisterWIdRequest.scala
@@ -1,0 +1,6 @@
+package edu.uci.ics.texera.web.model.request
+
+case class RegisterWIdRequest(wId: String, recoverFrontendState: Boolean)
+    extends TexeraWebSocketRequest
+
+case class HeartBeatRequest() extends TexeraWebSocketRequest

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/request/TexeraWebSocketRequest.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/request/TexeraWebSocketRequest.scala
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.{JsonSubTypes, JsonTypeInfo}
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "type")
 @JsonSubTypes(
   Array(
-    new Type(value = classOf[HelloWorldRequest]),
+    new Type(value = classOf[RegisterWIdRequest]),
     new Type(value = classOf[HeartBeatRequest]),
     new Type(value = classOf[ExecuteWorkflowRequest]),
     new Type(value = classOf[PauseWorkflowRequest]),

--- a/core/new-gui/src/app/workspace/types/workflow-websocket.interface.ts
+++ b/core/new-gui/src/app/workspace/types/workflow-websocket.interface.ts
@@ -21,7 +21,13 @@ import { BreakpointFaultedTuple, BreakpointTriggerInfo, PythonPrintTriggerInfo }
  * 2. value is the payload this request/event needs
  */
 
-export interface WebSocketHelloWorld extends Readonly<{ message: string }> {}
+export interface RegisterWIdRequest
+  extends Readonly<{
+  wId: string;
+  recoverFrontendState: boolean;
+  }> {}
+
+export interface RegisterWIdEvent extends Readonly<{ message: string }> {}
 
 export interface TexeraConstraintViolation
   extends Readonly<{
@@ -103,7 +109,7 @@ export interface CacheStatusUpdateEvent
   }> {}
 
 export type TexeraWebsocketRequestTypeMap = {
-  HelloWorldRequest: WebSocketHelloWorld;
+  RegisterWIdRequest: RegisterWIdRequest;
   HeartBeatRequest: {};
   ExecuteWorkflowRequest: LogicalPlan;
   PauseWorkflowRequest: {};
@@ -119,7 +125,7 @@ export type TexeraWebsocketRequestTypeMap = {
 };
 
 export type TexeraWebsocketEventTypeMap = {
-  HelloWorldResponse: WebSocketHelloWorld;
+  RegisterWIdResponse: RegisterWIdEvent;
   HeartBeatResponse: {};
   WorkflowErrorEvent: WorkflowError;
   WorkflowStartedEvent: {};


### PR DESCRIPTION
This PR:
1. logs events sent to the frontend. The developer can mark each event as either `StateSynchorization` or `FrameSynchorization` to enable the corresponding logging mechanism. 
2. recover frontend state by sending the logged events.

Notes:
1. Currently each web socket can only bind to one workflow execution but one workflow execution can be shared across different web sockets. And one workflow can only have one execution at a time.
2. The lifespan of the operator cache is still within one web socket session. If the web socket closes, the operator cache will be cleared no matter what.