### PR TITLE
Deployment configuration fix

### DIFF
--- a/core/amber/src/main/resources/logback.xml
+++ b/core/amber/src/main/resources/logback.xml
@@ -11,10 +11,10 @@
 
 
     <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-        <file>../log/amber.log</file>
+        <file>../log/amber-worker.log</file>
         <immediateFlush>true</immediateFlush>
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>../log/amber-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
+            <fileNamePattern>../log/amber-worker-%d{yyyy-MM-dd}.log.gz</fileNamePattern>
         </rollingPolicy>
         <encoder>
             <pattern>[%date{ISO8601}] [%level] [%logger] [%thread] - %msg %n</pattern>

--- a/core/amber/src/main/resources/web-config.yml
+++ b/core/amber/src/main/resources/web-config.yml
@@ -31,7 +31,7 @@ logging:
     - type: console
       logFormat: "[%date{ISO8601}] [%level] [%logger] [%thread] - %msg %n"
     - type: file
-      currentLogFilename: ../log/amber.log
+      currentLogFilename: ../log/amber-server.log
       threshold: ALL
       queueSize: 512
       discardingThreshold: 0

--- a/core/scripts/depoly-daemon.sh
+++ b/core/scripts/depoly-daemon.sh
@@ -3,15 +3,15 @@ green=$(tput setaf 2)
 reset=$(tput sgr0)
 
 skipCompilation=false
-while getopts s: flag
+while getopts s flag
 do
     case "${flag}" in
-        s) skipCompilation="$OPTARG";;
+        s) skipCompilation=true;;
         *) exit 1
     esac
 done
 
-if [ ! "$skipCompilation" ]
+if  ! $skipCompilation
 then
   echo "${green}Compiling Amber...${reset}"
   cd amber && sbt clean package


### PR DESCRIPTION
This PR:
1. fixes the wrong skipCompilation option in `deploy-daemon.sh`.
2. separates the log files into `amber-worker.log` and `amber-server.log` by default.