### PR TITLE
Fix CSV operator cannot display full file name in drop down list.

### DIFF
--- a/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.scss
+++ b/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.scss
@@ -1,5 +1,32 @@
 @import "../workspace.component.scss";
 
+
+// CSS properties to make drop-down menu display long text in multiple lines
+// solution from https://stackoverflow.com/questions/52832889/not-enough-space-in-mat-select-how-to-add-multiple-line-mat-option
+// !important is used to override Angular's default styles
+
+// the following styles are for dropdown menu
+::ng-deep .mat-select-panel mat-option.mat-option {
+  height: unset !important;
+  padding-top: 0.5em !important;
+  padding-bottom: 0.5em !important;
+}
+
+::ng-deep .mat-option-text.mat-option-text {
+  white-space: normal !important;
+  line-height: 1.5em !important;
+}
+
+// the following styles are for selected value
+::ng-deep .mat-select-value {
+  height: unset !important;
+}
+
+::ng-deep .mat-select-value-text {
+  white-space: normal !important;
+  line-height: 1.4em !important;
+}
+
 .texera-workspace-property-editor-body {
   padding: 16px;
   padding-right: 24px;

--- a/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.scss
+++ b/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.scss
@@ -1,6 +1,5 @@
 @import "../workspace.component.scss";
 
-
 // CSS properties to make drop-down menu display long text in multiple lines
 // solution from https://stackoverflow.com/questions/52832889/not-enough-space-in-mat-select-how-to-add-multiple-line-mat-option
 // !important is used to override Angular's default styles


### PR DESCRIPTION
This PR fixes #1544.

**Before**: long file names are truncated:
<img width="338" alt="Screen Shot 2022-06-23 at 3 32 04 PM" src="https://user-images.githubusercontent.com/12578068/175426004-fae80482-01a1-4861-b92a-8b42a9bdf2e0.png">

**After**: long files names are completely displayed:
<img width="335" alt="Screen Shot 2022-06-23 at 3 31 35 PM" src="https://user-images.githubusercontent.com/12578068/175426035-97d8c7a6-5cb3-402a-a2c0-90850166666e.png">

