### PR TITLE
Reshape 2/5: Adding the ability to detect skew

### DIFF
--- a/core/amber/src/main/resources/application.conf
+++ b/core/amber/src/main/resources/application.conf
@@ -3,6 +3,9 @@ constants {
     logging-queue-size-interval = 30000
     num-worker-per-node = 2
     data-volume-per-node = 10
+    reshape-skew-handling-enabled = false
+    reshape-eta-threshold = 100
+    reshape-tau-threshold = 100
 }
 
 cache {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
@@ -35,13 +35,15 @@ object ControllerConfig {
     ControllerConfig(
       statusUpdateIntervalMs = Option(100),
       resultUpdateIntervalMs = Option(1000),
-      monitoringIntervalMs = Option(3000)
+      monitoringIntervalMs = Option(3000),
+      skewDetectionIntervalMs = Option(3000)
     )
 }
 final case class ControllerConfig(
     statusUpdateIntervalMs: Option[Long],
     resultUpdateIntervalMs: Option[Long],
-    monitoringIntervalMs: Option[Long]
+    monitoringIntervalMs: Option[Long],
+    skewDetectionIntervalMs: Option[Long]
 )
 
 object Controller {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/MonitoringHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/MonitoringHandler.scala
@@ -15,8 +15,6 @@ import scala.collection.mutable
 
 object MonitoringHandler {
   var previousCallFinished = true
-  var startTimeForMetricColl: Long = _
-  var endTimeForMetricColl: Long = _
 
   final case class ControllerInitiateMonitoring(
       filterByWorkers: List[ActorVirtualIdentity] = List()

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/PauseHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/PauseHandler.scala
@@ -71,6 +71,7 @@ trait PauseHandler {
           sendToClient(WorkflowPaused())
           disableStatusUpdate() // to be enabled in resume
           disableMonitoring()
+          disableSkewHandling()
         }
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/ResumeHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/ResumeHandler.scala
@@ -37,6 +37,7 @@ trait ResumeHandler {
           sendToClient(WorkflowStatusUpdate(workflow.getWorkflowStatus))
           enableStatusUpdate() //re-enabled it since it is disabled in pause
           enableMonitoring()
+          enableSkewHandling()
         }
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/SkewDetectionHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/SkewDetectionHandler.scala
@@ -1,0 +1,150 @@
+package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
+
+import com.twitter.util.Future
+import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
+import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.SkewDetectionHandler.{
+  ControllerInitiateSkewDetection,
+  getSkewedAndHelperWorkersEligibleForFirstPhase,
+  previousCallFinished
+}
+import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.WorkerWorkloadInfo
+import edu.uci.ics.amber.engine.common.Constants
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
+import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
+import edu.uci.ics.texera.workflow.operators.hashJoin.HashJoinOpExecConfig
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+import scala.util.control.Breaks.{break, breakable}
+
+object SkewDetectionHandler {
+  var previousCallFinished = true
+
+  var skewedToHelperWorkerHistory =
+    new mutable.HashMap[ActorVirtualIdentity, ActorVirtualIdentity]()
+
+  final case class ControllerInitiateSkewDetection(
+      filterByWorkers: List[ActorVirtualIdentity] = List()
+  ) extends ControlCommand[Unit]
+
+  /**
+    * worker is eligible for first phase if no mitigation has happened till now or it is in second phase right now.
+    *
+    * @param worker
+    * @return
+    */
+  def isEligibleForSkewed(worker: ActorVirtualIdentity): Boolean = {
+    !skewedToHelperWorkerHistory.values.toList.contains(
+      worker
+    )
+  }
+
+  /**
+    * worker is eligible for free if it is being used in neither of the phases.
+    *
+    * @param worker
+    * @return
+    */
+  def isEligibleForHelper(worker: ActorVirtualIdentity): Boolean = {
+    !skewedToHelperWorkerHistory.keySet.contains(
+      worker
+    )
+  }
+
+  def passSkewTest(
+      skewedWorkerCand: ActorVirtualIdentity,
+      helperWorkerCand: ActorVirtualIdentity,
+      loads: mutable.HashMap[ActorVirtualIdentity, WorkerWorkloadInfo],
+      etaThreshold: Int,
+      tauThreshold: Int
+  ): Boolean = {
+    if (
+      loads(
+        skewedWorkerCand
+      ).dataInputWorkload / Constants.defaultBatchSize > etaThreshold && (loads(
+        skewedWorkerCand
+      ).dataInputWorkload / Constants.defaultBatchSize > tauThreshold + loads(
+        helperWorkerCand
+      ).dataInputWorkload / Constants.defaultBatchSize)
+    ) {
+      return true
+    }
+    false
+  }
+
+  /** *
+    * returns an array of (skewedWorker, freeWorker, whether state replication has to be done)
+    */
+  def getSkewedAndHelperWorkersEligibleForFirstPhase(
+      loads: mutable.HashMap[ActorVirtualIdentity, WorkerWorkloadInfo]
+  ): ArrayBuffer[(ActorVirtualIdentity, ActorVirtualIdentity, Boolean)] = {
+    val retPairs = new ArrayBuffer[(ActorVirtualIdentity, ActorVirtualIdentity, Boolean)]()
+    // Get workers in increasing load
+    val sortedWorkers = loads.keys.toList.sortBy(loads(_).dataInputWorkload)
+
+    for (i <- sortedWorkers.size - 1 to 0 by -1) {
+      if (isEligibleForSkewed(sortedWorkers(i))) {
+        // worker has been previously paired with some worker and that worker will be used again.
+        if (skewedToHelperWorkerHistory.keySet.contains(sortedWorkers(i))) {
+          if (
+            passSkewTest(
+              sortedWorkers(i),
+              skewedToHelperWorkerHistory(sortedWorkers(i)),
+              loads,
+              Constants.reshapeEtaThreshold,
+              Constants.reshapeTauThreshold
+            )
+          ) {
+            // build table has already been replicated
+            retPairs.append(
+              (sortedWorkers(i), skewedToHelperWorkerHistory(sortedWorkers(i)), false)
+            )
+          }
+        } else if (i > 0) {
+          breakable {
+            for (j <- 0 to i - 1) {
+              if (
+                isEligibleForHelper(sortedWorkers(j)) && passSkewTest(
+                  sortedWorkers(i),
+                  sortedWorkers(j),
+                  loads,
+                  Constants.reshapeEtaThreshold,
+                  Constants.reshapeTauThreshold
+                )
+              ) {
+                retPairs.append((sortedWorkers(i), sortedWorkers(j), true))
+                skewedToHelperWorkerHistory(sortedWorkers(i)) = sortedWorkers(j)
+                break
+              }
+            }
+          }
+        }
+      }
+    }
+
+    retPairs
+  }
+
+}
+
+trait SkewDetectionHandler {
+  this: ControllerAsyncRPCHandlerInitializer =>
+
+  registerHandler((msg: ControllerInitiateSkewDetection, sender) => {
+    if (!previousCallFinished) {
+      Future.Done
+    } else {
+      previousCallFinished = false
+
+      workflow.getAllOperators.foreach(opConfig => {
+        if (opConfig.isInstanceOf[HashJoinOpExecConfig[Any]]) {
+          // Skew handling is only for hash-join operator for now
+          val skewedAndHelperPairs =
+            getSkewedAndHelperWorkersEligibleForFirstPhase(opConfig.workerToWorkloadInfo)
+        }
+      })
+      previousCallFinished = true
+      Future.Done
+    }
+  })
+}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/SkewDetectionHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/SkewDetectionHandler.scala
@@ -4,10 +4,13 @@ import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.SkewDetectionHandler.{
   ControllerInitiateSkewDetection,
+  endTimeForBuildRepl,
   getSkewedAndHelperWorkersEligibleForFirstPhase,
-  previousCallFinished
+  previousCallFinished,
+  startTimeForBuildRepl
 }
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.WorkerWorkloadInfo
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.SendImmutableStateHandler.SendImmutableState
 import edu.uci.ics.amber.engine.common.Constants
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
@@ -19,6 +22,8 @@ import scala.util.control.Breaks.{break, breakable}
 
 object SkewDetectionHandler {
   var previousCallFinished = true
+  var startTimeForBuildRepl: Long = _
+  var endTimeForBuildRepl: Long = _
 
   var skewedToHelperWorkerHistory =
     new mutable.HashMap[ActorVirtualIdentity, ActorVirtualIdentity]()
@@ -47,6 +52,8 @@ object SkewDetectionHandler {
     */
   def isEligibleForHelper(worker: ActorVirtualIdentity): Boolean = {
     !skewedToHelperWorkerHistory.keySet.contains(
+      worker
+    ) && !skewedToHelperWorkerHistory.values.toList.contains(
       worker
     )
   }
@@ -130,13 +137,44 @@ trait SkewDetectionHandler {
     } else {
       previousCallFinished = false
 
+      var skewedAndHelperPairs =
+        new ArrayBuffer[(ActorVirtualIdentity, ActorVirtualIdentity, Boolean)]
       workflow.getAllOperators.foreach(opConfig => {
         if (opConfig.isInstanceOf[HashJoinOpExecConfig[Any]]) {
           // Skew handling is only for hash-join operator for now
-          val skewedAndHelperPairs =
+          skewedAndHelperPairs =
             getSkewedAndHelperWorkersEligibleForFirstPhase(opConfig.workerToWorkloadInfo)
+          skewedAndHelperPairs.foreach(skewedAndHelper =>
+            logger.info(
+              s"Reshape: Skewed ${skewedAndHelper._1.toString()} :: Helper ${skewedAndHelper._2
+                .toString()} - Replication required: ${skewedAndHelper._3.toString()}"
+            )
+          )
         }
       })
+      if (skewedAndHelperPairs.nonEmpty) {
+        val stateMigrateFuturesArr = new ArrayBuffer[Future[Boolean]]()
+        startTimeForBuildRepl = System.nanoTime()
+        skewedAndHelperPairs.foreach(skewedAndHelper => {
+          if (skewedAndHelper._3) {
+            stateMigrateFuturesArr.append(
+              send(SendImmutableState(skewedAndHelper._2), skewedAndHelper._1)
+            )
+          }
+        })
+
+        if (stateMigrateFuturesArr.nonEmpty) {
+          Future
+            .collect(stateMigrateFuturesArr)
+            .flatMap(res => {
+              endTimeForBuildRepl = System.nanoTime()
+              logger.info(
+                s"Reshape: Build Tables Copied in ${(endTimeForBuildRepl - startTimeForBuildRepl) / 1e9d}s"
+              )
+              Future.Done
+            })
+        }
+      }
       previousCallFinished = true
       Future.Done
     }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/SkewDetectionHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/SkewDetectionHandler.scala
@@ -54,16 +54,14 @@ object SkewDetectionHandler {
   def passSkewTest(
       skewedWorkerCand: ActorVirtualIdentity,
       helperWorkerCand: ActorVirtualIdentity,
-      loads: mutable.HashMap[ActorVirtualIdentity, WorkerWorkloadInfo],
-      etaThreshold: Int,
-      tauThreshold: Int
+      loads: mutable.HashMap[ActorVirtualIdentity, WorkerWorkloadInfo]
   ): Boolean = {
     if (
       loads(
         skewedWorkerCand
-      ).dataInputWorkload / Constants.defaultBatchSize > etaThreshold && (loads(
+      ).dataInputWorkload / Constants.defaultBatchSize > Constants.reshapeEtaThreshold && (loads(
         skewedWorkerCand
-      ).dataInputWorkload / Constants.defaultBatchSize > tauThreshold + loads(
+      ).dataInputWorkload / Constants.defaultBatchSize > Constants.reshapeTauThreshold + loads(
         helperWorkerCand
       ).dataInputWorkload / Constants.defaultBatchSize)
     ) {
@@ -90,9 +88,7 @@ object SkewDetectionHandler {
             passSkewTest(
               sortedWorkers(i),
               skewedToHelperWorkerHistory(sortedWorkers(i)),
-              loads,
-              Constants.reshapeEtaThreshold,
-              Constants.reshapeTauThreshold
+              loads
             )
           ) {
             // build table has already been replicated
@@ -107,9 +103,7 @@ object SkewDetectionHandler {
                 isEligibleForHelper(sortedWorkers(j)) && passSkewTest(
                   sortedWorkers(i),
                   sortedWorkers(j),
-                  loads,
-                  Constants.reshapeEtaThreshold,
-                  Constants.reshapeTauThreshold
+                  loads
                 )
               ) {
                 retPairs.append((sortedWorkers(i), sortedWorkers(j), true))

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/SkewDetectionHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/SkewDetectionHandler.scala
@@ -40,7 +40,7 @@ object SkewDetectionHandler {
   }
 
   /**
-    * worker is eligible for free if it is being used in neither of the phases.
+    * worker is eligible for being a helper if it is being used in neither of the phases.
     *
     * @param worker
     * @return

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/StartWorkflowHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/StartWorkflowHandler.scala
@@ -46,6 +46,7 @@ trait StartWorkflowHandler {
         .map { _ =>
           enableStatusUpdate()
           enableMonitoring()
+          enableSkewHandling()
         }
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/WorkerExecutionCompletedHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/WorkerExecutionCompletedHandler.scala
@@ -63,6 +63,7 @@ trait WorkerExecutionCompletedHandler {
             sendToClient(WorkflowCompleted(ret))
             disableStatusUpdate()
             disableMonitoring()
+            disableSkewHandling()
             Future.Done
           })
         } else {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -63,6 +63,8 @@ class DataProcessor( // dependencies:
   private var currentOutputIterator: Iterator[ITuple] = _
   private var isCompleted = false
 
+  def getOperatorExecutor(): IOperatorExecutor = operator
+
   /** provide API for actor to get stats of this operator
     * @return (input tuple count, output tuple count)
     */

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerAsyncRPCHandlerInitializer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerAsyncRPCHandlerInitializer.scala
@@ -46,6 +46,8 @@ class WorkerAsyncRPCHandlerInitializer(
     with UpdateInputLinkingHandler
     with AssignLocalBreakpointHandler
     with ShutdownDPThreadHandler
-    with MonitoringHandler {
+    with MonitoringHandler
+    with SendImmutableStateHandler
+    with AcceptImmutableStateHandler {
   var lastReportTime = 0L
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/AcceptImmutableStateHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/AcceptImmutableStateHandler.scala
@@ -1,0 +1,36 @@
+package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
+
+import edu.uci.ics.amber.engine.architecture.worker.WorkerAsyncRPCHandlerInitializer
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.AcceptImmutableStateHandler.AcceptImmutableState
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
+import edu.uci.ics.texera.workflow.common.tuple.Tuple
+import edu.uci.ics.texera.workflow.operators.hashJoin.HashJoinOpExec
+
+import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
+
+// join-skew research related.
+object AcceptImmutableStateHandler {
+  final case class AcceptImmutableState(
+      buildHashMap: mutable.HashMap[Any, ArrayBuffer[Tuple]]
+  ) extends ControlCommand[Unit]
+}
+
+trait AcceptImmutableStateHandler {
+  this: WorkerAsyncRPCHandlerInitializer =>
+
+  registerHandler { (cmd: AcceptImmutableState, sender) =>
+    try {
+      dataProcessor
+        .getOperatorExecutor()
+        .asInstanceOf[HashJoinOpExec[Any]]
+        .mergeIntoHashTable(cmd.buildHashMap)
+    } catch {
+      case exception: Exception =>
+        logger.error(
+          "Reshape: AcceptImmutableStateHandler exception" + exception
+            .getMessage() + " stacktrace " + exception.getStackTrace()
+        )
+    }
+  }
+}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/SendImmutableStateHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/SendImmutableStateHandler.scala
@@ -1,0 +1,55 @@
+package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
+
+import com.twitter.util.Future
+import edu.uci.ics.amber.engine.architecture.worker.WorkerAsyncRPCHandlerInitializer
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.AcceptImmutableStateHandler.AcceptImmutableState
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.SendImmutableStateHandler.SendImmutableState
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
+import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
+import edu.uci.ics.texera.workflow.operators.hashJoin.HashJoinOpExec
+
+import scala.collection.mutable.ArrayBuffer
+
+// join-skew research related.
+object SendImmutableStateHandler {
+  final case class SendImmutableState(
+      helperReceiverId: ActorVirtualIdentity
+  ) extends ControlCommand[Boolean]
+}
+
+trait SendImmutableStateHandler {
+  this: WorkerAsyncRPCHandlerInitializer =>
+
+  registerHandler { (cmd: SendImmutableState, sender) =>
+    // Returns true if the build table was replicated successfully.
+    try {
+      val joinOpExec = dataProcessor.getOperatorExecutor().asInstanceOf[HashJoinOpExec[Any]]
+      if (joinOpExec.isBuildTableFinished) {
+        val immutableStates = joinOpExec.getBuildHashTable()
+        val immutableStatesSendingFutures = new ArrayBuffer[Future[Unit]]()
+        immutableStates.foreach(map => {
+          immutableStatesSendingFutures.append(
+            send(AcceptImmutableState(map), cmd.helperReceiverId)
+          )
+        })
+        Future
+          .collect(immutableStatesSendingFutures)
+          .flatMap(seq => {
+            logger.info(
+              s"Reshape: Replication of all parts of build table done to ${cmd.helperReceiverId}"
+            )
+            Future.True
+          })
+      } else {
+        Future.False
+      }
+    } catch {
+      case exception: Exception =>
+        logger.error(
+          "Reshape: SendImmutableStateHandler exception" + exception
+            .getMessage() + " stacktrace " + exception.getStackTrace()
+        )
+        Future.False
+    }
+  }
+}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/Constants.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/Constants.scala
@@ -15,4 +15,11 @@ object Constants {
   var currentDataSetNum = 0
   var masterNodeAddr: Option[String] = None
   var defaultTau: FiniteDuration = 10.milliseconds
+
+  var reshapeSkewHandlingEnabled: Boolean =
+    AmberUtils.amberConfig.getBoolean("constants.reshape-skew-handling-enabled")
+  var reshapeEtaThreshold: Int =
+    AmberUtils.amberConfig.getInt("constants.reshape-eta-threshold")
+  var reshapeTauThreshold: Int =
+    AmberUtils.amberConfig.getInt("constants.reshape-tau-threshold")
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCServer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCServer.scala
@@ -2,6 +2,7 @@ package edu.uci.ics.amber.engine.common.rpc
 
 import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkOutputPort
+import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.AcceptImmutableStateHandler.AcceptImmutableState
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
 import edu.uci.ics.amber.engine.common.AmberLogging
 import edu.uci.ics.amber.engine.common.ambermessage.ControlPayload
@@ -94,6 +95,12 @@ class AsyncRPCServer(
       return
     }
     if (call.command.isInstanceOf[QueryStatistics]) {
+      return
+    }
+    if (call.command.isInstanceOf[AcceptImmutableState]) {
+      logger.info(
+        s"receive command: AcceptImmutableState from $sender (controlID: ${call.commandID}). Content of control message not printed to be succinct."
+      )
       return
     }
     logger.info(


### PR DESCRIPTION
This PR introduces the ability to use the collected metrics to detect skew. Once skew is detected, a helper worker is chosen for each skewed worker. The skew detection logic will be disabled using the `reshapeSkewHandlingEnabled` flag in the config. 