### PR TITLE
Drop Python 3.6 support

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -90,7 +90,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [  3.7, 3.8, 3.9 ]
 
     steps:
       - name: Cancel Previous Runs

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -90,7 +90,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version: [  3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9 ]
 
     steps:
       - name: Cancel Previous Runs


### PR DESCRIPTION
as title. 

- TensorFlow, PyTorch, PyArrow have all dropped support for Python 3.6. 

- It also has deadlock issues in `queue.get()` with GC [details](https://codewithoutrules.com/2017/08/16/concurrency-python/). 