### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -61,6 +61,11 @@ jobs:
           access_token: ${{ github.token }}
       - name: Checkout Texera
         uses: actions/checkout@v2
+      - name: Setup Java
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: [ '8', '11']
       - uses: coursier/cache-action@v6
       - name: Lint with scalafmt
         run: cd core/amber && sbt scalafmtCheckAll

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -6,12 +6,6 @@ on:
       - 'ci-enable/**'
       - 'master'
   pull_request:
-    paths-ignore:
-      - 'core/scripts/**'
-      - '**/.gitignore'
-      - '**.md'
-      - '**.csv'
-      - '**.txt'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -55,9 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        java-version:
-          - 8
-          - 11
+        java-version: [ 8, 11 ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Cancel Previous Runs
@@ -85,6 +83,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+        os:
+          - ubuntu-latest
         python-version: [ 3.6, 3.7, 3.8, 3.9 ]
 
     steps:

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        node_version:
+        node-version:
           - 14
         architecture:
           - x64
@@ -31,7 +31,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
         with:
-          node-version: ${{ matrix.node_version }}
+          node-version: ${{ matrix.node-version }}
           architecture: ${{ matrix.architecture }}
       - uses: actions/cache@v2
         with:
@@ -51,7 +51,14 @@ jobs:
         run: yarn --cwd core/new-gui run build
 
   amber:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+        java-version:
+          - 8
+          - 11
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Cancel Previous Runs
         uses: styfle/cancel-workflow-action@0.9.1
@@ -65,7 +72,7 @@ jobs:
         uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: [ '8', '11']
+          java-version: ${{ matrix.java-version }}
       - uses: coursier/cache-action@v6
       - name: Lint with scalafmt
         run: cd core/amber && sbt scalafmtCheckAll
@@ -75,7 +82,7 @@ jobs:
         run: cd core/amber && sbt -v -J-Xmx2G test
 
   python_udf:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [ 3.6, 3.7, 3.8, 3.9 ]


### PR DESCRIPTION
This PR:
1. include java distribution `temurin` (originally Adopt OpenJDK) with v8 and v11.
2. remove ignore files, so all changes to repo will trigger CI. This change now unblocks PRs that only edits logistic files, also due to the fact that CI runs relatively faster now.