### PR TITLE
Introduce types of pause in Amber

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -136,7 +136,7 @@ class DataProcessor( // dependencies:
 
     val (outputTuple, outputPortOpt) = out
     if (breakpointManager.evaluateTuple(outputTuple)) {
-      pauseManager.recordRequest(PauseType.BreakpointPause, true)
+      pauseManager.recordRequest(PauseType.UserPause, true)
       disableDataQueue()
       stateManager.transitTo(PAUSED)
     } else {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -61,7 +61,6 @@ class DataProcessor( // dependencies:
   private var currentInputLink: LinkIdentity = _
   private var currentOutputIterator: Iterator[(ITuple, Option[LinkIdentity])] = _
   private var isCompleted = false
-  var backpressured = false
 
   def getOperatorExecutor(): IOperatorExecutor = operator
 
@@ -105,7 +104,7 @@ class DataProcessor( // dependencies:
       if (currentInputTuple.isLeft) {
         inputTupleCount += 1
       }
-      if (pauseManager.pausedByOperatorLogic) {
+      if (pauseManager.getPauseStatusByType(PauseType.OperatorLogicPause)) {
         // if the operatorLogic decides to pause, we need to disable the data queue for this worker.
         disableDataQueue()
       }
@@ -137,7 +136,7 @@ class DataProcessor( // dependencies:
 
     val (outputTuple, outputPortOpt) = out
     if (breakpointManager.evaluateTuple(outputTuple)) {
-      pauseManager.pause()
+      pauseManager.recordRequest(PauseType.BreakpointPause, true)
       disableDataQueue()
       stateManager.transitTo(PAUSED)
     } else {
@@ -243,9 +242,7 @@ class DataProcessor( // dependencies:
   }
 
   private[this] def processControlCommandsDuringExecution(): Unit = {
-    while (
-      !isControlQueueEmpty || pauseManager.isPaused || backpressured || pauseManager.pausedByOperatorLogic
-    ) {
+    while (!isControlQueueEmpty || pauseManager.isPaused()) {
       takeOneControlCommandAndProcess()
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/PauseManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/PauseManager.scala
@@ -3,9 +3,6 @@ package edu.uci.ics.amber.engine.architecture.worker
 import scala.collection.mutable
 
 object PauseManager {
-  //  final val NoPause = 0
-  //  final val Paused = 1
-
   final case class ExecutionPaused()
 }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/PauseManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/PauseManager.scala
@@ -18,15 +18,7 @@ class PauseManager {
     pauseInvocations.getOrElse(pauseType, false)
 
   def isPaused(): Boolean = {
-    var isPaused = false
-    pauseInvocations.foreach(entry => {
-      if (entry._2) { isPaused = true }
-    })
-    isPaused
-  }
-
-  def canEnableDataQueue(): Boolean = {
-    pauseInvocations.forall(entry => entry._2 == false)
+    pauseInvocations.values.exists(isPaused => isPaused)
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/PauseType.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/PauseType.scala
@@ -1,0 +1,5 @@
+package edu.uci.ics.amber.engine.architecture.worker
+
+object PauseType extends Enumeration {
+  val UserPause, BackpressurePause, OperatorLogicPause, BreakpointPause = Value
+}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/PauseType.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/PauseType.scala
@@ -1,5 +1,5 @@
 package edu.uci.ics.amber.engine.architecture.worker
 
 object PauseType extends Enumeration {
-  val UserPause, BackpressurePause, OperatorLogicPause, BreakpointPause = Value
+  val UserPause, BackpressurePause, OperatorLogicPause = Value
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/AcceptMutableStateHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/AcceptMutableStateHandler.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
-import edu.uci.ics.amber.engine.architecture.worker.WorkerAsyncRPCHandlerInitializer
+import edu.uci.ics.amber.engine.architecture.worker.{PauseType, WorkerAsyncRPCHandlerInitializer}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.AcceptMutableStateHandler.AcceptMutableState
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
@@ -35,13 +35,13 @@ trait AcceptMutableStateHandler {
         .asInstanceOf[SortPartitionOpExec]
         .mergeIntoStoredTuplesList(cmd.tuples, cmd.totalMessagesToExpect)
 
-      if (canResume && pauseManager.pausedByOperatorLogic) {
+      if (canResume && pauseManager.getPauseStatusByType(PauseType.OperatorLogicPause)) {
         // All tuples have been received. The worker is paused due to operator logic
         // and not due to user pressing pause
-        if (!pauseManager.isPaused) {
+        if (pauseManager.canEnableDataQueue()) {
           dataProcessor.enableDataQueue()
         }
-        pauseManager.pausedByOperatorLogic = false
+        pauseManager.recordRequest(PauseType.OperatorLogicPause, false)
         dataProcessor.setCurrentOutputIterator(
           dataProcessor
             .getOperatorExecutor()

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/AcceptMutableStateHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/AcceptMutableStateHandler.scala
@@ -38,7 +38,7 @@ trait AcceptMutableStateHandler {
       if (canResume && pauseManager.getPauseStatusByType(PauseType.OperatorLogicPause)) {
         // All tuples have been received. The worker is paused due to operator logic
         // and not due to user pressing pause
-        if (pauseManager.canEnableDataQueue()) {
+        if (!pauseManager.isPaused()) {
           dataProcessor.enableDataQueue()
         }
         pauseManager.recordRequest(PauseType.OperatorLogicPause, false)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/BackpressureHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/BackpressureHandler.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
-import edu.uci.ics.amber.engine.architecture.worker.WorkerAsyncRPCHandlerInitializer
+import edu.uci.ics.amber.engine.architecture.worker.{PauseType, WorkerAsyncRPCHandlerInitializer}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.BackpressureHandler.Backpressure
 import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState.PAUSED
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
@@ -18,13 +18,13 @@ trait BackpressureHandler {
 
   registerHandler { (msg: Backpressure, _) =>
     if (msg.enableBackpressure) {
+      pauseManager.recordRequest(PauseType.BackpressurePause, true)
       dataProcessor.disableDataQueue()
-      dataProcessor.backpressured = true
     } else {
-      if (stateManager.getCurrentState != PAUSED) {
+      pauseManager.recordRequest(PauseType.BackpressurePause, false)
+      if (pauseManager.canEnableDataQueue()) {
         dataProcessor.enableDataQueue()
       }
-      dataProcessor.backpressured = false
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/BackpressureHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/BackpressureHandler.scala
@@ -22,7 +22,7 @@ trait BackpressureHandler {
       dataProcessor.disableDataQueue()
     } else {
       pauseManager.recordRequest(PauseType.BackpressurePause, false)
-      if (pauseManager.canEnableDataQueue()) {
+      if (!pauseManager.isPaused()) {
         dataProcessor.enableDataQueue()
       }
     }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/PauseHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/PauseHandler.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
-import edu.uci.ics.amber.engine.architecture.worker.WorkerAsyncRPCHandlerInitializer
+import edu.uci.ics.amber.engine.architecture.worker.{PauseType, WorkerAsyncRPCHandlerInitializer}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.PauseHandler.PauseWorker
 import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState
 import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState.{PAUSED, READY, RUNNING}
@@ -16,7 +16,7 @@ trait PauseHandler {
 
   registerHandler { (pause: PauseWorker, sender) =>
     if (stateManager.confirmState(RUNNING, READY)) {
-      pauseManager.pause()
+      pauseManager.recordRequest(PauseType.UserPause, true)
       dataProcessor.disableDataQueue()
       stateManager.transitTo(PAUSED)
     }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ResumeHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ResumeHandler.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
-import edu.uci.ics.amber.engine.architecture.worker.WorkerAsyncRPCHandlerInitializer
+import edu.uci.ics.amber.engine.architecture.worker.{PauseType, WorkerAsyncRPCHandlerInitializer}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.ResumeHandler.ResumeWorker
 import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState
 import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState.{PAUSED, RUNNING}
@@ -15,12 +15,8 @@ trait ResumeHandler {
 
   registerHandler { (msg: ResumeWorker, sender) =>
     if (stateManager.getCurrentState == PAUSED) {
-      if (pauseManager.isPaused) {
-        pauseManager.resume()
-      }
-      if (!dataProcessor.backpressured && !pauseManager.pausedByOperatorLogic) {
-        // if the processor is backpressured or paused by operator logic,
-        // it should not enable the data queue.
+      pauseManager.recordRequest(PauseType.UserPause, false)
+      if (pauseManager.canEnableDataQueue()) {
         dataProcessor.enableDataQueue()
       }
       stateManager.transitTo(RUNNING)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ResumeHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ResumeHandler.scala
@@ -16,7 +16,7 @@ trait ResumeHandler {
   registerHandler { (msg: ResumeWorker, sender) =>
     if (stateManager.getCurrentState == PAUSED) {
       pauseManager.recordRequest(PauseType.UserPause, false)
-      if (pauseManager.canEnableDataQueue()) {
+      if (!pauseManager.isPaused()) {
         dataProcessor.enableDataQueue()
       }
       stateManager.transitTo(RUNNING)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sortPartitions/SortPartitionOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sortPartitions/SortPartitionOpExec.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.texera.workflow.operators.sortPartitions
 
 import com.twitter.util.Future
-import edu.uci.ics.amber.engine.architecture.worker.PauseManager
+import edu.uci.ics.amber.engine.architecture.worker.{PauseManager, PauseType}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.AcceptMutableStateHandler.AcceptMutableState
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
@@ -152,7 +152,7 @@ class SortPartitionOpExec(
             } else {
               // It will pause its execution here. The execution will be resumed once the state is received
               // from the helper worker
-              pauseManager.pausedByOperatorLogic = true
+              pauseManager.recordRequest(PauseType.OperatorLogicPause, true)
               Iterator()
             }
           } else if (skewedWorkerIdentity != null) {


### PR DESCRIPTION
Currently a worker can be paused in different ways - user, backpressure, flow control. The scheduling PR will introduce another type of pause. This PR standardizes the pause types and introduce helper functions that makes the managing of different pause types easier.