### PR TITLE
Fix regex operator serialization issue

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/regex/RegexOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/regex/RegexOpExec.scala
@@ -6,7 +6,7 @@ import edu.uci.ics.texera.workflow.common.operators.filter.FilterOpExec
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 
 class RegexOpExec(val opDesc: RegexOpDesc) extends FilterOpExec {
-  val pattern: Pattern =
+  lazy val pattern: Pattern =
     if (opDesc.caseInsensitive) Pattern.compile(opDesc.regex, Pattern.CASE_INSENSITIVE)
     else Pattern.compile(opDesc.regex)
   this.setFilterFunc(this.matchRegex)


### PR DESCRIPTION
The regex operator executor holds a `Pattern` object. Currently the executor instance is created at the controller site, and then shipped to the worker side. However the `Pattern` object cannot be propertly serailized (case insensitive match flag is lost). 

This PR fixes this problem by changing from `val` to `lazy val`, so the `Pattern` instance is created at the worker side (when the worker processes the first input tuple).