### PR TITLE
Add back workflow version related code

### DIFF
--- a/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.spec.ts
@@ -16,11 +16,14 @@ import { BreakpointPropertyEditFrameComponent } from "./breakpoint-property-edit
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { OperatorMetadataService } from "../../service/operator-metadata/operator-metadata.service";
 import { StubOperatorMetadataService } from "../../service/operator-metadata/stub-operator-metadata.service";
+import { WorkflowVersionService } from "src/app/dashboard/service/workflow-version/workflow-version.service";
+import { VersionsListDisplayComponent } from "./versions-display/versions-display.component";
 
 describe("PropertyEditorComponent", () => {
   let component: PropertyEditorComponent;
   let fixture: ComponentFixture<PropertyEditorComponent>;
   let workflowActionService: WorkflowActionService;
+  let workflowVersionService: WorkflowVersionService;
   environment.schemaPropagationEnabled = true;
 
   beforeEach(
@@ -41,6 +44,7 @@ describe("PropertyEditorComponent", () => {
     fixture = TestBed.createComponent(PropertyEditorComponent);
     component = fixture.componentInstance;
     workflowActionService = TestBed.inject(WorkflowActionService);
+    workflowVersionService = TestBed.inject(WorkflowVersionService);
     fixture.detectChanges();
   });
 
@@ -183,6 +187,51 @@ describe("PropertyEditorComponent", () => {
     expect(component.frameComponentConfig?.component).toBe(BreakpointPropertyEditFrameComponent);
     expect(component.frameComponentConfig?.componentInputs).toEqual({
       currentLinkId: mockSentimentResultLink.linkID,
+    });
+  });
+
+  it("should switch the content of property editor to version display component correctly if the versions display is clicked and switch back when done", () => {
+    const jointGraphWrapper = workflowActionService.getJointGraphWrapper();
+
+    // add one operator
+    workflowActionService.addOperator(mockScanPredicate, mockPoint);
+
+    // highlight the first operator
+    jointGraphWrapper.highlightOperators(mockScanPredicate.operatorID);
+    fixture.detectChanges();
+
+    //the operator shall be highlighted
+    expect(workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs().length).toBe(1);
+
+    // the operator property editor should be displayed
+    expect(component.frameComponentConfig?.component).toBe(OperatorPropertyEditFrameComponent);
+    expect(component.frameComponentConfig?.componentInputs).toEqual({
+      currentOperatorId: mockScanPredicate.operatorID,
+    });
+
+    // click on versions display
+    workflowVersionService.clickDisplayWorkflowVersions();
+    fixture.detectChanges();
+
+    // all the elements shall be unhighlighted
+    expect(workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs().length).toBe(0);
+    expect(workflowActionService.getJointGraphWrapper().getCurrentHighlightedGroupIDs().length).toBe(0);
+    expect(workflowActionService.getJointGraphWrapper().getCurrentHighlightedLinkIDs().length).toBe(0);
+
+    // the component should switch to versions display
+    expect(component.frameComponentConfig?.component).toBe(VersionsListDisplayComponent);
+
+    // add one more operator
+    workflowActionService.addOperator(mockResultPredicate, mockPoint);
+
+    // highlight the new operator
+    jointGraphWrapper.highlightOperators(mockResultPredicate.operatorID);
+    fixture.detectChanges();
+
+    // the operator property editor should be displayed
+    expect(component.frameComponentConfig?.component).toBe(OperatorPropertyEditFrameComponent);
+    expect(component.frameComponentConfig?.componentInputs).toEqual({
+      currentOperatorId: mockResultPredicate.operatorID,
     });
   });
 });

--- a/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.ts
@@ -5,10 +5,16 @@ import { OperatorPropertyEditFrameComponent } from "./operator-property-edit-fra
 import { BreakpointPropertyEditFrameComponent } from "./breakpoint-property-edit-frame/breakpoint-property-edit-frame.component";
 import { DynamicComponentConfig } from "../../../common/type/dynamic-component-config";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
-import { DISPLAY_WORKFLOW_VERIONS_EVENT, WorkflowVersionService } from "src/app/dashboard/service/workflow-version/workflow-version.service";
+import {
+  DISPLAY_WORKFLOW_VERIONS_EVENT,
+  WorkflowVersionService,
+} from "src/app/dashboard/service/workflow-version/workflow-version.service";
 import { VersionsListDisplayComponent } from "./versions-display/versions-display.component";
 
-export type PropertyEditFrameComponent = OperatorPropertyEditFrameComponent | BreakpointPropertyEditFrameComponent | VersionsListDisplayComponent;
+export type PropertyEditFrameComponent =
+  | OperatorPropertyEditFrameComponent
+  | BreakpointPropertyEditFrameComponent
+  | VersionsListDisplayComponent;
 
 export type PropertyEditFrameConfig = DynamicComponentConfig<PropertyEditFrameComponent>;
 
@@ -29,7 +35,8 @@ export class PropertyEditorComponent implements OnInit {
 
   constructor(
     public workflowActionService: WorkflowActionService,
-    public workflowVersionService: WorkflowVersionService) {}
+    public workflowVersionService: WorkflowVersionService
+  ) {}
 
   ngOnInit(): void {
     this.registerHighlightEventsHandler();
@@ -61,7 +68,7 @@ export class PropertyEditorComponent implements OnInit {
       this.workflowActionService.getJointGraphWrapper().getJointGroupUnhighlightStream(),
       this.workflowActionService.getJointGraphWrapper().getLinkHighlightStream(),
       this.workflowActionService.getJointGraphWrapper().getLinkUnhighlightStream(),
-      this.workflowVersionService.workflowVersionsDisplayObservable(),
+      this.workflowVersionService.workflowVersionsDisplayObservable()
     )
       .pipe(untilDestroyed(this))
       .subscribe(event => {

--- a/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.ts
@@ -5,8 +5,10 @@ import { OperatorPropertyEditFrameComponent } from "./operator-property-edit-fra
 import { BreakpointPropertyEditFrameComponent } from "./breakpoint-property-edit-frame/breakpoint-property-edit-frame.component";
 import { DynamicComponentConfig } from "../../../common/type/dynamic-component-config";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { DISPLAY_WORKFLOW_VERIONS_EVENT, WorkflowVersionService } from "src/app/dashboard/service/workflow-version/workflow-version.service";
+import { VersionsListDisplayComponent } from "./versions-display/versions-display.component";
 
-export type PropertyEditFrameComponent = OperatorPropertyEditFrameComponent | BreakpointPropertyEditFrameComponent;
+export type PropertyEditFrameComponent = OperatorPropertyEditFrameComponent | BreakpointPropertyEditFrameComponent | VersionsListDisplayComponent;
 
 export type PropertyEditFrameConfig = DynamicComponentConfig<PropertyEditFrameComponent>;
 
@@ -25,7 +27,9 @@ export type PropertyEditFrameConfig = DynamicComponentConfig<PropertyEditFrameCo
 export class PropertyEditorComponent implements OnInit {
   frameComponentConfig?: PropertyEditFrameConfig;
 
-  constructor(public workflowActionService: WorkflowActionService) {}
+  constructor(
+    public workflowActionService: WorkflowActionService,
+    public workflowVersionService: WorkflowVersionService) {}
 
   ngOnInit(): void {
     this.registerHighlightEventsHandler();
@@ -56,17 +60,24 @@ export class PropertyEditorComponent implements OnInit {
       this.workflowActionService.getJointGraphWrapper().getJointGroupHighlightStream(),
       this.workflowActionService.getJointGraphWrapper().getJointGroupUnhighlightStream(),
       this.workflowActionService.getJointGraphWrapper().getLinkHighlightStream(),
-      this.workflowActionService.getJointGraphWrapper().getLinkUnhighlightStream()
+      this.workflowActionService.getJointGraphWrapper().getLinkUnhighlightStream(),
+      this.workflowVersionService.workflowVersionsDisplayObservable(),
     )
       .pipe(untilDestroyed(this))
-      .subscribe(() => {
+      .subscribe(event => {
+        const isDisplayWorkflowVersions = event.length === 1 && event[0] === DISPLAY_WORKFLOW_VERIONS_EVENT;
+
         const highlightedOperators = this.workflowActionService
           .getJointGraphWrapper()
           .getCurrentHighlightedOperatorIDs();
         const highlightedGroups = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedGroupIDs();
         const highlightLinks = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedLinkIDs();
 
-        if (highlightedOperators.length === 1 && highlightedGroups.length === 0 && highlightLinks.length === 0) {
+        if (isDisplayWorkflowVersions) {
+          this.switchFrameComponent({
+            component: VersionsListDisplayComponent,
+          });
+        } else if (highlightedOperators.length === 1 && highlightedGroups.length === 0 && highlightLinks.length === 0) {
           this.switchFrameComponent({
             component: OperatorPropertyEditFrameComponent,
             componentInputs: { currentOperatorId: highlightedOperators[0] },


### PR DESCRIPTION
In #1164 we accidentally deleted code related to displaying workflow version. This PR adds back the logic. (fixes issue #1406)

I have tested the fix and both workflow versions and the user presets functionailities work well. 
![Kapture 2022-01-19 at 17 26 45](https://user-images.githubusercontent.com/12578068/150245616-418956af-cf42-4144-84bd-c09f9843c3fe.gif)

