### PR TITLE
Improve clustering behavior

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
@@ -33,15 +33,15 @@ class ClusterListener extends Actor with ActorLogging {
     case ClusterListener.GetAvailableNodeAddresses => sender ! getAllAddressExcludingMaster.toArray
   }
 
-
-  private def getAllAddressExcludingMaster:Iterable[Address] = {
-    cluster.state.members.filter {
-      member =>
-      member.address != Constants.masterNodeAddr
-    }.map(_.address)
+  private def getAllAddressExcludingMaster: Iterable[Address] = {
+    cluster.state.members
+      .filter { member =>
+        member.address != Constants.masterNodeAddr
+      }
+      .map(_.address)
   }
 
-  private def updateClusterStatus():Unit = {
+  private def updateClusterStatus(): Unit = {
     val addr = getAllAddressExcludingMaster
     Constants.currentWorkerNum = addr.size * Constants.numWorkerPerNode
     log.info(

--- a/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
@@ -14,7 +14,6 @@ object ClusterListener {
 class ClusterListener extends Actor with ActorLogging {
 
   val cluster: Cluster = Cluster(context.system)
-  val availableNodeAddresses = new mutable.HashSet[Address]()
 
   // subscribe to cluster changes, re-subscribe when restart
   override def preStart(): Unit = {
@@ -28,59 +27,26 @@ class ClusterListener extends Actor with ActorLogging {
   override def postStop(): Unit = cluster.unsubscribe(self)
 
   def receive: Receive = {
-    case MemberUp(member) =>
-      if (
-        context.system
-          .asInstanceOf[ExtendedActorSystem]
-          .provider
-          .getDefaultAddress == member.address
-      ) {
-        if (Constants.masterNodeAddr.isDefined) {
-          availableNodeAddresses.add(self.path.address)
-          Constants.currentDataSetNum += Constants.dataVolumePerNode
-          Constants.currentWorkerNum += Constants.numWorkerPerNode
-        }
-      } else {
-        if (Constants.masterNodeAddr != member.address.host) {
-          availableNodeAddresses.add(member.address)
-          Constants.currentDataSetNum += Constants.dataVolumePerNode
-          Constants.currentWorkerNum += Constants.numWorkerPerNode
-        }
-      }
-      log.info(
-        "---------Now we have " + availableNodeAddresses.size + " nodes in the cluster---------"
-      )
-      log.info(
-        "currentDataSetNum: " + Constants.currentDataSetNum + " numWorkers: " + Constants.currentWorkerNum
-      )
-    case UnreachableMember(member) =>
-      removeMember(member)
-      log.info("Member detected as unreachable: {}", member)
-    case MemberRemoved(member, previousStatus) =>
-      removeMember(member)
-      log.info("Member is Removed: {} after {}", member.address, previousStatus)
-    case _: MemberEvent                            => // ignore
-    case ClusterListener.GetAvailableNodeAddresses => sender ! availableNodeAddresses.toArray
+    case evt: MemberEvent =>
+      updateClusterStatus()
+      log.info(s"received member event = $evt")
+    case ClusterListener.GetAvailableNodeAddresses => sender ! getAllAddressExcludingMaster.toArray
   }
 
-  private def removeMember(member: Member): Unit = {
-    if (
-      context.system
-        .asInstanceOf[ExtendedActorSystem]
-        .provider
-        .getDefaultAddress == member.address
-    ) {
-      if (Constants.masterNodeAddr.isDefined) {
-        availableNodeAddresses.remove(self.path.address)
-        Constants.currentDataSetNum -= Constants.dataVolumePerNode
-        Constants.currentWorkerNum -= Constants.numWorkerPerNode
-      }
-    } else {
-      if (Constants.masterNodeAddr != member.address.host) {
-        availableNodeAddresses.remove(member.address)
-        Constants.currentDataSetNum -= Constants.dataVolumePerNode
-        Constants.currentWorkerNum -= Constants.numWorkerPerNode
-      }
-    }
+
+  private def getAllAddressExcludingMaster:Iterable[Address] = {
+    cluster.state.members.filter {
+      member =>
+      member.address != Constants.masterNodeAddr
+    }.map(_.address)
   }
+
+  private def updateClusterStatus():Unit = {
+    val addr = getAllAddressExcludingMaster
+    Constants.currentWorkerNum = addr.size * Constants.numWorkerPerNode
+    log.info(
+      "---------Now we have " + addr.size + s" nodes in the cluster [current default #worker per operator=${Constants.currentWorkerNum}]---------"
+    )
+  }
+
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
@@ -28,8 +28,8 @@ class ClusterListener extends Actor with ActorLogging {
 
   def receive: Receive = {
     case evt: MemberEvent =>
-      updateClusterStatus()
       log.info(s"received member event = $evt")
+      updateClusterStatus()
     case ClusterListener.GetAvailableNodeAddresses => sender ! getAllAddressExcludingMaster.toArray
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberUtils.scala
@@ -35,15 +35,15 @@ object AmberUtils {
         akka.cluster.seed-nodes = [ "akka://Amber@$localIpAddress:2552" ]
         """)
       .withFallback(akkaConfig)
-    Constants.masterNodeAddr = mkMasterAddress(localIpAddress)
-    initAmberSystem(masterConfig)
+    Constants.masterNodeAddr = createMasterAddress(localIpAddress)
+    createAmberSystem(masterConfig)
   }
 
   def akkaConfig: Config = ConfigFactory.load("cluster").withFallback(amberConfig)
 
   def amberConfig: Config = ConfigFactory.load()
 
-  def mkMasterAddress(addr:String):Address = Address("akka","Amber",addr,2552)
+  def createMasterAddress(addr:String):Address = Address("akka","Amber",addr,2552)
 
   def startActorWorker(mainNodeAddress: Option[String]): ActorSystem = {
     val addr = mainNodeAddress.getOrElse("localhost")
@@ -55,12 +55,12 @@ object AmberUtils {
         akka.cluster.seed-nodes = [ "akka://Amber@$addr:2552" ]
         """)
       .withFallback(akkaConfig)
-    Constants.masterNodeAddr = mkMasterAddress(addr)
-    initAmberSystem(workerConfig)
+    Constants.masterNodeAddr = createMasterAddress(addr)
+    createAmberSystem(workerConfig)
   }
 
 
-  def initAmberSystem(actorSystemConf:Config): ActorSystem ={
+  def createAmberSystem(actorSystemConf:Config): ActorSystem ={
     val system = ActorSystem("Amber", actorSystemConf)
     system.actorOf(Props[ClusterListener], "cluster-info")
     val deadLetterMonitorActor =

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberUtils.scala
@@ -43,7 +43,7 @@ object AmberUtils {
 
   def amberConfig: Config = ConfigFactory.load()
 
-  def createMasterAddress(addr:String):Address = Address("akka","Amber",addr,2552)
+  def createMasterAddress(addr: String): Address = Address("akka", "Amber", addr, 2552)
 
   def startActorWorker(mainNodeAddress: Option[String]): ActorSystem = {
     val addr = mainNodeAddress.getOrElse("localhost")
@@ -59,8 +59,7 @@ object AmberUtils {
     createAmberSystem(workerConfig)
   }
 
-
-  def createAmberSystem(actorSystemConf:Config): ActorSystem ={
+  def createAmberSystem(actorSystemConf: Config): ActorSystem = {
     val system = ActorSystem("Amber", actorSystemConf)
     system.actorOf(Props[ClusterListener], "cluster-info")
     val deadLetterMonitorActor =

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberUtils.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.amber.engine.common
 
-import akka.actor.{ActorSystem, DeadLetter, Props}
+import akka.actor.{ActorSystem, Address, DeadLetter, Props}
 import com.typesafe.config.{Config, ConfigFactory}
 import edu.uci.ics.amber.clustering.ClusterListener
 import edu.uci.ics.amber.engine.architecture.messaginglayer.DeadLetterMonitorActor
@@ -35,19 +35,15 @@ object AmberUtils {
         akka.cluster.seed-nodes = [ "akka://Amber@$localIpAddress:2552" ]
         """)
       .withFallback(akkaConfig)
-
-    val system = ActorSystem("Amber", masterConfig)
-    system.actorOf(Props[ClusterListener], "cluster-info")
-    val deadLetterMonitorActor =
-      system.actorOf(Props[DeadLetterMonitorActor], name = "dead-letter-monitor-actor")
-    system.eventStream.subscribe(deadLetterMonitorActor, classOf[DeadLetter])
-
-    system
+    Constants.masterNodeAddr = mkMasterAddress(localIpAddress)
+    initAmberSystem(masterConfig)
   }
 
   def akkaConfig: Config = ConfigFactory.load("cluster").withFallback(amberConfig)
 
   def amberConfig: Config = ConfigFactory.load()
+
+  def mkMasterAddress(addr:String):Address = Address("akka","Amber",addr,2552)
 
   def startActorWorker(mainNodeAddress: Option[String]): ActorSystem = {
     val addr = mainNodeAddress.getOrElse("localhost")
@@ -59,12 +55,17 @@ object AmberUtils {
         akka.cluster.seed-nodes = [ "akka://Amber@$addr:2552" ]
         """)
       .withFallback(akkaConfig)
-    val system = ActorSystem("Amber", workerConfig)
+    Constants.masterNodeAddr = mkMasterAddress(addr)
+    initAmberSystem(workerConfig)
+  }
+
+
+  def initAmberSystem(actorSystemConf:Config): ActorSystem ={
+    val system = ActorSystem("Amber", actorSystemConf)
     system.actorOf(Props[ClusterListener], "cluster-info")
     val deadLetterMonitorActor =
       system.actorOf(Props[DeadLetterMonitorActor], name = "dead-letter-monitor-actor")
     system.eventStream.subscribe(deadLetterMonitorActor, classOf[DeadLetter])
-    Constants.masterNodeAddr = Option(addr)
     system
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/Constants.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/Constants.scala
@@ -1,5 +1,7 @@
 package edu.uci.ics.amber.engine.common
 
+import akka.actor.Address
+
 import scala.concurrent.duration._
 
 object Constants {
@@ -13,10 +15,8 @@ object Constants {
 
   // Non constants: TODO: move out from Constants
   var numWorkerPerNode: Int = AmberUtils.amberConfig.getInt("constants.num-worker-per-node")
-  var dataVolumePerNode: Int = AmberUtils.amberConfig.getInt("constants.data-volume-per-node")
   var currentWorkerNum = 0
-  var currentDataSetNum = 0
-  var masterNodeAddr: Option[String] = None
+  var masterNodeAddr: Address =  Address("akka","Amber","localhost",2552)
   var defaultTau: FiniteDuration = 10.milliseconds
 
   var monitoringEnabled: Boolean =

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/Constants.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/Constants.scala
@@ -16,7 +16,7 @@ object Constants {
   // Non constants: TODO: move out from Constants
   var numWorkerPerNode: Int = AmberUtils.amberConfig.getInt("constants.num-worker-per-node")
   var currentWorkerNum = 0
-  var masterNodeAddr: Address =  Address("akka","Amber","localhost",2552)
+  var masterNodeAddr: Address = Address("akka", "Amber", "localhost", 2552)
   var defaultTau: FiniteDuration = 10.milliseconds
 
   var monitoringEnabled: Boolean =


### PR DESCRIPTION
This PR:
1. refactored the clustering logic, instead of maintaining a set of available nodes ourselves, now we use akka cluster to retrieve them so we can again use a node that recovered itself from an unreachable state.