### PR TITLE
Establish websocket connection for dev environment

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -70,8 +70,8 @@ class WorkflowWebsocketResource extends LazyLogging {
           // hack to refresh frontend run button state
           send(session, WorkflowStateEvent(Uninitialized))
           val workflowState = uidOpt match {
-            case Some(username) =>
-              val workflowStateId = username + "-" + wIdRequest.wId
+            case Some(user) =>
+              val workflowStateId = user + "-" + wIdRequest.wId
               WorkflowService.getOrCreate(workflowStateId)
             case None =>
               // set immediately cleanup

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -70,9 +70,9 @@ class WorkflowWebsocketResource extends LazyLogging {
           // hack to refresh frontend run button state
           send(session, WorkflowStateEvent(Uninitialized))
           val workflowState = uidOpt match {
-            case Some(value) =>
-              val wId = value + "-" + wIdRequest.wId
-              WorkflowService.getOrCreate(wId)
+            case Some(username) =>
+              val workflowStateId = username + "-" + wIdRequest.wId
+              WorkflowService.getOrCreate(workflowStateId)
             case None =>
               // set immediately cleanup
               WorkflowService.getOrCreate("anonymous session " + session.getId, 0)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -74,8 +74,12 @@ class WorkflowWebsocketResource extends LazyLogging {
               val workflowStateId = user + "-" + wIdRequest.wId
               WorkflowService.getOrCreate(workflowStateId)
             case None =>
-              // set immediately cleanup
-              WorkflowService.getOrCreate("anonymous session " + session.getId, 0)
+              // use a fixed wid for reconnection
+              val workflowStateId = "dummy wid"
+              WorkflowService.getOrCreate(workflowStateId)
+              // Alternative:
+              // anonymous session: set immediately cleanup
+              // WorkflowService.getOrCreate("anonymous session " + session.getId, 0)
           }
           sessionState.subscribe(workflowState)
           send(session, RegisterWIdResponse("wid registered"))

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -77,9 +77,9 @@ class WorkflowWebsocketResource extends LazyLogging {
               // use a fixed wid for reconnection
               val workflowStateId = "dummy wid"
               WorkflowService.getOrCreate(workflowStateId)
-              // Alternative:
-              // anonymous session: set immediately cleanup
-              // WorkflowService.getOrCreate("anonymous session " + session.getId, 0)
+            // Alternative:
+            // anonymous session: set immediately cleanup
+            // WorkflowService.getOrCreate("anonymous session " + session.getId, 0)
           }
           sessionState.subscribe(workflowState)
           send(session, RegisterWIdResponse("wid registered"))

--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -33,7 +33,6 @@ import { OperatorCacheStatusService } from "../service/workflow-status/operator-
 export class WorkspaceComponent implements AfterViewInit, OnDestroy {
   public gitCommitHash: string = Version.raw;
   public showResultPanel: boolean = false;
-  private currentWid = 0;
   userSystemEnabled = environment.userSystemEnabled;
 
   constructor(
@@ -83,29 +82,14 @@ export class WorkspaceComponent implements AfterViewInit, OnDestroy {
 
     this.registerResultPanelToggleHandler();
 
-    let wid = (this.workflowActionService.getWorkflowMetadata().wid) ?? 0;
-    this.workflowWebsocketService.openWebsocket(wid);
-    this.currentWid = wid;
+    let wid = this.route.snapshot.params.id ?? 0;
 
-    this.establishWebsocketConnectionIfWIdChanged();
+    this.workflowWebsocketService.openWebsocket(wid);
 
   }
 
   ngOnDestroy(){
     this.workflowWebsocketService.closeWebsocket();
-  }
-
-  establishWebsocketConnectionIfWIdChanged(){
-    this.workflowActionService.workflowMetaDataChanged()
-    .pipe(untilDestroyed(this))
-    .subscribe(() => {
-      let wid = (this.workflowActionService.getWorkflowMetadata().wid) ?? 0;
-      if(wid != this.currentWid){
-        this.workflowWebsocketService.closeWebsocket();
-        this.workflowWebsocketService.openWebsocket(wid);
-        this.currentWid = wid;
-      }
-    });
   }
 
   registerResultPanelToggleHandler() {

--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -1,5 +1,5 @@
 import { Location } from "@angular/common";
-import { AfterViewInit, Component } from "@angular/core";
+import { AfterViewInit, Component, OnDestroy } from "@angular/core";
 import { ActivatedRoute } from "@angular/router";
 import { environment } from "../../../environments/environment";
 import { Version } from "../../../environments/version";
@@ -30,7 +30,7 @@ import { OperatorCacheStatusService } from "../service/workflow-status/operator-
     // { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
   ],
 })
-export class WorkspaceComponent implements AfterViewInit {
+export class WorkspaceComponent implements AfterViewInit, OnDestroy {
   public gitCommitHash: string = Version.raw;
   public showResultPanel: boolean = false;
   private currentWid = 0;

--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -83,6 +83,10 @@ export class WorkspaceComponent implements AfterViewInit, OnDestroy {
 
     this.registerResultPanelToggleHandler();
 
+    let wid = (this.workflowActionService.getWorkflowMetadata().wid) ?? 0;
+    this.workflowWebsocketService.openWebsocket(wid);
+    this.currentWid = wid;
+
     this.establishWebsocketConnectionIfWIdChanged();
 
   }

--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -80,7 +80,12 @@ export class WorkspaceComponent implements AfterViewInit, OnDestroy {
     // clear the current workspace, reset as `WorkflowActionService.DEFAULT_WORKFLOW`
     this.workflowActionService.resetAsNewWorkflow();
 
-    this.registerReEstablishWebsocketUponWIdChange();
+    if(this.userSystemEnabled){
+      this.registerReEstablishWebsocketUponWIdChange();
+    }else{
+      let wid = this.route.snapshot.params.id ?? 0;
+      this.workflowWebsocketService.openWebsocket(wid);
+    }
 
     this.registerLoadOperatorMetadata();
 

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
@@ -913,6 +913,10 @@ export class WorkflowActionService {
   }
 
   public setWorkflowMetadata(workflowMetaData: WorkflowMetadata | undefined): void {
+    if (this.workflowMetadata === workflowMetaData) {
+      return;
+    }
+
     this.workflowMetadata = workflowMetaData === undefined ? WorkflowActionService.DEFAULT_WORKFLOW : workflowMetaData;
     this.workflowMetadataChangeSubject.next();
   }


### PR DESCRIPTION
This PR:
1. Originally we establish WebSocket upon workflow metadata change. But it does not allow the developer to test their workflow easily since the user system must be enabled. Now we establish WebSocket if the user system is disabled.  
2. minor readability improvement and bug fix.