### PR TITLE
[Execution-master] Fix minor bugs in retrieval branch

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -170,6 +170,8 @@ object WorkflowService {
             })
             return retrievedWorkflowService
           }
+        case None =>
+          return new WorkflowService(uidOpt, wId, cleanupTimeout)
       }
     }
     new WorkflowService(uidOpt, wId, cleanupTimeout)
@@ -235,7 +237,7 @@ class WorkflowService(
     }
   }
   val wsInput = new WebsocketInput(errorHandler)
-  var status: WorkflowAggregatedState = _
+  var status: WorkflowAggregatedState = WorkflowAggregatedState.UNINITIALIZED
   val stateStore = new WorkflowStateStore()
   val resultService: JobResultService =
     new JobResultService(opResultStorage, stateStore)


### PR DESCRIPTION
returns a new `workflowservice` if one doesn't exist already
default value for enum is null https://stackoverflow.com/questions/31086787/default-value-for-enum-in-auxilary-constructor-in-scala#:~:text=The%20%22default%22%20value%20produced%20by%20var%20x%3A%20SomeEnumType%20%3D%20_%20is%20null