### PR TITLE
Fix csv operator skipping lines start with #(default comment character)

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpExec.scala
@@ -56,6 +56,7 @@ class CSVScanSourceOpExec private[csv] (val desc: CSVScanSourceOpDesc)
 
     val csvFormat = new CsvFormat()
     csvFormat.setDelimiter(desc.customDelimiter.get.charAt(0))
+    csvFormat.setComment('\0') // disable skipping lines starting with # (default comment character)
     val csvSetting = new CsvParserSettings()
     csvSetting.setMaxCharsPerColumn(-1)
     csvSetting.setFormat(csvFormat)


### PR DESCRIPTION
After switching to the new CSV parser library in #1529, the new library automatically ignores lines starts with "#". Which causes some tweets with hashtags to be ignored, such as
"#Bernie2020 so we can ........... "

This PR fixes this issue.