### PR TITLE
Allow multiple users to share workflow execution

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -40,7 +40,7 @@ object WorkflowService {
   def mkWorkflowStateId(wId: Int, uidOpt: Option[UInteger]): String = {
     uidOpt match {
       case Some(user) =>
-        user + "-" + wId
+        wId.toString
       case None =>
         // use a fixed wid for reconnection
         "dummy wid"


### PR DESCRIPTION
This PR changed the workflow service to make multiple users share the same workflow executions. 
In the existing implementation, user A and user B can have two different executions of the same workflow at the same time. 
In the new implementation, both users see the same execution of the same workflow at the same time.