### PR TITLE
Collapse workflow versions(positional, and aggregated by time)

### DIFF
--- a/core/amber/src/main/resources/application.conf
+++ b/core/amber/src/main/resources/application.conf
@@ -29,7 +29,7 @@ cache {
 
 user-sys {
     enabled = false
-    version-time-limit = 1 # in hours
+    version-time-limit = 60 # in minutes
     jwt {
         exp-in-days = 30
         256-bit-secret = random

--- a/core/amber/src/main/resources/application.conf
+++ b/core/amber/src/main/resources/application.conf
@@ -29,7 +29,7 @@ cache {
 
 user-sys {
     enabled = false
-    version-time-limit = 60 # in minutes
+    version-time-limit-in-minutes = 60 # in minutes
     jwt {
         exp-in-days = 30
         256-bit-secret = random

--- a/core/amber/src/main/resources/application.conf
+++ b/core/amber/src/main/resources/application.conf
@@ -29,6 +29,7 @@ cache {
 
 user-sys {
     enabled = false
+    version-time-limit = 1 # in hours
     jwt {
         exp-in-days = 30
         256-bit-secret = random

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
@@ -35,7 +35,7 @@ object WorkflowVersionResource {
   final private val workflowDao = new WorkflowDao(context.configuration)
   // constant to indicate versions should be aggregated if they are within the specified time limit
   private final val AGGREGATE_TIME_LIMIT_MILLSEC =
-    AmberUtils.amberConfig.getInt("user-sys.version-time-limit") * 60000
+    AmberUtils.amberConfig.getInt("user-sys.version-time-limit-in-minutes") * 60000
   // list of Json keys in the diff patch that are considered UNimportant
   private final val VERSION_UNIMPORTANCE_RULES = List("/operatorPositions/")
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
@@ -54,6 +54,9 @@ object WorkflowVersionResource {
       versions: List[VersionEntry]
   ): List[ImpEncodedVersionEntry] = {
     var impEncodedVersions: List[ImpEncodedVersionEntry] = List()
+    if (versions.isEmpty) {
+      return impEncodedVersions
+    }
     val lastVersion = versions.head
     var lastVersionTime = lastVersion.creationTime
     impEncodedVersions = impEncodedVersions :+ ImpEncodedVersionEntry(

--- a/core/new-gui/src/app/dashboard/type/workflow-version-entry.ts
+++ b/core/new-gui/src/app/dashboard/type/workflow-version-entry.ts
@@ -3,4 +3,9 @@ export interface WorkflowVersionEntry
     vId: number;
     creationTime: number;
     content: string;
+    importance: boolean;
   }> {}
+
+export interface WorkflowVersionCollapsableEntry extends WorkflowVersionEntry {
+  expand: boolean;
+}

--- a/core/new-gui/src/app/dashboard/type/workflow-version-entry.ts
+++ b/core/new-gui/src/app/dashboard/type/workflow-version-entry.ts
@@ -7,5 +7,5 @@ export interface WorkflowVersionEntry
   }> {}
 
 export interface WorkflowVersionCollapsableEntry extends WorkflowVersionEntry {
-  expand: boolean;
+  expand: boolean; // for double binding with nzExpand
 }

--- a/core/new-gui/src/app/workspace/component/property-editor/versions-display/versions-display.component.html
+++ b/core/new-gui/src/app/workspace/component/property-editor/versions-display/versions-display.component.html
@@ -8,7 +8,7 @@
     <tbody>
       <ng-container *ngFor="let row of versionsList; let i=index; let l=count;">
         <tr *ngIf="(!row.importance && row.expand) || row.importance">
-          <td [nzShowExpand]="!!row.importance" [(nzExpand)]="row.expand" (nzExpandChange)="collapse(i, $event)">
+          <td [nzShowExpand]="row.importance" [(nzExpand)]="row.expand" (nzExpandChange)="collapse(i, $event)">
             {{(l-i)}}
           </td>
           <td nzEllipsis (click)="getVersion(row.vId)">{{row.creationTime | date:'MM/dd/yyyy HH:mm:ss zzz'}}</td>

--- a/core/new-gui/src/app/workspace/component/property-editor/versions-display/versions-display.component.html
+++ b/core/new-gui/src/app/workspace/component/property-editor/versions-display/versions-display.component.html
@@ -6,10 +6,14 @@
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let row of versionsList; let i=index; let l=count;">
-        <td nzEllipsis (click)="getVersion(row.vId)">{{(l-i)}}</td>
-        <td nzEllipsis (click)="getVersion(row.vId)">{{row.creationTime | date:'MM/dd/yyyy HH:mm:ss zzz'}}</td>
-      </tr>
+      <ng-container *ngFor="let row of versionsList; let i=index; let l=count;">
+        <tr *ngIf="(!row.importance && row.expand) || row.importance">
+          <td [nzShowExpand]="!!row.importance" [(nzExpand)]="row.expand" (nzExpandChange)="collapse(i, $event)">
+            {{(l-i)}}
+          </td>
+          <td nzEllipsis (click)="getVersion(row.vId)">{{row.creationTime | date:'MM/dd/yyyy HH:mm:ss zzz'}}</td>
+        </tr>
+      </ng-container>
     </tbody>
   </nz-table>
 </div>

--- a/core/new-gui/src/app/workspace/component/property-editor/versions-display/versions-display.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/versions-display/versions-display.component.ts
@@ -1,6 +1,9 @@
 import { Component, OnInit } from "@angular/core";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
-import { WorkflowVersionEntry } from "../../../../dashboard/type/workflow-version-entry";
+import {
+  WorkflowVersionCollapsableEntry,
+  WorkflowVersionEntry,
+} from "../../../../dashboard/type/workflow-version-entry";
 import { WorkflowActionService } from "../../../service/workflow-graph/model/workflow-action.service";
 import { WorkflowVersionService } from "../../../../dashboard/service/workflow-version/workflow-version.service";
 import { Observable } from "rxjs";
@@ -19,7 +22,7 @@ export const WORKFLOW_VERSIONS_API_BASE_URL = "version";
   styleUrls: ["./versions-display.component.scss"],
 })
 export class VersionsListDisplayComponent implements OnInit {
-  public versionsList: WorkflowVersionEntry[] | undefined;
+  public versionsList: WorkflowVersionCollapsableEntry[] | undefined;
 
   public versionTableHeaders: string[] = ["Version#", "Timestamp"];
 
@@ -28,7 +31,22 @@ export class VersionsListDisplayComponent implements OnInit {
     private workflowActionService: WorkflowActionService,
     private workflowVersionService: WorkflowVersionService
   ) {}
-
+  collapse(index: number, $event: boolean): void {
+    if (this.versionsList == undefined) {
+      return;
+    }
+    if (!$event) {
+      if (this.versionsList[index].importance) {
+        while (++index < this.versionsList.length && !this.versionsList[index].importance) {
+          const target = this.versionsList[index]!;
+          target.expand = false;
+          this.collapse(index, false);
+        }
+      } else {
+        return;
+      }
+    }
+  }
   ngOnInit(): void {
     // gets the versions result and updates the workflow versions table displayed on the form
     this.displayWorkflowVersions();
@@ -53,7 +71,13 @@ export class VersionsListDisplayComponent implements OnInit {
     this.retrieveVersionsOfWorkflow(wid)
       .pipe(untilDestroyed(this))
       .subscribe(versionsList => {
-        this.versionsList = versionsList;
+        this.versionsList = versionsList.map(version => ({
+          vId: version.vId,
+          creationTime: version.creationTime,
+          content: version.content,
+          importance: version.importance,
+          expand: false,
+        }));
       });
   }
 

--- a/core/new-gui/src/app/workspace/component/property-editor/versions-display/versions-display.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/versions-display/versions-display.component.ts
@@ -31,19 +31,18 @@ export class VersionsListDisplayComponent implements OnInit {
     private workflowActionService: WorkflowActionService,
     private workflowVersionService: WorkflowVersionService
   ) {}
+
   collapse(index: number, $event: boolean): void {
     if (this.versionsList == undefined) {
       return;
     }
     if (!$event) {
-      if (this.versionsList[index].importance) {
-        while (++index < this.versionsList.length && !this.versionsList[index].importance) {
-          const target = this.versionsList[index]!;
-          target.expand = false;
-          this.collapse(index, false);
-        }
-      } else {
-        return;
+      while (++index < this.versionsList.length && !this.versionsList[index].importance) {
+        this.versionsList[index].expand = false;
+      }
+    } else {
+      while (++index < this.versionsList.length && !this.versionsList[index].importance) {
+        this.versionsList[index].expand = true;
       }
     }
   }


### PR DESCRIPTION
![ezgif com-gif-maker](https://user-images.githubusercontent.com/9158114/153932566-c9a5f95d-db97-4333-8393-9dba84dcb36b.gif)

This PR collapses the workflow versions lists under major snapshots(aggregates).
Currently, the two rules to do the snapshot is 1 hour(following Google's version control) and ignore positions.

The aggregation only happens when the user requests to view the list of versions for various reasons:
1. easier to implement.
2. backwards compatible. No need to change the existing database.
3. extensible. If in the future, we wish to change the rule of aggregation, then we can do so as we keep the entire list of versions
4. to maintain consistency and avoid delay since the frontend sends a persist request very frequently, hence we do the aggregation computation logic when retrieving the list of versions not when inserting the version to the database.

~~Since the database entry doesn't contain information of our rules, we create a new class in the backend `ImpEncodedVersionEntry` to extend the previous class `VersionEntry`.~~
We also create a new subclass `WorkflowVersionCollapsableEntry` in the frontend to contain some flags to indicate their status of being collapsed or expanded.