### PR TITLE
Disable google export

### DIFF
--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -128,9 +128,9 @@
             <!--              File-->
             <!--              (*.xlsx)-->
             <!--            </li> -->
-<!--            <li (click)="onClickExportExecutionResult('google_sheet')" class="drop-down-item" nz-menu-item>-->
-<!--              Google Sheet-->
-<!--            </li>-->
+            <!--            <li (click)="onClickExportExecutionResult('google_sheet')" class="drop-down-item" nz-menu-item>-->
+            <!--              Google Sheet-->
+            <!--            </li>-->
           </ul>
         </nz-dropdown-menu>
         <!-- <button

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -128,9 +128,9 @@
             <!--              File-->
             <!--              (*.xlsx)-->
             <!--            </li> -->
-            <li (click)="onClickExportExecutionResult('google_sheet')" class="drop-down-item" nz-menu-item>
-              Google Sheet
-            </li>
+<!--            <li (click)="onClickExportExecutionResult('google_sheet')" class="drop-down-item" nz-menu-item>-->
+<!--              Google Sheet-->
+<!--            </li>-->
           </ul>
         </nz-dropdown-menu>
         <!-- <button

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -20,7 +20,6 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { isSink } from "../../service/workflow-graph/model/workflow-graph";
 import { WorkflowVersionService } from "../../../dashboard/service/workflow-version/workflow-version.service";
 import { WorkflowCollabService } from "../../service/workflow-collab/workflow-collab.service";
-import { delay } from "lodash";
 
 /**
  * NavigationComponent is the top level navigation bar that shows
@@ -68,7 +67,7 @@ export class NavigationComponent {
   public displayParticularWorkflowVersion: boolean = false;
   public onClickRunHandler: () => void;
 
-  // whether the disable operator button should be enabled
+  // whether the disable-operator-button should be enabled
   public isDisableOperatorClickable: boolean = false;
   public isDisableOperator: boolean = true;
 


### PR DESCRIPTION
We disable the google export temporarily, since it is not the recommended way of exporting results. Ideally, we want the results to stay in our system.

We can make export options configurable in the future.