### PR TITLE
Fix difference op execution dependency

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpExecConf.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpExecConf.scala
@@ -31,7 +31,7 @@ class DifferenceOpExecConf[K](
   }
 
   override def checkStartDependencies(workflow: Workflow): Unit = {
-    val rightLink = inputToOrdinalMapping.find({    case (_, (ordinal, _)) => ordinal == 1 }).get._1
+    val rightLink = inputToOrdinalMapping.find({ case (_, (ordinal, _)) => ordinal == 1 }).get._1
     topology.layers.head.initIOperatorExecutor = _ => new DifferenceOpExec(rightLink)
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpExecConf.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpExecConf.scala
@@ -31,7 +31,7 @@ class DifferenceOpExecConf[K](
   }
 
   override def checkStartDependencies(workflow: Workflow): Unit = {
-    val rightLink = inputToOrdinalMapping.find(pair => pair._2 == 1).get._1
+    val rightLink = inputToOrdinalMapping.find({    case (_, (ordinal, _)) => ordinal == 1 }).get._1
     topology.layers.head.initIOperatorExecutor = _ => new DifferenceOpExec(rightLink)
   }
 


### PR DESCRIPTION
This PR fixes #1512. The source error is introduced by the change from #1494, where the dependency format changed from `(portOrdinal, portName)` to `(LinkIdentity, (portOrdinal, portName))`. Now we reflect the change in difference op's config as well.