### PR TITLE
Fix workflow execution DB insertion in dev mode

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionsMetadataPersistService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionsMetadataPersistService.scala
@@ -22,13 +22,6 @@ object ExecutionsMetadataPersistService extends LazyLogging {
     context.configuration
   )
 
-  /**
-    * This method inserts a new entry of a workflow execution in the database and returns the generated eId
-    *
-    * @param wid     the given workflow
-    * @return generated execution ID
-    */
-
   private def getLatestVersion(wid: UInteger): UInteger = {
     context
       .select(WORKFLOW_VERSION.VID)
@@ -41,6 +34,12 @@ object ExecutionsMetadataPersistService extends LazyLogging {
       .max
   }
 
+  /**
+    * @param state indicates the workflow state
+    * @return code indicates the status of the execution in the DB it is 0 by default for any unused states.
+    *         This code is stored in the DB and read in the frontend.
+    *             If these codes are changed, they also have to be changed in the frontend `ngbd-modal-workflow-executions.component.ts`
+    */
   private def maptoStatusCode(state: WorkflowAggregatedState): Byte = {
     state match {
       case WorkflowAggregatedState.UNINITIALIZED                   => 0
@@ -56,6 +55,13 @@ object ExecutionsMetadataPersistService extends LazyLogging {
       case WorkflowAggregatedState.Unrecognized(unrecognizedValue) => ???
     }
   }
+
+  /**
+    * This method inserts a new entry of a workflow execution in the database and returns the generated eId
+    *
+    * @param wid     the given workflow
+    * @return generated execution ID
+    */
 
   def insertNewExecution(
       wid: Long

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobRuntimeService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobRuntimeService.scala
@@ -39,7 +39,9 @@ class JobRuntimeService(
       val outputEvts = new mutable.ArrayBuffer[TexeraWebSocketEvent]()
       // Update workflow state
       if (newState.state != oldState.state) {
-        ExecutionsMetadataPersistService.tryUpdateExistingExecution(newState.eid, newState.state)
+        if (WorkflowService.userSystemEnabled) {
+          ExecutionsMetadataPersistService.tryUpdateExistingExecution(newState.eid, newState.state)
+        }
         outputEvts.append(WorkflowStateEvent(Utils.aggregatedStateToString(newState.state)))
       }
       // Check if new error occurred

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -32,6 +32,7 @@ import org.jooq.types.UInteger
 
 object WorkflowService {
   private val wIdToWorkflowState = new ConcurrentHashMap[String, WorkflowService]()
+  final val userSystemEnabled: Boolean = AmberUtils.amberConfig.getBoolean("user-sys.enabled")
   val cleanUpDeadlineInSeconds: Int =
     AmberUtils.amberConfig.getInt("web-server.workflow-state-cleanup-in-seconds")
   def getOrCreate(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/WorkflowContext.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/WorkflowContext.scala
@@ -4,5 +4,6 @@ import org.jooq.types.UInteger
 class WorkflowContext(
     var jobId: String = null,
     var userId: Option[UInteger] = None,
-    var wId: Int = -1
+    var wId: Int = -1,
+    var executionID: Long = -1
 )


### PR DESCRIPTION
In this PR,
1. include `executionID` in `WorkflowContext`
2. not attempt to insert and update metdatata info of execution when user system is disabled
3. added description of the status encoding in the database