### PR TITLE
Fix several bugs on the backend

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -84,7 +84,6 @@ class DataProcessor( // dependencies:
   }
 
   def shutdown(): Unit = {
-    operator.close() // close operator
     dpThread.cancel(true) // interrupt
     dpThreadExecutor.shutdownNow() // destroy thread
   }
@@ -169,6 +168,7 @@ class DataProcessor( // dependencies:
     asyncRPCClient.send(WorkerExecutionCompleted(), CONTROLLER)
     stateManager.transitTo(COMPLETED)
     disableDataQueue()
+    operator.close() // close operator
     processControlCommandsAfterCompletion()
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -165,10 +165,10 @@ class DataProcessor( // dependencies:
     }
     // Send Completed signal to worker actor.
     logger.info(s"$operator completed")
-    asyncRPCClient.send(WorkerExecutionCompleted(), CONTROLLER)
-    stateManager.transitTo(COMPLETED)
     disableDataQueue()
     operator.close() // close operator
+    asyncRPCClient.send(WorkerExecutionCompleted(), CONTROLLER)
+    stateManager.transitTo(COMPLETED)
     processControlCommandsAfterCompletion()
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/client/AmberClient.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/client/AmberClient.scala
@@ -6,7 +6,12 @@ import akka.util.Timeout
 import com.twitter.util.{Future, Promise}
 import edu.uci.ics.amber.engine.architecture.controller.{ControllerConfig, Workflow}
 import edu.uci.ics.amber.engine.common.FutureBijection._
-import edu.uci.ics.amber.engine.common.client.ClientActor.{ClosureRequest, CommandRequest, InitializeRequest, ObservableRequest}
+import edu.uci.ics.amber.engine.common.client.ClientActor.{
+  ClosureRequest,
+  CommandRequest,
+  InitializeRequest,
+  ObservableRequest
+}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import rx.lang.scala.{Observable, Subject}
 
@@ -30,7 +35,6 @@ class AmberClient(system: ActorSystem, workflow: Workflow, controllerConfig: Con
       clientActor ! PoisonPill
     }
   }
-
 
   def sendAsync[T](controlCommand: ControlCommand[T]): Future[T] = {
     if (!isActive) {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/client/ClientActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/client/ClientActor.scala
@@ -61,7 +61,12 @@ private[client] class ClientActor extends Actor {
         handlers(controlReturn)
       }
       if (promiseMap.contains(originalCommandID)) {
-        promiseMap(originalCommandID).setValue(controlReturn)
+        controlReturn match {
+          case t: Throwable =>
+            promiseMap(originalCommandID).setException(t)
+          case other =>
+            promiseMap(originalCommandID).setValue(other)
+        }
         promiseMap.remove(originalCommandID)
       }
     case NetworkMessage(mId, _ @WorkflowControlMessage(_, _, _ @ControlInvocation(_, command))) =>

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/client/ClientActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/client/ClientActor.scala
@@ -3,9 +3,17 @@ package edu.uci.ics.amber.engine.common.client
 import akka.actor.{Actor, ActorRef}
 import com.twitter.util.Promise
 import edu.uci.ics.amber.engine.architecture.controller.{Controller, ControllerConfig, Workflow}
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor.{NetworkAck, NetworkMessage}
+import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor.{
+  NetworkAck,
+  NetworkMessage
+}
 import edu.uci.ics.amber.engine.common.ambermessage.WorkflowControlMessage
-import edu.uci.ics.amber.engine.common.client.ClientActor.{ClosureRequest, CommandRequest, InitializeRequest, ObservableRequest}
+import edu.uci.ics.amber.engine.common.client.ClientActor.{
+  ClosureRequest,
+  CommandRequest,
+  InitializeRequest,
+  ObservableRequest
+}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.{ControlInvocation, ReturnInvocation}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 
@@ -16,7 +24,7 @@ private[client] object ClientActor {
   case class InitializeRequest(workflow: Workflow, controllerConfig: ControllerConfig)
   case class ObservableRequest(pf: PartialFunction[Any, Unit])
   case class ClosureRequest[T](closure: () => T)
-  case class CommandRequest(command:ControlCommand[_], promise:Promise[Any])
+  case class CommandRequest(command: ControlCommand[_], promise: Promise[Any])
 }
 
 private[client] class ClientActor extends Actor {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/project/ProjectResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/project/ProjectResource.scala
@@ -2,39 +2,12 @@ package edu.uci.ics.texera.web.resource.dashboard.project
 
 import edu.uci.ics.texera.web.SqlServer
 import edu.uci.ics.texera.web.auth.SessionUser
-import edu.uci.ics.texera.web.model.jooq.generated.Tables.{
-  FILE,
-  FILE_OF_PROJECT,
-  USER,
-  USER_FILE_ACCESS,
-  WORKFLOW,
-  WORKFLOW_OF_PROJECT,
-  WORKFLOW_OF_USER,
-  WORKFLOW_USER_ACCESS
-}
-import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{
-  FileOfProjectDao,
-  UserProjectDao,
-  WorkflowOfProjectDao
-}
-import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.{
-  FileOfProject,
-  UserProject,
-  Workflow,
-  WorkflowOfProject,
-  WorkflowUserAccess,
-  UserFileAccess,
-  File
-}
-import edu.uci.ics.texera.web.resource.dashboard.project.ProjectResource.{
-  context,
-  fileOfProjectDao,
-  userProjectDao,
-  workflowOfProjectDao
-}
+import edu.uci.ics.texera.web.model.jooq.generated.Tables.{FILE, FILE_OF_PROJECT, USER, USER_FILE_ACCESS, WORKFLOW, WORKFLOW_OF_PROJECT, WORKFLOW_OF_USER, WORKFLOW_USER_ACCESS}
+import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{FileOfProjectDao, UserProjectDao, WorkflowOfProjectDao}
+import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.{File, FileOfProject, UserFileAccess, UserProject, Workflow, WorkflowOfProject, WorkflowUserAccess}
+import edu.uci.ics.texera.web.resource.dashboard.project.ProjectResource.{context, fileOfProjectDao, userProjectDao, workflowOfProjectDao}
 import edu.uci.ics.texera.web.resource.dashboard.file.UserFileResource.DashboardFileEntry
 import edu.uci.ics.texera.web.resource.dashboard.workflow.WorkflowAccessResource.toAccessLevel
-
 import edu.uci.ics.texera.web.resource.dashboard.workflow.WorkflowResource.DashboardWorkflowEntry
 import org.jooq.types.UInteger
 
@@ -43,6 +16,7 @@ import javax.ws.rs.core.MediaType
 import java.util
 import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 import io.dropwizard.auth.Auth
+import org.apache.commons.lang3.StringUtils
 
 import javax.annotation.security.PermitAll
 
@@ -267,7 +241,7 @@ class ProjectResource {
   @POST
   @Path("/{pid}/rename/{name}")
   def updateProjectName(@PathParam("pid") pid: UInteger, @PathParam("name") name: String): Unit = {
-    if (name.isBlank) {
+    if (StringUtils.isBlank(name)) {
       throw new BadRequestException("Cannot rename project to empty or blank name.")
     }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/project/ProjectResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/project/ProjectResource.scala
@@ -2,10 +2,36 @@ package edu.uci.ics.texera.web.resource.dashboard.project
 
 import edu.uci.ics.texera.web.SqlServer
 import edu.uci.ics.texera.web.auth.SessionUser
-import edu.uci.ics.texera.web.model.jooq.generated.Tables.{FILE, FILE_OF_PROJECT, USER, USER_FILE_ACCESS, WORKFLOW, WORKFLOW_OF_PROJECT, WORKFLOW_OF_USER, WORKFLOW_USER_ACCESS}
-import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{FileOfProjectDao, UserProjectDao, WorkflowOfProjectDao}
-import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.{File, FileOfProject, UserFileAccess, UserProject, Workflow, WorkflowOfProject, WorkflowUserAccess}
-import edu.uci.ics.texera.web.resource.dashboard.project.ProjectResource.{context, fileOfProjectDao, userProjectDao, workflowOfProjectDao}
+import edu.uci.ics.texera.web.model.jooq.generated.Tables.{
+  FILE,
+  FILE_OF_PROJECT,
+  USER,
+  USER_FILE_ACCESS,
+  WORKFLOW,
+  WORKFLOW_OF_PROJECT,
+  WORKFLOW_OF_USER,
+  WORKFLOW_USER_ACCESS
+}
+import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{
+  FileOfProjectDao,
+  UserProjectDao,
+  WorkflowOfProjectDao
+}
+import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.{
+  File,
+  FileOfProject,
+  UserFileAccess,
+  UserProject,
+  Workflow,
+  WorkflowOfProject,
+  WorkflowUserAccess
+}
+import edu.uci.ics.texera.web.resource.dashboard.project.ProjectResource.{
+  context,
+  fileOfProjectDao,
+  userProjectDao,
+  workflowOfProjectDao
+}
 import edu.uci.ics.texera.web.resource.dashboard.file.UserFileResource.DashboardFileEntry
 import edu.uci.ics.texera.web.resource.dashboard.workflow.WorkflowAccessResource.toAccessLevel
 import edu.uci.ics.texera.web.resource.dashboard.workflow.WorkflowResource.DashboardWorkflowEntry

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobRuntimeService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobRuntimeService.scala
@@ -3,7 +3,10 @@ package edu.uci.ics.texera.web.service
 import com.google.common.collect.EvictingQueue
 import com.twitter.util.Await
 import com.typesafe.scalalogging.LazyLogging
-import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.{ConditionalGlobalBreakpoint, CountGlobalBreakpoint}
+import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.{
+  ConditionalGlobalBreakpoint,
+  CountGlobalBreakpoint
+}
 import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent._
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.AssignBreakpointHandler.AssignGlobalBreakpoint
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.EvaluatePythonExpressionHandler.EvaluatePythonExpression
@@ -25,7 +28,12 @@ import edu.uci.ics.texera.web.model.websocket.request.{RemoveBreakpointRequest, 
 import edu.uci.ics.texera.workflow.common.WorkflowContext
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
-import edu.uci.ics.texera.workflow.common.workflow.{Breakpoint, BreakpointCondition, ConditionBreakpoint, CountBreakpoint}
+import edu.uci.ics.texera.workflow.common.workflow.{
+  Breakpoint,
+  BreakpointCondition,
+  ConditionBreakpoint,
+  CountBreakpoint
+}
 import org.jooq.types.UInteger
 import rx.lang.scala.subjects.BehaviorSubject
 import rx.lang.scala.{Observable, Observer}
@@ -189,21 +197,28 @@ class JobRuntimeService(
             tuple => !tuple.getField(column).toString.trim.contains(conditionBp.value)
         }
 
-        Await.result(client.sendAsync(
-          AssignGlobalBreakpoint(
-            new ConditionalGlobalBreakpoint(
-              breakpointID,
-              tuple => {
-                val texeraTuple = tuple.asInstanceOf[Tuple]
-                predicate.apply(texeraTuple)
-              }
-            ),
-            operatorID
+        Await.result(
+          client.sendAsync(
+            AssignGlobalBreakpoint(
+              new ConditionalGlobalBreakpoint(
+                breakpointID,
+                tuple => {
+                  val texeraTuple = tuple.asInstanceOf[Tuple]
+                  predicate.apply(texeraTuple)
+                }
+              ),
+              operatorID
+            )
           )
-        ))
+        )
       case countBp: CountBreakpoint =>
-        Await.result(client.sendAsync(
-          AssignGlobalBreakpoint(new CountGlobalBreakpoint(breakpointID, countBp.count), operatorID))
+        Await.result(
+          client.sendAsync(
+            AssignGlobalBreakpoint(
+              new CountGlobalBreakpoint(breakpointID, countBp.count),
+              operatorID
+            )
+          )
         )
     }
   }
@@ -284,7 +299,11 @@ class JobRuntimeService(
   }
 
   def evaluatePythonExpression(request: PythonExpressionEvaluateRequest): Unit = {
-    send(Await.result(client.sendAsync(EvaluatePythonExpression(request.expression, request.operatorId))))
+    send(
+      Await.result(
+        client.sendAsync(EvaluatePythonExpression(request.expression, request.operatorId))
+      )
+    )
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobRuntimeService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobRuntimeService.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.texera.web.service
 
 import com.google.common.collect.EvictingQueue
-import com.twitter.util.Await
+import com.twitter.util.{Await, Duration}
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.{
   ConditionalGlobalBreakpoint,
@@ -172,54 +172,61 @@ class JobRuntimeService(
   }
 
   def addBreakpoint(operatorID: String, breakpoint: Breakpoint): Unit = {
-    val breakpointID = "breakpoint-" + operatorID + "-" + System.currentTimeMillis()
-    breakpoint match {
-      case conditionBp: ConditionBreakpoint =>
-        val column = conditionBp.column
-        val predicate: Tuple => Boolean = conditionBp.condition match {
-          case BreakpointCondition.EQ =>
-            tuple => {
-              tuple.getField(column).toString.trim == conditionBp.value
-            }
-          case BreakpointCondition.LT =>
-            tuple => tuple.getField(column).toString.trim < conditionBp.value
-          case BreakpointCondition.LE =>
-            tuple => tuple.getField(column).toString.trim <= conditionBp.value
-          case BreakpointCondition.GT =>
-            tuple => tuple.getField(column).toString.trim > conditionBp.value
-          case BreakpointCondition.GE =>
-            tuple => tuple.getField(column).toString.trim >= conditionBp.value
-          case BreakpointCondition.NE =>
-            tuple => tuple.getField(column).toString.trim != conditionBp.value
-          case BreakpointCondition.CONTAINS =>
-            tuple => tuple.getField(column).toString.trim.contains(conditionBp.value)
-          case BreakpointCondition.NOT_CONTAINS =>
-            tuple => !tuple.getField(column).toString.trim.contains(conditionBp.value)
-        }
+    try {
+      val breakpointID = "breakpoint-" + operatorID + "-" + System.currentTimeMillis()
+      breakpoint match {
+        case conditionBp: ConditionBreakpoint =>
+          val column = conditionBp.column
+          val predicate: Tuple => Boolean = conditionBp.condition match {
+            case BreakpointCondition.EQ =>
+              tuple => {
+                tuple.getField(column).toString.trim == conditionBp.value
+              }
+            case BreakpointCondition.LT =>
+              tuple => tuple.getField(column).toString.trim < conditionBp.value
+            case BreakpointCondition.LE =>
+              tuple => tuple.getField(column).toString.trim <= conditionBp.value
+            case BreakpointCondition.GT =>
+              tuple => tuple.getField(column).toString.trim > conditionBp.value
+            case BreakpointCondition.GE =>
+              tuple => tuple.getField(column).toString.trim >= conditionBp.value
+            case BreakpointCondition.NE =>
+              tuple => tuple.getField(column).toString.trim != conditionBp.value
+            case BreakpointCondition.CONTAINS =>
+              tuple => tuple.getField(column).toString.trim.contains(conditionBp.value)
+            case BreakpointCondition.NOT_CONTAINS =>
+              tuple => !tuple.getField(column).toString.trim.contains(conditionBp.value)
+          }
 
-        Await.result(
-          client.sendAsync(
-            AssignGlobalBreakpoint(
-              new ConditionalGlobalBreakpoint(
-                breakpointID,
-                tuple => {
-                  val texeraTuple = tuple.asInstanceOf[Tuple]
-                  predicate.apply(texeraTuple)
-                }
-              ),
-              operatorID
-            )
+          Await.result(
+            client.sendAsync(
+              AssignGlobalBreakpoint(
+                new ConditionalGlobalBreakpoint(
+                  breakpointID,
+                  tuple => {
+                    val texeraTuple = tuple.asInstanceOf[Tuple]
+                    predicate.apply(texeraTuple)
+                  }
+                ),
+                operatorID
+              )
+            ),
+            Duration.fromSeconds(10)
           )
-        )
-      case countBp: CountBreakpoint =>
-        Await.result(
-          client.sendAsync(
-            AssignGlobalBreakpoint(
-              new CountGlobalBreakpoint(breakpointID, countBp.count),
-              operatorID
-            )
+        case countBp: CountBreakpoint =>
+          Await.result(
+            client.sendAsync(
+              AssignGlobalBreakpoint(
+                new CountGlobalBreakpoint(breakpointID, countBp.count),
+                operatorID
+              )
+            ),
+            Duration.fromSeconds(10)
           )
-        )
+      }
+    } catch {
+      case t: Throwable =>
+        send(WorkflowExecutionErrorEvent(t.getMessage))
     }
   }
 
@@ -299,11 +306,16 @@ class JobRuntimeService(
   }
 
   def evaluatePythonExpression(request: PythonExpressionEvaluateRequest): Unit = {
-    send(
-      Await.result(
-        client.sendAsync(EvaluatePythonExpression(request.expression, request.operatorId))
+    try {
+      val result = Await.result(
+        client.sendAsync(EvaluatePythonExpression(request.expression, request.operatorId)),
+        Duration.fromSeconds(10)
       )
-    )
+      send(result)
+    } catch {
+      case t: Throwable =>
+        send(WorkflowExecutionErrorEvent(t.getMessage))
+    }
   }
 
 }

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -189,13 +189,14 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
       (asyncRPCServer.receive _).expects(*, *).repeat(3)
       (operator.close _).expects().once()
     }
-    val dp = wire[DataProcessor]
+    val dp:DataProcessor = wire[DataProcessor]
     operator.open()
     Await.result(
       sendControlToDP(dp, (0 until 3).map(_ => ControlInvocation(0, DummyControl()))),
       1.second
     )
     waitForControlProcessing(dp)
+    operator.close()
     dp.shutdown()
   }
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -189,7 +189,7 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
       (asyncRPCServer.receive _).expects(*, *).repeat(3)
       (operator.close _).expects().once()
     }
-    val dp:DataProcessor = wire[DataProcessor]
+    val dp: DataProcessor = wire[DataProcessor]
     operator.open()
     Await.result(
       sendControlToDP(dp, (0 until 3).map(_ => ControlInvocation(0, DummyControl()))),

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -98,7 +98,7 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
       timeout: FiniteDuration = 5.seconds
   ): Unit = {
     val deadline = timeout.fromNow
-    while (deadline.hasTimeLeft() && workerStateManager.getCurrentState != COMPLETED) {
+    while (deadline.hasTimeLeft()) {
       //wait
     }
     assert(workerStateManager.getCurrentState == COMPLETED)
@@ -106,7 +106,7 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
 
   def waitForControlProcessing(dp: DataProcessor, timeout: FiniteDuration = 5.seconds): Unit = {
     val deadline = timeout.fromNow
-    while (deadline.hasTimeLeft() && !dp.isControlQueueEmpty) {
+    while (deadline.hasTimeLeft()) {
       //wait
     }
     assert(dp.isControlQueueEmpty)

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
@@ -75,7 +75,7 @@ class DataProcessingSpec
           .toMap
         completion.setDone()
       })
-    client.sendSync(StartWorkflow(), 1.second)
+    Await.result(client.sendAsync(StartWorkflow()))
     Await.result(completion)
     results
   }

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/PauseSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/PauseSpec.scala
@@ -56,14 +56,14 @@ class PauseSpec
       .subscribe(evt => {
         completion.setDone()
       })
-    client.sendSync(StartWorkflow(), 1.second)
-    client.sendSync(PauseWorkflow(), 1.second)
+    Await.result(client.sendAsync(StartWorkflow()))
+    Await.result(client.sendAsync(PauseWorkflow()))
     Thread.sleep(4000)
-    client.sendSync(ResumeWorkflow(), 1.second)
+    Await.result(client.sendAsync(ResumeWorkflow()))
     Thread.sleep(400)
-    client.sendSync(PauseWorkflow(), 1.second)
+    Await.result(client.sendAsync(PauseWorkflow()))
     Thread.sleep(4000)
-    client.sendSync(ResumeWorkflow(), 1.second)
+    Await.result(client.sendAsync(ResumeWorkflow()))
     Await.result(completion)
   }
 


### PR DESCRIPTION
This PR:
1. fixes #1430 by calling close() before sending WorkerExecutionCompleted() to controller to push buffered results to mongoDB. Previously, close() is called in shutdown() which is after frontend receives WorkflowCompleted event.
2. fixes #1424 by enforcing single-thread execution for all control commands sent to AmberClient to make sure WorkflowStarted is handled before WorkflowCompleted.
3. fixes #1431 by replacing "String.isBlank" with "StringUtils.isBlank"