### PR TITLE
Adding an autocomplete feature of workflow share access users selection

### DIFF
--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.html
@@ -8,8 +8,23 @@
   <form (ngSubmit)="onClickShareWorkflow(workflow)" [formGroup]="shareForm">
     <div class="form-group">
       <label for="username"> Username of the target user to share </label>
-      <input class="form-control" formControlName="username" id="username" type="text" />
-
+      <input
+        [(ngModel)]="ownerSearchValue"
+        nz-input
+        nzBackdrop="false"
+        class="form-control"
+        formControlName="username"
+        id="username"
+        type="text"
+        (ngModelChange)="onChange($event)"
+        [nzAutocomplete]="auto"
+      />
+      <nz-autocomplete
+        [nzDefaultActiveFirstOption]="false"
+        [nzDataSource]="filteredOwners"
+        nzBackfill
+        #auto
+      ></nz-autocomplete>
       <br />
       <label for="accessLevel"> Access Level </label>
       <div id="accessLevel">

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.scss
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.scss
@@ -10,3 +10,6 @@
     transform: translateY(-20%);
   }
 }
+::ng-deep .cdk-overlay-container {
+  z-index: 1100;
+}

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.ts
@@ -17,6 +17,7 @@ import { UserFileService } from "../../../../service/user-file/user-file.service
 export class NgbdModalWorkflowShareAccessComponent implements OnInit {
   @Input() workflow!: Workflow;
   @Input() filenames!: string[];
+  @Input() allOwners!: string[];
 
   public shareForm = this.formBuilder.group({
     username: ["", [Validators.required]],
@@ -29,6 +30,10 @@ export class NgbdModalWorkflowShareAccessComponent implements OnInit {
 
   public workflowOwner: string = "";
 
+  public filteredOwners: Array<string> = new Array();
+
+  public ownerSearchValue?: string;
+  
   constructor(
     public activeModal: NgbActiveModal,
     private workflowGrantAccessService: WorkflowAccessService,
@@ -43,7 +48,12 @@ export class NgbdModalWorkflowShareAccessComponent implements OnInit {
   public onClickGetAllSharedAccess(workflow: Workflow): void {
     this.refreshGrantedList(workflow);
   }
-
+  
+  public onChange(value: string): void {
+    this.filteredOwners = [];
+    this.filteredOwners = this.allOwners.filter(owner => owner.toLowerCase().indexOf(value.toLowerCase()) !== -1);
+  }
+  
   /**
    * get all shared access of the current workflow
    * @param workflow target/current workflow

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
@@ -172,6 +172,7 @@ export class SavedWorkflowSectionComponent implements OnInit, OnChanges {
   public onClickOpenShareAccess({ workflow }: DashboardWorkflowEntry): void {
     const modalRef = this.modalService.open(NgbdModalWorkflowShareAccessComponent);
     modalRef.componentInstance.workflow = workflow;
+    modalRef.componentInstance.allOwners = this.owners.map(owner => owner.userName);
     this.workflowPersistService
       .retrieveWorkflow(<number>workflow.wid)
       .pipe(untilDestroyed(this))


### PR DESCRIPTION
We want to an autocomplete feature to the workflow share access to help users  type in usernames quickly and correctly. This PR adds the feature which shows all usernames contains the users’ input string with a drop-down list.

![autocompleteDEMO](https://user-images.githubusercontent.com/113659248/191145221-989f86c6-1203-433c-818a-8159d91ef887.gif)
