### PR TITLE
Update to a faster CSV parser library

### DIFF
--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -189,6 +189,9 @@ libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
 // https://mvnrepository.com/artifact/org.scalactic/scalactic
 libraryDependencies += "org.scalactic" %% "scalactic" % "3.2.2"
 
+// https://mvnrepository.com/artifact/com.github.tototoshi/scala-csv
+libraryDependencies += "com.github.tototoshi" %% "scala-csv" % "1.3.6"
+
 // https://mvnrepository.com/artifact/com.univocity/univocity-parsers
 libraryDependencies += "com.univocity" % "univocity-parsers" % "2.9.1"
 

--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -189,8 +189,8 @@ libraryDependencies += "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
 // https://mvnrepository.com/artifact/org.scalactic/scalactic
 libraryDependencies += "org.scalactic" %% "scalactic" % "3.2.2"
 
-// https://mvnrepository.com/artifact/com.github.tototoshi/scala-csv
-libraryDependencies += "com.github.tototoshi" %% "scala-csv" % "1.3.6"
+// https://mvnrepository.com/artifact/com.univocity/univocity-parsers
+libraryDependencies += "com.univocity" % "univocity-parsers" % "2.9.1"
 
 // https://mvnrepository.com/artifact/com.konghq/unirest-java
 libraryDependencies += "com.konghq" % "unirest-java" % "3.11.11"

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeTypeUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/AttributeTypeUtils.scala
@@ -8,6 +8,7 @@ import java.text.SimpleDateFormat
 import java.time.Instant
 import scala.util.Try
 import scala.util.control.Exception.allCatch
+import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 
 object AttributeTypeUtils extends Serializable {
 
@@ -62,6 +63,10 @@ object AttributeTypeUtils extends Serializable {
       builder.add(attr, parseField(tuple.getField(attr.getName), attr.getType))
     )
     builder.build()
+  }
+
+  def parseFields(fields: Array[Object], schema: Schema): Array[Object] = {
+    parseFields(fields, schema.getAttributes.map(attr => attr.getType).toArray)
   }
 
   /**

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpDesc.scala
@@ -6,7 +6,12 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.engine.operators.OpExecConfig
 import edu.uci.ics.texera.workflow.common.operators.ManyToOneOpExecConfig
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils.inferSchemaFromRows
-import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, OperatorSchemaInfo, Schema}
+import edu.uci.ics.texera.workflow.common.tuple.schema.{
+  Attribute,
+  AttributeType,
+  OperatorSchemaInfo,
+  Schema
+}
 import edu.uci.ics.texera.workflow.operators.source.scan.ScanSourceOpDesc
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.univocity.parsers.csv.{CsvFormat, CsvParser, CsvParserSettings}
@@ -57,8 +62,7 @@ class CSVScanSourceOpDesc extends ScanSourceOpDesc {
     if (filePath.isEmpty) {
       return null
     }
-    val inputReader = new InputStreamReader(new FileInputStream(
-      new File(filePath.get)))
+    val inputReader = new InputStreamReader(new FileInputStream(new File(filePath.get)))
 
     val csvFormat = new CsvFormat()
     csvFormat.setDelimiter(customDelimiter.get.charAt(0))
@@ -85,7 +89,10 @@ class CSVScanSourceOpDesc extends ScanSourceOpDesc {
       if (hasHeader) parser.getContext.headers()
       else (1 to attributeTypeList.length).map(i => "column-" + i).toArray
 
-    Schema.newBuilder().add(header.indices.map(i => new Attribute(header(i), attributeTypeList(i))).asJava).build()
+    Schema
+      .newBuilder()
+      .add(header.indices.map(i => new Attribute(header(i), attributeTypeList(i))).asJava)
+      .build()
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpExec.scala
@@ -3,38 +3,52 @@ package edu.uci.ics.texera.workflow.operators.source.scan.csv
 import com.univocity.parsers.csv.{CsvFormat, CsvParser, CsvParserSettings}
 import edu.uci.ics.texera.workflow.common.operators.source.SourceOperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
-import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeTypeUtils, Schema}
+import edu.uci.ics.texera.workflow.common.tuple.schema.{AttributeTypeUtils, Schema}
 
 import java.io.{File, FileInputStream, InputStreamReader}
-import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 
 class CSVScanSourceOpExec private[csv] (val desc: CSVScanSourceOpDesc)
     extends SourceOperatorExecutor {
   val schema: Schema = desc.inferSchema()
   var inputReader: InputStreamReader = _
   var parser: CsvParser = _
-  var rows: Iterator[Seq[String]] = _
+
+  var nextRow: Array[String] = _
 
   override def produceTexeraTuple(): Iterator[Tuple] = {
 
-    var tuples = rows
-      .map(fields =>
+    val rowIterator = new Iterator[Array[String]] {
+      override def hasNext: Boolean = {
+        if (nextRow != null) {
+          return true
+        }
+        nextRow = parser.parseNext()
+        nextRow != null
+      }
+
+      override def next(): Array[String] = {
+        val ret = nextRow
+        nextRow = null
+        ret
+      }
+    }
+
+    var tupleIterator = rowIterator
+      .drop(desc.offset.getOrElse(0))
+      .map(row => {
         try {
-          val parsedFields: Array[Object] = AttributeTypeUtils.parseFields(
-            fields.toArray,
-            schema.getAttributes
-              .map((attr: Attribute) => attr.getType)
-              .toArray
-          )
+          val parsedFields: Array[Object] =
+            AttributeTypeUtils.parseFields(row.asInstanceOf[Array[Object]], schema)
           Tuple.newBuilder(schema).addSequentially(parsedFields).build
         } catch {
           case _: Throwable => null
         }
-      )
-      .filter(tuple => tuple != null)
+      })
+      .filter(t => t != null)
 
-    if (desc.limit.isDefined) tuples = tuples.take(desc.limit.get)
-    tuples
+    if (desc.limit.isDefined) tupleIterator = tupleIterator.take(desc.limit.get)
+
+    tupleIterator
   }
 
   override def open(): Unit = {
@@ -49,9 +63,6 @@ class CSVScanSourceOpExec private[csv] (val desc: CSVScanSourceOpDesc)
 
     parser = new CsvParser(csvSetting)
     parser.beginParsing(inputReader)
-
-    // drop start offset
-    (0 until desc.offset.getOrElse(0)).foreach(parser.parseNext())
   }
 
   override def close(): Unit = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpExec.scala
@@ -38,8 +38,7 @@ class CSVScanSourceOpExec private[csv] (val desc: CSVScanSourceOpDesc)
   }
 
   override def open(): Unit = {
-    inputReader = new InputStreamReader(new FileInputStream(
-      new File(desc.filePath.get)))
+    inputReader = new InputStreamReader(new FileInputStream(new File(desc.filePath.get)))
 
     val csvFormat = new CsvFormat()
     csvFormat.setDelimiter(desc.customDelimiter.get.charAt(0))


### PR DESCRIPTION
This PR switchs the CSV parser library from [scala-csv](https://github.com/tototoshi/scala-csv) to [univocity-parser](https://github.com/uniVocity/univocity-parsers). 
This is because `scala-csv` is very very slow for csv data with large rows. This makes the system completely unresponsive when doing schema inference for CSV files.

Here's some simple comparison statistics of CSV parser libraries. The CSV file contains 2 HTML pages in each record.
|                      | 100 records                    | 1000 records                    |
|----------------------|-----------------------------|------------------------------|
| scala-csv (current)            | 250 **seconds** (estimated) | 2500 **seconds** (estimated) |
| apache-commons-csv   | 294 **ms**                      | 1865 **ms**                      |
| **univocity-parser-csv** | 153 **ms**                      | 894 **ms**                        |

We choose univocity-parser-csv because it's fastest. Here's another online comparsion as a reference: https://github.com/uniVocity/csv-parsers-comparison


Moreover, the speed of schema inference is also tested. We compare our own implementation vs the schema inference implementation in [spark-csv](https://github.com/databricks/spark-csv/blob/master/src/main/scala/com/databricks/spark/csv/util/InferSchema.scala). 

|                      | 1000 records |
|----------------------|--------------|
| our schema inference | 31 ms        |
| spark-csv inference  | 17 ms        |

Result shows spark-csv's implementation is faster than our own implementation, however, since this is not a bottleneck, we stick with our current implementation.



