### PR TITLE
Fix frontend bugs on debug panel and result panel after updating libraries 

### DIFF
--- a/core/new-gui/src/app/workspace/component/result-panel/debugger-frame/debugger-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/debugger-frame/debugger-frame.component.ts
@@ -158,9 +158,9 @@ class PythonExpressionSource implements DataSource<FlatTreeNode> {
     const changes = [
       collectionViewer.viewChange,
       this.treeControl.expansionModel.changed.pipe(tap(change => this.handleExpansionChange(change))),
-      this.flattenedDataSubject,
+      this.flattenedDataSubject.asObservable(),
     ];
-    return merge(changes).pipe(map(() => this.expandFlattenedNodes(this.flattenedDataSubject.getValue())));
+    return merge(...changes).pipe(map(() => this.expandFlattenedNodes(this.flattenedDataSubject.getValue())));
   }
 
   expandFlattenedNodes(nodes: FlatTreeNode[]): FlatTreeNode[] {

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, OnInit } from "@angular/core";
 import { merge } from "rxjs";
 import { ExecuteWorkflowService } from "../../service/execute-workflow/execute-workflow.service";
 import { ResultPanelToggleService } from "../../service/result-panel-toggle/result-panel-toggle.service";
@@ -48,7 +48,8 @@ export class ResultPanelComponent implements OnInit {
     private resultPanelToggleService: ResultPanelToggleService,
     private workflowActionService: WorkflowActionService,
     private workflowResultService: WorkflowResultService,
-    private workflowVersionService: WorkflowVersionService
+    private workflowVersionService: WorkflowVersionService,
+    private changeDetectorRef: ChangeDetectorRef,
   ) {}
 
   ngOnInit(): void {
@@ -140,6 +141,7 @@ export class ResultPanelComponent implements OnInit {
       .pipe(untilDestroyed(this))
       .subscribe(_ => {
         this.rerenderResultPanel();
+        this.changeDetectorRef.detectChanges();
       });
   }
 

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -49,7 +49,7 @@ export class ResultPanelComponent implements OnInit {
     private workflowActionService: WorkflowActionService,
     private workflowResultService: WorkflowResultService,
     private workflowVersionService: WorkflowVersionService,
-    private changeDetectorRef: ChangeDetectorRef,
+    private changeDetectorRef: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {


### PR DESCRIPTION
This PR fixes two bugs that occured after upgrading libraries.

1: cannot evaluate expression in debug panel. 

**Current:**
![1](https://user-images.githubusercontent.com/12578068/160322920-b9faf2b6-fbe2-46a7-a9dc-4ec12f5a85d0.gif)

**After fix:**
![2](https://user-images.githubusercontent.com/12578068/160322943-8ebc1a07-3681-4395-be2e-cb9d5ce5119a.gif)


2: result panel is not immediately switched with highlighting an operator

**Current:**
![3](https://user-images.githubusercontent.com/12578068/160322974-b3eda7a3-db93-41e6-91c7-72c20c538877.gif)

**After fix:**
![4](https://user-images.githubusercontent.com/12578068/160322984-a5d6dfb7-ee2d-4258-9536-64cb61bbb0bb.gif)

