### PR TITLE
Fix macOS CI timeout on frontend unit tests

### DIFF
--- a/core/new-gui/karma.conf.js
+++ b/core/new-gui/karma.conf.js
@@ -32,5 +32,7 @@ module.exports = function (config) {
     browsers: ["Chrome"],
     singleRun: false,
     captureTimeout: 60000,
+    browserDisconnectTimeout : 10000,
+    browserDisconnectTolerance : 3,
   });
 };

--- a/core/new-gui/karma.conf.js
+++ b/core/new-gui/karma.conf.js
@@ -31,6 +31,6 @@ module.exports = function (config) {
     autoWatch: true,
     browsers: ["Chrome"],
     singleRun: false,
-    browserNoActivityTimeout: 20000,
+    captureTimeout: 60000,
   });
 };

--- a/core/new-gui/karma.conf.js
+++ b/core/new-gui/karma.conf.js
@@ -34,5 +34,6 @@ module.exports = function (config) {
     captureTimeout: 60000,
     browserDisconnectTimeout : 10000,
     browserDisconnectTolerance : 3,
+    browserNoActivityTimeout : 60000,
   });
 };


### PR DESCRIPTION
Sometimes frontend unit tests will fail in macOS CI randomly ([Example error log](https://github.com/Texera/texera/actions/runs/3279266111/jobs/5398601440)).
The specific error is `Disconnected (0 times) , because no message in 20000 ms.`

Some [searches](https://stackoverflow.com/questions/24119506/karma-jasmine-times-out-without-running-tests) indicate that the cause is Karma takes time to load the browser (`captureTimeout`) and load tests (`browserNoActivityTimeout`) and that could make the headless browser in CI with no action, causing timeout. The suggested solution is to either increase RAM to speed up the test loading or enlarge the timeout tolerance. As Github Action runners runs on a fixed VM that is not tunable, we need to enlarge the timeout tolerance.

This PR enlarges both the `captureTimeout` and `browserNoActivityTimeout` to be 60s, `browserDisconnectTimeout` to be 10s, and give 3 attempts tolerance for timeout. 