### PR TITLE
Invalidate workflow execution reattachment if the version is different

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
@@ -133,8 +133,8 @@ object WorkflowVersionResource {
       UpperBound: UInteger,
       wid: UInteger
   ): Boolean = {
-    if (lowerBound==UpperBound) {
-      return false
+    if (lowerBound == UpperBound) {
+      return true
     }
     val contents = context
       .select(WORKFLOW_VERSION.CONTENT)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
@@ -37,7 +37,8 @@ object WorkflowVersionResource {
   private final val AGGREGATE_TIME_LIMIT_MILLSEC =
     AmberUtils.amberConfig.getInt("user-sys.version-time-limit-in-minutes") * 60000
   // list of Json keys in the diff patch that are considered UNimportant
-  private final val VERSION_UNIMPORTANCE_RULES = List("/operatorPositions/")
+  private final val VERSION_UNIMPORTANCE_RULES =
+    List("/operatorPositions/", "/commentBoxes/", "/comments/")
 
   /**
     * This function retrieves the latest version of a workflow

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
@@ -133,11 +133,12 @@ object WorkflowVersionResource {
       UpperBound: UInteger,
       wid: UInteger
   ): Boolean = {
+    if (lowerBound==UpperBound) {
+      return false
+    }
     val contents = context
       .select(WORKFLOW_VERSION.CONTENT)
       .from(WORKFLOW_VERSION)
-      .leftJoin(WORKFLOW)
-      .on(WORKFLOW_VERSION.WID.eq(WORKFLOW.WID))
       .where(WORKFLOW_VERSION.WID.eq(wid))
       .and(WORKFLOW_VERSION.VID.between(lowerBound).and(UpperBound))
       .fetchInto(classOf[String])

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
@@ -121,6 +121,30 @@ object WorkflowVersionResource {
     workflowVersionDao.update(workflowVersion)
   }
 
+  /*
+   * This function retrieves the content of versions from a specific workflow in a range
+   * @param lowerBound lower bound of the version search range
+   * @param UpperBound upper bound of the search range
+   * @param wid workflow id
+   * @return a list of contents as strings
+   */
+  def isVersionInRangeUnimportant(
+      lowerBound: UInteger,
+      UpperBound: UInteger,
+      wid: UInteger
+  ): Boolean = {
+    val contents = context
+      .select(WORKFLOW_VERSION.CONTENT)
+      .from(WORKFLOW_VERSION)
+      .leftJoin(WORKFLOW)
+      .on(WORKFLOW_VERSION.WID.eq(WORKFLOW.WID))
+      .where(WORKFLOW_VERSION.WID.eq(wid))
+      .and(WORKFLOW_VERSION.VID.between(lowerBound).and(UpperBound))
+      .fetchInto(classOf[String])
+      .toList
+    contents.forall(content => !isVersionImportant(content))
+  }
+
   /**
     * This function is for testing if the version is following the current design of keeping an empty delta for the
     * last version for migrating versions that followed the old design to the new design.

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionsMetadataPersistService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionsMetadataPersistService.scala
@@ -53,14 +53,14 @@ object ExecutionsMetadataPersistService extends LazyLogging {
 
   def insertNewExecution(
       wid: Long,
+      vid: Int,
       uid: Option[UInteger]
   ): Long = {
     // first retrieve the latest version of this workflow
     val uint = UInteger.valueOf(wid)
-    val vid = WorkflowVersionResource.getLatestVersion(uint)
     val newExecution = new WorkflowExecutions()
     newExecution.setWid(uint)
-    newExecution.setVid(vid)
+    newExecution.setVid(UInteger.valueOf(vid))
     newExecution.setUid(uid.getOrElse(null))
     newExecution.setStartingTime(new Timestamp(System.currentTimeMillis()))
     workflowExecutionsDao.insert(newExecution)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowJobService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowJobService.scala
@@ -70,6 +70,7 @@ class WorkflowJobService(
     if (WorkflowService.userSystemEnabled) {
       workflowContext.executionID = ExecutionsMetadataPersistService.insertNewExecution(
         workflowContext.wId,
+        workflowContext.vId,
         workflowContext.userId
       )
     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowJobService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowJobService.scala
@@ -66,15 +66,6 @@ class WorkflowJobService(
       )
     }
     resultService.attachToJob(stateStore, workflowInfo, client)
-
-    if (WorkflowService.userSystemEnabled) {
-      workflowContext.executionID = ExecutionsMetadataPersistService.insertNewExecution(
-        workflowContext.wId,
-        workflowContext.vId,
-        workflowContext.userId
-      )
-    }
-
     stateStore.jobMetadataStore.updateState(jobInfo =>
       jobInfo.withState(READY).withEid(workflowContext.executionID).withError(null)
     )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -183,8 +183,8 @@ class WorkflowService(
     new WorkflowContext(
       jobID,
       uidOpt,
-      getLatestVersion(UInteger.valueOf(wId)).intValue(),
       vId,
+      wId,
       executionID
     )
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -62,7 +62,13 @@ object WorkflowService {
           //if user system is not enabled, return v
           if (userSystemEnabled) {
             // retrieve the version stored in memory as lowerBound and the latest one stored in mysql as upperBound
-            if (isVersionInRangeUnimportant(UInteger.valueOf(v.vId), getLatestVersion(UInteger.valueOf(wId)), UInteger.valueOf(wId))) {
+            if (
+              isVersionInRangeUnimportant(
+                UInteger.valueOf(v.vId),
+                getLatestVersion(UInteger.valueOf(wId)),
+                UInteger.valueOf(wId)
+              )
+            ) {
               v
             } else {
               new WorkflowService(uidOpt, wId, cleanupTimeout)
@@ -107,7 +113,7 @@ class WorkflowService(
   val operatorCache: WorkflowCacheService =
     new WorkflowCacheService(opResultStorage, stateStore, wsInput)
   var jobService: BehaviorSubject[WorkflowJobService] = BehaviorSubject.create()
-  var vId:Int = -1
+  var vId: Int = -1
   val lifeCycleManager: WorkflowLifecycleManager = new WorkflowLifecycleManager(
     s"uid=$uidOpt wid=$wId",
     cleanUpTimeout,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -59,16 +59,18 @@ object WorkflowService {
         if (v == null) {
           new WorkflowService(uidOpt, wId, cleanupTimeout)
         } else {
-          //if usre system is not enabled, return v
-          // retrieve the one stored in memory
-          val lowerBound = UInteger.valueOf(v.workflowContxt.vId)
-          // retrieve the latest one in mysql
-          val upperBound = getLatestVersion(UInteger.valueOf(wId))
-          if (isVersionInRangeUnimportant(lowerBound, upperBound, UInteger.valueOf(wId))) {
-            v
+          //if user system is not enabled, return v
+          if (userSystemEnabled) {
+            // retrieve the version stored in memory as lowerBound and the latest one stored in mysql as upperBound
+            if (isVersionInRangeUnimportant(UInteger.valueOf(v.workflowContxt.vId), getLatestVersion(UInteger.valueOf(wId)), UInteger.valueOf(wId))) {
+              v
+            } else {
+              new WorkflowService(uidOpt, wId, cleanupTimeout)
+            }
           } else {
-            new WorkflowService(uidOpt, wId, cleanupTimeout)
+            v
           }
+
         }
       }
     )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -62,7 +62,7 @@ object WorkflowService {
           //if user system is not enabled, return v
           if (userSystemEnabled) {
             // retrieve the version stored in memory as lowerBound and the latest one stored in mysql as upperBound
-            if (isVersionInRangeUnimportant(UInteger.valueOf(v.workflowContxt.vId), getLatestVersion(UInteger.valueOf(wId)), UInteger.valueOf(wId))) {
+            if (isVersionInRangeUnimportant(UInteger.valueOf(v.vId), getLatestVersion(UInteger.valueOf(wId)), UInteger.valueOf(wId))) {
               v
             } else {
               new WorkflowService(uidOpt, wId, cleanupTimeout)
@@ -107,7 +107,7 @@ class WorkflowService(
   val operatorCache: WorkflowCacheService =
     new WorkflowCacheService(opResultStorage, stateStore, wsInput)
   var jobService: BehaviorSubject[WorkflowJobService] = BehaviorSubject.create()
-  var workflowContxt = new WorkflowContext()
+  var vId:Int = -1
   val lifeCycleManager: WorkflowLifecycleManager = new WorkflowLifecycleManager(
     s"uid=$uidOpt wid=$wId",
     cleanUpTimeout,
@@ -176,7 +176,8 @@ class WorkflowService(
       //unsubscribe all
       jobService.getValue.unsubscribeAll()
     }
-    workflowContxt = createWorkflowContext(req)
+    var workflowContxt: WorkflowContext = createWorkflowContext(req)
+    vId = workflowContxt.vId
     val job = new WorkflowJobService(
       workflowContxt,
       wsInput,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -21,6 +21,7 @@ import edu.uci.ics.texera.web.model.websocket.request.{
   WorkflowExecuteRequest,
   WorkflowKillRequest
 }
+import edu.uci.ics.texera.web.resource.dashboard.workflow.WorkflowVersionResource.getLatestVersion
 import edu.uci.ics.texera.web.resource.WorkflowWebsocketResource
 import edu.uci.ics.texera.web.service.WorkflowService.mkWorkflowStateId
 import edu.uci.ics.texera.web.storage.WorkflowStateStore
@@ -38,9 +39,11 @@ object WorkflowService {
     AmberUtils.amberConfig.getInt("web-server.workflow-state-cleanup-in-seconds")
 
   def mkWorkflowStateId(wId: Int, uidOpt: Option[UInteger]): String = {
+    val vId = getLatestVersion(UInteger.valueOf(wId))
+
     uidOpt match {
       case Some(user) =>
-        user + "-" + wId
+        user + "-" + wId + "-" + vId
       case None =>
         // use a fixed wid for reconnection
         "dummy wid"

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -179,7 +179,13 @@ class WorkflowService(
     if (WorkflowService.userSystemEnabled) {
       executionID = ExecutionsMetadataPersistService.insertNewExecution(wId, uidOpt)
     }
-    new WorkflowContext(jobID, uidOpt, getLatestVersion(UInteger.valueOf(wId)).intValue(), wId, executionID)
+    new WorkflowContext(
+      jobID,
+      uidOpt,
+      getLatestVersion(UInteger.valueOf(wId)).intValue(),
+      wId,
+      executionID
+    )
 
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -113,7 +113,7 @@ class WorkflowService(
   val operatorCache: WorkflowCacheService =
     new WorkflowCacheService(opResultStorage, stateStore, wsInput)
   var jobService: BehaviorSubject[WorkflowJobService] = BehaviorSubject.create()
-  var vId: Int = -1
+  var vId: Int = getLatestVersion(UInteger.valueOf(wId)).intValue()
   val lifeCycleManager: WorkflowLifecycleManager = new WorkflowLifecycleManager(
     s"uid=$uidOpt wid=$wId",
     cleanUpTimeout,
@@ -175,6 +175,7 @@ class WorkflowService(
     }
 
     var executionID: Long = -1 // for every new execution,
+
     // reset it so that the value doesn't carry over across executions
     if (WorkflowService.userSystemEnabled) {
       executionID = ExecutionsMetadataPersistService.insertNewExecution(wId, vId, uidOpt)
@@ -183,7 +184,7 @@ class WorkflowService(
       jobID,
       uidOpt,
       getLatestVersion(UInteger.valueOf(wId)).intValue(),
-      wId,
+      vId,
       executionID
     )
 
@@ -194,10 +195,8 @@ class WorkflowService(
       //unsubscribe all
       jobService.getValue.unsubscribeAll()
     }
-    var workflowContxt: WorkflowContext = createWorkflowContext(req)
-    vId = workflowContxt.vId
     val job = new WorkflowJobService(
-      workflowContxt,
+      createWorkflowContext(req),
       wsInput,
       operatorCache,
       resultService,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -113,7 +113,7 @@ class WorkflowService(
   val operatorCache: WorkflowCacheService =
     new WorkflowCacheService(opResultStorage, stateStore, wsInput)
   var jobService: BehaviorSubject[WorkflowJobService] = BehaviorSubject.create()
-  var vId: Int = getLatestVersion(UInteger.valueOf(wId)).intValue()
+  var vId: Int = -1
   val lifeCycleManager: WorkflowLifecycleManager = new WorkflowLifecycleManager(
     s"uid=$uidOpt wid=$wId",
     cleanUpTimeout,
@@ -175,9 +175,9 @@ class WorkflowService(
     }
 
     var executionID: Long = -1 // for every new execution,
-
     // reset it so that the value doesn't carry over across executions
     if (WorkflowService.userSystemEnabled) {
+      vId = getLatestVersion(UInteger.valueOf(wId)).intValue()
       executionID = ExecutionsMetadataPersistService.insertNewExecution(wId, vId, uidOpt)
     }
     new WorkflowContext(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -177,7 +177,7 @@ class WorkflowService(
     var executionID: Long = -1 // for every new execution,
     // reset it so that the value doesn't carry over across executions
     if (WorkflowService.userSystemEnabled) {
-      executionID = ExecutionsMetadataPersistService.insertNewExecution(wId, uidOpt)
+      executionID = ExecutionsMetadataPersistService.insertNewExecution(wId, vId, uidOpt)
     }
     new WorkflowContext(
       jobID,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/WorkflowContext.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/WorkflowContext.scala
@@ -4,6 +4,7 @@ import org.jooq.types.UInteger
 class WorkflowContext(
     var jobId: String = null,
     var userId: Option[UInteger] = None,
+    var vId: Int = -1,
     var wId: Int = -1,
     var executionID: Long = -1
 )


### PR DESCRIPTION
fixes #1591 
versions containing comments are now collapsed
hashkey for workflow now only contains workflow id, hasmap value now contains execution version id
execution no longer reattaches if version is different
![execution reattachment fix](https://user-images.githubusercontent.com/44384988/179322971-be5b9696-104b-4aa8-8b6a-07c45d6ad466.gif)

