### PR TITLE
Fix Regex Op Property Description

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/regex/RegexOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/regex/RegexOpDesc.scala
@@ -26,7 +26,7 @@ class RegexOpDesc extends FilterOpDesc {
 
   @JsonProperty(required = false, defaultValue = "false")
   @JsonSchemaTitle("Case Insensitive")
-  @JsonPropertyDescription("Regex match is case sensitive")
+  @JsonPropertyDescription("regex match is case sensitive")
   var caseInsensitive: Boolean = _
 
   override def operatorExecutor(operatorSchemaInfo: OperatorSchemaInfo): OneToOneOpExecConfig = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/regex/RegexOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/regex/RegexOpDesc.scala
@@ -26,7 +26,7 @@ class RegexOpDesc extends FilterOpDesc {
 
   @JsonProperty(required = false, defaultValue = "false")
   @JsonSchemaTitle("Case Insensitive")
-  @JsonPropertyDescription("whether the regular expression match is case insensitive")
+  @JsonPropertyDescription("Regex match is case sensitive")
   var caseInsensitive: Boolean = _
 
   override def operatorExecutor(operatorSchemaInfo: OperatorSchemaInfo): OneToOneOpExecConfig = {


### PR DESCRIPTION
This PR fixes the overlayed text in Regex Op. 

Before:
<img width="366" alt="Screen Shot 2022-04-26 at 10 19 26 AM" src="https://user-images.githubusercontent.com/17627829/165356759-ff0edbf2-8310-4af6-a500-43dd5709e1a5.png">
After:
<img width="341" alt="Screen Shot 2022-04-26 at 10 20 05 AM" src="https://user-images.githubusercontent.com/17627829/165356849-efc6d005-ad14-4a41-98cb-bcabf921c324.png">

