### PR TITLE
Add new AttributeType.Binary

### DIFF
--- a/core/amber/src/main/python/core/util/arrow_utils.py
+++ b/core/amber/src/main/python/core/util/arrow_utils.py
@@ -13,6 +13,7 @@ ARROW_TYPE_MAPPING = {
     'double': pa.float64(),
     'boolean': pa.bool_(),
     'timestamp': pa.timestamp('ms', tz="UTC"),
+    'binary': pa.binary(),
     'ANY': pa.string()
 }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/ArrowUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/ArrowUtils.scala
@@ -2,12 +2,27 @@ package edu.uci.ics.amber.engine.architecture.pythonworker
 
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils.AttributeTypeException
-import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, AttributeTypeUtils, Schema}
+import edu.uci.ics.texera.workflow.common.tuple.schema.{
+  Attribute,
+  AttributeType,
+  AttributeTypeUtils,
+  Schema
+}
 import org.apache.arrow.vector.types.FloatingPointPrecision
 import org.apache.arrow.vector.types.TimeUnit.MILLISECOND
 import org.apache.arrow.vector.types.pojo.ArrowType.PrimitiveType
 import org.apache.arrow.vector.types.pojo.{ArrowType, Field}
-import org.apache.arrow.vector.{BigIntVector, BitVector, FieldVector, Float8Vector, IntVector, TimeStampVector, VarBinaryVector, VarCharVector, VectorSchemaRoot}
+import org.apache.arrow.vector.{
+  BigIntVector,
+  BitVector,
+  FieldVector,
+  Float8Vector,
+  IntVector,
+  TimeStampVector,
+  VarBinaryVector,
+  VarCharVector,
+  VectorSchemaRoot
+}
 
 import java.nio.charset.StandardCharsets
 import java.util
@@ -32,9 +47,9 @@ object ArrowUtils {
     * @return
     */
   def getTexeraTuple(
-                      rowIndex: Int,
-                      vectorSchemaRoot: VectorSchemaRoot
-                    ): Tuple = {
+      rowIndex: Int,
+      vectorSchemaRoot: VectorSchemaRoot
+  ): Tuple = {
     val arrowSchema = vectorSchemaRoot.getSchema
     val schema = toTexeraSchema(arrowSchema)
 
@@ -182,11 +197,12 @@ object ArrowUtils {
             vector
               .asInstanceOf[VarCharVector]
               .setSafe(index, value.asInstanceOf[String].getBytes(StandardCharsets.UTF_8))
-        case _: ArrowType.Binary | _: ArrowType.LargeBinary=>
+        case _: ArrowType.Binary | _: ArrowType.LargeBinary =>
           if (isNull) vector.asInstanceOf[VarBinaryVector].setNull(index)
           else
-            vector.asInstanceOf[VarBinaryVector]
-            .setSafe(index, value.asInstanceOf[Array[Byte]])
+            vector
+              .asInstanceOf[VarBinaryVector]
+              .setSafe(index, value.asInstanceOf[Array[Byte]])
 
       }
     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeType.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeType.java
@@ -50,6 +50,7 @@ public enum AttributeType implements Serializable {
     DOUBLE("double", Double.class),
     BOOLEAN("boolean", Boolean.class),
     TIMESTAMP("timestamp", Timestamp.class),
+    BINARY("binary", byte[].class),
     ANY("ANY", Object.class);
 
     private final String name;
@@ -82,6 +83,8 @@ public enum AttributeType implements Serializable {
             return BOOLEAN;
         } else if (fieldClass.equals(Timestamp.class)) {
             return TIMESTAMP;
+        }else if (fieldClass.equals(byte[].class)){
+            return BINARY;
         } else {
             return ANY;
         }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeTypeUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeTypeUtils.scala
@@ -33,7 +33,7 @@ object AttributeTypeUtils extends Serializable {
     for (i <- attributes.indices) {
       if (attributes.apply(i).getName.equals(attribute)) {
         resultType match {
-          case STRING | INTEGER | DOUBLE | LONG | BOOLEAN | TIMESTAMP =>
+          case STRING | INTEGER | DOUBLE | LONG | BOOLEAN | TIMESTAMP | BINARY =>
             builder.add(attribute, resultType)
           case ANY | _ =>
             builder.add(attribute, attributes.apply(i).getType)
@@ -98,6 +98,7 @@ object AttributeTypeUtils extends Serializable {
       case BOOLEAN   => parseBoolean(field)
       case TIMESTAMP => parseTimestamp(field)
       case STRING    => field.toString
+      case BINARY    => field
       case ANY | _   => field
     }
   }
@@ -110,7 +111,7 @@ object AttributeTypeUtils extends Serializable {
       case long: java.lang.Long       => long.toInt
       case double: java.lang.Double   => double.toInt
       case boolean: java.lang.Boolean => if (boolean) 1 else 0
-      // Timestamp is considered to be illegal here.
+      // Timestamp and Binary are considered to be illegal here.
       case _ =>
         throw new AttributeTypeException(
           s"not able to parse type ${fieldValue.getClass} to Integer: ${fieldValue.toString}"
@@ -127,6 +128,7 @@ object AttributeTypeUtils extends Serializable {
       case double: java.lang.Double   => double.toLong
       case boolean: java.lang.Boolean => if (boolean) 1L else 0L
       case timestamp: Timestamp       => timestamp.toInstant.toEpochMilli
+      // Binary is considered to be illegal here.
       case _ =>
         throw new AttributeTypeException(
           s"not able to parse type ${fieldValue.getClass} to Long: ${fieldValue.toString}"
@@ -160,7 +162,7 @@ object AttributeTypeUtils extends Serializable {
       case long: java.lang.Long => new Timestamp(long)
       case timestamp: Timestamp => timestamp
       case date: java.util.Date => new Timestamp(date.getTime)
-      // Integer, Double and Boolean are considered to be illegal here.
+      // Integer, Double, Boolean, Binary are considered to be illegal here.
       case _ =>
         throw parseError
     }
@@ -174,7 +176,7 @@ object AttributeTypeUtils extends Serializable {
       case long: java.lang.Long       => long.toDouble
       case double: java.lang.Double   => double
       case boolean: java.lang.Boolean => if (boolean) 1 else 0
-      // Timestamp is considered to be illegal here.
+      // Timestamp and Binary are considered to be illegal here.
       case _ =>
         throw new AttributeTypeException(
           s"not able to parse type ${fieldValue.getClass} to Double: ${fieldValue.toString}"
@@ -195,7 +197,7 @@ object AttributeTypeUtils extends Serializable {
       case long: java.lang.Long       => long != 0
       case double: java.lang.Double   => double != 0
       case boolean: java.lang.Boolean => boolean
-      // Timestamp is considered to be illegal here.
+      // Timestamp and Binary are considered to be illegal here.
       case _ =>
         throw parseError
     }
@@ -307,6 +309,7 @@ object AttributeTypeUtils extends Serializable {
       case LONG      => tryParseLong(fieldValue)
       case INTEGER   => tryParseInteger(fieldValue)
       case TIMESTAMP => tryParseTimestamp(fieldValue)
+      case BINARY    => tryParseString()
       case _         => tryParseString()
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/SQLSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/SQLSourceOpDesc.scala
@@ -114,7 +114,7 @@ abstract class SQLSourceOpDesc extends SourceOperatorDescriptor {
   override def sourceSchema(): Schema = {
     if (
       this.host == null || this.port == null || this.database == null
-      || this.table == null || this.username == null || this.password == null
+        || this.table == null || this.username == null || this.password == null
     )
       return null
     querySchema
@@ -138,30 +138,33 @@ abstract class SQLSourceOpDesc extends SourceOperatorDescriptor {
       connection.setReadOnly(true)
       val databaseMetaData = connection.getMetaData
       val columns = databaseMetaData.getColumns(null, null, this.table, null)
-      while ({ columns.next }) {
+      while ( {
+        columns.next
+      }) {
         val columnName = columns.getString("COLUMN_NAME")
         val datatype = columns.getInt("DATA_TYPE")
         datatype match {
           case Types.TINYINT | // -6 Types.TINYINT
-              Types.SMALLINT | // 5 Types.SMALLINT
-              Types.INTEGER => // 4 Types.INTEGER
+               Types.SMALLINT | // 5 Types.SMALLINT
+               Types.INTEGER => // 4 Types.INTEGER
             schemaBuilder.add(new Attribute(columnName, AttributeType.INTEGER))
           case Types.FLOAT | // 6 Types.FLOAT
-              Types.REAL | // 7 Types.REAL
-              Types.DOUBLE | // 8 Types.DOUBLE
-              Types.NUMERIC => // 3 Types.NUMERIC
+               Types.REAL | // 7 Types.REAL
+               Types.DOUBLE | // 8 Types.DOUBLE
+               Types.NUMERIC => // 3 Types.NUMERIC
             schemaBuilder.add(new Attribute(columnName, AttributeType.DOUBLE))
           case Types.BIT | // -7 Types.BIT
-              Types.BOOLEAN => // 16 Types.BOOLEAN
+               Types.BOOLEAN => // 16 Types.BOOLEAN
             schemaBuilder.add(new Attribute(columnName, AttributeType.BOOLEAN))
-          case Types.BINARY | //-2 Types.BINARY
-              Types.DATE | //91 Types.DATE
-              Types.TIME | //92 Types.TIME
-              Types.LONGVARCHAR | //-1 Types.LONGVARCHAR
-              Types.CHAR | //1 Types.CHAR
-              Types.VARCHAR | //12 Types.VARCHAR
-              Types.NULL | //0 Types.NULL
-              Types.OTHER => //1111 Types.OTHER
+          case Types.BINARY => //-2 Types.BINARY
+            schemaBuilder.add(new Attribute(columnName, AttributeType.BINARY))
+          case Types.DATE | //91 Types.DATE
+               Types.TIME | //92 Types.TIME
+               Types.LONGVARCHAR | //-1 Types.LONGVARCHAR
+               Types.CHAR | //1 Types.CHAR
+               Types.VARCHAR | //12 Types.VARCHAR
+               Types.NULL | //0 Types.NULL
+               Types.OTHER => //1111 Types.OTHER
             schemaBuilder.add(new Attribute(columnName, AttributeType.STRING))
           case Types.BIGINT => //-5 Types.BIGINT
             schemaBuilder.add(new Attribute(columnName, AttributeType.LONG))
@@ -176,7 +179,7 @@ abstract class SQLSourceOpDesc extends SourceOperatorDescriptor {
       connection.close()
       schemaBuilder.build
     } catch {
-      case e @ (_: SQLException | _: ClassCastException) =>
+      case e@(_: SQLException | _: ClassCastException) =>
         e.printStackTrace()
         throw new RuntimeException(
           this.getClass.getSimpleName + " failed to connect to the database. " + e.getMessage

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/SQLSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/SQLSourceOpDesc.scala
@@ -114,7 +114,7 @@ abstract class SQLSourceOpDesc extends SourceOperatorDescriptor {
   override def sourceSchema(): Schema = {
     if (
       this.host == null || this.port == null || this.database == null
-        || this.table == null || this.username == null || this.password == null
+      || this.table == null || this.username == null || this.password == null
     )
       return null
     querySchema
@@ -138,33 +138,33 @@ abstract class SQLSourceOpDesc extends SourceOperatorDescriptor {
       connection.setReadOnly(true)
       val databaseMetaData = connection.getMetaData
       val columns = databaseMetaData.getColumns(null, null, this.table, null)
-      while ( {
+      while ({
         columns.next
       }) {
         val columnName = columns.getString("COLUMN_NAME")
         val datatype = columns.getInt("DATA_TYPE")
         datatype match {
           case Types.TINYINT | // -6 Types.TINYINT
-               Types.SMALLINT | // 5 Types.SMALLINT
-               Types.INTEGER => // 4 Types.INTEGER
+              Types.SMALLINT | // 5 Types.SMALLINT
+              Types.INTEGER => // 4 Types.INTEGER
             schemaBuilder.add(new Attribute(columnName, AttributeType.INTEGER))
           case Types.FLOAT | // 6 Types.FLOAT
-               Types.REAL | // 7 Types.REAL
-               Types.DOUBLE | // 8 Types.DOUBLE
-               Types.NUMERIC => // 3 Types.NUMERIC
+              Types.REAL | // 7 Types.REAL
+              Types.DOUBLE | // 8 Types.DOUBLE
+              Types.NUMERIC => // 3 Types.NUMERIC
             schemaBuilder.add(new Attribute(columnName, AttributeType.DOUBLE))
           case Types.BIT | // -7 Types.BIT
-               Types.BOOLEAN => // 16 Types.BOOLEAN
+              Types.BOOLEAN => // 16 Types.BOOLEAN
             schemaBuilder.add(new Attribute(columnName, AttributeType.BOOLEAN))
           case Types.BINARY => //-2 Types.BINARY
             schemaBuilder.add(new Attribute(columnName, AttributeType.BINARY))
           case Types.DATE | //91 Types.DATE
-               Types.TIME | //92 Types.TIME
-               Types.LONGVARCHAR | //-1 Types.LONGVARCHAR
-               Types.CHAR | //1 Types.CHAR
-               Types.VARCHAR | //12 Types.VARCHAR
-               Types.NULL | //0 Types.NULL
-               Types.OTHER => //1111 Types.OTHER
+              Types.TIME | //92 Types.TIME
+              Types.LONGVARCHAR | //-1 Types.LONGVARCHAR
+              Types.CHAR | //1 Types.CHAR
+              Types.VARCHAR | //12 Types.VARCHAR
+              Types.NULL | //0 Types.NULL
+              Types.OTHER => //1111 Types.OTHER
             schemaBuilder.add(new Attribute(columnName, AttributeType.STRING))
           case Types.BIGINT => //-5 Types.BIGINT
             schemaBuilder.add(new Attribute(columnName, AttributeType.LONG))
@@ -179,7 +179,7 @@ abstract class SQLSourceOpDesc extends SourceOperatorDescriptor {
       connection.close()
       schemaBuilder.build
     } catch {
-      case e@(_: SQLException | _: ClassCastException) =>
+      case e @ (_: SQLException | _: ClassCastException) =>
         e.printStackTrace()
         throw new RuntimeException(
           this.getClass.getSimpleName + " failed to connect to the database. " + e.getMessage

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/pythonworker/ArrowUtilsSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/pythonworker/ArrowUtilsSpec.scala
@@ -92,10 +92,6 @@ class ArrowUtilsSpec extends AnyFlatSpec {
     }
 
     assertThrows[AttributeTypeException] {
-      ArrowUtils.toAttributeType(new ArrowType.Binary)
-    }
-
-    assertThrows[AttributeTypeException] {
       ArrowUtils.toAttributeType(new ArrowType.Date(DateUnit.DAY))
     }
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/pythonworker/ArrowUtilsSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/pythonworker/ArrowUtilsSpec.scala
@@ -126,10 +126,10 @@ class ArrowUtilsSpec extends AnyFlatSpec {
       .newBuilder(texeraSchema)
       .addSequentially(
         Array(
-          new Integer(2),
-          new java.lang.Long(1L),
-          new java.lang.Boolean(true),
-          new java.lang.Double(1.1),
+          Int.box(2),
+          Long.box(1L),
+          Boolean.box(true),
+          Double.box(1.1),
           new Timestamp(10000L),
           "hello world"
         )
@@ -176,10 +176,10 @@ class ArrowUtilsSpec extends AnyFlatSpec {
       .newBuilder(texeraSchema)
       .addSequentially(
         Array(
-          new Integer(2),
-          new java.lang.Long(1L),
-          new java.lang.Boolean(true),
-          new java.lang.Double(1.1),
+          Int.box(2),
+          Long.box(1L),
+          Boolean.box(true),
+          Double.box(1.1),
           new Timestamp(10000L),
           "hello world"
         )
@@ -203,10 +203,10 @@ class ArrowUtilsSpec extends AnyFlatSpec {
       .newBuilder(texeraSchema)
       .addSequentially(
         Array(
-          new Integer(2),
+          Int.box(2),
           null,
-          new java.lang.Boolean(true),
-          new java.lang.Double(1.1),
+          Boolean.box(true),
+          Double.box(1.1),
           null,
           null
         )


### PR DESCRIPTION
This PR adds a new AttributeType, namely `BINARY`. 

Current size limitation: 
- akka: no known maximum size limit, usually set to 30 - 120 MiB.
- arrow: 2GB for now. To enlarge the limit, we have to use `LargeBinary`, but it is not useable right now as it is not fully supported in all contexts (Python, Java, tensor, etc.)

Other issues/Todos:
1. since binary can contain any arbitrary data, right now it cannot be properly cast in `AttributeTypeUtils.inferField`. 