### PR TITLE
Update Results Display (edit: please ignore this pull request)

### DIFF
--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.html
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.html
@@ -1,4 +1,9 @@
 <div [hidden]="!showResultPanel" class="texera-workspace-result-panel-body texera-workflow-component-body">
+
+  <div *ngIf="frameComponentConfigs.size == 0" style="text-align: center">
+    <h4>No results available to display.</h4>
+  </div>
+  
   <nz-tabset [nzSize]="'small'" [nzTabPosition]="'left'">
     <div *ngFor="let config of frameComponentConfigs | keyvalue">
       <nz-tab nzTitle="{{config.key}}">

--- a/core/new-gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
@@ -1,4 +1,8 @@
+
 <div [hidden]="!currentColumns" class="result-table">
+
+
+  <div ngClass="scroll">
   <nz-table
     #basicTable
     (nzQueryParams)="onTableQueryParamsChange($event)"
@@ -27,4 +31,5 @@
       </tr>
     </tbody>
   </nz-table>
+  </div>
 </div>

--- a/core/new-gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.scss
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.scss
@@ -1,0 +1,22 @@
+:host ::ng-deep .ant-table-wrapper{
+  width: 300px;
+}
+
+:host ::ng-deep .ant-table-header{
+  width: 300vw;
+}
+
+:host ::ng-deep .ant-table-body{
+  width: 300vw;
+}
+
+ 
+
+div.scroll {
+  margin: 4px, 4px;
+  padding: 4px;
+  width:100%;
+  overflow-x: auto;
+}
+
+ 


### PR DESCRIPTION
Updating the Texera UI display for the results table with enhanced readability with larger columns and adding scroll bars. Also displaying message when no results are shown in empty results panel

1. Before running with empty results panel:

<img width="959" alt="Empty_Panel_Display" src="https://user-images.githubusercontent.com/108291232/177209883-0550819f-68e3-4d63-8022-3f49dd7a6388.png">

2. After running and displaying the results table:

<img width="959" alt="Results_Panel_Display" src="https://user-images.githubusercontent.com/108291232/177209964-241ce404-deee-4b02-87dc-6dd38dc1b84d.png">

