### PR TITLE
Temporary fix for ubuntu CI missing libncurses.so

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -70,7 +70,7 @@ jobs:
           all_but_latest: true
           access_token: ${{ github.token }}
       - name: Prepare ENV
-        uses: apt-get install libncurses5
+        run: apt-get install libncurses5
       - name: Checkout Texera
         uses: actions/checkout@v2
       - name: Setup Java

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -70,7 +70,7 @@ jobs:
           all_but_latest: true
           access_token: ${{ github.token }}
       - name: Prepare ENV
-        run: apt-get install libncurses5
+        run: sudo apt-get install libncurses5
       - name: Checkout Texera
         uses: actions/checkout@v2
       - name: Setup Java

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -69,6 +69,8 @@ jobs:
           ignore_sha: true
           all_but_latest: true
           access_token: ${{ github.token }}
+      - name: Prepare ENV
+        uses: apt-get install libncurses5
       - name: Checkout Texera
         uses: actions/checkout@v2
       - name: Setup Java


### PR DESCRIPTION
Now ubuntu CIs (e.g., [master-run](https://github.com/Texera/texera/actions/runs/3651954397/jobs/6169772992)) are failing due to the following error:
```
libncurses.so.5: cannot open shared object file: No such file or directory
```

The actual cause is unknown, but likely due to ubuntu-latest snapshot we used in Github Action has been updated. I was tracking [Ubuntu 22.04 (20221204 update)](https://github.com/actions/runner-images/releases/tag/ubuntu22%2F20221204.2) but did not find related changes.

For a temporary solution, I have edited our CI to install the missing library `libncurses`. 