### PR TITLE
Temp fix for operator cyclic dependency

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/ManyToOneOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/ManyToOneOpExecConfig.scala
@@ -47,7 +47,6 @@ class ManyToOneOpExecConfig(
         workflow.getSources(opId).foreach { dependeeSource =>
           if (dependerSource != dependeeSource) {
             workflow.getOperator(dependerSource).topology.layers.head.startAfter(dependeeLink)
-            println(s"$dependerSource is waiting for $dependeeLink")
           }
         }
       }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/ManyToOneOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/ManyToOneOpExecConfig.scala
@@ -44,12 +44,11 @@ class ManyToOneOpExecConfig(
         inputToOrdinalMapping.find({ case (_, (ordinal, _)) => ordinal == dependerOrdinal }).get._1
       workflow.getSources(toOperatorIdentity(dependerLink.from)).foreach { dependerSource =>
         val opId = workflow.getOperator(dependeeLink.from.operator).id
-        workflow.getSources(opId).foreach{
-          dependeeSource =>
-            if (dependerSource != dependeeSource){
-              workflow.getOperator(dependerSource).topology.layers.head.startAfter(dependeeLink)
-              println(s"$dependerSource is waiting for $dependeeLink")
-            }
+        workflow.getSources(opId).foreach { dependeeSource =>
+          if (dependerSource != dependeeSource) {
+            workflow.getOperator(dependerSource).topology.layers.head.startAfter(dependeeLink)
+            println(s"$dependerSource is waiting for $dependeeLink")
+          }
         }
       }
     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/ManyToOneOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/ManyToOneOpExecConfig.scala
@@ -42,8 +42,15 @@ class ManyToOneOpExecConfig(
         inputToOrdinalMapping.find({ case (_, (ordinal, _)) => ordinal == dependeeOrdinal }).get._1
       val dependerLink =
         inputToOrdinalMapping.find({ case (_, (ordinal, _)) => ordinal == dependerOrdinal }).get._1
-      workflow.getSources(toOperatorIdentity(dependerLink.from)).foreach { source =>
-        workflow.getOperator(source).topology.layers.head.startAfter(dependeeLink)
+      workflow.getSources(toOperatorIdentity(dependerLink.from)).foreach { dependerSource =>
+        val opId = workflow.getOperator(dependeeLink.from.operator).id
+        workflow.getSources(opId).foreach{
+          dependeeSource =>
+            if (dependerSource != dependeeSource){
+              workflow.getOperator(dependerSource).topology.layers.head.startAfter(dependeeLink)
+              println(s"$dependerSource is waiting for $dependeeLink")
+            }
+        }
       }
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OneToOneOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OneToOneOpExecConfig.scala
@@ -42,8 +42,16 @@ class OneToOneOpExecConfig(
         inputToOrdinalMapping.find({ case (_, (ordinal, _)) => ordinal == dependeeOrdinal }).get._1
       val dependerLink =
         inputToOrdinalMapping.find({ case (_, (ordinal, _)) => ordinal == dependerOrdinal }).get._1
-      workflow.getSources(toOperatorIdentity(dependerLink.from)).foreach { source =>
-        workflow.getOperator(source).topology.layers.head.startAfter(dependeeLink)
+      workflow.getSources(toOperatorIdentity(dependerLink.from)).foreach { dependerSource =>
+        val opId = workflow.getOperator(dependeeLink.from.operator).id
+        workflow.getSources(opId).foreach{
+          dependeeSource =>
+            if (dependerSource != dependeeSource){
+              workflow.getOperator(dependerSource).topology.layers.head.startAfter(dependeeLink)
+              println(s"$dependerSource is waiting for $dependeeLink")
+            }
+        }
+
       }
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OneToOneOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OneToOneOpExecConfig.scala
@@ -44,12 +44,11 @@ class OneToOneOpExecConfig(
         inputToOrdinalMapping.find({ case (_, (ordinal, _)) => ordinal == dependerOrdinal }).get._1
       workflow.getSources(toOperatorIdentity(dependerLink.from)).foreach { dependerSource =>
         val opId = workflow.getOperator(dependeeLink.from.operator).id
-        workflow.getSources(opId).foreach{
-          dependeeSource =>
-            if (dependerSource != dependeeSource){
-              workflow.getOperator(dependerSource).topology.layers.head.startAfter(dependeeLink)
-              println(s"$dependerSource is waiting for $dependeeLink")
-            }
+        workflow.getSources(opId).foreach { dependeeSource =>
+          if (dependerSource != dependeeSource) {
+            workflow.getOperator(dependerSource).topology.layers.head.startAfter(dependeeLink)
+            println(s"$dependerSource is waiting for $dependeeLink")
+          }
         }
 
       }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OneToOneOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OneToOneOpExecConfig.scala
@@ -47,10 +47,8 @@ class OneToOneOpExecConfig(
         workflow.getSources(opId).foreach { dependeeSource =>
           if (dependerSource != dependeeSource) {
             workflow.getOperator(dependerSource).topology.layers.head.startAfter(dependeeLink)
-            println(s"$dependerSource is waiting for $dependeeLink")
           }
         }
-
       }
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpExecConfig.scala
@@ -44,8 +44,15 @@ class HashJoinOpExecConfig[K](
     val buildLink = inputToOrdinalMapping.find(pair => pair._2._1 == 0).get._1
     buildTable = buildLink
     val probeLink = inputToOrdinalMapping.find(pair => pair._2._1 == 1).get._1
-    workflow.getSources(toOperatorIdentity(probeLink.from)).foreach { source =>
-      workflow.getOperator(source).topology.layers.head.startAfter(buildLink)
+    val dependerLink = probeLink
+    val dependeeLink = buildLink
+    workflow.getSources(toOperatorIdentity(dependerLink.from)).foreach { dependerSource =>
+      val opId = workflow.getOperator(dependeeLink.from.operator).id
+      workflow.getSources(opId).foreach { dependeeSource =>
+        if (dependerSource != dependeeSource) {
+          workflow.getOperator(dependerSource).topology.layers.head.startAfter(dependeeLink)
+        }
+      }
     }
     topology.layers.head.initIOperatorExecutor = _ =>
       new HashJoinOpExec[K](


### PR DESCRIPTION
There are some operators have dependency on input ports (HashJoin, 2-in Python UDF, etc). When there are two instances of the operator, they can introduce more than one dependencies and there could exist cycles.

For example, in the following workflow, we have a "left-only-plan" on using models onto tuples.
<img width="538" alt="Screen Shot 2022-04-23 at 8 44 21 AM" src="https://user-images.githubusercontent.com/17627829/164913180-6d5b49f7-3b12-4290-86db-c7d7a700a6c4.png">

C needs A to run before B starts (B depends on A). 
D needs A to run before C starts (C depends on A).

The current implementation when C depends on A, it will find all sources of the depender C (A and B in this case) and introduce wait on all sources to the dependee, thus A will wait for A, introducing a cycle.

This PR fixes it by ignoring "self-waiting" cycle.

There are more cyclic dependency cases to be solved (e.g., #1324). This PR only covers the above simple case, to make sure the left-join-only plan can execute properly.
