### PR TITLE
Change mongo collection name

### DIFF
--- a/core/amber/src/main/resources/application.conf
+++ b/core/amber/src/main/resources/application.conf
@@ -42,6 +42,11 @@ storage {
         url = "mongodb://localhost:27017"
         database = "texera_storage"
         commit-batch-size = 1000
+        cleanup {
+                catalog-collection-name = "texera_collections_catalog"
+                ttl-in-seconds = 86400 # time to live for a collection is 2 days
+                collection-check-interval-in-seconds = 86400 # 2 days
+        }
     }
 }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWebApplication.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWebApplication.scala
@@ -4,9 +4,11 @@ import akka.actor.{ActorSystem, Cancellable}
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.github.dirkraft.dropwizard.fileassets.FileAssetsBundle
 import com.github.toastshaman.dropwizard.auth.jwt.JwtAuthFilter
+import com.mongodb.BasicDBObject
+import com.mongodb.client.model.Indexes
+import com.mongodb.client.{MongoClient, MongoClients, MongoCollection, MongoCursor, MongoDatabase}
 import edu.uci.ics.amber.engine.architecture.controller.{ControllerConfig, Workflow}
 import edu.uci.ics.amber.engine.common.AmberUtils
-import edu.uci.ics.amber.engine.common.client.AmberClient
 import edu.uci.ics.texera.Utils
 import edu.uci.ics.texera.web.auth.JwtAuth.jwtConsumer
 import edu.uci.ics.texera.web.auth.{
@@ -34,14 +36,15 @@ import org.eclipse.jetty.websocket.server.WebSocketUpgradeFilter
 import org.glassfish.jersey.media.multipart.MultiPartFeature
 import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature
 
-import java.time.Duration
 import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import java.time.Duration
-
 import edu.uci.ics.amber.engine.common.client.AmberClient
+import edu.uci.ics.texera.web.TexeraWebApplication.scheduleRecurringCallThroughActorSystem
 import org.apache.commons.jcs3.access.exception.InvalidArgumentException
+import org.bson.Document
 
+import java.util.concurrent.TimeUnit
 import scala.annotation.tailrec
 
 object TexeraWebApplication {
@@ -180,6 +183,54 @@ class TexeraWebApplication extends io.dropwizard.Application[TexeraWebConfigurat
     environment.jersey.register(classOf[WorkflowVersionResource])
     environment.jersey.register(classOf[ProjectResource])
     environment.jersey.register(classOf[WorkflowExecutionsResource])
+
+    // create a mongo collection that handles cleanup of other stored collections only when mode is mongodb
+    if (AmberUtils.amberConfig.getString("storage.mode").equalsIgnoreCase("mongodb")) {
+      // create the new catalog collection
+      val url: String = AmberUtils.amberConfig.getString("storage.mongodb.url")
+      val databaseName: String = AmberUtils.amberConfig.getString("storage.mongodb.database")
+      val client: MongoClient = MongoClients.create(url)
+      val database: MongoDatabase = client.getDatabase(databaseName)
+      val catalogCollectionName: String =
+        AmberUtils.amberConfig.getString("storage.mongodb.cleanup.catalog-collection-name")
+      val catalogCollection: MongoCollection[Document] =
+        database.getCollection(catalogCollectionName)
+      val timeToLive: Int = AmberUtils.amberConfig.getInt("storage.mongodb.cleanup.ttl-in-seconds")
+      // if the collection doesn't exist, then create it and add an index on the timestamp column
+      if (catalogCollection.countDocuments() == 0) {
+        catalogCollection.createIndex(Indexes.ascending("createdAt"))
+      }
+
+      scheduleRecurringCallThroughActorSystem(
+        2.seconds,
+        AmberUtils.amberConfig
+          .getInt("storage.mongodb.cleanup.collection-check-interval-in-seconds")
+          .seconds
+      ) {
+        cleanOldCollections(database, catalogCollection, timeToLive)
+      }
+
+    }
   }
 
+  /**
+    * This function is called periodically and checks all expired collections and deletes them
+    * MongoDB doesn't have an API of drop collection where collection name in (from a subquery), so the implementation is to retrieve
+    * the entire list of those documents that have expired, then loop the list to drop them one by one
+    */
+  def cleanOldCollections(
+      database: MongoDatabase,
+      catalogCollection: MongoCollection[Document],
+      timeToLive: Int
+  ): Unit = {
+    val condition: BasicDBObject = new BasicDBObject
+    condition.put(
+      "createdAt",
+      new BasicDBObject("$lt", System.currentTimeMillis() - TimeUnit.SECONDS.toMillis(timeToLive))
+    )
+    val expiredDocuments: MongoCursor[Document] = catalogCollection.find(condition).cursor()
+    while (expiredDocuments.hasNext) {
+      database.getCollection(expiredDocuments.next().getString("collectionName")).drop()
+    }
+  }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionsMetadataPersistService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionsMetadataPersistService.scala
@@ -67,12 +67,23 @@ object ExecutionsMetadataPersistService extends LazyLogging {
     newExecution.getEid.longValue()
   }
 
-  def tryUpdateExistingExecution(eid: Long, state: WorkflowAggregatedState): Unit = {
+  def tryUpdateExistingExecutionStatus(eid: Long, state: WorkflowAggregatedState): Unit = {
     try {
       val code = maptoStatusCode(state)
       val execution = workflowExecutionsDao.fetchOneByEid(UInteger.valueOf(eid))
       execution.setStatus(code)
       execution.setCompletionTime(new Timestamp(System.currentTimeMillis()))
+      workflowExecutionsDao.update(execution)
+    } catch {
+      case t: Throwable =>
+        logger.info("Unable to update execution. Error = " + t.getMessage)
+    }
+  }
+
+  def updateExistingExecutionVolumnPointers(eid: Long, pointers: String): Unit = {
+    try {
+      val execution = workflowExecutionsDao.fetchOneByEid(UInteger.valueOf(eid))
+      execution.setResult(pointers)
       workflowExecutionsDao.update(execution)
     } catch {
       case t: Throwable =>

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobRuntimeService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobRuntimeService.scala
@@ -39,7 +39,10 @@ class JobRuntimeService(
       // Update workflow state
       if (newState.state != oldState.state) {
         if (WorkflowService.userSystemEnabled) {
-          ExecutionsMetadataPersistService.tryUpdateExistingExecution(newState.eid, newState.state)
+          ExecutionsMetadataPersistService.tryUpdateExistingExecutionStatus(
+            newState.eid,
+            newState.state
+          )
         }
         outputEvts.append(WorkflowStateEvent(Utils.aggregatedStateToString(newState.state)))
       }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowJobService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowJobService.scala
@@ -35,7 +35,8 @@ class WorkflowJobService(
   val workflowCompiler: WorkflowCompiler = createWorkflowCompiler(workflowInfo)
   val workflow: Workflow = workflowCompiler.amberWorkflow(
     WorkflowIdentity(workflowContext.jobId),
-    resultService.opResultStorage
+    resultService.opResultStorage,
+    workflowContext
   )
 
   // Runtime starts from here:
@@ -57,8 +58,6 @@ class WorkflowJobService(
     client.sendAsync(ModifyLogic(req.operator))
   }))
 
-  workflowContext.executionID = -1 // for every new execution,
-  // reset it so that the value doesn't carry over across executions
   def startWorkflow(): Unit = {
     for (pair <- workflowInfo.breakpoints) {
       Await.result(
@@ -67,12 +66,6 @@ class WorkflowJobService(
       )
     }
     resultService.attachToJob(stateStore, workflowInfo, client)
-    if (WorkflowService.userSystemEnabled) {
-      workflowContext.executionID = ExecutionsMetadataPersistService.insertNewExecution(
-        workflowContext.wId,
-        workflowContext.userId
-      )
-    }
     stateStore.jobMetadataStore.updateState(jobInfo =>
       jobInfo.withState(READY).withEid(workflowContext.executionID).withError(null)
     )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -153,7 +153,12 @@ class WorkflowService(
         )
       )
     }
-    new WorkflowContext(jobID, uidOpt, wId)
+    var executionID: Long = -1 // for every new execution,
+    // reset it so that the value doesn't carry over across executions
+    if (WorkflowService.userSystemEnabled) {
+      executionID = ExecutionsMetadataPersistService.insertNewExecution(wId, uidOpt)
+    }
+    new WorkflowContext(jobID, uidOpt, wId, executionID)
   }
 
   def initJobService(req: WorkflowExecuteRequest, uidOpt: Option[UInteger]): Unit = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/storage/OpResultStorage.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/storage/OpResultStorage.scala
@@ -27,13 +27,13 @@ class OpResultStorage(mode: String = "memory") extends Serializable with LazyLog
     cache.get(key)
   }
 
-  def create(key: String, schema: Schema): SinkStorageReader = {
+  def create(executionID: Long, key: String, schema: Schema): SinkStorageReader = {
     val storage: SinkStorageReader =
       if (mode == "memory") {
         new MemoryStorage(schema)
       } else {
         try {
-          new MongoDBStorage(key, schema)
+          new MongoDBStorage(executionID + "_" + key, schema)
         } catch {
           case t: Throwable =>
             t.printStackTrace()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/storage/OpResultStorage.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/storage/OpResultStorage.scala
@@ -27,13 +27,13 @@ class OpResultStorage(mode: String = "memory") extends Serializable with LazyLog
     cache.get(key)
   }
 
-  def create(executionID: Long, key: String, schema: Schema): SinkStorageReader = {
+  def create(executionID: String = "", key: String, schema: Schema): SinkStorageReader = {
     val storage: SinkStorageReader =
       if (mode == "memory") {
         new MemoryStorage(schema)
       } else {
         try {
-          new MongoDBStorage(executionID + "_" + key, schema)
+          new MongoDBStorage(executionID + key, schema)
         } catch {
           case t: Throwable =>
             t.printStackTrace()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
@@ -16,6 +16,8 @@ import edu.uci.ics.texera.workflow.common.{ConstraintViolation, WorkflowContext}
 import edu.uci.ics.texera.workflow.operators.sink.SinkOpDesc
 import edu.uci.ics.texera.workflow.operators.sink.managed.ProgressiveSinkOpDesc
 import edu.uci.ics.texera.workflow.operators.visualization.VisualizationOperator
+import edu.uci.ics.texera.Utils.objectMapper
+import edu.uci.ics.texera.web.service.ExecutionsMetadataPersistService
 
 import scala.collection.mutable
 
@@ -84,6 +86,11 @@ class WorkflowCompiler(val workflowInfo: WorkflowInfo, val context: WorkflowCont
 
     val inputSchemaMap = propagateWorkflowSchema()
     val amberOperators: mutable.Map[OperatorIdentity, OpExecConfig] = mutable.Map()
+    // create a JSON object that holds pointers to the workflow's results in Mongo
+    // TODO in the future, will extract this logic from here when we need pointers to the stats storage
+    val resultsJSON = objectMapper.createObjectNode()
+    val sinksPointers = objectMapper.createArrayNode()
+
     workflowInfo.operators.foreach(o => {
       val inputSchemas: Array[Schema] =
         if (!o.isInstanceOf[SourceOperatorDescriptor])
@@ -100,8 +107,14 @@ class WorkflowCompiler(val workflowInfo: WorkflowInfo, val context: WorkflowCont
               )
             case None =>
               sink.setStorage(
-                opResultStorage.create(workflowContext.executionID + "_", o.operatorID, outputSchemas(0))
+                opResultStorage.create(
+                  workflowContext.executionID + "_",
+                  o.operatorID,
+                  outputSchemas(0)
+                )
               )
+              // add the sink collection name to the JSON array of sinks
+              sinksPointers.add(workflowContext.executionID + "_" + o.operatorID)
           }
         case _ =>
       }
@@ -109,6 +122,12 @@ class WorkflowCompiler(val workflowInfo: WorkflowInfo, val context: WorkflowCont
         o.operatorExecutor(OperatorSchemaInfo(inputSchemas, outputSchemas))
       amberOperators.put(amberOperator.id, amberOperator)
     })
+// update execution entry in MySQL to have pointers to the mongo collections
+    resultsJSON.put("results", sinksPointers)
+    ExecutionsMetadataPersistService.updateExistingExecutionVolumnPointers(
+      workflowContext.executionID,
+      resultsJSON.toString
+    )
 
     val outLinks: mutable.Map[OperatorIdentity, mutable.Set[OperatorIdentity]] = mutable.Map()
     workflowInfo.links.foreach(link => {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
@@ -96,11 +96,11 @@ class WorkflowCompiler(val workflowInfo: WorkflowInfo, val context: WorkflowCont
           sink.getCachedUpstreamId match {
             case Some(upstreamId) =>
               sink.setStorage(
-                opResultStorage.create(workflowContext.executionID, upstreamId, outputSchemas(0))
+                opResultStorage.create(key = upstreamId, schema = outputSchemas(0))
               )
             case None =>
               sink.setStorage(
-                opResultStorage.create(workflowContext.executionID, o.operatorID, outputSchemas(0))
+                opResultStorage.create(workflowContext.executionID + "_", o.operatorID, outputSchemas(0))
               )
           }
         case _ =>

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowPipelinedRegionsSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowPipelinedRegionsSpec.scala
@@ -32,7 +32,11 @@ class WorkflowPipelinedRegionsSpec extends AnyFlatSpec with MockFactory {
       WorkflowInfo(operators, links, mutable.MutableList[BreakpointInfo]()),
       context
     )
-    texeraWorkflowCompiler.amberWorkflow(WorkflowIdentity("workflow-test"), new OpResultStorage())
+    texeraWorkflowCompiler.amberWorkflow(
+      WorkflowIdentity("workflow-test"),
+      new OpResultStorage(),
+      context
+    )
   }
 
   "Pipelined Regions" should "correctly find regions in headerlessCsv->keyword->sink workflow" in {

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
@@ -59,7 +59,7 @@ class DataProcessingSpec
       WorkflowInfo(operators, links, mutable.MutableList[BreakpointInfo]()),
       context
     )
-    texeraWorkflowCompiler.amberWorkflow(WorkflowIdentity("workflow-test"), resultStorage)
+    texeraWorkflowCompiler.amberWorkflow(WorkflowIdentity("workflow-test"), resultStorage, context)
   }
 
   def executeWorkflow(workflow: Workflow): Map[String, List[ITuple]] = {

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/Utils.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/Utils.scala
@@ -31,7 +31,11 @@ object Utils {
       context
     )
 
-    texeraWorkflowCompiler.amberWorkflow(WorkflowIdentity(workflowTag), new OpResultStorage())
+    texeraWorkflowCompiler.amberWorkflow(
+      WorkflowIdentity(workflowTag),
+      new OpResultStorage(),
+      context
+    )
   }
 
 }


### PR DESCRIPTION
Currently, each new execution, drops the existing mongo collection, then overwrites it with the new execution result. 
This causes a problem when we want to track the results of all historical executions.
This PR is the first step to materialize all the results of all the executions.
This is done by appending the execution number to the mongo collection name. In order to append the execution number, the logic is now moved from the `WorkflowJobService` to the `WorkflowService` when the request of a new execution happens in order to attach the `executionID` before the compilation of amberWorkflow
This PR will first be merged into a temp branch `executions-master` until a storage cleanup logic is added and more other features, then merge into `master`. fixes #1560 and fixes #1561 and fixes #1499 

- [x]  add a pointer of each sink's result in mongo to mysql as a JSON string.
- [x] no need to follow the same logic for intermediate cached operators.
- [x] add a cleanup logic to drop the collections after some time or storage or count threshold.
