### PR TITLE
Yjs-based Shared Editing [1/4] Change Unnecessary Event Stream APIs in WorkflowGraph

### DIFF
--- a/core/new-gui/src/app/workspace/service/dynamic-schema/dynamic-schema.service.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/dynamic-schema.service.ts
@@ -58,7 +58,7 @@ export class DynamicSchemaService {
     this.workflowActionService
       .getTexeraGraph()
       .getOperatorDeleteStream()
-      .subscribe(event => this.dynamicSchemaMap.delete(event.deletedOperator.operatorID));
+      .subscribe(event => this.dynamicSchemaMap.delete(event.deletedOperatorID));
 
     // when a link is deleted, remove it from the dynamic schema map
     this.workflowActionService

--- a/core/new-gui/src/app/workspace/service/validation/validation-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/validation/validation-workflow.service.ts
@@ -148,7 +148,7 @@ export class ValidationWorkflowService {
     this.workflowActionService
       .getTexeraGraph()
       .getOperatorDeleteStream()
-      .subscribe(operator => this.updateValidationStateOnDelete(operator.deletedOperator.operatorID));
+      .subscribe(operator => this.updateValidationStateOnDelete(operator.deletedOperatorID));
 
     // Capture the link add and delete event and validate the source and target operators for this link
     merge(
@@ -158,8 +158,13 @@ export class ValidationWorkflowService {
         .getLinkDeleteStream()
         .pipe(map(link => link.deletedLink))
     ).subscribe(link => {
-      this.updateValidationState(link.source.operatorID, this.validateOperator(link.source.operatorID));
-      this.updateValidationState(link.target.operatorID, this.validateOperator(link.target.operatorID));
+      if (
+        this.workflowActionService.getTexeraGraph().hasOperator(link.source.operatorID) &&
+        this.workflowActionService.getTexeraGraph().hasOperator(link.target.operatorID)
+      ) {
+        this.updateValidationState(link.source.operatorID, this.validateOperator(link.source.operatorID));
+        this.updateValidationState(link.target.operatorID, this.validateOperator(link.target.operatorID));
+      }
     });
 
     // Capture the operator property change event and validate the current operator being changed

--- a/core/new-gui/src/app/workspace/service/validation/validation-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/validation/validation-workflow.service.ts
@@ -158,11 +158,10 @@ export class ValidationWorkflowService {
         .getLinkDeleteStream()
         .pipe(map(link => link.deletedLink))
     ).subscribe(link => {
-      if (
-        this.workflowActionService.getTexeraGraph().hasOperator(link.source.operatorID) &&
-        this.workflowActionService.getTexeraGraph().hasOperator(link.target.operatorID)
-      ) {
+      if (this.workflowActionService.getTexeraGraph().hasOperator(link.source.operatorID)) {
         this.updateValidationState(link.source.operatorID, this.validateOperator(link.source.operatorID));
+      }
+      if (this.workflowActionService.getTexeraGraph().hasOperator(link.target.operatorID)) {
         this.updateValidationState(link.target.operatorID, this.validateOperator(link.target.operatorID));
       }
     });

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/sync-operator-group.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/sync-operator-group.ts
@@ -29,14 +29,14 @@ export class SyncOperatorGroup {
   private handleTexeraGraphOperatorDelete(): void {
     this.texeraGraph
       .getOperatorDeleteStream()
-      .pipe(map(operator => operator.deletedOperator))
-      .subscribe(deletedOperator => {
-        const group = this.operatorGroup.getGroupByOperator(deletedOperator.operatorID);
+      .pipe(map(operator => operator.deletedOperatorID))
+      .subscribe(deletedOperatorID => {
+        const group = this.operatorGroup.getGroupByOperator(deletedOperatorID);
         if (group && !group.collapsed && group.operators.size > 1) {
-          group.operators.delete(deletedOperator.operatorID);
+          group.operators.delete(deletedOperatorID);
           this.operatorGroup.repositionGroup(group);
         } else if (group) {
-          group.operators.delete(deletedOperator.operatorID);
+          group.operators.delete(deletedOperatorID);
         }
       });
   }

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
@@ -60,7 +60,7 @@ export class WorkflowGraph {
   private readonly operatorAddSubject = new Subject<OperatorPredicate>();
 
   private readonly operatorDeleteSubject = new Subject<{
-    deletedOperator: OperatorPredicate;
+    deletedOperatorID: string;
   }>();
   private readonly disabledOperatorChangedSubject = new Subject<{
     newDisabled: string[];
@@ -167,7 +167,7 @@ export class WorkflowGraph {
       throw new Error(`operator with ID ${operatorID} doesn't exist`);
     }
     this.operatorIDMap.delete(operatorID);
-    this.operatorDeleteSubject.next({ deletedOperator: operator });
+    this.operatorDeleteSubject.next({ deletedOperatorID: operator.operatorID });
   }
 
   public deleteCommentBox(commentBoxID: string): void {
@@ -537,7 +537,7 @@ export class WorkflowGraph {
    * The observable value is the deleted operator.
    */
   public getOperatorDeleteStream(): Observable<{
-    deletedOperator: OperatorPredicate;
+    deletedOperatorID: string;
   }> {
     return this.operatorDeleteSubject.asObservable();
   }


### PR DESCRIPTION
## Content
This PR is a prequel to the main content of Yjs shared editing. It only involves changes on event stream API(s) in `WorkflowGraph` that are needed to accommodate Yjs.

## Next Steps
- The next PR ([2/4]) would be to change test cases that are not compatible with the upcoming new frontend architecture. Steps 1 and 2 are needed but not directly related to the implementation of Yjs-based shared editing, and the changes are mostly outside of the `workflow-graph` package. (If feasible, we can also get rid of the old implementation in this step.)
- Step [3/4] would contain the main content of this work, which implements the new architecture in #1573 and are mostly within the `workflow-graph` package.
- Step [4/4] adds the co-editor presence features, which are mostly new files.