### PR TITLE
Fix Python Protocol instantiation Issue

### DIFF
--- a/core/amber/src/main/python/core/util/customized_queue/double_blocking_queue.py
+++ b/core/amber/src/main/python/core/util/customized_queue/double_blocking_queue.py
@@ -13,7 +13,6 @@ class DoubleBlockingQueue(IQueue):
     """
 
     def __init__(self, *sub_types: type):
-        super().__init__()
         self._input_queue = queue.Queue()
         self._main_queue = queue.Queue()
         self._sub_queue = queue.Queue()

--- a/core/amber/src/main/python/core/util/stoppable/stoppable_queue_blocking_thread.py
+++ b/core/amber/src/main/python/core/util/stoppable/stoppable_queue_blocking_thread.py
@@ -34,7 +34,6 @@ class StoppableQueueBlockingRunnable(Runnable, Stoppable):
     RUNNABLE_STOP = IQueue.QueueControl(msg="__RUNNABLE__STOP__MARKER__")
 
     def __init__(self, name: str, queue: IQueue):
-        super().__init__()
         self._internal_queue = queue
         self.name = name
 


### PR DESCRIPTION
Python 3.9.7 disallows instantiating a Protocol. This PR reflects the change.