### PR TITLE
Change engine status update interval from 100ms to 500ms

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
@@ -33,7 +33,7 @@ import scala.concurrent.{Await, ExecutionContext}
 object ControllerConfig {
   def default: ControllerConfig =
     ControllerConfig(
-      statusUpdateIntervalMs = Option(100),
+      statusUpdateIntervalMs = Option(500),
       resultUpdateIntervalMs = Option(1000)
     )
 }


### PR DESCRIPTION
This PR changes the status udpate interval in the engine from 100ms to 500ms by default.

This change is made to decrease the overhead of frequent status updates both on the engine and on the frontend