### PR TITLE
Separate workflow state and job state in web server

### DIFF
--- a/core/amber/src/main/protobuf/edu/uci/ics/texera/workflowruntimestate.proto
+++ b/core/amber/src/main/protobuf/edu/uci/ics/texera/workflowruntimestate.proto
@@ -69,7 +69,7 @@ message JobStatsStore {
   map<string,OperatorRuntimeStats> operator_info = 3;
 }
 
-message JobStateStore{
+message JobMetadataStore{
   WorkflowAggregatedState state = 1;
   string error = 2;
   int64 eid = 3;

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobBreakpointService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobBreakpointService.scala
@@ -10,7 +10,7 @@ import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.AssignBr
 import edu.uci.ics.amber.engine.common.client.AmberClient
 import edu.uci.ics.texera.web.SubscriptionManager
 import edu.uci.ics.texera.web.model.websocket.event.{BreakpointTriggeredEvent, TexeraWebSocketEvent}
-import edu.uci.ics.texera.web.storage.WorkflowStateStore
+import edu.uci.ics.texera.web.storage.{JobStateStore, WorkflowStateStore}
 import edu.uci.ics.texera.web.workflowruntimestate.BreakpointFault.BreakpointTuple
 import edu.uci.ics.texera.web.workflowruntimestate.{
   BreakpointFault,
@@ -31,7 +31,7 @@ import scala.collection.mutable
 
 class JobBreakpointService(
     client: AmberClient,
-    stateStore: WorkflowStateStore
+    stateStore: JobStateStore
 ) extends SubscriptionManager {
 
   registerCallbackOnBreakpoint()
@@ -62,7 +62,7 @@ class JobBreakpointService(
     addSubscription(
       client
         .registerCallback[BreakpointTriggered]((evt: BreakpointTriggered) => {
-          stateStore.jobStateStore.updateState { oldState =>
+          stateStore.jobMetadataStore.updateState { oldState =>
             oldState.withState(PAUSED)
           }
           stateStore.breakpointStore.updateState { jobInfo =>

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobPythonService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobPythonService.scala
@@ -13,7 +13,7 @@ import edu.uci.ics.texera.web.model.websocket.request.python.PythonExpressionEva
 import edu.uci.ics.texera.web.model.websocket.request.{RetryRequest, SkipTupleRequest}
 import edu.uci.ics.texera.web.model.websocket.response.python.PythonExpressionEvaluateResponse
 import edu.uci.ics.texera.web.service.JobPythonService.bufferSize
-import edu.uci.ics.texera.web.storage.WorkflowStateStore
+import edu.uci.ics.texera.web.storage.{JobStateStore, WorkflowStateStore}
 import edu.uci.ics.texera.web.workflowruntimestate.{EvaluatedValueList, PythonOperatorInfo}
 import edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState.{RESUMING, RUNNING}
 
@@ -26,7 +26,7 @@ object JobPythonService {
 
 class JobPythonService(
     client: AmberClient,
-    stateStore: WorkflowStateStore,
+    stateStore: JobStateStore,
     wsInput: WebsocketInput,
     breakpointService: JobBreakpointService
 ) extends SubscriptionManager {
@@ -87,10 +87,10 @@ class JobPythonService(
   //Receive retry request
   addSubscription(wsInput.subscribe((req: RetryRequest, uidOpt) => {
     breakpointService.clearTriggeredBreakpoints()
-    stateStore.jobStateStore.updateState(jobInfo => jobInfo.withState(RESUMING))
+    stateStore.jobMetadataStore.updateState(jobInfo => jobInfo.withState(RESUMING))
     client.sendAsyncWithCallback[Unit](
       RetryWorkflow(),
-      _ => stateStore.jobStateStore.updateState(jobInfo => jobInfo.withState(RUNNING))
+      _ => stateStore.jobMetadataStore.updateState(jobInfo => jobInfo.withState(RUNNING))
     )
   }))
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobStatsService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobStatsService.scala
@@ -13,12 +13,12 @@ import edu.uci.ics.texera.web.model.websocket.event.{
   OperatorStatisticsUpdateEvent,
   TexeraWebSocketEvent
 }
-import edu.uci.ics.texera.web.storage.WorkflowStateStore
+import edu.uci.ics.texera.web.storage.{JobStateStore, WorkflowStateStore}
 import edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState.{ABORTED, COMPLETED}
 
 class JobStatsService(
     client: AmberClient,
-    stateStore: WorkflowStateStore
+    stateStore: JobStateStore
 ) extends SubscriptionManager {
 
   registerCallbacks()
@@ -67,7 +67,7 @@ class JobStatsService(
       client
         .registerCallback[WorkflowCompleted]((evt: WorkflowCompleted) => {
           client.shutdown()
-          stateStore.jobStateStore.updateState(jobInfo => jobInfo.withState(COMPLETED))
+          stateStore.jobMetadataStore.updateState(jobInfo => jobInfo.withState(COMPLETED))
         })
     )
   }
@@ -77,7 +77,7 @@ class JobStatsService(
       client
         .registerCallback[FatalError]((evt: FatalError) => {
           client.shutdown()
-          stateStore.jobStateStore.updateState { jobInfo =>
+          stateStore.jobMetadataStore.updateState { jobInfo =>
             jobInfo.withState(ABORTED).withError(evt.e.getLocalizedMessage)
           }
         })

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/storage/JobStateStore.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/storage/JobStateStore.scala
@@ -1,0 +1,20 @@
+package edu.uci.ics.texera.web.storage
+
+import edu.uci.ics.texera.web.workflowruntimestate.{
+  JobBreakpointStore,
+  JobMetadataStore,
+  JobPythonStore,
+  JobStatsStore
+}
+
+// states that within one execution.
+class JobStateStore {
+  val statsStore = new StateStore(JobStatsStore())
+  val jobMetadataStore = new StateStore(JobMetadataStore())
+  val pythonStore = new StateStore(JobPythonStore())
+  val breakpointStore = new StateStore(JobBreakpointStore())
+
+  def getAllStores: Iterable[StateStore[_]] = {
+    Iterable(statsStore, pythonStore, breakpointStore, jobMetadataStore)
+  }
+}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/storage/StateStore.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/storage/StateStore.scala
@@ -44,8 +44,9 @@ class StateStore[T](defaultState: T) {
     }
   }
 
-  def getWebsocketEventObservable: Observable[Iterable[TexeraWebSocketEvent]] = diffSubject
+  def getWebsocketEventObservable: Observable[Iterable[TexeraWebSocketEvent]] =
+    diffSubject.onTerminateDetach()
 
-  def getStateObservable: Observable[T] = serializedSubject
+  def getStateObservable: Observable[T] = serializedSubject.onTerminateDetach()
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/storage/WorkflowStateStore.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/storage/WorkflowStateStore.scala
@@ -2,23 +2,14 @@ package edu.uci.ics.texera.web.storage
 
 import edu.uci.ics.texera.web.workflowcachestate.WorkflowCacheStore
 import edu.uci.ics.texera.web.workflowresultstate.WorkflowResultStore
-import edu.uci.ics.texera.web.workflowruntimestate.{
-  JobBreakpointStore,
-  JobPythonStore,
-  JobStateStore,
-  JobStatsStore
-}
 
+// states that across executions.
 class WorkflowStateStore {
   val cacheStore = new StateStore(WorkflowCacheStore())
-  val statsStore = new StateStore(JobStatsStore())
-  val jobStateStore = new StateStore(JobStateStore())
-  val pythonStore = new StateStore(JobPythonStore())
-  val breakpointStore = new StateStore(JobBreakpointStore())
   val resultStore = new StateStore(WorkflowResultStore())
 
   def getAllStores: Iterable[StateStore[_]] = {
-    Iterable(cacheStore, statsStore, pythonStore, breakpointStore, resultStore, jobStateStore)
+    Iterable(cacheStore, resultStore)
   }
 
 }

--- a/core/amber/src/main/scalapb/edu/uci/ics/texera/web/workflowruntimestate/JobMetadataStore.scala
+++ b/core/amber/src/main/scalapb/edu/uci/ics/texera/web/workflowruntimestate/JobMetadataStore.scala
@@ -6,11 +6,11 @@
 package edu.uci.ics.texera.web.workflowruntimestate
 
 @SerialVersionUID(0L)
-final case class JobStateStore(
+final case class JobMetadataStore(
     state: edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState = edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState.UNINITIALIZED,
     error: _root_.scala.Predef.String = "",
     eid: _root_.scala.Long = 0L
-    ) extends scalapb.GeneratedMessage with scalapb.lenses.Updatable[JobStateStore] {
+    ) extends scalapb.GeneratedMessage with scalapb.lenses.Updatable[JobMetadataStore] {
     @transient
     private[this] var __serializedSizeCachedValue: _root_.scala.Int = 0
     private[this] def __computeSerializedValue(): _root_.scala.Int = {
@@ -66,9 +66,9 @@ final case class JobStateStore(
         }
       };
     }
-    def withState(__v: edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState): JobStateStore = copy(state = __v)
-    def withError(__v: _root_.scala.Predef.String): JobStateStore = copy(error = __v)
-    def withEid(__v: _root_.scala.Long): JobStateStore = copy(eid = __v)
+    def withState(__v: edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState): JobMetadataStore = copy(state = __v)
+    def withError(__v: _root_.scala.Predef.String): JobMetadataStore = copy(error = __v)
+    def withEid(__v: _root_.scala.Long): JobMetadataStore = copy(eid = __v)
     def getFieldByNumber(__fieldNumber: _root_.scala.Int): _root_.scala.Any = {
       (__fieldNumber: @_root_.scala.unchecked) match {
         case 1 => {
@@ -94,13 +94,13 @@ final case class JobStateStore(
       }
     }
     def toProtoString: _root_.scala.Predef.String = _root_.scalapb.TextFormat.printToSingleLineUnicodeString(this)
-    def companion = edu.uci.ics.texera.web.workflowruntimestate.JobStateStore
-    // @@protoc_insertion_point(GeneratedMessage[edu.uci.ics.texera.web.JobStateStore])
+    def companion = edu.uci.ics.texera.web.workflowruntimestate.JobMetadataStore
+    // @@protoc_insertion_point(GeneratedMessage[edu.uci.ics.texera.web.JobMetadataStore])
 }
 
-object JobStateStore extends scalapb.GeneratedMessageCompanion[edu.uci.ics.texera.web.workflowruntimestate.JobStateStore] {
-  implicit def messageCompanion: scalapb.GeneratedMessageCompanion[edu.uci.ics.texera.web.workflowruntimestate.JobStateStore] = this
-  def parseFrom(`_input__`: _root_.com.google.protobuf.CodedInputStream): edu.uci.ics.texera.web.workflowruntimestate.JobStateStore = {
+object JobMetadataStore extends scalapb.GeneratedMessageCompanion[edu.uci.ics.texera.web.workflowruntimestate.JobMetadataStore] {
+  implicit def messageCompanion: scalapb.GeneratedMessageCompanion[edu.uci.ics.texera.web.workflowruntimestate.JobMetadataStore] = this
+  def parseFrom(`_input__`: _root_.com.google.protobuf.CodedInputStream): edu.uci.ics.texera.web.workflowruntimestate.JobMetadataStore = {
     var __state: edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState = edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState.UNINITIALIZED
     var __error: _root_.scala.Predef.String = ""
     var __eid: _root_.scala.Long = 0L
@@ -118,16 +118,16 @@ object JobStateStore extends scalapb.GeneratedMessageCompanion[edu.uci.ics.texer
         case tag => _input__.skipField(tag)
       }
     }
-    edu.uci.ics.texera.web.workflowruntimestate.JobStateStore(
+    edu.uci.ics.texera.web.workflowruntimestate.JobMetadataStore(
         state = __state,
         error = __error,
         eid = __eid
     )
   }
-  implicit def messageReads: _root_.scalapb.descriptors.Reads[edu.uci.ics.texera.web.workflowruntimestate.JobStateStore] = _root_.scalapb.descriptors.Reads{
+  implicit def messageReads: _root_.scalapb.descriptors.Reads[edu.uci.ics.texera.web.workflowruntimestate.JobMetadataStore] = _root_.scalapb.descriptors.Reads{
     case _root_.scalapb.descriptors.PMessage(__fieldsMap) =>
       _root_.scala.Predef.require(__fieldsMap.keys.forall(_.containingMessage eq scalaDescriptor), "FieldDescriptor does not match message type.")
-      edu.uci.ics.texera.web.workflowruntimestate.JobStateStore(
+      edu.uci.ics.texera.web.workflowruntimestate.JobMetadataStore(
         state = edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState.fromValue(__fieldsMap.get(scalaDescriptor.findFieldByNumber(1).get).map(_.as[_root_.scalapb.descriptors.EnumValueDescriptor]).getOrElse(edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState.UNINITIALIZED.scalaValueDescriptor).number),
         error = __fieldsMap.get(scalaDescriptor.findFieldByNumber(2).get).map(_.as[_root_.scala.Predef.String]).getOrElse(""),
         eid = __fieldsMap.get(scalaDescriptor.findFieldByNumber(3).get).map(_.as[_root_.scala.Long]).getOrElse(0L)
@@ -143,12 +143,12 @@ object JobStateStore extends scalapb.GeneratedMessageCompanion[edu.uci.ics.texer
       case 1 => edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState
     }
   }
-  lazy val defaultInstance = edu.uci.ics.texera.web.workflowruntimestate.JobStateStore(
+  lazy val defaultInstance = edu.uci.ics.texera.web.workflowruntimestate.JobMetadataStore(
     state = edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState.UNINITIALIZED,
     error = "",
     eid = 0L
   )
-  implicit class JobStateStoreLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, edu.uci.ics.texera.web.workflowruntimestate.JobStateStore]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, edu.uci.ics.texera.web.workflowruntimestate.JobStateStore](_l) {
+  implicit class JobMetadataStoreLens[UpperPB](_l: _root_.scalapb.lenses.Lens[UpperPB, edu.uci.ics.texera.web.workflowruntimestate.JobMetadataStore]) extends _root_.scalapb.lenses.ObjectLens[UpperPB, edu.uci.ics.texera.web.workflowruntimestate.JobMetadataStore](_l) {
     def state: _root_.scalapb.lenses.Lens[UpperPB, edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState] = field(_.state)((c_, f_) => c_.copy(state = f_))
     def error: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Predef.String] = field(_.error)((c_, f_) => c_.copy(error = f_))
     def eid: _root_.scalapb.lenses.Lens[UpperPB, _root_.scala.Long] = field(_.eid)((c_, f_) => c_.copy(eid = f_))
@@ -160,10 +160,10 @@ object JobStateStore extends scalapb.GeneratedMessageCompanion[edu.uci.ics.texer
     state: edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState,
     error: _root_.scala.Predef.String,
     eid: _root_.scala.Long
-  ): _root_.edu.uci.ics.texera.web.workflowruntimestate.JobStateStore = _root_.edu.uci.ics.texera.web.workflowruntimestate.JobStateStore(
+  ): _root_.edu.uci.ics.texera.web.workflowruntimestate.JobMetadataStore = _root_.edu.uci.ics.texera.web.workflowruntimestate.JobMetadataStore(
     state,
     error,
     eid
   )
-  // @@protoc_insertion_point(GeneratedMessageCompanion[edu.uci.ics.texera.web.JobStateStore])
+  // @@protoc_insertion_point(GeneratedMessageCompanion[edu.uci.ics.texera.web.JobMetadataStore])
 }

--- a/core/amber/src/main/scalapb/edu/uci/ics/texera/web/workflowruntimestate/WorkflowruntimestateProto.scala
+++ b/core/amber/src/main/scalapb/edu/uci/ics/texera/web/workflowruntimestate/WorkflowruntimestateProto.scala
@@ -20,7 +20,7 @@ object WorkflowruntimestateProto extends _root_.scalapb.GeneratedFileObject {
       edu.uci.ics.texera.web.workflowruntimestate.JobPythonStore,
       edu.uci.ics.texera.web.workflowruntimestate.OperatorRuntimeStats,
       edu.uci.ics.texera.web.workflowruntimestate.JobStatsStore,
-      edu.uci.ics.texera.web.workflowruntimestate.JobStateStore
+      edu.uci.ics.texera.web.workflowruntimestate.JobMetadataStore
     )
   private lazy val ProtoBytes: _root_.scala.Array[Byte] =
       scalapb.Encoding.fromBase64(scala.collection.immutable.Seq(
@@ -52,12 +52,12 @@ object WorkflowruntimestateProto extends _root_.scalapb.GeneratedFileObject {
   291dHB1dENvdW50UgtvdXRwdXRDb3VudCKGAgoNSm9iU3RhdHNTdG9yZRJvCg1vcGVyYXRvcl9pbmZvGAMgAygLMjcuZWR1LnVja
   S5pY3MudGV4ZXJhLndlYi5Kb2JTdGF0c1N0b3JlLk9wZXJhdG9ySW5mb0VudHJ5QhHiPw4SDG9wZXJhdG9ySW5mb1IMb3BlcmF0b
   3JJbmZvGoMBChFPcGVyYXRvckluZm9FbnRyeRIaCgNrZXkYASABKAlCCOI/BRIDa2V5UgNrZXkSTgoFdmFsdWUYAiABKAsyLC5lZ
-  HUudWNpLmljcy50ZXhlcmEud2ViLk9wZXJhdG9yUnVudGltZVN0YXRzQgriPwcSBXZhbHVlUgV2YWx1ZToCOAEioAEKDUpvYlN0Y
-  XRlU3RvcmUSUQoFc3RhdGUYASABKA4yLy5lZHUudWNpLmljcy50ZXhlcmEud2ViLldvcmtmbG93QWdncmVnYXRlZFN0YXRlQgriP
-  wcSBXN0YXRlUgVzdGF0ZRIgCgVlcnJvchgCIAEoCUIK4j8HEgVlcnJvclIFZXJyb3ISGgoDZWlkGAMgASgDQgjiPwUSA2VpZFIDZ
-  WlkKqQBChdXb3JrZmxvd0FnZ3JlZ2F0ZWRTdGF0ZRIRCg1VTklOSVRJQUxJWkVEEAASCQoFUkVBRFkQARILCgdSVU5OSU5HEAISC
-  woHUEFVU0lORxADEgoKBlBBVVNFRBAEEgwKCFJFU1VNSU5HEAUSDgoKUkVDT1ZFUklORxAGEg0KCUNPTVBMRVRFRBAHEgsKB0FCT
-  1JURUQQCBILCgdVTktOT1dOEAlCCeI/BkgAWAB4AGIGcHJvdG8z"""
+  HUudWNpLmljcy50ZXhlcmEud2ViLk9wZXJhdG9yUnVudGltZVN0YXRzQgriPwcSBXZhbHVlUgV2YWx1ZToCOAEiowEKEEpvYk1ld
+  GFkYXRhU3RvcmUSUQoFc3RhdGUYASABKA4yLy5lZHUudWNpLmljcy50ZXhlcmEud2ViLldvcmtmbG93QWdncmVnYXRlZFN0YXRlQ
+  griPwcSBXN0YXRlUgVzdGF0ZRIgCgVlcnJvchgCIAEoCUIK4j8HEgVlcnJvclIFZXJyb3ISGgoDZWlkGAMgASgDQgjiPwUSA2VpZ
+  FIDZWlkKqQBChdXb3JrZmxvd0FnZ3JlZ2F0ZWRTdGF0ZRIRCg1VTklOSVRJQUxJWkVEEAASCQoFUkVBRFkQARILCgdSVU5OSU5HE
+  AISCwoHUEFVU0lORxADEgoKBlBBVVNFRBAEEgwKCFJFU1VNSU5HEAUSDgoKUkVDT1ZFUklORxAGEg0KCUNPTVBMRVRFRBAHEgsKB
+  0FCT1JURUQQCBILCgdVTktOT1dOEAlCCeI/BkgAWAB4AGIGcHJvdG8z"""
       ).mkString)
   lazy val scalaDescriptor: _root_.scalapb.descriptors.FileDescriptor = {
     val scalaProto = com.google.protobuf.descriptor.FileDescriptorProto.parseFrom(ProtoBytes)


### PR DESCRIPTION
The webserver re-uses the previous execution state without cleaning it up for the next execution. This leads to the accumulation of python print statements. 
This PR:
1. Separate the workflow state(across multiple executions) and job state(within one execution). The workflow state will be initialized once a user connects the WebSocket without executing the workflow. The job state will be created per execution. The old job state will be discarded so that we can get rid of the python print accumulation.