### PR TITLE
Enable User Workflow and Uploaded File Name Change

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/WorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/WorkflowResource.scala
@@ -296,4 +296,27 @@ class WorkflowResource {
     }
   }
 
+  /**
+    * This method updates the name of a given workflow
+    *
+    * @param session HttpSession
+    * @return the updated workflow
+    */
+  @POST
+  @Path("/update/name")
+  @Consumes(Array(MediaType.APPLICATION_JSON))
+  @Produces(Array(MediaType.APPLICATION_JSON))
+  def changeWorkflowName(workflow: Workflow, @Auth sessionUser: SessionUser): Response = {
+    val user = sessionUser.getUser
+    val wid = workflow.getWid
+    if (workflowOfUserExists(wid, user.getUid)) {
+      val userWorkflow = workflowDao.fetchOneByWid(wid);
+      userWorkflow.setName(workflow.getName)
+      workflowDao.update(userWorkflow)
+      Response.ok(userWorkflow).build()
+    } else {
+      Response.notModified().build()
+    }
+  }
+
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/file/UserFileResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/file/UserFileResource.scala
@@ -258,4 +258,34 @@ class UserFileResource {
 
   }
 
+  /**
+    * This method updates the name of a given userFile
+    *
+    * @param session HttpSession
+    * @return the updated userFile
+    */
+  @POST
+  @Path("/update/name")
+  @Consumes(Array(MediaType.APPLICATION_JSON))
+  @Produces(Array(MediaType.APPLICATION_JSON))
+  def changeUserFileName(file: File, @Auth sessionUser: SessionUser): Response = {
+    val user = sessionUser.getUser
+    val fid = file.getFid
+    val newFileName = file.getName
+
+    val validationRes = this.validateFileName(newFileName, user.getUid)
+    if (validationRes.getLeft) {
+      val userFile = fileDao.fetchOneByFid(fid)
+      userFile.setName(newFileName)
+      fileDao.update(userFile)
+      Response.ok(userFile).build()
+    } else {
+      Response
+        .status(Response.Status.BAD_REQUEST)
+        .`type`(MediaType.TEXT_PLAIN)
+        .entity(validationRes.getRight)
+        .build()
+    }
+  }
+
 }

--- a/core/new-gui/src/app/common/service/workflow-persist/workflow-persist.service.ts
+++ b/core/new-gui/src/app/common/service/workflow-persist/workflow-persist.service.ts
@@ -12,6 +12,7 @@ export const WORKFLOW_PERSIST_URL = WORKFLOW_BASE_URL + "/persist";
 export const WORKFLOW_LIST_URL = WORKFLOW_BASE_URL + "/list";
 export const WORKFLOW_CREATE_URL = WORKFLOW_BASE_URL + "/create";
 export const WORKFLOW_DUPLICATE_URL = WORKFLOW_BASE_URL + "/duplicate";
+export const WORKFLOW_UPDATENAME_URL = WORKFLOW_BASE_URL + "/update/name";
 
 @Injectable({
   providedIn: "root",
@@ -95,5 +96,20 @@ export class WorkflowPersistService {
    */
   public deleteWorkflow(wid: number): Observable<Response> {
     return this.http.delete<Response>(`${AppSettings.getApiEndpoint()}/${WORKFLOW_BASE_URL}/${wid}`);
+  }
+
+  /**
+   * updates the name of a given workflow, the user in the session must own the workflow.
+   */
+  public updateWorkflowName(wid: number | undefined, name: string): Observable<Workflow> {
+    return this.http
+      .post<Workflow>(`${AppSettings.getApiEndpoint()}/${WORKFLOW_UPDATENAME_URL}`, {
+      wid: wid,
+      name: name,
+    })
+      .pipe(
+        filter((updatedWorkflow: Workflow) => updatedWorkflow != null),
+        map(WorkflowUtilService.parseWorkflowInfo)
+      );
   }
 }

--- a/core/new-gui/src/app/common/type/workflow.ts
+++ b/core/new-gui/src/app/common/type/workflow.ts
@@ -23,4 +23,4 @@ export interface WorkflowContent
     breakpoints: Record<string, Breakpoint>;
   }> {}
 
-export type Workflow = { content: WorkflowContent } & WorkflowMetadata;
+export type Workflow = { content: WorkflowContent, isEditingName?: Boolean } & WorkflowMetadata;

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.html
@@ -37,7 +37,7 @@
 
   <nz-card class="workflow-list-container subsection-grid-container">
     <nz-list>
-      <nz-list-item *ngFor="let dashboardWorkflowEntry of dashboardWorkflowEntries" class="workflow-list-item">
+      <nz-list-item *ngFor="let dashboardWorkflowEntry of dashboardWorkflowEntries;let indexOfElement=index" class="workflow-list-item">
         <nz-list-item-meta>
           <nz-list-item-meta-avatar>
             <nz-avatar
@@ -50,9 +50,28 @@
           </nz-list-item-meta-avatar>
           <nz-list-item-meta-title>
             <span class="workflow-dashboard-entry">
-              <label (click)="jumpToWorkflow(dashboardWorkflowEntry)" class="workflow-name"
+              <label *ngIf="dashboardWorkflowEntry.workflow.isEditingName !== true; else customeWorkflow " (click)="jumpToWorkflow(dashboardWorkflowEntry)" class="workflow-name"
                 >{{ dashboardWorkflowEntry.workflow.name }}</label
               >
+              <ng-template #customeWorkflow>
+                <input  
+                  #customName
+                  (focusout)="confirmUpdateWorkflowCustomName(dashboardWorkflowEntry, customName.value, indexOfElement)"
+                  (keyup.enter)="confirmUpdateWorkflowCustomName(dashboardWorkflowEntry, customName.value, indexOfElement)"
+                  placeholder="{{ dashboardWorkflowEntry.workflow.name }}"
+                  value="{{ dashboardWorkflowEntry.workflow.name }}"
+                />
+              </ng-template>
+              <button
+              (click)="dashboardWorkflowEntry.workflow.isEditingName = true"
+              nz-button
+              nz-tooltip="Customize Workflow Name"
+              nzSize="small"
+              nzTooltipPlacement="bottom"
+              nzType="text"
+            >
+              <i nz-icon nzTheme="outline" nzType="edit"></i>
+            </button>
               <i
                 *ngIf="dashboardWorkflowEntry.isOwner"
                 ngbTooltip="You are the OWNER"

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.scss
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.scss
@@ -13,6 +13,10 @@
   margin-left: 5px;
 }
 
+.ant-btn-icon-only {
+  margin-right: 10px;
+}
+
 /**
 * this css is used for creating a 2*1 grid area for the 2 main
 * sub parts. The first row contains add and sort button. The second
@@ -77,7 +81,6 @@ $header-height: 120px;
 .workflow-name {
   font-size: 20px;
   font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-  margin-right: 10px;
   text-align: center;
 }
 

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
@@ -1,3 +1,4 @@
+import { Workflow } from './../../../../common/type/workflow';
 import { Component, OnInit } from "@angular/core";
 import { Router } from "@angular/router";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
@@ -167,5 +168,17 @@ export class SavedWorkflowSectionComponent implements OnInit {
 
   private clearDashboardWorkflowEntries(): void {
     this.dashboardWorkflowEntries = [];
+  }
+
+  public confirmUpdateWorkflowCustomName(dashboardWorkflowEntry: DashboardWorkflowEntry, name: string, index: number) : void {
+    const { workflow } = dashboardWorkflowEntry
+    this.workflowPersistService.updateWorkflowName(workflow.wid, name)
+    .pipe(untilDestroyed(this))
+    .subscribe((updatedWorkflow: Workflow) => {
+      let updatedDashboardWorkFlowEntry = {...dashboardWorkflowEntry}
+      updatedDashboardWorkFlowEntry.workflow = {...updatedWorkflow}
+
+      this.dashboardWorkflowEntries[index] = updatedDashboardWorkFlowEntry
+    });
   }
 }

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.html
@@ -20,9 +20,28 @@
         <nz-list-item-meta>
           <nz-list-item-meta-title>
             <div class="file-name">
-              <h4 class="file-title">
+              <h4 *ngIf="dashboardUserFileEntry.file.isEditingName !== true; else customeFileName " class="file-title">
                 {{ dashboardUserFileEntry.ownerName + "/" + dashboardUserFileEntry.file.name }}
               </h4>
+              <ng-template #customeFileName>
+                <input  
+                  #customeFileName
+                  (focusout)="confirmUpdateFileCustomName(dashboardUserFileEntry, customeFileName.value)"
+                  (keyup.enter)="confirmUpdateFileCustomName(dashboardUserFileEntry, customeFileName.value)"
+                  placeholder="{{ dashboardUserFileEntry.file.name }}"
+                  value="{{ dashboardUserFileEntry.file.name }}"
+                />
+              </ng-template>
+              <button
+              (click)="dashboardUserFileEntry.file.isEditingName = true"
+              nz-button
+              nz-tooltip="Customize File Name"
+              nzSize="small"
+              nzTooltipPlacement="bottom"
+              nzType="text"
+            >
+            <i nz-icon nzTheme="outline" nzType="edit"></i>
+          </button>
               <i
                 *ngIf="dashboardUserFileEntry.isOwner"
                 ngbTooltip="You are the OWNER"

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.scss
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.scss
@@ -61,7 +61,6 @@ $header-height: 120px;
 
 .file-title {
   color: rgb(62, 202, 253);
-  margin-right: 10px;
 }
 
 .file-name > i {
@@ -73,4 +72,8 @@ $header-height: 120px;
 button {
   border-radius: 5px;
   border: none;
+}
+
+.ant-btn-icon-only {
+  margin-right: 10px;
 }

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.ts
@@ -2,7 +2,7 @@ import { Component } from "@angular/core";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { NgbdModalFileAddComponent } from "./ngbd-modal-file-add/ngbd-modal-file-add.component";
 import { UserFileService } from "../../../service/user-file/user-file.service";
-import { DashboardUserFileEntry } from "../../../type/dashboard-user-file-entry";
+import { DashboardUserFileEntry, UserFile } from "../../../type/dashboard-user-file-entry";
 import { UserService } from "../../../../common/service/user/user.service";
 import { NgbdModalUserFileShareAccessComponent } from "./ngbd-modal-file-share-access/ngbd-modal-user-file-share-access.component";
 import { NzMessageService } from "ng-zorro-antd/message";
@@ -77,5 +77,14 @@ export class UserFileSectionComponent {
           this.message.error(err.error.message);
         }
       );
+  }
+
+  public confirmUpdateFileCustomName(dashboardUserFileEntry: DashboardUserFileEntry, name: string): void {
+    const { file : { fid } } = dashboardUserFileEntry
+    this.userFileService.updateFileName(fid, name)
+      .pipe(untilDestroyed(this))
+      .subscribe((updatedFile: UserFile) => {
+        this.userFileService.refreshDashboardUserFileEntries()
+      })
   }
 }


### PR DESCRIPTION
This **PR** enables users to change the name of existing workflows and files.  
There are no restrictions on the new name of an existing workflow.
Demo: 
![workflow_name_change](https://user-images.githubusercontent.com/52941906/136058146-bd627f71-456e-4c61-b192-13dbebc62a15.gif)
The new name of an uploaded file cannot be duplicate or empty. 
Demo:
![user_file_name_change](https://user-images.githubusercontent.com/52941906/136058847-baa5c8e7-4412-4f37-9b31-34852ce2c6b2.gif)
![name_empty](https://user-images.githubusercontent.com/52941906/136059313-ee979203-833b-46c3-b622-56ea6a9fd8b8.gif)

 