### PR TITLE
Add Autocomplete of Target User Names for Sharing a Workflow

### DIFF
--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.html
@@ -8,8 +8,23 @@
   <form (ngSubmit)="onClickShareWorkflow(workflow)" [formGroup]="shareForm">
     <div class="form-group">
       <label for="username"> Username of the target user to share </label>
-      <input class="form-control" formControlName="username" id="username" type="text" />
-
+      <input
+        [(ngModel)]="ownerSearchValue"
+        nz-input
+        nzBackdrop="false"
+        class="form-control"
+        formControlName="username"
+        id="username"
+        type="text"
+        (ngModelChange)="onChange($event)"
+        [nzAutocomplete]="auto"
+      />
+      <nz-autocomplete
+        [nzDefaultActiveFirstOption]="false"
+        [nzDataSource]="filteredOwners"
+        nzBackfill
+        #auto
+      ></nz-autocomplete>
       <br />
       <label for="accessLevel"> Access Level </label>
       <div id="accessLevel">

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.scss
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.scss
@@ -10,3 +10,6 @@
     transform: translateY(-20%);
   }
 }
+::ng-deep .cdk-overlay-container {
+  z-index: 1100;
+}

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/ngbd-modal-share-access/ngbd-modal-workflow-share-access.component.ts
@@ -17,6 +17,7 @@ import { UserFileService } from "../../../../service/user-file/user-file.service
 export class NgbdModalWorkflowShareAccessComponent implements OnInit {
   @Input() workflow!: Workflow;
   @Input() filenames!: string[];
+  @Input() allOwners!: string[];
 
   public shareForm = this.formBuilder.group({
     username: ["", [Validators.required]],
@@ -28,6 +29,10 @@ export class NgbdModalWorkflowShareAccessComponent implements OnInit {
   public allUserWorkflowAccess: ReadonlyArray<AccessEntry> = [];
 
   public workflowOwner: string = "";
+
+  public filteredOwners: Array<string> = [];
+
+  public ownerSearchValue?: string;
 
   constructor(
     public activeModal: NgbActiveModal,
@@ -42,6 +47,14 @@ export class NgbdModalWorkflowShareAccessComponent implements OnInit {
 
   public onClickGetAllSharedAccess(workflow: Workflow): void {
     this.refreshGrantedList(workflow);
+  }
+
+  public onChange(value: string): void {
+    if (value === undefined) {
+      this.filteredOwners = [];
+    } else {
+      this.filteredOwners = this.allOwners.filter(owner => owner.toLowerCase().indexOf(value.toLowerCase()) !== -1);
+    }
   }
 
   /**

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
@@ -172,6 +172,7 @@ export class SavedWorkflowSectionComponent implements OnInit, OnChanges {
   public onClickOpenShareAccess({ workflow }: DashboardWorkflowEntry): void {
     const modalRef = this.modalService.open(NgbdModalWorkflowShareAccessComponent);
     modalRef.componentInstance.workflow = workflow;
+    modalRef.componentInstance.allOwners = this.owners.map(owner => owner.userName);
     this.workflowPersistService
       .retrieveWorkflow(<number>workflow.wid)
       .pipe(untilDestroyed(this))


### PR DESCRIPTION
We want to an autocomplete feature to the workflow share access to help users type in usernames quickly and correctly. This PR adds the feature which shows all usernames contains the users’ input string with a drop-down list.

![191333088-7c9ffe16-80f5-44ca-bb9a-0bdcbd2557e8](https://user-images.githubusercontent.com/113659248/192447011-08a82086-e36c-4225-9426-2d2ee844ef0c.gif)
