### PR TITLE
Fix property editor not updated when highlighting operator

### DIFF
--- a/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
@@ -216,6 +216,7 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
     setTimeout(() => {
       const interactive = this.evaluateInteractivity();
       this.setInteractivity(interactive);
+      this.changeDetectorRef.detectChanges();
     }, 0);
   }
 

--- a/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/property-editor.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from "@angular/core";
+import { ChangeDetectorRef, Component, OnInit } from "@angular/core";
 import { merge } from "rxjs";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 import { OperatorPropertyEditFrameComponent } from "./operator-property-edit-frame/operator-property-edit-frame.component";
@@ -35,7 +35,8 @@ export class PropertyEditorComponent implements OnInit {
 
   constructor(
     public workflowActionService: WorkflowActionService,
-    public workflowVersionService: WorkflowVersionService
+    public workflowVersionService: WorkflowVersionService,
+    private changeDetectorRef: ChangeDetectorRef
   ) {}
 
   ngOnInit(): void {
@@ -102,6 +103,7 @@ export class PropertyEditorComponent implements OnInit {
         } else {
           this.switchFrameComponent(undefined);
         }
+        this.changeDetectorRef.detectChanges();
       });
   }
 }


### PR DESCRIPTION
This PR fixes a frontend issue where the property editor is not immediately updated after an operator is highlighted.

This PR did a temporary fix by directly calling Angular's change detection, but the root reason that why Angular is not able to automatically detect changes need to be further investigated.

**Before**:
![bug2](https://user-images.githubusercontent.com/12578068/175763518-7ba48679-b6f4-4536-8892-d52adc09c67b.gif)

**After**:
![fix2](https://user-images.githubusercontent.com/12578068/175763524-557ef3d5-a250-441f-88a1-1367fd92fe7a.gif)

