### PR TITLE
Add Build Support for Shared Editing Server.

### DIFF
--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/shared-model.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/shared-model.ts
@@ -12,6 +12,7 @@ import { User, CoeditorState } from "../../../../common/type/user";
 import { getWebsocketUrl } from "../../../../common/util/url";
 import { v4 as uuid } from "uuid";
 import { YType } from "../../../types/shared-editing.interface";
+import {environment} from "../../../../../environments/environment";
 
 /**
  * SharedModel encapsulates everything related to real-time shared editing for the current workflow.
@@ -54,7 +55,7 @@ export class SharedModel {
     );
 
     // Generate editing room number.
-    const websocketUrl = getWebsocketUrl("rtc");
+    const websocketUrl = SharedModel.getYWebSocketBaseUrl();
     const suffix = wid ? `${wid}` : uuid();
     this.wsProvider = new WebsocketProvider(websocketUrl, suffix, this.yDoc);
 
@@ -69,6 +70,16 @@ export class SharedModel {
       };
       this.awareness.setLocalState(userState);
     }
+  }
+
+  /**
+   * Shared editing needs y-websocket to be running. The base url depends on whether reverse proxy is set up. For local
+   * development, we need to use localhost; For production server which has reverse proxy, we can use the same base url
+   * as the server.
+   * @private
+   */
+  private static getYWebSocketBaseUrl() {
+    return environment.productionSharedEditingServer ? getWebsocketUrl("rtc") : "ws://localhost:1234";
   }
 
   /**

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/shared-model.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/shared-model.ts
@@ -12,7 +12,7 @@ import { User, CoeditorState } from "../../../../common/type/user";
 import { getWebsocketUrl } from "../../../../common/util/url";
 import { v4 as uuid } from "uuid";
 import { YType } from "../../../types/shared-editing.interface";
-import {environment} from "../../../../../environments/environment";
+import { environment } from "../../../../../environments/environment";
 
 /**
  * SharedModel encapsulates everything related to real-time shared editing for the current workflow.

--- a/core/new-gui/src/environments/environment.default.ts
+++ b/core/new-gui/src/environments/environment.default.ts
@@ -83,9 +83,10 @@ export const defaultEnvironment = {
   },
 
   /**
-   * Whether workflow collab should be active
+   * Whether to connect to local or production shared editing server. Set to true if you have
+   * reverse proxy set up for y-websocket.
    */
-  workflowCollabEnabled: false,
+  productionSharedEditingServer: false,
 };
 
 export type AppEnv = typeof defaultEnvironment;

--- a/core/scripts/shared-editing-server.sh
+++ b/core/scripts/shared-editing-server.sh
@@ -1,0 +1,2 @@
+cd new-gui
+npx y-websocket


### PR DESCRIPTION
This PR adds support for starting shared editing server in build mode, so that new users of Texera can look at our wiki and run shared editing. We use different ws address for production and dev/build because only production environment can have reverse proxy which enables `ws://[server_base_url]/rtc/...`, otherwise `ws://localhost:1234` will need to be used.

Also the environment variable for old shared editing is deleted.