### PR TITLE
Fix the operator state when it has not been initialized yet

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/operators/OpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/operators/OpExecConfig.scala
@@ -65,6 +65,9 @@ abstract class OpExecConfig(val id: OperatorIdentity) extends Serializable {
 
   def getState: WorkflowAggregatedState = {
     val workerStates = getAllWorkerStates
+    if (workerStates.isEmpty) {
+      return WorkflowAggregatedState.UNINITIALIZED
+    }
     if (workerStates.forall(_ == COMPLETED)) {
       return WorkflowAggregatedState.COMPLETED
     }


### PR DESCRIPTION
This PR fixes a bug where an operator is wrongly marked complete if it has no workers