### PR TITLE
Inherited file sharing from workflow sharing

### DIFF
--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.ts
@@ -5,6 +5,8 @@ import { WorkflowAccessService } from "../../../../service/workflow-access/workf
 import { Workflow } from "../../../../../common/type/workflow";
 import { AccessEntry } from "../../../../type/access.interface";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import {DashboardUserFileEntry, UserFile} from "../../../../type/dashboard-user-file-entry";
+import {UserFileService} from "../../../../service/user-file/user-file.service";
 
 @UntilDestroy()
 @Component({
@@ -14,6 +16,7 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 })
 export class NgbdModalWorkflowShareAccessComponent implements OnInit {
   @Input() workflow!: Workflow;
+  @Input() filenames!: string[];
 
   public shareForm = this.formBuilder.group({
     username: ["", [Validators.required]],
@@ -29,7 +32,8 @@ export class NgbdModalWorkflowShareAccessComponent implements OnInit {
   constructor(
     public activeModal: NgbActiveModal,
     private workflowGrantAccessService: WorkflowAccessService,
-    private formBuilder: FormBuilder
+    private formBuilder: FormBuilder,
+    private userFileService: UserFileService
   ) {}
 
   ngOnInit(): void {
@@ -68,6 +72,32 @@ export class NgbdModalWorkflowShareAccessComponent implements OnInit {
    * @param accessLevel the type of access to be given
    */
   public grantWorkflowAccess(workflow: Workflow, userToShareWith: string, accessLevel: string): void {
+    this.filenames.forEach(filename => {
+      const [owner, fname] = filename.split("/", 2);
+      let userFile: UserFile;
+      userFile = {
+        fid: undefined!,
+        name: fname,
+        path: undefined!,
+        size: undefined!,
+        description: undefined!,
+        uploadTime: undefined!
+      };
+      const dashboardUserFileEntry: DashboardUserFileEntry = {
+        ownerName: owner,
+        file: userFile,
+        accessLevel: accessLevel,
+        isOwner: true,
+        projectIDs: undefined!,
+      };
+      this.userFileService
+        .grantUserFileAccess(dashboardUserFileEntry, userToShareWith, accessLevel)
+        .pipe(untilDestroyed(this))
+        .subscribe(
+          // @ts-ignore // TODO: fix this with notification component
+          (err: unknown) => alert(err.error)
+        );
+    });
     this.workflowGrantAccessService
       .grantUserWorkflowAccess(workflow, userToShareWith, accessLevel)
       .pipe(untilDestroyed(this))

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.ts
@@ -86,12 +86,12 @@ export class NgbdModalWorkflowShareAccessComponent implements OnInit {
       const dashboardUserFileEntry: DashboardUserFileEntry = {
         ownerName: owner,
         file: userFile,
-        accessLevel: accessLevel,
+        accessLevel: "read",
         isOwner: true,
         projectIDs: undefined!,
       };
       this.userFileService
-        .grantUserFileAccess(dashboardUserFileEntry, userToShareWith, accessLevel)
+        .grantUserFileAccess(dashboardUserFileEntry, userToShareWith, "read")
         .pipe(untilDestroyed(this))
         .subscribe(
           // @ts-ignore // TODO: fix this with notification component

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.ts
@@ -5,8 +5,8 @@ import { WorkflowAccessService } from "../../../../service/workflow-access/workf
 import { Workflow } from "../../../../../common/type/workflow";
 import { AccessEntry } from "../../../../type/access.interface";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
-import {DashboardUserFileEntry, UserFile} from "../../../../type/dashboard-user-file-entry";
-import {UserFileService} from "../../../../service/user-file/user-file.service";
+import { DashboardUserFileEntry, UserFile } from "../../../../type/dashboard-user-file-entry";
+import { UserFileService } from "../../../../service/user-file/user-file.service";
 
 @UntilDestroy()
 @Component({
@@ -72,32 +72,35 @@ export class NgbdModalWorkflowShareAccessComponent implements OnInit {
    * @param accessLevel the type of access to be given
    */
   public grantWorkflowAccess(workflow: Workflow, userToShareWith: string, accessLevel: string): void {
-    this.filenames.forEach(filename => {
-      const [owner, fname] = filename.split("/", 2);
-      let userFile: UserFile;
-      userFile = {
-        fid: undefined!,
-        name: fname,
-        path: undefined!,
-        size: undefined!,
-        description: undefined!,
-        uploadTime: undefined!
-      };
-      const dashboardUserFileEntry: DashboardUserFileEntry = {
-        ownerName: owner,
-        file: userFile,
-        accessLevel: "read",
-        isOwner: true,
-        projectIDs: undefined!,
-      };
-      this.userFileService
-        .grantUserFileAccess(dashboardUserFileEntry, userToShareWith, "read")
-        .pipe(untilDestroyed(this))
-        .subscribe(
-          // @ts-ignore // TODO: fix this with notification component
-          (err: unknown) => alert(err.error)
-        );
-    });
+    if (this.filenames) {
+      this.filenames.forEach(filename => {
+        const [owner, fname] = filename.split("/", 2);
+        let userFile: UserFile;
+        userFile = {
+          fid: undefined!,
+          name: fname,
+          path: undefined!,
+          size: undefined!,
+          description: undefined!,
+          uploadTime: undefined!,
+        };
+        const dashboardUserFileEntry: DashboardUserFileEntry = {
+          ownerName: owner,
+          file: userFile,
+          accessLevel: "read",
+          isOwner: true,
+          projectIDs: undefined!,
+        };
+        this.userFileService
+          .grantUserFileAccess(dashboardUserFileEntry, userToShareWith, "read")
+          .pipe(untilDestroyed(this))
+          .subscribe(
+            // @ts-ignore // TODO: fix this with notification component
+            (err: unknown) => alert(err.error)
+          );
+      });
+    }
+
     this.workflowGrantAccessService
       .grantUserWorkflowAccess(workflow, userToShareWith, accessLevel)
       .pipe(untilDestroyed(this))

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
@@ -171,6 +171,23 @@ export class SavedWorkflowSectionComponent implements OnInit, OnChanges {
   public onClickOpenShareAccess({ workflow }: DashboardWorkflowEntry): void {
     const modalRef = this.modalService.open(NgbdModalWorkflowShareAccessComponent);
     modalRef.componentInstance.workflow = workflow;
+    this.workflowPersistService
+      .retrieveWorkflow(<number>workflow.wid)
+      .pipe(untilDestroyed(this))
+      .subscribe(data => {
+        const workflowCopy: Workflow = {
+          ...data,
+          wid: undefined,
+          creationTime: undefined,
+          lastModifiedTime: undefined,
+        };
+        let filenames: string[] = [];
+        workflowCopy.content.operators.forEach(operator => {
+          const filename: string = operator.operatorProperties.fileName;
+          if(filename) filenames.push(filename);
+        });
+        modalRef.componentInstance.filenames = [...new Set(filenames)];
+      });
   }
 
   /**

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
@@ -184,7 +184,7 @@ export class SavedWorkflowSectionComponent implements OnInit, OnChanges {
         let filenames: string[] = [];
         workflowCopy.content.operators.forEach(operator => {
           const filename: string = operator.operatorProperties.fileName;
-          if(filename) filenames.push(filename);
+          if (filename) filenames.push(filename);
         });
         modalRef.componentInstance.filenames = [...new Set(filenames)];
       });

--- a/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
@@ -186,6 +186,7 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
    * @param event
    */
   onFormChanges(event: Record<string, unknown>): void {
+    // This assumes "fileName" to be the only key for file names in an operator property.
     const filename: string = <string>event["fileName"];
     if (filename) {
       const [owner, fname] = filename.split("/", 2);
@@ -203,10 +204,7 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
             "read"
           )
           .pipe(untilDestroyed(this))
-          .subscribe(
-            // @ts-ignore // TODO: fix this with notification component
-            (err: unknown) => alert(err.error)
-          );
+          .subscribe();
       });
     }
 

--- a/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
@@ -33,6 +33,10 @@ import { PresetWrapperComponent } from "src/app/common/formly/preset-wrapper/pre
 import { environment } from "src/environments/environment";
 import { WorkflowCollabService } from "../../../service/workflow-collab/workflow-collab.service";
 import { WorkflowVersionService } from "../../../../dashboard/service/workflow-version/workflow-version.service";
+import {DashboardUserFileEntry, UserFile} from "../../../../dashboard/type/dashboard-user-file-entry";
+import { UserFileService } from "../../../../dashboard/service/user-file/user-file.service";
+import { AccessEntry } from "../../../../dashboard/type/access.interface";
+import { WorkflowAccessService } from "../../../../dashboard/service/workflow-access/workflow-access.service";
 
 export type PropertyDisplayComponent = TypeCastingDisplayComponent;
 
@@ -102,7 +106,8 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
   // used to tear down subscriptions that takeUntil(teardownObservable)
   private teardownObservable: Subject<void> = new Subject();
   public lockGranted: boolean = true;
-
+  public allUserWorkflowAccess: ReadonlyArray<AccessEntry> = [];
+  
   constructor(
     private formlyJsonschema: FormlyJsonschema,
     private workflowActionService: WorkflowActionService,
@@ -112,7 +117,9 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
     private notificationService: NotificationService,
     private workflowCollabService: WorkflowCollabService,
     private changeDetectorRef: ChangeDetectorRef,
-    private workflowVersionService: WorkflowVersionService
+    private workflowVersionService: WorkflowVersionService,
+    private userFileService: UserFileService,
+    private workflowGrantAccessService: WorkflowAccessService
   ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
@@ -150,6 +157,15 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
     this.registerOperatorDisplayNameChangeHandler();
 
     this.registerLockChangeHandler();
+
+    this.workflowGrantAccessService
+      .retrieveGrantedWorkflowAccessList(this.workflowActionService.getWorkflow())
+      // eslint-disable-next-line rxjs-angular/prefer-takeuntil
+      .subscribe(
+        (userWorkflowAccess: ReadonlyArray<AccessEntry>) => (this.allUserWorkflowAccess = userWorkflowAccess),
+        // @ts-ignore // TODO: fix this with notification component
+        (err: unknown) => console.log(err.error)
+      );
   }
 
   async ngOnDestroy() {
@@ -164,6 +180,37 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
    * @param event
    */
   onFormChanges(event: Record<string, unknown>): void {
+    const filename: string =<string>event["fileName"];
+    if(filename) {
+      const [owner, fname] = filename.split("/", 2);
+      let userFile: UserFile;
+      userFile = {
+        fid: undefined!,
+        name: fname,
+        path: undefined!,
+        size: undefined!,
+        description: undefined!,
+        uploadTime: undefined!
+      };
+      const dashboardUserFileEntry: DashboardUserFileEntry = {
+        ownerName: owner,
+        file: userFile,
+        accessLevel: "read",
+        isOwner: true,
+        projectIDs: undefined!,
+      };
+
+      this.allUserWorkflowAccess.forEach(userWorkflowAccess => {
+        this.userFileService
+          .grantUserFileAccess(dashboardUserFileEntry, userWorkflowAccess.userName, "read")
+          .pipe(untilDestroyed(this))
+          .subscribe(
+            // @ts-ignore // TODO: fix this with notification component
+            (err: unknown) => alert(err.error)
+          );
+      });
+    }
+
     this.sourceFormChangeEventStream.next(event);
   }
 


### PR DESCRIPTION
All the files are shared with the read access regardless of the workflow access level. Additionally, we may want to allow the other users to reject the sharing. (Deleting the shared workflows and files from their end)

Revoke workflow sharing doesn't revoke the shared files. Users can revoke the file sharing manually. File share revoking is not restricted to shared workflow, so users can still break the workflow by revoking file sharing. 

![Animation](https://user-images.githubusercontent.com/11544314/187629734-68ec1828-ced2-43d4-94f9-84ac3b846701.gif)
