### PR TITLE
Optimize Python process proxy connection

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonProxyClient.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonProxyClient.scala
@@ -32,7 +32,7 @@ class PythonProxyClient(portNumber: Int, val actorId: ActorVirtualIdentity)
   val allocator: BufferAllocator =
     new RootAllocator().newChildAllocator("flight-client", 0, Long.MaxValue)
   val location: Location = Location.forGrpcInsecure("localhost", portNumber)
-  private val MAX_TRY_COUNT: Int = 6
+  private val MAX_TRY_COUNT: Int = 5
   private val UNIT_WAIT_TIME_MS = 200
   private var flightClient: FlightClient = _
   private var running: Boolean = true
@@ -61,7 +61,7 @@ class PythonProxyClient(portNumber: Int, val actorId: ActorVirtualIdentity)
           flightClient.close()
           Thread.sleep(retryWaitTimeInMs)
           tryCount += 1
-          if (tryCount >= MAX_TRY_COUNT)
+          if (tryCount > MAX_TRY_COUNT)
             throw new WorkflowRuntimeException(
               s"Exceeded try limit of $MAX_TRY_COUNT when connecting to Flight Server!"
             )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonProxyClient.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonProxyClient.scala
@@ -53,7 +53,7 @@ class PythonProxyClient(portNumber: Int, val actorId: ActorVirtualIdentity)
           throw new RuntimeException("heartbeat failed")
       } catch {
         case e: RuntimeException =>
-          logger.warn("Not connected to the server in this try, retrying", e)
+          logger.warn("Not connected to the server in this try, retrying... remaining attempts: " +(MAX_TRY_COUNT - tryCount))
           flightClient.close()
           Thread.sleep(WAIT_TIME_MS)
           tryCount += 1

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonProxyClient.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonProxyClient.scala
@@ -24,7 +24,7 @@ import scala.collection.mutable
 import scala.math.pow
 
 class PythonProxyClient(portNumber: Int, val actorId: ActorVirtualIdentity)
-  extends Runnable
+    extends Runnable
     with AmberLogging
     with AutoCloseable
     with WorkerBatchInternalQueue {
@@ -95,9 +95,9 @@ class PythonProxyClient(portNumber: Int, val actorId: ActorVirtualIdentity)
   }
 
   def sendControlV2(
-                     from: ActorVirtualIdentity,
-                     payload: ControlPayloadV2
-                   ): Result = {
+      from: ActorVirtualIdentity,
+      payload: ControlPayloadV2
+  ): Result = {
     val controlMessage = PythonControlMessage(from, payload)
     val action: Action = new Action("control", controlMessage.toByteArray)
     logger.debug(s"sending control $controlMessage")
@@ -116,10 +116,10 @@ class PythonProxyClient(portNumber: Int, val actorId: ActorVirtualIdentity)
   }
 
   private def writeArrowStream(
-                                tuples: mutable.Queue[Tuple],
-                                from: ActorVirtualIdentity,
-                                isEnd: Boolean
-                              ): Unit = {
+      tuples: mutable.Queue[Tuple],
+      from: ActorVirtualIdentity,
+      isEnd: Boolean
+  ): Unit = {
 
     val schema = if (tuples.isEmpty) new Schema() else tuples.front.getSchema
     val descriptor = FlightDescriptor.command(PythonDataHeader(from, isEnd).toByteArray)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonProxyClient.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonProxyClient.scala
@@ -52,7 +52,7 @@ class PythonProxyClient(portNumber: Int, val actorId: ActorVirtualIdentity)
         if (!connected)
           throw new RuntimeException("heartbeat failed")
       } catch {
-        case e: RuntimeException =>
+        case _: RuntimeException =>
           logger.warn("Not connected to the server in this try, retrying... remaining attempts: " +(MAX_TRY_COUNT - tryCount))
           flightClient.close()
           Thread.sleep(WAIT_TIME_MS)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonProxyClient.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonProxyClient.scala
@@ -1,9 +1,16 @@
 package edu.uci.ics.amber.engine.architecture.pythonworker
 
-import edu.uci.ics.amber.engine.architecture.pythonworker.WorkerBatchInternalQueue.{ControlElement, ControlElementV2, DataElement}
+import edu.uci.ics.amber.engine.architecture.pythonworker.WorkerBatchInternalQueue.{
+  ControlElement,
+  ControlElementV2,
+  DataElement
+}
 import edu.uci.ics.amber.engine.common.AmberLogging
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
-import edu.uci.ics.amber.engine.common.ambermessage.InvocationConvertUtils.{controlInvocationToV2, returnInvocationToV2}
+import edu.uci.ics.amber.engine.common.ambermessage.InvocationConvertUtils.{
+  controlInvocationToV2,
+  returnInvocationToV2
+}
 import edu.uci.ics.amber.engine.common.ambermessage.{PythonControlMessage, _}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.{ControlInvocation, ReturnInvocation}
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
@@ -17,7 +24,7 @@ import scala.collection.mutable
 import scala.math.pow
 
 class PythonProxyClient(portNumber: Int, val actorId: ActorVirtualIdentity)
-  extends Runnable
+    extends Runnable
     with AmberLogging
     with AutoCloseable
     with WorkerBatchInternalQueue {
@@ -48,7 +55,9 @@ class PythonProxyClient(portNumber: Int, val actorId: ActorVirtualIdentity)
       } catch {
         case _: RuntimeException =>
           val retryWaitTimeInMs = UNIT_WAIT_TIME_MS * pow(2, tryCount).toInt
-          logger.warn(s"Not connected to the server in this try, retrying after $retryWaitTimeInMs ms... remaining attempts: ${MAX_TRY_COUNT - tryCount}")
+          logger.warn(
+            s"Not connected to the server in this try, retrying after $retryWaitTimeInMs ms... remaining attempts: ${MAX_TRY_COUNT - tryCount}"
+          )
           flightClient.close()
           Thread.sleep(retryWaitTimeInMs)
           tryCount += 1
@@ -85,9 +94,9 @@ class PythonProxyClient(portNumber: Int, val actorId: ActorVirtualIdentity)
   }
 
   def sendControlV2(
-                     from: ActorVirtualIdentity,
-                     payload: ControlPayloadV2
-                   ): Result = {
+      from: ActorVirtualIdentity,
+      payload: ControlPayloadV2
+  ): Result = {
     val controlMessage = PythonControlMessage(from, payload)
     val action: Action = new Action("control", controlMessage.toByteArray)
     logger.debug(s"sending control $controlMessage")
@@ -106,10 +115,10 @@ class PythonProxyClient(portNumber: Int, val actorId: ActorVirtualIdentity)
   }
 
   private def writeArrowStream(
-                                tuples: mutable.Queue[Tuple],
-                                from: ActorVirtualIdentity,
-                                isEnd: Boolean
-                              ): Unit = {
+      tuples: mutable.Queue[Tuple],
+      from: ActorVirtualIdentity,
+      isEnd: Boolean
+  ): Unit = {
 
     val schema = if (tuples.isEmpty) new Schema() else tuples.front.getSchema
     val descriptor = FlightDescriptor.command(PythonDataHeader(from, isEnd).toByteArray)


### PR DESCRIPTION
This PR makes the attempt to connect logic more stable in Python proxy layer. Whenever user starts a workflow execution, if there is a Python UDF operator, for each worker, a python processes will be started and the Scala side's PythonProxyClient will start to attempt to connect to the proxy server inside the python process. However, depending on machine the server start time may vary. Thus we do multiple attempts for such a connection.

This attempt logic is problematic and now been optimized as followed:
1. after each attempt failure, it used to log a WARN with the exception. This confuses the log reader as connection has some ERROR instead. Now we only log WARN with the appropriate message to let user know we are retrying in a bit.
2. After each attempt failure, now we wait for longer before the next attempt. This is to help some particular slow machine.
3. Total `6` attempts (1 + 5 retries) will be made. The first wait time is changed to `200ms`. The last wait time is `6400ms`. 