### PR TITLE
Fix Several Incompatibility of Shared Editing With Version Preview

### DIFF
--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/shared-model-change-handler.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/shared-model-change-handler.ts
@@ -59,16 +59,15 @@ export class SharedModelChangeHandler {
       event.changes.keys.forEach((change, key) => {
         if (change.action === "add") {
           const newOperator = this.texeraGraph.sharedModel.operatorIDMap.get(key) as YType<OperatorPredicate>;
-          // Also find its position
+          // Also find its position or set to default if not found.
+          let newPos: Point = { x: 0, y: 0 };
           if (this.texeraGraph.sharedModel.elementPositionMap?.has(key)) {
-            const newPos = this.texeraGraph.sharedModel.elementPositionMap?.get(key) as Point;
-            // Add the operator into joint graph
-            const jointOperator = this.jointUIService.getJointOperatorElement(newOperator.toJSON(), newPos);
-            jointElementsToAdd.push(jointOperator);
-            newOpIDs.push(key);
-          } else {
-            throw new Error(`operator with key ${key} does not exist in position map`);
+            newPos = this.texeraGraph.sharedModel.elementPositionMap?.get(key) as Point;
           }
+          // Add the operator into joint graph
+          const jointOperator = this.jointUIService.getJointOperatorElement(newOperator.toJSON(), newPos);
+          jointElementsToAdd.push(jointOperator);
+          newOpIDs.push(key);
         }
         if (change.action === "delete") {
           // Disables JointGraph -> TexeraGraph sync temporarily

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/shared-model-change-handler.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/shared-model-change-handler.ts
@@ -59,15 +59,16 @@ export class SharedModelChangeHandler {
       event.changes.keys.forEach((change, key) => {
         if (change.action === "add") {
           const newOperator = this.texeraGraph.sharedModel.operatorIDMap.get(key) as YType<OperatorPredicate>;
-          // Also find its position or set to default if not found.
-          let newPos: Point = { x: 0, y: 0 };
+          // Also find its position
           if (this.texeraGraph.sharedModel.elementPositionMap?.has(key)) {
-            newPos = this.texeraGraph.sharedModel.elementPositionMap?.get(key) as Point;
+            const newPos = this.texeraGraph.sharedModel.elementPositionMap?.get(key) as Point;
+            // Add the operator into joint graph
+            const jointOperator = this.jointUIService.getJointOperatorElement(newOperator.toJSON(), newPos);
+            jointElementsToAdd.push(jointOperator);
+            newOpIDs.push(key);
+          } else {
+            throw new Error(`operator with key ${key} does not exist in position map`);
           }
-          // Add the operator into joint graph
-          const jointOperator = this.jointUIService.getJointOperatorElement(newOperator.toJSON(), newPos);
-          jointElementsToAdd.push(jointOperator);
-          newOpIDs.push(key);
         }
         if (change.action === "delete") {
           // Disables JointGraph -> TexeraGraph sync temporarily

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/shared-model.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/shared-model.ts
@@ -96,15 +96,7 @@ export class SharedModel {
    * @param callback Put whatever need to be atomically done within this callback function.
    */
   public transact(callback: Function) {
-    try {
-      if (this.wsProvider.shouldConnect) {
-        this.yDoc.transact(() => callback());
-      } else {
-        callback();
-      }
-    } catch (e) {
-      throw e;
-    }
+    this.yDoc.transact(() => callback());
   }
 
   /**

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
@@ -216,6 +216,8 @@ export class WorkflowActionService {
       linksToDelete.forEach((linkLayer, link) => this.deleteLinkWithID(link.linkID));
       this.texeraGraph.assertOperatorExists(operatorID);
       this.texeraGraph.deleteOperator(operatorID);
+      if (this.texeraGraph.sharedModel.elementPositionMap.has(operatorID))
+        this.texeraGraph.sharedModel.elementPositionMap.delete(operatorID);
     });
   }
 
@@ -704,7 +706,7 @@ export class WorkflowActionService {
    */
   public setTempWorkflow(workflow: Workflow): void {
     if (this.texeraGraph.sharedModel.wsProvider.shouldConnect) {
-      this.destroySharedModel();
+      this.texeraGraph.sharedModel.wsProvider.disconnect();
     }
     this.tempWorkflow = workflow;
   }


### PR DESCRIPTION
This PR fixes several problems in shared editing:

1. Fix `transact` not actually executed atomically in version preview.
2. Fix shared editing disconnected after version preview.