### PR TITLE
Add option to toggle canvas grids on or off

### DIFF
--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -101,6 +101,9 @@
 
     <div class="texera-navigation-utilities">
       <nz-button-group nzSize="large">
+        <button (click)="onClickToggleGrids()" nz-button title="Toggle Grids">
+          <i nz-icon nzTheme="outline" nzType="border-outer"></i>
+        </button>
         <button (click)="onClickZoomOut()" nz-button title="zoom out">
           <i nz-icon nzTheme="outline" nzType="zoom-out"></i>
         </button>

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -243,9 +243,7 @@ export class NavigationComponent implements OnInit {
    * This option is only for the current session and will be cleared on refresh.
    */
   public onClickToggleGrids(): void {
-    this.workflowActionService
-      .getJointGraphWrapper()
-      .toggleGrids();
+    this.workflowActionService.getJointGraphWrapper().toggleGrids();
   }
 
   /**

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -239,6 +239,16 @@ export class NavigationComponent implements OnInit {
   }
 
   /**
+   * This method will flip the current status of whether to draw grids in jointPaper.
+   * This option is only for the current session and will be cleared on refresh.
+   */
+  public onClickToggleGrids(): void {
+    this.workflowActionService
+      .getJointGraphWrapper()
+      .toggleGrids();
+  }
+
+  /**
    * This method will decrease the zoom ratio and send the new zoom ratio value
    *  to the joint graph wrapper to change overall zoom ratio that is used in
    *  zoom buttons and mouse wheel zoom.

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -88,6 +88,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
 
   private paper: joint.dia.Paper | undefined;
   private interactive: boolean = true;
+  private gridOn: boolean = true;
 
   // private ifMouseDown: boolean = false;
   private mouseDown: Point | undefined;
@@ -153,6 +154,7 @@ export class WorkflowEditorComponent implements AfterViewInit {
     this.handleOperatorPaste();
 
     this.handleLinkCursorHover();
+    this.handleGridsToggle();
     if (environment.linkBreakpointEnabled) {
       this.handleLinkBreakpoint();
     }
@@ -1656,5 +1658,26 @@ export class WorkflowEditorComponent implements AfterViewInit {
     event: joint.dia.Event
   ): boolean {
     return magnet && magnet.getAttribute("port-group") === "out";
+  }
+
+  /**
+   * This function handles the event stream from jointGraph to toggle the grids in jointPaper on or off.
+   * @private
+   */
+  private handleGridsToggle(): void {
+    this.workflowActionService
+      .getJointGraphWrapper()
+      .getJointPaperGridsToggleStream()
+      .pipe(untilDestroyed(this))
+      .subscribe(() => {
+        if (this.gridOn) {
+          this.getJointPaper().clearGrid();
+          this.gridOn = false;
+        } else {
+          this.getJointPaper().drawGrid();
+          this.gridOn = true;
+        }
+      });
+
   }
 }

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -1678,6 +1678,5 @@ export class WorkflowEditorComponent implements AfterViewInit {
           this.gridOn = true;
         }
       });
-
   }
 }

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
@@ -126,7 +126,7 @@ export class JointGraphWrapper {
   // event stream of restoring zoom / offset default of the jointJS paper
   private restorePaperOffsetSubject: Subject<void> = new Subject<void>();
   // event stream to toggle the jointPaper grids on or off.
-  private jointPaperGridsToggleStream =  new Subject<void>();
+  private jointPaperGridsToggleStream = new Subject<void>();
 
   // event stream of showing the breakpoint button of a link
   private jointLinkBreakpointShowStream = new Subject<linkIDType>();

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
@@ -125,6 +125,8 @@ export class JointGraphWrapper {
   private workflowEditorZoomSubject: Subject<number> = new Subject<number>();
   // event stream of restoring zoom / offset default of the jointJS paper
   private restorePaperOffsetSubject: Subject<void> = new Subject<void>();
+  // event stream to toggle the jointPaper grids on or off.
+  private jointPaperGridsToggleStream =  new Subject<void>();
 
   // event stream of showing the breakpoint button of a link
   private jointLinkBreakpointShowStream = new Subject<linkIDType>();
@@ -1025,5 +1027,19 @@ export class JointGraphWrapper {
     }
 
     return JointGraphContext;
+  }
+
+  /**
+   * Returns an observable to indicate a toggle of grids has happened, and lets workflow editor to handle the state.
+   */
+  public getJointPaperGridsToggleStream(): Observable<void> {
+    return this.jointPaperGridsToggleStream.asObservable();
+  }
+
+  /**
+   * Triggers a toggle of whether to show grids in jointPaper.
+   */
+  public toggleGrids() {
+    this.jointPaperGridsToggleStream.next();
   }
 }


### PR DESCRIPTION
This PR adresses #1375. A new button to toggle grids on/off is added to navigation component. Note the toggle only stays for this session and will be cleared on refreshing, i.e., it is not persisted as a user option. See the following gif for a demo.
![Screen Recording 2022-05-17 at 15 11 32](https://user-images.githubusercontent.com/36582710/168920723-d6b0f993-ca99-4879-8ca3-e02c6b71e2d0.gif)

