### PR TITLE
Enable configuration on Python worker number

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OneToOneOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OneToOneOpExecConfig.scala
@@ -11,7 +11,8 @@ import edu.uci.ics.amber.engine.operators.OpExecConfig
 
 class OneToOneOpExecConfig(
     override val id: OperatorIdentity,
-    val opExec: Int => IOperatorExecutor
+    val opExec: Int => IOperatorExecutor,
+    val numWorkers: Int = Constants.currentWorkerNum
 ) extends OpExecConfig(id) {
 
   override lazy val topology: Topology = {
@@ -20,7 +21,7 @@ class OneToOneOpExecConfig(
         new WorkerLayer(
           makeLayer(id, "main"),
           opExec,
-          Constants.currentWorkerNum,
+          numWorkers,
           FollowPrevious(),
           RoundRobinDeployment()
         )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/filter/SpecializedFilterOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/filter/SpecializedFilterOpDesc.java
@@ -2,6 +2,7 @@ package edu.uci.ics.texera.workflow.operators.filter;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import edu.uci.ics.amber.engine.common.Constants;
 import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
@@ -25,7 +26,8 @@ public class SpecializedFilterOpDesc extends FilterOpDesc {
     public OneToOneOpExecConfig operatorExecutor(OperatorSchemaInfo operatorSchemaInfo) {
         return new OneToOneOpExecConfig(
                 operatorIdentifier(),
-                worker -> new SpecializedFilterOpExec(this)
+                worker -> new SpecializedFilterOpExec(this),
+                Constants.currentWorkerNum()
         );
     }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sentiment/SentimentAnalysisOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sentiment/SentimentAnalysisOpDesc.java
@@ -4,6 +4,7 @@ package edu.uci.ics.texera.workflow.operators.sentiment;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.google.common.base.Preconditions;
+import edu.uci.ics.amber.engine.common.Constants;
 import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
@@ -34,7 +35,7 @@ public class SentimentAnalysisOpDesc extends MapOpDesc {
         if (attribute == null) {
             throw new RuntimeException("sentiment analysis: attribute is null");
         }
-        return new OneToOneOpExecConfig(operatorIdentifier(), worker -> new SentimentAnalysisOpExec(this, operatorSchemaInfo));
+        return new OneToOneOpExecConfig(operatorIdentifier(), worker -> new SentimentAnalysisOpExec(this, operatorSchemaInfo), Constants.currentWorkerNum());
     }
 
     @Override

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/typecasting/TypeCastingOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/typecasting/TypeCastingOpDesc.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.google.common.base.Preconditions;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
+import edu.uci.ics.amber.engine.common.Constants;
 import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
@@ -30,17 +31,12 @@ public class TypeCastingOpDesc extends MapOpDesc {
     @Override
     public OneToOneOpExecConfig operatorExecutor(OperatorSchemaInfo operatorSchemaInfo) {
         Preconditions.checkArgument(!typeCastingUnits.isEmpty());
-        return new OneToOneOpExecConfig(operatorIdentifier(), worker -> new TypeCastingOpExec(operatorSchemaInfo.outputSchema()));
+        return new OneToOneOpExecConfig(operatorIdentifier(), worker -> new TypeCastingOpExec(operatorSchemaInfo.outputSchema()), Constants.currentWorkerNum());
     }
 
     @Override
     public OperatorInfo operatorInfo() {
-        return new OperatorInfo(
-                "Type Casting",
-                "Cast between types",
-                OperatorGroupConstants.UTILITY_GROUP(),
-                asScalaBuffer(singletonList(new InputPort("", false))).toList(),
-                asScalaBuffer(singletonList(new OutputPort(""))).toList());
+        return new OperatorInfo("Type Casting", "Cast between types", OperatorGroupConstants.UTILITY_GROUP(), asScalaBuffer(singletonList(new InputPort("", false))).toList(), asScalaBuffer(singletonList(new OutputPort(""))).toList());
     }
 
     @Override

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV1/PythonUDFOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV1/PythonUDFOpDesc.java
@@ -3,6 +3,7 @@ package edu.uci.ics.texera.workflow.operators.udf.pythonV1;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
+import edu.uci.ics.amber.engine.common.Constants;
 import edu.uci.ics.amber.engine.common.IOperatorExecutor;
 import edu.uci.ics.amber.engine.operators.OpExecConfig;
 import edu.uci.ics.texera.workflow.common.metadata.InputPort;
@@ -81,7 +82,7 @@ public class PythonUDFOpDesc extends OperatorDescriptor {
                         batchSize
                 );
         if (PythonUDFType.supportsParallel.contains(pythonUDFType)) {
-            return new OneToOneOpExecConfig(operatorIdentifier(), exec);
+            return new OneToOneOpExecConfig(operatorIdentifier(), exec, Constants.currentWorkerNum());
         } else {
             // changed it to 1 because training with python needs all data in one node.
             return new ManyToOneOpExecConfig(operatorIdentifier(), exec);
@@ -105,7 +106,8 @@ public class PythonUDFOpDesc extends OperatorDescriptor {
         // check if inputColumns are presented in inputSchema.
         if (inputColumns != null) {
             for (String column : inputColumns) {
-                if (!inputSchema.containsAttribute(column)) throw new RuntimeException("No such column:" + column + ".");
+                if (!inputSchema.containsAttribute(column))
+                    throw new RuntimeException("No such column:" + column + ".");
             }
         }
 
@@ -126,8 +128,9 @@ public class PythonUDFOpDesc extends OperatorDescriptor {
         // for any pythonUDFType, it can add custom output columns (attributes).
         if (outputColumns != null) {
             for (Attribute column : outputColumns) {
-                if (inputSchema.containsAttribute(column.getName())) throw new RuntimeException("Column name " + column.getName()
-                        + " already exists!");
+                if (inputSchema.containsAttribute(column.getName()))
+                    throw new RuntimeException("Column name " + column.getName()
+                            + " already exists!");
             }
             outputSchemaBuilder.add(outputColumns).build();
         }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/PythonUDFOpDescV2.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/PythonUDFOpDescV2.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.google.common.base.Preconditions;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
+import edu.uci.ics.amber.engine.common.Constants;
 import edu.uci.ics.amber.engine.common.IOperatorExecutor;
 import edu.uci.ics.amber.engine.operators.OpExecConfig;
 import edu.uci.ics.texera.workflow.common.metadata.InputPort;
@@ -50,9 +51,9 @@ public class PythonUDFOpDescV2 extends OperatorDescriptor {
     public String code;
 
     @JsonProperty(required = true)
-    @JsonSchemaTitle("Parallel")
-    @JsonPropertyDescription("Run with multiple workers?")
-    public Boolean parallel;
+    @JsonSchemaTitle("Worker count")
+    @JsonPropertyDescription("Specify how many parallel workers to lunch")
+    public Integer workers = 1;
 
     @JsonProperty(required = true, defaultValue = "true")
     @JsonSchemaTitle("Retain input columns")
@@ -68,8 +69,9 @@ public class PythonUDFOpDescV2 extends OperatorDescriptor {
     public OpExecConfig operatorExecutor(OperatorSchemaInfo operatorSchemaInfo) {
         Function1<Object, IOperatorExecutor> exec = (i) ->
                 new PythonUDFOpExecV2(code, operatorSchemaInfo.outputSchema());
-        if (parallel) {
-            return new OneToOneOpExecConfig(operatorIdentifier(), exec);
+        Preconditions.checkArgument(workers >= 1, "Need at least 1 worker.");
+        if (workers > 1) {
+            return new OneToOneOpExecConfig(operatorIdentifier(), exec, Constants.currentWorkerNum());
         } else {
             return new ManyToOneOpExecConfig(operatorIdentifier(), exec);
         }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/PythonUDFOpDescV2.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/PythonUDFOpDescV2.java
@@ -71,7 +71,7 @@ public class PythonUDFOpDescV2 extends OperatorDescriptor {
                 new PythonUDFOpExecV2(code, operatorSchemaInfo.outputSchema());
         Preconditions.checkArgument(workers >= 1, "Need at least 1 worker.");
         if (workers > 1) {
-            return new OneToOneOpExecConfig(operatorIdentifier(), exec, Constants.currentWorkerNum());
+            return new OneToOneOpExecConfig(operatorIdentifier(), exec, workers);
         } else {
             return new ManyToOneOpExecConfig(operatorIdentifier(), exec);
         }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/source/PythonUDFSourceOpDescV2.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/source/PythonUDFSourceOpDescV2.java
@@ -64,7 +64,7 @@ public class PythonUDFSourceOpDescV2 extends SourceOperatorDescriptor {
                 new PythonUDFSourceOpExecV2(code, operatorSchemaInfo.outputSchema());
         Preconditions.checkArgument(workers >= 1, "Need at least 1 worker.");
         if (workers > 1) {
-            return new OneToOneOpExecConfig(operatorIdentifier(), exec, Constants.currentWorkerNum());
+            return new OneToOneOpExecConfig(operatorIdentifier(), exec, workers);
         } else {
             return new ManyToOneOpExecConfig(operatorIdentifier(), exec);
         }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/source/PythonUDFSourceOpDescV2.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/source/PythonUDFSourceOpDescV2.java
@@ -2,7 +2,9 @@ package edu.uci.ics.texera.workflow.operators.udf.pythonV2.source;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.google.common.base.Preconditions;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
+import edu.uci.ics.amber.engine.common.Constants;
 import edu.uci.ics.amber.engine.common.IOperatorExecutor;
 import edu.uci.ics.amber.engine.operators.OpExecConfig;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
@@ -47,9 +49,9 @@ public class PythonUDFSourceOpDescV2 extends SourceOperatorDescriptor {
     public String code;
 
     @JsonProperty(required = true)
-    @JsonSchemaTitle("Parallel")
-    @JsonPropertyDescription("Run with multiple workers?")
-    public Boolean parallel;
+    @JsonSchemaTitle("Worker count")
+    @JsonPropertyDescription("Specify how many parallel workers to lunch")
+    public Integer workers = 1;
 
     @JsonProperty()
     @JsonSchemaTitle("Columns")
@@ -60,8 +62,9 @@ public class PythonUDFSourceOpDescV2 extends SourceOperatorDescriptor {
     public OpExecConfig operatorExecutor(OperatorSchemaInfo operatorSchemaInfo) {
         Function1<Object, IOperatorExecutor> exec = (i) ->
                 new PythonUDFSourceOpExecV2(code, operatorSchemaInfo.outputSchema());
-        if (parallel) {
-            return new OneToOneOpExecConfig(operatorIdentifier(), exec);
+        Preconditions.checkArgument(workers >= 1, "Need at least 1 worker.");
+        if (workers > 1) {
+            return new OneToOneOpExecConfig(operatorIdentifier(), exec, Constants.currentWorkerNum());
         } else {
             return new ManyToOneOpExecConfig(operatorIdentifier(), exec);
         }


### PR DESCRIPTION
This PR makes the number of workers for the execution as a property of the Python UDF operator. So that users can decide the parallelism according to their needs during runtime.

<img width="800" alt="Screen Shot 2022-03-16 at 12 31 12 AM" src="https://user-images.githubusercontent.com/17627829/158538839-fae5ba28-f9d8-413d-8a6d-7d8d93e96932.png">

