### PR TITLE
Fix NaN in Tuple and Table by treating them as None

### DIFF
--- a/core/amber/src/main/python/core/proxy/proxy_client.py
+++ b/core/amber/src/main/python/core/proxy/proxy_client.py
@@ -57,7 +57,6 @@ class ProxyClient(FlightClient):
         """
         descriptor = FlightDescriptor.for_command(command)
         table = Table.from_arrays([]) if table is None else table
-        print("sending table")
         writer, _ = self.do_put(descriptor, table.schema)
         writer: FlightStreamWriter
         with writer:

--- a/core/amber/src/main/python/core/proxy/proxy_client.py
+++ b/core/amber/src/main/python/core/proxy/proxy_client.py
@@ -57,6 +57,7 @@ class ProxyClient(FlightClient):
         """
         descriptor = FlightDescriptor.for_command(command)
         table = Table.from_arrays([]) if table is None else table
+        print("sending table")
         writer, _ = self.do_put(descriptor, table.schema)
         writer: FlightStreamWriter
         with writer:

--- a/core/amber/src/main/python/core/runnables/data_processor.py
+++ b/core/amber/src/main/python/core/runnables/data_processor.py
@@ -191,7 +191,7 @@ class DataProcessor(StoppableQueueBlockingRunnable):
         input_ = self._input_link_map[link]
 
         return map(
-            lambda t: Tuple(t) if t is not None else None,
+            lambda t: None if t is None else Tuple(t),
             self._operator.process_tuple(tuple_, input_)
             if isinstance(tuple_, Tuple)
             else self._operator.on_finish(input_),
@@ -354,6 +354,6 @@ class DataProcessor(StoppableQueueBlockingRunnable):
         for field_name in output_tuple.get_field_names():
             field_value = output_tuple[field_name]
             field = schema.field(field_name)
-            field_type = field.type if field is not None else None
+            field_type = None if field is None else field.type
             if field_type == pyarrow.binary():
                 output_tuple[field_name] = b"pickle    " + pickle.dumps(field_value)

--- a/core/amber/src/main/python/core/runnables/data_processor.py
+++ b/core/amber/src/main/python/core/runnables/data_processor.py
@@ -352,6 +352,9 @@ class DataProcessor(StoppableQueueBlockingRunnable):
         import pickle
 
         for field_name in output_tuple.get_field_names():
+            # convert NaN to None to support null value conversion
+            if pyarrow.compute.is_nan(output_tuple[field_name]):
+                output_tuple[field_name] = None
             field_value = output_tuple[field_name]
             field = schema.field(field_name)
             field_type = None if field is None else field.type

--- a/core/amber/src/main/python/core/runnables/data_processor.py
+++ b/core/amber/src/main/python/core/runnables/data_processor.py
@@ -6,6 +6,7 @@ import pyarrow
 from loguru import logger
 from overrides import overrides
 from pampy import match
+from pandas._libs.missing import checknull
 
 from core.architecture.managers.context import Context
 from core.architecture.managers.pause_manager import PauseType
@@ -353,7 +354,7 @@ class DataProcessor(StoppableQueueBlockingRunnable):
 
         for field_name in output_tuple.get_field_names():
             # convert NaN to None to support null value conversion
-            if pyarrow.compute.is_nan(output_tuple[field_name]):
+            if checknull(output_tuple[field_name]):
                 output_tuple[field_name] = None
             field_value = output_tuple[field_name]
             field = schema.field(field_name)

--- a/core/amber/src/main/python/core/runnables/network_receiver.py
+++ b/core/amber/src/main/python/core/runnables/network_receiver.py
@@ -41,7 +41,6 @@ class NetworkReceiver(Runnable, Stoppable):
         # register the control handler to deserialize control messages.
         @logger.catch(reraise=True)
         def control_handler(message: bytes):
-            print("received", message)
             python_control_message = PythonControlMessage().parse(message)
             shared_queue.put(
                 ControlElement(


### PR DESCRIPTION
In pandas, numpy, the null(missing) values in numerical types are treated as `NaN`. There are some usages regarding `NaN` in the context of pandas and numpy, thus it is a good idea to keep them within Tuple and Table within the PVM. However, it is troublesome to transfer `NaN` through Arrow: 
1. if `NaN` present, the dtype of the column becomes float. Arrow is not able to force cast a float `NaN` to an integral type.
2. `NaN` is not comparable, which means `NaN == NaN` will return false, while `None == None` would return true, which can cause issues in value check and conversions.

This PR leaves `NaN` within the Python context, but before transferring through Arrow back to java side, it converts all `NaN` values to `None`. On Java side, those values will be `null` and preserve the integral types if applicable. 

The issue was seen via https://github.com/Texera/texera/pull/1690.
