### PR TITLE
Adding an autocomplete feature of workflow share access users selection

### DIFF
--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.html
@@ -8,7 +8,23 @@
   <form (ngSubmit)="onClickShareWorkflow(workflow)" [formGroup]="shareForm">
     <div class="form-group">
       <label for="username"> Username of the target user to share </label>
-      <input class="form-control" formControlName="username" id="username" type="text" />
+      <input 
+        [(ngModel)]="ownerSearchValue"
+        nz-input
+        nzBackdrop="false"
+        class="form-control"
+        formControlName="username"
+        id="username"
+        type="text" 
+        (ngModelChange)="onChange($event)"
+        [nzAutocomplete]="auto"
+      />
+      <nz-autocomplete
+        [nzDefaultActiveFirstOption]="false"
+        [nzDataSource]="filteredOwners"
+        nzBackfill
+        #auto
+      ></nz-autocomplete>
 
       <br />
       <label for="accessLevel"> Access Level </label>

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.scss
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.scss
@@ -10,3 +10,7 @@
     transform: translateY(-20%);
   }
 }
+
+::ng-deep .cdk-overlay-container {
+  z-index: 1100;
+}

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.ts
@@ -14,6 +14,7 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 })
 export class NgbdModalWorkflowShareAccessComponent implements OnInit {
   @Input() workflow!: Workflow;
+  @Input() allOwners!: string[];
 
   public shareForm = this.formBuilder.group({
     username: ["", [Validators.required]],
@@ -25,6 +26,8 @@ export class NgbdModalWorkflowShareAccessComponent implements OnInit {
   public allUserWorkflowAccess: ReadonlyArray<AccessEntry> = [];
 
   public workflowOwner: string = "";
+  public filteredOwners: Array<string> = new Array();
+  public ownerSearchValue?: string;
 
   constructor(
     public activeModal: NgbActiveModal,
@@ -39,7 +42,11 @@ export class NgbdModalWorkflowShareAccessComponent implements OnInit {
   public onClickGetAllSharedAccess(workflow: Workflow): void {
     this.refreshGrantedList(workflow);
   }
-
+  
+  public onChange(value: string): void {
+    this.filteredOwners = [];
+    this.filteredOwners = this.allOwners.filter(owner => owner.toLowerCase().indexOf(value.toLowerCase()) !== -1);
+  }
   /**
    * get all shared access of the current workflow
    * @param workflow target/current workflow

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
@@ -171,6 +171,7 @@ export class SavedWorkflowSectionComponent implements OnInit, OnChanges {
   public onClickOpenShareAccess({ workflow }: DashboardWorkflowEntry): void {
     const modalRef = this.modalService.open(NgbdModalWorkflowShareAccessComponent);
     modalRef.componentInstance.workflow = workflow;
+    modalRef.componentInstance.allOwners = this.owners.map(owner => owner.userName);
   }
 
   /**


### PR DESCRIPTION
We want to an autocomplete feature to the workflow share access to help users  type in usernames quickly and correctly. This PR adds the feature which shows all usernames contains the users’ input string with a drop-down list.

![autocompleteDEMO](https://user-images.githubusercontent.com/113659248/190588415-93dd80e7-279d-488b-8540-272b05b56fec.gif)
