### PR TITLE
Fix CSV parser to parse null as empty strings

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpDesc.scala
@@ -69,6 +69,7 @@ class CSVScanSourceOpDesc extends ScanSourceOpDesc {
     csvSetting.setMaxCharsPerColumn(-1)
     csvSetting.setFormat(csvFormat)
     csvSetting.setHeaderExtractionEnabled(hasHeader)
+    csvSetting.setNullValue("")
     val parser = new CsvParser(csvSetting)
     parser.beginParsing(inputReader)
 


### PR DESCRIPTION
The new Univocity parser [by default parses empty values as null](https://stackoverflow.com/questions/51290565/univocity-parser-issue-with-empty-string-field). When a header contains a null value, Texera's `Attribute` is complaining about using null value as the field name. 

This PR sets the empty value to be parsed as empty string. For other types, Texera's `AttributeTypeUtils` will take care of converting empty string to null values.