### PR TITLE
Fix GUI not loaded caused by JWT error

### DIFF
--- a/core/new-gui/package.json
+++ b/core/new-gui/package.json
@@ -32,7 +32,7 @@
     "@angular/platform-browser": "^13.0.1",
     "@angular/platform-browser-dynamic": "^13.0.1",
     "@angular/router": "^13.0.1",
-    "@auth0/angular-jwt": "~5.0.2",
+    "@auth0/angular-jwt": "^5.1.0",
     "@danmarshall/deckgl-typings": "~4.9.15",
     "@ng-bootstrap/ng-bootstrap": "~9.1.3",
     "@ngneat/until-destroy": "~8.1.4",

--- a/core/new-gui/yarn.lock
+++ b/core/new-gui/yarn.lock
@@ -385,10 +385,10 @@
   resolved "https://registry.yarnpkg.com/@assemblyscript/loader/-/loader-0.10.1.tgz#70e45678f06c72fa2e350e8553ec4a4d72b92e06"
   integrity sha512-H71nDOOL8Y7kWRLqf6Sums+01Q5msqBW2KhDUTemh1tvY04eSkSXrK0uj/4mmY0Xr16/3zyZmsrxN7CKuRbNRg==
 
-"@auth0/angular-jwt@~5.0.2":
-  version "5.0.2"
-  resolved "https://registry.yarnpkg.com/@auth0/angular-jwt/-/angular-jwt-5.0.2.tgz#0a23f240e8c6ed37c5c7a354ad79a755a217936e"
-  integrity sha512-rSamC9mu+gUxoR86AXcIo+KD7xRIro+/iu1F2Ld85YAZEVKlpB5vYG+g0yGaEOqjtQWP/i0H6fi6XMGPVHSYYQ==
+"@auth0/angular-jwt@^5.1.0":
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/@auth0/angular-jwt/-/angular-jwt-5.1.0.tgz#766abad6e6ee2e30b7c24362303c16b13e198a84"
+  integrity sha512-EAQoNKPQSZYphcX6FnY2e7xQpD4ZdHQ1DbHq/m+G1U1qA60m3XnhdjPPfu+blVHARlxEbRzWXc48UOVrnMsrZw==
   dependencies:
     tslib "^2.0.0"
 


### PR DESCRIPTION
This PR fixes the following error by bumping up the `@auth0/angular-jwt` to v5.1.0.
<img width="587" alt="Screenshot 2022-10-20 at 20 40 21" src="https://user-images.githubusercontent.com/17627829/197112643-69da914f-36c7-4066-81bb-b639831f642b.png">
