### PR TITLE
Fix workflow current version number

### DIFF
--- a/core/amber/src/main/resources/application.conf
+++ b/core/amber/src/main/resources/application.conf
@@ -44,7 +44,7 @@ cache {
 
 user-sys {
     enabled = false
-    version-time-limit-in-minutes = 60 # in minutes
+    version-time-limit-in-minutes = 60
     jwt {
         exp-in-days = 30
         256-bit-secret = random

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowResource.scala
@@ -162,6 +162,8 @@ class WorkflowResource {
     * @param workflow , a workflow
     * @return Workflow, which contains the generated wid if not provided//
     *         TODO: divide into two endpoints -> one for new-workflow and one for updating existing workflow
+    *         TODO: if the persist is triggered in parallel, the none atomic actions currently might cause an issue.
+    *             Should consider making the operations atomic
     */
   @POST
   @Path("/persist")

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowResource.scala
@@ -179,6 +179,7 @@ class WorkflowResource {
         insertWorkflow(workflow, user)
         WorkflowVersionResource.insertVersion(workflow, true)
       } else if (WorkflowAccessResource.hasWriteAccess(workflow.getWid, user.getUid)) {
+        WorkflowVersionResource.insertVersion(workflow, false)
         // not owner but has write access
         workflowDao.update(workflow)
       } else {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowResource.scala
@@ -239,6 +239,7 @@ class WorkflowResource {
       throw new BadRequestException("Cannot create a new workflow with a provided id.")
     } else {
       insertWorkflow(workflow, user)
+      WorkflowVersionResource.insertVersion(workflow, true)
       DashboardWorkflowEntry(
         isOwner = true,
         WorkflowAccess.WRITE.toString,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
@@ -120,12 +120,15 @@ object WorkflowVersionResource {
     * @return
     */
   private def encodeVersionImportance(
-      versions: List[WorkflowVersion]
+      currentVersions: List[WorkflowVersion]
   ): List[VersionEntry] = {
     var impEncodedVersions: List[VersionEntry] = List()
-    if (versions.isEmpty) {
+    if (currentVersions.size <= 2) {
       return impEncodedVersions
     }
+    val versions =
+      currentVersions.init.reverse.init // remove the last empty patch and remove the first version because current
+    // frontend can't display an empty workflow on paper TODO fix reload in `workflow-action-service.ts`
     val lastVersion = versions.head
     var lastVersionTime = lastVersion.getCreationTime
     impEncodedVersions = impEncodedVersions :+ VersionEntry(
@@ -260,9 +263,6 @@ class WorkflowVersionResource {
           .where(WORKFLOW_VERSION.WID.eq(wid))
           .fetchInto(classOf[WorkflowVersion])
           .toList
-          .init // remove the last empty patch
-          .reverse
-          .init // remove the first version because current frontend can't display an empty workflow on paper TODO fix reload in `workflow-action-service.ts`
       )
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
@@ -1,12 +1,12 @@
 package edu.uci.ics.texera.web.resource.dashboard.workflow
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.flipkart.zjsonpatch.JsonPatch
 import edu.uci.ics.amber.engine.common.AmberUtils
+import edu.uci.ics.texera.Utils.objectMapper
 import edu.uci.ics.texera.web.SqlServer
 import edu.uci.ics.texera.web.auth.SessionUser
 import edu.uci.ics.texera.web.model.jooq.generated.Tables.{WORKFLOW, WORKFLOW_VERSION}
-import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.WorkflowDao
+import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{WorkflowDao, WorkflowVersionDao}
 import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.{Workflow, WorkflowVersion}
 import edu.uci.ics.texera.web.resource.dashboard.workflow.WorkflowVersionResource.{
   VersionEntry,
@@ -31,12 +31,61 @@ import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 
 object WorkflowVersionResource {
   final private lazy val context = SqlServer.createDSLContext()
+  final private val workflowVersionDao = new WorkflowVersionDao(context.configuration)
   final private val workflowDao = new WorkflowDao(context.configuration)
   // constant to indicate versions should be aggregated if they are within the specified time limit
   private final val AGGREGATE_TIME_LIMIT_MILLSEC =
     AmberUtils.amberConfig.getInt("user-sys.version-time-limit-in-minutes") * 60000
   // list of Json keys in the diff patch that are considered UNimportant
   private final val VERSION_UNIMPORTANCE_RULES = List("/operatorPositions/")
+
+  /**
+    * This function retrieves the latest version of a workflow
+    * @param wid
+    * @return vid
+    */
+  def getLatestVersion(wid: UInteger): UInteger = {
+    context
+      .select(WORKFLOW_VERSION.VID)
+      .from(WORKFLOW_VERSION)
+      .leftJoin(WORKFLOW)
+      .on(WORKFLOW_VERSION.WID.eq(WORKFLOW.WID))
+      .where(WORKFLOW_VERSION.WID.eq(wid))
+      .fetchInto(classOf[UInteger])
+      .toList
+      .max
+  }
+
+  /**
+    * This function inserts a new version for the current workflow
+    * @param patch
+    * @param wid
+    */
+  def insertVersion(patch: String, wid: UInteger): Unit = {
+    // write the new version with empty diff
+    val workflowVersion = new WorkflowVersion()
+    workflowVersion.setContent(patch)
+    workflowVersion.setWid(wid)
+    workflowVersionDao.insert(workflowVersion)
+  }
+
+  /**
+    * This function updates the content of the latest version and inserts a new empty version for the current workflow
+    * @param patch to update latest version
+    * @param wid
+    */
+  def insertAndUpdateVersion(patch: String, wid: UInteger): Unit = {
+    // get the latest version to update its content
+    val vid = getLatestVersion(wid)
+    var workflowVersion = workflowVersionDao.fetchOneByVid(vid)
+    workflowVersion.setContent(patch)
+    workflowVersionDao.update(workflowVersion)
+    // write the new version with empty diff
+    workflowVersion = new WorkflowVersion()
+    workflowVersion.setContent("[]")
+    workflowVersion.setWid(wid)
+    workflowVersionDao.insert(workflowVersion)
+  }
 
   /**
     * This function gives a label to each version whether it is significant or not based on a few rules
@@ -66,7 +115,7 @@ object WorkflowVersionResource {
     ) // the first (latest)
     // version is important even if it is positional
     var versionImportance: Boolean = true
-    for (version <- versions.init) {
+    for (version <- versions.tail) {
       if (isWithinTimeLimit(lastVersionTime, version.getCreationTime)) {
         versionImportance = false
       } // try reducing unnecessary check of positional versions
@@ -104,8 +153,7 @@ object WorkflowVersionResource {
     * @return
     */
   private def isVersionImportant(versionContent: String): Boolean = {
-    val mapper = new ObjectMapper()
-    val jsonTreeIterator = mapper.readTree(versionContent).iterator()
+    val jsonTreeIterator = objectMapper.readTree(versionContent).iterator()
     while (jsonTreeIterator.hasNext) {
       // if the change(which is marked by the key `path` using the Json patch library
       // doesn't contain any of the specified keywords then it shall be deemed important
@@ -126,11 +174,13 @@ object WorkflowVersionResource {
     */
   private def applyPatch(versions: List[WorkflowVersion], workflow: Workflow): Workflow = {
     // loop all versions and apply the patch
-    val mapper = new ObjectMapper()
     for (patch <- versions) {
       workflow.setContent(
         JsonPatch
-          .apply(mapper.readTree(patch.getContent), mapper.readTree(workflow.getContent))
+          .apply(
+            objectMapper.readTree(patch.getContent),
+            objectMapper.readTree(workflow.getContent)
+          )
           .toString
       )
       workflow.setCreationTime(patch.getCreationTime)
@@ -189,7 +239,9 @@ class WorkflowVersionResource {
           .where(WORKFLOW_VERSION.WID.eq(wid))
           .fetchInto(classOf[WorkflowVersion])
           .toList
+          .init // remove the last empty patch
           .reverse
+          .init // remove the first version because current frontend can't display an empty workflow on paper TODO fix reload in `workflow-action-service.ts`
       )
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
@@ -72,7 +72,7 @@ object WorkflowVersionResource {
     // retrieve current workflow from DB
     val currentWorkflow = workflowDao.fetchOneByWid(wid)
     // if the workflow is new then previous workflow is empty
-    val content = if (currentWorkflow == null) "{}" else currentWorkflow.getContent
+    val content = if (insertNewFlag) "{}" else currentWorkflow.getContent
     // compute diff
     val patch = JsonDiff.asJson(
       objectMapper.readTree(workflow.getContent),

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionsMetadataPersistService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionsMetadataPersistService.scala
@@ -2,14 +2,13 @@ package edu.uci.ics.texera.web.service
 
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.texera.web.SqlServer
-import edu.uci.ics.texera.web.model.jooq.generated.Tables.{WORKFLOW, WORKFLOW_VERSION}
 import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.WorkflowExecutionsDao
 import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.WorkflowExecutions
+import edu.uci.ics.texera.web.resource.dashboard.workflow.WorkflowVersionResource
 import edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState
 import org.jooq.types.UInteger
 
 import java.sql.Timestamp
-import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 
 /**
   * This global object handles inserting a new entry to the DB to store metadata information about every workflow execution
@@ -21,18 +20,6 @@ object ExecutionsMetadataPersistService extends LazyLogging {
   private val workflowExecutionsDao = new WorkflowExecutionsDao(
     context.configuration
   )
-
-  private def getLatestVersion(wid: UInteger): UInteger = {
-    context
-      .select(WORKFLOW_VERSION.VID)
-      .from(WORKFLOW_VERSION)
-      .leftJoin(WORKFLOW)
-      .on(WORKFLOW_VERSION.WID.eq(WORKFLOW.WID))
-      .where(WORKFLOW_VERSION.WID.eq(wid))
-      .fetchInto(classOf[UInteger])
-      .toList
-      .max
-  }
 
   /**
     * @param state indicates the workflow state
@@ -68,7 +55,7 @@ object ExecutionsMetadataPersistService extends LazyLogging {
   ): Long = {
     // first retrieve the latest version of this workflow
     val uint = UInteger.valueOf(wid)
-    val vid = getLatestVersion(uint)
+    val vid = WorkflowVersionResource.getLatestVersion(uint)
     val newExecution = new WorkflowExecutions()
     newExecution.setWid(uint)
     newExecution.setVid(vid)


### PR DESCRIPTION
This PR fixes the following:

- Currently, the latest version of the workflow is stored in the `Workflow` table, so it doesn't have a version number yet, because we store deltas to be able to go back to previous versions starting from current. This however causes a problem when `tracking executions` because a version number has to be linked, but the latest version (current workflow) isn't present in `versions` table. To fix this, we should always have an empty delta which indicates the workflow itself to be able to refer to it before a new version is created.
- Fixed a bug of removing the last entry of the version instead of the first.
- Readability and placement of functions.
- Fixed a bug that was not creating a new version when a user (not owner) of the workflow updates the workflow.

Since this PR does many extra checks, we  report the performance decay it introduces.
- Before this PR, an average response time for `persist` request is `(474 + 218 + 117)/3 = 269.7 ms`.
- After the PR, the average response time for `persist` request became `(128 + 202 + 249)/3 = 193 ms`. This could be because of cache in DB. So another test of another workflow with similar number of past versions `(124 + 182 + 118) = 141.3 ms`.

- [ ] Future todo is to allow the first version (empty canvas) to be viewed in the frontend and the last (current workflow) to be shown in the frontend.