### PR TITLE
Bump Apache Arrow to 9.0.0

### DIFF
--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -116,7 +116,7 @@ val googleServiceDependencies = Seq(
 
 /////////////////////////////////////////////////////////////////////////////
 // Arrow related
-val arrowVersion = "8.0.0"
+val arrowVersion = "9.0.0"
 val arrowDependencies = Seq(
   // https://mvnrepository.com/artifact/org.apache.arrow/flight-grpc
   "org.apache.arrow" % "flight-grpc" % arrowVersion,

--- a/core/amber/requirements.txt
+++ b/core/amber/requirements.txt
@@ -9,7 +9,7 @@ loguru==0.5.3
 packaging==20.9
 pluggy==0.13.1
 py==1.10.0
-pyarrow==8.0.0
+pyarrow==9.0.0
 pyparsing==2.4.7
 pytest==6.2.4
 python-dateutil==2.8.1


### PR DESCRIPTION
This PR bumps Apache Arrow version from 8.0.0 to 9.0.0.

Main changes related to PyAmber:

Java/Scala side:
- [ARROW-16427](https://issues.apache.org/jira/browse/ARROW-16427) - [Java] Provide explicit column type mapping
- [ARROW-16529](https://issues.apache.org/jira/browse/ARROW-16529) - [Java] Fix ArrowVectorIterator.hasNext()
- [ARROW-16913](https://issues.apache.org/jira/browse/ARROW-16913) - [Java] Implement ArrowArrayStream (#13465)

Python side:
- [ARROW-16592](https://issues.apache.org/jira/browse/ARROW-16592) - [C++][Python][FlightRPC] Finish after failed writes (#13191)
- [ARROW-16597](https://issues.apache.org/jira/browse/ARROW-16597) - [Python][FlightRPC] Force server shutdown at interpreter exit
- [ARROW-16606](https://issues.apache.org/jira/browse/ARROW-16606) - [FlightRPC][Python] Handle non-lowercase header names (#13274)
- [ARROW-16898](https://issues.apache.org/jira/browse/ARROW-16898) - [Python] Fix pandas conversion failure when using non-str index name (#13402)
- [ARROW-17018](https://issues.apache.org/jira/browse/ARROW-17018) - [C++][Python] Timedelta dtype metadata base unit is globally mutated by the Table.to_pandas() method (#13553)
- [ARROW-17066](https://issues.apache.org/jira/browse/ARROW-17066) - [C++][Python][Substrait] “ignore_unknown_fields” should be specified when converting JSON to binary (#13605)
- [ARROW-14632](https://issues.apache.org/jira/browse/ARROW-14632) - [Python] Make write_dataset arguments keyword-only
- [ARROW-16382](https://issues.apache.org/jira/browse/ARROW-16382) - [Python] Disable memory mapping by default in pyarrow (#13342)
- [ARROW-16779](https://issues.apache.org/jira/browse/ARROW-16779) - [CI][Python] Request for Pyarrow Flight to be shipped in arm64 MacOS version of the wheel (#13460)



For detailed updates, see [Apache Arrow 9.0.0 Release (3 August 2022)](https://arrow.apache.org/release/9.0.0.html)