### PR TITLE
Use ArrayBuffer instead of HashSet for buffering tuples in sink to preserve the order

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/storage/MongoDBStorage.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/storage/MongoDBStorage.scala
@@ -15,6 +15,10 @@ import collection.JavaConverters._
 
 class MongoDBStorage(id: String, schema: Schema) extends SinkStorageReader {
 
+  schema.getAttributeNames.stream.forEach(name =>
+    assert(!name.matches(".*[\\$\\.].*"), s"illegal attribute name '$name' for mongo DB")
+  )
+
   val url: String = AmberUtils.amberConfig.getString("storage.mongodb.url")
   val databaseName: String = AmberUtils.amberConfig.getString("storage.mongodb.database")
   val client: MongoClient = MongoClients.create(url)


### PR DESCRIPTION
This PR replaced the usage of HashSet with ArrayBuffer so we can maintain the order of tuples from upstream when doing insertions to MongoDB.