### PR TITLE
Revert sbt version to 1.5.5 

### DIFF
--- a/core/amber/project/build.properties
+++ b/core/amber/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.5.5

--- a/core/util/project/build.properties
+++ b/core/util/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.6.2
+sbt.version=1.5.5


### PR DESCRIPTION
In #1471 we upgraded sbt version to 1.6.3, which breaks the scripts to start the server. This PR reverts it back to 1.5.5 