### PR TITLE
Implement Modifying Existing Columns in Lambda Expression Operator

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/ModifyAttributeUnit.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/ModifyAttributeUnit.java
@@ -1,0 +1,39 @@
+package edu.uci.ics.texera.workflow.operators.udf.pythonV2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName;
+import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeType;
+
+import java.util.Objects;
+
+public class ModifyAttributeUnit {
+    @JsonProperty(required = true)
+    @JsonSchemaTitle("Attribute Name")
+    @AutofillAttributeName
+    public String attributeName;
+
+    @JsonProperty
+    @JsonSchemaTitle("Expression")
+    @JsonPropertyDescription("Type the lambda expression. To specify an existing column, wrap the column name in backticks(`), e.g. `Unit Price`")
+    public String expression;
+
+    ModifyAttributeUnit(String attributeName, String expression) {
+        this.attributeName = attributeName;
+        this.expression = expression;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ModifyAttributeUnit that = (ModifyAttributeUnit) o;
+        return Objects.equals(attributeName, that.attributeName) && Objects.equals(expression, that.expression);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(attributeName, expression);
+    }
+}


### PR DESCRIPTION
This PR implements modifying existing columns in the lambda expression operator by innerly calling `Python UDF Operator`.

In the demo below, the lambda expression operator adds an attribute called `Original Unit Price`, which will be assigned with the the original unit prices. It also modifies the `Unit Price` column to increment by `100`.

![Kapture 2023-01-04 at 12 57 33](https://user-images.githubusercontent.com/59754711/210648686-9b33bf93-2380-4dbe-8b62-c3f67d75a455.gif)

Issue: #1776 