### PR TITLE
Change link behavior to support open in current tab and in new tab

### DIFF
--- a/core/new-gui/src/app/dashboard/component/feature-bar/feature-bar.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-bar/feature-bar.component.html
@@ -10,7 +10,7 @@
       nzType="text"
     >
       <i class="feature-bar-btn-icon" nz-icon nzTheme="outline" nzType="container"></i>
-      User Projects
+      Projects
     </button>
   </nz-list-item>
   <nz-list-item>
@@ -36,7 +36,7 @@
       nzType="text"
     >
       <i class="feature-bar-btn-icon" nz-icon nzTheme="outline" nzType="folder-open"></i>
-      User Files
+      Files
     </button>
   </nz-list-item>
 </nz-list>

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.html
@@ -284,7 +284,7 @@
               <div class="workflow-item-meta-title">
                 <a
                   *ngIf="dashboardWorkflowEntriesIsEditingName.indexOf(indexOfElement) === -1; else customWorkflowTitle "
-                  [href]="ROUTER_WORKFLOW_BASE_URL + '/' + dashboardWorkflowEntry.workflow.wid"
+                  [routerLink]="ROUTER_WORKFLOW_BASE_URL + '/' + dashboardWorkflowEntry.workflow.wid"
                   class="workflow-name"
                   >{{ dashboardWorkflowEntry.workflow.name }}</a>
                 <ng-template #customWorkflowTitle>
@@ -378,7 +378,7 @@
                 class="project-label-name"
                 [ngClass]="{'color-tag' : true, 'light-color' : colorBrightnessMap.get(projectID), 'dark-color' : !colorBrightnessMap.get(projectID)}"
                 [ngStyle]="{'color' : colorBrightnessMap.get(projectID) ? 'black' : 'white', 'background-color' : '#' + userProjectsMap.get(projectID)!.color}"
-                [href]="ROUTER_USER_PROJECT_BASE_URL + '/' + userProjectsMap.get(projectID)!.pid"
+                [routerLink]="ROUTER_USER_PROJECT_BASE_URL + '/' + userProjectsMap.get(projectID)!.pid"
               >
                 {{userProjectsMap.get(projectID)!.name | shorten: 15 }}
               </a>

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.html
@@ -286,7 +286,8 @@
                   *ngIf="dashboardWorkflowEntriesIsEditingName.indexOf(indexOfElement) === -1; else customWorkflowTitle "
                   [routerLink]="ROUTER_WORKFLOW_BASE_URL + '/' + dashboardWorkflowEntry.workflow.wid"
                   class="workflow-name"
-                  >{{ dashboardWorkflowEntry.workflow.name }}</a>
+                  >{{ dashboardWorkflowEntry.workflow.name }}</a
+                >
                 <ng-template #customWorkflowTitle>
                   <input
                     #customName

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.html
@@ -282,12 +282,11 @@
             <!-- editable name of saved workflow -->
             <nz-list-item-meta-title class="meta-title-container">
               <div class="workflow-item-meta-title">
-                <label
+                <a
                   *ngIf="dashboardWorkflowEntriesIsEditingName.indexOf(indexOfElement) === -1; else customWorkflowTitle "
-                  (click)="jumpToWorkflow(dashboardWorkflowEntry)"
+                  [href]="ROUTER_WORKFLOW_BASE_URL + '/' + dashboardWorkflowEntry.workflow.wid"
                   class="workflow-name"
-                  >{{ dashboardWorkflowEntry.workflow.name }}</label
-                >
+                  >{{ dashboardWorkflowEntry.workflow.name }}</a>
                 <ng-template #customWorkflowTitle>
                   <input
                     #customName
@@ -372,22 +371,22 @@
 
           <div *ngIf="userProjectsLoaded" class="project-label-container">
             <div *ngFor="let projectID of dashboardWorkflowEntry.projectIDs" class="project-label">
-              <div
+              <a
                 *ngIf="userProjectsMap.has(projectID) && userProjectsMap.get(projectID)!.color !== null && projectID !== pid"
                 nz-tooltip="{{userProjectsMap.get(projectID)!.name}}"
                 nzTooltipPlacement="bottom"
-                class="left-div"
+                class="project-label-name"
                 [ngClass]="{'color-tag' : true, 'light-color' : colorBrightnessMap.get(projectID), 'dark-color' : !colorBrightnessMap.get(projectID)}"
                 [ngStyle]="{'color' : colorBrightnessMap.get(projectID) ? 'black' : 'white', 'background-color' : '#' + userProjectsMap.get(projectID)!.color}"
-                (click)="jumpToProject(userProjectsMap.get(projectID)!)"
+                [href]="ROUTER_USER_PROJECT_BASE_URL + '/' + userProjectsMap.get(projectID)!.pid"
               >
                 {{userProjectsMap.get(projectID)!.name | shorten: 15 }}
-              </div>
+              </a>
               <div
                 *ngIf="userProjectsMap.has(projectID) && userProjectsMap.get(projectID)!.color !== null && projectID !== pid"
                 nz-tooltip="Remove from project"
                 nzTooltipPlacement="bottom"
-                class="right-div"
+                class="project-label-remove"
                 [ngClass]="{'color-tag' : true, 'light-color' : colorBrightnessMap.get(projectID), 'dark-color' : !colorBrightnessMap.get(projectID)}"
                 [ngStyle]="{'color' : colorBrightnessMap.get(projectID) ? 'black' : 'white', 'background-color' : '#' + userProjectsMap.get(projectID)!.color}"
                 (click)="removeWorkflowFromProject(projectID, dashboardWorkflowEntry, indexOfElement)"

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.scss
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.scss
@@ -143,6 +143,8 @@ $section-search-bar-height: 60px;
       font-family: -apple-system, BlinkMacSystemFont, sans-serif;
       text-align: center;
       margin-bottom: 0px;
+      color: inherit;
+      text-decoration: none;
     }
 
     .workflow-name:hover {
@@ -211,13 +213,15 @@ $section-search-bar-height: 60px;
       cursor: pointer;
     }
 
-    .left-div {
+    .project-label-name {
       padding: 1.5px 7px;
       border-top-left-radius: 2px;
       border-bottom-left-radius: 2px;
+      color: inherit;
+      text-decoration: none;
     }
 
-    .right-div {
+    .project-label-remove {
       padding: 1.5px 7px;
       border-top-right-radius: 2px;
       border-bottom-right-radius: 2px;

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
@@ -137,8 +137,8 @@ export class SavedWorkflowSectionComponent implements OnInit, OnChanges {
   public downloadListWorkflow = new Map<number, string>();
   public zip = new JSZip();
 
-  public ROUTER_WORKFLOW_BASE_URL = ROUTER_WORKFLOW_BASE_URL
-  public ROUTER_USER_PROJECT_BASE_URL = ROUTER_USER_PROJECT_BASE_URL
+  public ROUTER_WORKFLOW_BASE_URL = ROUTER_WORKFLOW_BASE_URL;
+  public ROUTER_USER_PROJECT_BASE_URL = ROUTER_USER_PROJECT_BASE_URL;
 
   constructor(
     private http: HttpClient,

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.ts
@@ -137,6 +137,9 @@ export class SavedWorkflowSectionComponent implements OnInit, OnChanges {
   public downloadListWorkflow = new Map<number, string>();
   public zip = new JSZip();
 
+  public ROUTER_WORKFLOW_BASE_URL = ROUTER_WORKFLOW_BASE_URL
+  public ROUTER_USER_PROJECT_BASE_URL = ROUTER_USER_PROJECT_BASE_URL
+
   constructor(
     private http: HttpClient,
     private userService: UserService,
@@ -861,20 +864,6 @@ export class SavedWorkflowSectionComponent implements OnInit, OnChanges {
             );
         }
       });
-  }
-
-  /**
-   * jump to the target workflow canvas
-   */
-  public jumpToWorkflow({ workflow: { wid } }: DashboardWorkflowEntry): void {
-    window.open(`${ROUTER_WORKFLOW_BASE_URL}/${wid}`);
-  }
-
-  /**
-   * navigate to individual project page
-   */
-  public jumpToProject({ pid }: UserProject): void {
-    this.router.navigate([`${ROUTER_USER_PROJECT_BASE_URL}/${pid}`]).then(null);
   }
 
   private registerDashboardWorkflowEntriesRefresh(): void {

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.html
@@ -189,17 +189,17 @@
 
           <div *ngIf="userProjectsLoaded" class="project-label-container">
             <div *ngFor="let pid of dashboardUserFileEntry.projectIDs" class="project-label">
-              <div
+              <a
                 *ngIf="userProjectsMap.has(pid) && userProjectsMap.get(pid)!.color != null"
                 nz-tooltip="{{userProjectsMap.get(pid)!.name}}"
                 nzTooltipPlacement="bottom"
                 class="left-div"
                 [ngClass]="{'color-tag' : true, 'light-color' : colorBrightnessMap.get(pid), 'dark-color' : !colorBrightnessMap.get(pid)}"
                 [ngStyle]="{'color' : colorBrightnessMap.get(pid) ? 'black' : 'white', 'background-color' : '#' + userProjectsMap.get(pid)!.color}"
-                (click)="jumpToProject(userProjectsMap.get(pid)!)"
+                [routerLink]="ROUTER_USER_PROJECT_BASE_URL + '/' + userProjectsMap.get(pid)?.pid"
               >
                 {{userProjectsMap.get(pid)!.name}}
-              </div>
+              </a>
               <div
                 *ngIf="userProjectsMap.has(pid) && userProjectsMap.get(pid)!.color != null"
                 nz-tooltip="Remove from project"

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-file-section/user-file-section.component.ts
@@ -14,8 +14,6 @@ import Fuse from "fuse.js";
 import { DeletePromptComponent } from "../../delete-prompt/delete-prompt.component";
 import { from } from "rxjs";
 
-export const ROUTER_USER_PROJECT_BASE_URL = "/dashboard/user-project";
-
 @UntilDestroy()
 @Component({
   selector: "texera-user-file-section",
@@ -60,6 +58,8 @@ export class UserFileSectionComponent {
   public userProjectsList: ReadonlyArray<UserProject> = []; // list of projects accessible by user
   public projectFilterList: number[] = []; // for filter by project mode, track which projects are selected
   public isSearchByProject: boolean = false; // track searching mode user currently selects
+
+  public readonly ROUTER_USER_PROJECT_BASE_URL = "/dashboard/user-project";
 
   public openFileAddComponent() {
     const modalRef = this.modalService.open(NgbdModalFileAddComponent);
@@ -188,13 +188,6 @@ export class UserFileSectionComponent {
     // if (this.isSearchByProject) {
     // } else {
     // }
-  }
-
-  /**
-   * navigate to individual project page
-   */
-  public jumpToProject({ pid }: UserProject): void {
-    this.router.navigate([`${ROUTER_USER_PROJECT_BASE_URL}/${pid}`]).then(null);
   }
 
   public removeFileFromProject(pid: number, fid: number): void {

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-project-list/user-project-list.component.html
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-project-list/user-project-list.component.html
@@ -70,8 +70,8 @@
             <ng-container
               *ngIf="userProjectEntriesIsEditingName.indexOf(dashboardUserProjectEntry.pid) === -1;else editingProject"
             >
-              <span class="project-name" (click)="jumpToProject(dashboardUserProjectEntry)"
-                >{{dashboardUserProjectEntry.name}}</span
+              <a class="project-name" [routerLink]="ROUTER_USER_PROJECT_BASE_URL + '/' + dashboardUserProjectEntry.pid">
+                {{dashboardUserProjectEntry.name}}</a
               >
               <button
                 (click)="userProjectEntriesIsEditingName.push(dashboardUserProjectEntry.pid)"

--- a/core/new-gui/src/app/dashboard/component/feature-container/user-project-list/user-project-list.component.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/user-project-list/user-project-list.component.ts
@@ -7,7 +7,6 @@ import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { NotificationService } from "../../../../common/service/notification/notification.service";
 import { DeletePromptComponent } from "../../delete-prompt/delete-prompt.component";
 import { from } from "rxjs";
-export const ROUTER_USER_PROJECT_BASE_URL = "/dashboard/user-project";
 
 @UntilDestroy()
 @Component({
@@ -27,6 +26,8 @@ export class UserProjectListComponent implements OnInit {
   public userProjectInputColors: string[] = []; // stores the color wheel input for each project, each color string must start with '#'
   public colorBrightnessMap: Map<number, boolean> = new Map(); // tracks brightness of each project's color, to make sure info remains visible against white background
   public colorInputToggleArray: boolean[] = []; // tracks which project's color wheel is toggled on or off
+
+  public readonly ROUTER_USER_PROJECT_BASE_URL = "/dashboard/user-project";
 
   constructor(
     private userProjectService: UserProjectService,
@@ -61,13 +62,6 @@ export class UserProjectListComponent implements OnInit {
           index++;
         }
       });
-  }
-
-  /**
-   * navigate to individual project page
-   */
-  public jumpToProject({ pid }: UserProject): void {
-    this.router.navigate([`${ROUTER_USER_PROJECT_BASE_URL}/${pid}`]).then(null);
   }
 
   public removeEditStatus(pid: number): void {

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -76,9 +76,11 @@
 
     <div class="texera-navigation-dashboard" *ngIf="!displayParticularWorkflowVersion">
       <nz-button-group nzSize="large">
-        <button *ngIf="userSystemEnabled" [routerLink]="'/dashboard'" nz-button title="dashboard">
-          <i nz-icon nzTheme="outline" nzType="profile"></i>
-        </button>
+        <a [routerLink]="'/dashboard'">
+          <button *ngIf="userSystemEnabled"  nz-button title="dashboard">
+            <i nz-icon nzTheme="outline" nzType="profile"></i>
+          </button>
+        </a>
         <button (click)="onClickCreateNewWorkflow()" *ngIf="userSystemEnabled" nz-button title="create new">
           <i nz-icon nzTheme="outline" nzType="form"></i>
         </button>

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -77,7 +77,7 @@
     <div class="texera-navigation-dashboard" *ngIf="!displayParticularWorkflowVersion">
       <nz-button-group nzSize="large">
         <a [routerLink]="'/dashboard'">
-          <button *ngIf="userSystemEnabled"  nz-button title="dashboard">
+          <button *ngIf="userSystemEnabled" nz-button title="dashboard">
             <i nz-icon nzTheme="outline" nzType="profile"></i>
           </button>
         </a>

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -76,7 +76,7 @@
 
     <div class="texera-navigation-dashboard" *ngIf="!displayParticularWorkflowVersion">
       <nz-button-group nzSize="large">
-        <a [routerLink]="'/dashboard'">
+        <a [routerLink]="'/dashboard/workflow'">
           <button *ngIf="userSystemEnabled" nz-button title="dashboard">
             <i nz-icon nzTheme="outline" nzType="profile"></i>
           </button>

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -20,6 +20,7 @@
         <i nz-icon nzTheme="outline" nzType="arrow-left"></i>
       </button>
       <label>
+        <nz-avatar *ngIf="workflowIdChanged | async as wid" [nzText]="wid?.toString() || ''"></nz-avatar>
         <input
           *ngIf="!displayParticularWorkflowVersion"
           (change)="onWorkflowNameChange()"

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.scss
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.scss
@@ -127,7 +127,7 @@
       margin: 0 8px 0 0;
 
       display: inline-block;
-      min-width: 17ch;
+      min-width: 30ch;
       font-size: 18px;
       border: 0 none;
       outline: none; // some user agent stylesheets add an outline that interferes

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -15,7 +15,7 @@ import { WorkflowActionService } from "../../service/workflow-graph/model/workfl
 import { ExecutionState } from "../../types/execute-workflow.interface";
 import { WorkflowWebsocketService } from "../../service/workflow-websocket/workflow-websocket.service";
 import { WorkflowResultExportService } from "../../service/workflow-result-export/workflow-result-export.service";
-import { debounceTime } from "rxjs/operators";
+import { debounceTime, map } from "rxjs/operators";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { WorkflowUtilService } from "../../service/workflow-graph/util/workflow-util.service";
 import { isSink } from "../../service/workflow-graph/model/workflow-graph";
@@ -72,6 +72,8 @@ export class NavigationComponent implements OnInit {
   // flag to display a particular version in the current canvas
   public displayParticularWorkflowVersion: boolean = false;
   public onClickRunHandler: () => void;
+
+  public workflowIdChanged = this.workflowActionService.workflowMetaDataChanged().pipe(map(metadata => metadata.wid));
 
   constructor(
     public executeWorkflowService: ExecuteWorkflowService,

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
@@ -51,7 +51,7 @@ import { SharedModelChangeHandler } from "./shared-model-change-handler";
   providedIn: "root",
 })
 export class WorkflowActionService {
-  private static readonly DEFAULT_WORKFLOW_NAME = "Untitled Workflow";
+  public static readonly DEFAULT_WORKFLOW_NAME = "Untitled Workflow";
   private static readonly DEFAULT_WORKFLOW = {
     name: WorkflowActionService.DEFAULT_WORKFLOW_NAME,
     description: undefined,
@@ -73,7 +73,7 @@ export class WorkflowActionService {
   private enableModificationStream = new BehaviorSubject<boolean>(true);
 
   private workflowMetadata: WorkflowMetadata;
-  private workflowMetadataChangeSubject: Subject<void> = new Subject<void>();
+  private workflowMetadataChangeSubject: Subject<WorkflowMetadata> = new Subject<WorkflowMetadata>();
 
   constructor(
     private operatorMetadataService: OperatorMetadataService,
@@ -622,7 +622,7 @@ export class WorkflowActionService {
     );
   }
 
-  public workflowMetaDataChanged(): Observable<void> {
+  public workflowMetaDataChanged(): Observable<WorkflowMetadata> {
     return this.workflowMetadataChangeSubject.asObservable();
   }
 
@@ -635,8 +635,9 @@ export class WorkflowActionService {
       return;
     }
 
-    this.workflowMetadata = workflowMetaData === undefined ? WorkflowActionService.DEFAULT_WORKFLOW : workflowMetaData;
-    this.workflowMetadataChangeSubject.next();
+    const newMetadata = workflowMetaData === undefined ? WorkflowActionService.DEFAULT_WORKFLOW : workflowMetaData;
+    this.workflowMetadata = newMetadata;
+    this.workflowMetadataChangeSubject.next(newMetadata);
   }
 
   public getWorkflowMetadata(): WorkflowMetadata {
@@ -726,8 +727,8 @@ export class WorkflowActionService {
    * @param name
    */
   public setWorkflowName(name: string): void {
-    this.workflowMetadata.name = name.trim().length > 0 ? name : WorkflowActionService.DEFAULT_WORKFLOW_NAME;
-    this.workflowMetadataChangeSubject.next();
+    const newName = name.trim().length > 0 ? name : WorkflowActionService.DEFAULT_WORKFLOW_NAME;
+    this.setWorkflowMetadata({ ...this.workflowMetadata, name: newName });
   }
 
   /**


### PR DESCRIPTION
This PR changes the behavior of a few links in Texera to behave like a normal link in browser:
regular click: open in current tab
ctrl/cmd+ click: open in a new tab

The links include:
- open a workflow in user dashboard
- open a project in user dashboard
- open user dashboard from workflow page

This PR also does a few minor improvements, including:
 - increase width for displaying workflow title to 30 characters
 - display workflow id in navigation bar
 - rename "user projects" -> "projects", "user files" -> "files"