### PR TITLE
Fix not correctly set current session user in shared execution

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -59,7 +59,7 @@ class WorkflowWebsocketResource extends LazyLogging {
         case wIdRequest: RegisterWIdRequest =>
           // hack to refresh frontend run button state
           send(session, WorkflowStateEvent("Uninitialized"))
-          val workflowState = WorkflowService.getOrCreate(wIdRequest.wId, uidOpt)
+          val workflowState = WorkflowService.getOrCreate(wIdRequest.wId)
           sessionState.subscribe(workflowState)
           send(session, RegisterWIdResponse("wid registered"))
         case heartbeat: HeartBeatRequest =>

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/file/UserFileAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/file/UserFileAccessResource.scala
@@ -4,7 +4,7 @@ import edu.uci.ics.texera.web.SqlServer
 import edu.uci.ics.texera.web.model.common.AccessEntry
 import edu.uci.ics.texera.web.model.http.request.auth.GrantAccessRequest
 import edu.uci.ics.texera.web.model.jooq.generated.Tables.{FILE, USER_FILE_ACCESS}
-import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{FileDao, UserDao, UserFileAccessDao}
+import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{UserDao, UserFileAccessDao}
 import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.UserFileAccess
 import edu.uci.ics.texera.web.resource.dashboard.file.UserFileAccessResource.{
   context,
@@ -27,7 +27,6 @@ object UserFileAccessResource {
     context.configuration
   )
   private lazy val userDao = new UserDao(context.configuration)
-  private lazy val fileDao = new FileDao(context.configuration)
   private lazy val context: DSLContext = SqlServer.createDSLContext
 
   def getFileId(ownerName: String, fileName: String): UInteger = {
@@ -62,12 +61,12 @@ object UserFileAccessResource {
   }
 
   def hasAccessTo(uid: UInteger, fid: UInteger): Boolean = {
-    val userFileAccess = new UserFileAccess()
-    userFileAccess.setUid(uid)
-    userFileAccess.setFid(fid)
-
-    // the user is the file owner, or the user has shared access to the file
-    fileDao.fetchOneByFid(fid).getUid == uid || userFileAccessDao.exists(userFileAccess)
+    context
+      .fetchExists(
+        context
+          .selectFrom(USER_FILE_ACCESS)
+          .where(USER_FILE_ACCESS.UID.eq(uid).and(USER_FILE_ACCESS.FID.eq(fid)))
+      )
   }
 }
 @PermitAll

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -58,7 +58,6 @@ object WorkflowService {
 }
 
 class WorkflowService(
-//    uidOpt: Option[UInteger],
     wId: Int,
     cleanUpTimeout: Int
 ) extends SubscriptionManager

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -37,25 +37,18 @@ object WorkflowService {
   val cleanUpDeadlineInSeconds: Int =
     AmberUtils.amberConfig.getInt("web-server.workflow-state-cleanup-in-seconds")
 
-  def mkWorkflowStateId(wId: Int, uidOpt: Option[UInteger]): String = {
-    uidOpt match {
-      case Some(user) =>
-        wId.toString
-      case None =>
-        // use a fixed wid for reconnection
-        "dummy wid"
-    }
+  def mkWorkflowStateId(wId: Int): String = {
+    wId.toString
   }
   def getOrCreate(
       wId: Int,
-      uidOpt: Option[UInteger],
       cleanupTimeout: Int = cleanUpDeadlineInSeconds
   ): WorkflowService = {
     wIdToWorkflowState.compute(
-      mkWorkflowStateId(wId, uidOpt),
+      mkWorkflowStateId(wId),
       (_, v) => {
         if (v == null) {
-          new WorkflowService(uidOpt, wId, cleanupTimeout)
+          new WorkflowService(wId, cleanupTimeout)
         } else {
           v
         }
@@ -65,7 +58,7 @@ object WorkflowService {
 }
 
 class WorkflowService(
-    uidOpt: Option[UInteger],
+//    uidOpt: Option[UInteger],
     wId: Int,
     cleanUpTimeout: Int
 ) extends SubscriptionManager
@@ -95,11 +88,11 @@ class WorkflowService(
     new WorkflowCacheService(opResultStorage, stateStore, wsInput)
   var jobService: BehaviorSubject[WorkflowJobService] = BehaviorSubject.create()
   val lifeCycleManager: WorkflowLifecycleManager = new WorkflowLifecycleManager(
-    s"uid=$uidOpt wid=$wId",
+    s"wid=$wId",
     cleanUpTimeout,
     () => {
       opResultStorage.close()
-      WorkflowService.wIdToWorkflowState.remove(mkWorkflowStateId(wId, uidOpt))
+      WorkflowService.wIdToWorkflowState.remove(mkWorkflowStateId(wId))
       wsInput.onNext(WorkflowKillRequest(), None)
       unsubscribeAll()
     }
@@ -141,7 +134,7 @@ class WorkflowService(
     )
   }
 
-  private[this] def createWorkflowContext(request: WorkflowExecuteRequest): WorkflowContext = {
+  private[this] def createWorkflowContext(request: WorkflowExecuteRequest, uidOpt: Option[UInteger]): WorkflowContext = {
     val jobID: String = String.valueOf(WorkflowWebsocketResource.nextExecutionID.incrementAndGet)
     if (WorkflowCacheService.isAvailable) {
       operatorCache.updateCacheStatus(
@@ -162,7 +155,7 @@ class WorkflowService(
       jobService.getValue.unsubscribeAll()
     }
     val job = new WorkflowJobService(
-      createWorkflowContext(req),
+      createWorkflowContext(req, uidOpt),
       wsInput,
       operatorCache,
       resultService,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -133,7 +133,10 @@ class WorkflowService(
     )
   }
 
-  private[this] def createWorkflowContext(request: WorkflowExecuteRequest, uidOpt: Option[UInteger]): WorkflowContext = {
+  private[this] def createWorkflowContext(
+      request: WorkflowExecuteRequest,
+      uidOpt: Option[UInteger]
+  ): WorkflowContext = {
     val jobID: String = String.valueOf(WorkflowWebsocketResource.nextExecutionID.incrementAndGet)
     if (WorkflowCacheService.isAvailable) {
       operatorCache.updateCacheStatus(


### PR DESCRIPTION
This PR fixed a bug after #1635. After allowing multiple users to share an execution, the user in workflow context is not updated after every execution - instead, the user that is first connected to the workflow is kept.