### PR TITLE
Fix Keyboard Actions Not Allowed With Undo-Redo Hotkey

### DIFF
--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -183,7 +183,6 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
 
   private _handleKeyboardAction(event: any) {
     this._onProcessKeyboardActionObservable = new Subject();
-    event.preventDefault();
     this.workflowVersionService
       .getDisplayParticularVersionStream()
       .pipe(takeUntil(this._onProcessKeyboardActionObservable))


### PR DESCRIPTION
The PR fixes a bug introduced by #1576, which blocks all other keyboard events other than undo/redo hotkeys.