### PR TITLE
Fix Python UDF V2 Evaluate Expression

### DIFF
--- a/core/amber/src/main/python/core/architecture/handlers/evaluate_expression_handler.py
+++ b/core/amber/src/main/python/core/architecture/handlers/evaluate_expression_handler.py
@@ -9,7 +9,7 @@ class EvaluateExpressionHandler(Handler):
 
     def __call__(self, context: Context, command: cmd, *args, **kwargs):
         runtime_context = {
-            r"self":   context.dp._udf_operator,
+            r"self":   context.dp._operator,
             r"tuple_": context.dp._current_input_tuple,
             r"link":   context.dp._current_input_link,
         }

--- a/core/amber/src/main/python/core/architecture/handlers/evaluate_expression_handler.py
+++ b/core/amber/src/main/python/core/architecture/handlers/evaluate_expression_handler.py
@@ -11,7 +11,7 @@ class EvaluateExpressionHandler(Handler):
         runtime_context = {
             r"self":   context.dp._operator,
             r"tuple_": context.dp._current_input_tuple,
-            r"link":   context.dp._current_input_link,
+            r"input_":   context.dp._current_input_link,
         }
 
         evaluated_value: EvaluatedValue = ExpressionEvaluator.evaluate(command.expression, runtime_context)


### PR DESCRIPTION
This PR fixes #1395, which is due to attribute name mismatch. Also updates the evaluation map to align with the latest API.