### PR TITLE
Fix frontend ExpressionChangedAfterItHasBeenCheckedError

### DIFF
--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -116,7 +116,7 @@
         <button
           (click)="persistWorkflow()"
           *ngIf="userSystemEnabled"
-          [disabled]="!userService.isLogin() || isSaving || !workflowActionService.checkWorkflowModificationEnabled()"
+          [disabled]="!userService.isLogin() || isSaving || !isWorkflowModifiable"
           nz-button
           title="save">
           <i
@@ -133,7 +133,7 @@
         </button>
         <button
           (click)="onClickDeleteAllOperators()"
-          [disabled]="!workflowActionService.checkWorkflowModificationEnabled()"
+          [disabled]="!isWorkflowModifiable"
           nz-button
           title="delete all">
           <i
@@ -142,11 +142,11 @@
             nzType="delete"></i>
         </button>
         <nz-upload
-          [nzDisabled]="!workflowActionService.checkWorkflowModificationEnabled()"
+          [nzDisabled]="!isWorkflowModifiable"
           [nzBeforeUpload]="onClickImportWorkflow">
           <button
             nz-button
-            [disabled]="!workflowActionService.checkWorkflowModificationEnabled()"
+            [disabled]="!isWorkflowModifiable"
             title="import workflow">
             <i
               nz-icon

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -4,7 +4,7 @@
       [ngClass]="{ 'user-system-enabled': userSystemEnabled }"
       alt="Texera"
       class="texera-navigation-title"
-      src="assets/logos/full_logo_small.png?v=1"/>
+      src="assets/logos/full_logo_small.png?v=1" />
 
     <!-- workflow metadata display -->
     <div
@@ -31,7 +31,7 @@
           (change)="onWorkflowNameChange()"
           [(ngModel)]="currentWorkflowName"
           class="workflow-name"
-          placeholder="Untitled Workflow"/>
+          placeholder="Untitled Workflow" />
         <span
           *ngIf="displayParticularWorkflowVersion"
           class="particular-version-metadata"
@@ -318,7 +318,7 @@
       <label class="execution-name">
         <input
           [(ngModel)]="currentExecutionName"
-          placeholder="Untitled Execution"/>
+          placeholder="Untitled Execution" />
       </label>
       <nz-button-group nzSize="large">
         <button

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -4,7 +4,7 @@
       [ngClass]="{ 'user-system-enabled': userSystemEnabled }"
       alt="Texera"
       class="texera-navigation-title"
-      src="assets/logos/full_logo_small.png?v=1" />
+      src="assets/logos/full_logo_small.png?v=1"/>
 
     <!-- workflow metadata display -->
     <div
@@ -24,14 +24,14 @@
       </button>
       <label>
         <nz-avatar
-          *ngIf="workflowIdChanged | async as wid"
-          [nzText]="wid?.toString() || ''"></nz-avatar>
+          *ngIf="workflowId"
+          [nzText]="workflowId?.toString() || ''"></nz-avatar>
         <input
           *ngIf="!displayParticularWorkflowVersion"
           (change)="onWorkflowNameChange()"
           [(ngModel)]="currentWorkflowName"
           class="workflow-name"
-          placeholder="Untitled Workflow" />
+          placeholder="Untitled Workflow"/>
         <span
           *ngIf="displayParticularWorkflowVersion"
           class="particular-version-metadata"
@@ -63,7 +63,7 @@
       *ngIf="userSystemEnabled"
       class="texera-navigation-coeditor-icons">
       <ng-container *ngFor="let user of coeditorPresenceService.coeditors">
-        <texera-coeditor-user-icon [coeditor]="user"> </texera-coeditor-user-icon>
+        <texera-coeditor-user-icon [coeditor]="user"></texera-coeditor-user-icon>
       </ng-container>
     </div>
 
@@ -207,7 +207,7 @@
         <button
           nz-button
           (click)="onClickAutoLayout()"
-          [disabled]="!workflowActionService.checkWorkflowModificationEnabled()"
+          [disabled]="!isWorkflowModifiable"
           title="auto layout">
           <i
             nz-icon
@@ -216,7 +216,7 @@
         </button>
         <button
           (click)="onClickAddCommentBox()"
-          [disabled]="!workflowActionService.checkWorkflowModificationEnabled()"
+          [disabled]="!isWorkflowModifiable"
           nz-button
           title="add a comment">
           <i
@@ -318,7 +318,7 @@
       <label class="execution-name">
         <input
           [(ngModel)]="currentExecutionName"
-          placeholder="Untitled Execution" />
+          placeholder="Untitled Execution"/>
       </label>
       <nz-button-group nzSize="large">
         <button

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -1,32 +1,32 @@
-import {DatePipe, Location} from "@angular/common";
-import {ChangeDetectorRef, Component, ElementRef, Input, OnInit, ViewChild} from "@angular/core";
-import {environment} from "../../../../environments/environment";
-import {UserService} from "../../../common/service/user/user.service";
+import { DatePipe, Location } from "@angular/common";
+import { ChangeDetectorRef, Component, ElementRef, Input, OnInit, ViewChild } from "@angular/core";
+import { environment } from "../../../../environments/environment";
+import { UserService } from "../../../common/service/user/user.service";
 import {
   DEFAULT_WORKFLOW_NAME,
   WorkflowPersistService,
 } from "../../../common/service/workflow-persist/workflow-persist.service";
-import {Workflow, WorkflowContent} from "../../../common/type/workflow";
-import {ExecuteWorkflowService} from "../../service/execute-workflow/execute-workflow.service";
-import {UndoRedoService} from "../../service/undo-redo/undo-redo.service";
-import {ValidationWorkflowService} from "../../service/validation/validation-workflow.service";
-import {JointGraphWrapper} from "../../service/workflow-graph/model/joint-graph-wrapper";
-import {WorkflowActionService} from "../../service/workflow-graph/model/workflow-action.service";
-import {ExecutionState} from "../../types/execute-workflow.interface";
-import {WorkflowWebsocketService} from "../../service/workflow-websocket/workflow-websocket.service";
-import {WorkflowResultExportService} from "../../service/workflow-result-export/workflow-result-export.service";
-import {debounceTime, map, takeUntil} from "rxjs/operators";
-import {UntilDestroy, untilDestroyed} from "@ngneat/until-destroy";
-import {WorkflowUtilService} from "../../service/workflow-graph/util/workflow-util.service";
-import {isSink} from "../../service/workflow-graph/model/workflow-graph";
-import {WorkflowVersionService} from "../../../dashboard/service/workflow-version/workflow-version.service";
-import {concatMap, catchError} from "rxjs/operators";
-import {UserProjectService} from "src/app/dashboard/service/user-project/user-project.service";
-import {NzUploadFile} from "ng-zorro-antd/upload";
-import {saveAs} from "file-saver";
-import {NotificationService} from "src/app/common/service/notification/notification.service";
-import {OperatorMenuService} from "../../service/operator-menu/operator-menu.service";
-import {CoeditorPresenceService} from "../../service/workflow-graph/model/coeditor-presence.service";
+import { Workflow, WorkflowContent } from "../../../common/type/workflow";
+import { ExecuteWorkflowService } from "../../service/execute-workflow/execute-workflow.service";
+import { UndoRedoService } from "../../service/undo-redo/undo-redo.service";
+import { ValidationWorkflowService } from "../../service/validation/validation-workflow.service";
+import { JointGraphWrapper } from "../../service/workflow-graph/model/joint-graph-wrapper";
+import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
+import { ExecutionState } from "../../types/execute-workflow.interface";
+import { WorkflowWebsocketService } from "../../service/workflow-websocket/workflow-websocket.service";
+import { WorkflowResultExportService } from "../../service/workflow-result-export/workflow-result-export.service";
+import { debounceTime, map, takeUntil } from "rxjs/operators";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { WorkflowUtilService } from "../../service/workflow-graph/util/workflow-util.service";
+import { isSink } from "../../service/workflow-graph/model/workflow-graph";
+import { WorkflowVersionService } from "../../../dashboard/service/workflow-version/workflow-version.service";
+import { concatMap, catchError } from "rxjs/operators";
+import { UserProjectService } from "src/app/dashboard/service/user-project/user-project.service";
+import { NzUploadFile } from "ng-zorro-antd/upload";
+import { saveAs } from "file-saver";
+import { NotificationService } from "src/app/common/service/notification/notification.service";
+import { OperatorMenuService } from "../../service/operator-menu/operator-menu.service";
+import { CoeditorPresenceService } from "../../service/workflow-graph/model/coeditor-presence.service";
 
 /**
  * NavigationComponent is the top level navigation bar that shows
@@ -75,7 +75,6 @@ export class NavigationComponent implements OnInit {
   public displayParticularWorkflowVersion: boolean = false;
   public onClickRunHandler: () => void;
 
-
   constructor(
     public executeWorkflowService: ExecuteWorkflowService,
     public workflowActionService: WorkflowActionService,
@@ -104,9 +103,14 @@ export class NavigationComponent implements OnInit {
     this.runDisable = initBehavior.disable;
     this.onClickRunHandler = initBehavior.onClick;
     // this.currentWorkflowName = this.workflowCacheService.getCachedWorkflow();
-    this.workflowActionService.getWorkflowModificationEnabledStream().pipe(untilDestroyed(this)).subscribe(a => this.isWorkflowModifiable = a);
-    this.workflowActionService.workflowMetaDataChanged().pipe(untilDestroyed(this)).subscribe(metadata => this.workflowId = metadata.wid);
-
+    this.workflowActionService
+      .getWorkflowModificationEnabledStream()
+      .pipe(untilDestroyed(this))
+      .subscribe(a => (this.isWorkflowModifiable = a));
+    this.workflowActionService
+      .workflowMetaDataChanged()
+      .pipe(untilDestroyed(this))
+      .subscribe(metadata => (this.workflowId = metadata.wid));
   }
 
   public ngOnInit(): void {
@@ -153,8 +157,7 @@ export class NavigationComponent implements OnInit {
         text: "Error",
         icon: "exclamation-circle",
         disable: true,
-        onClick: () => {
-        },
+        onClick: () => {},
       };
     }
     switch (executionState) {
@@ -172,8 +175,7 @@ export class NavigationComponent implements OnInit {
           text: "Submitting",
           icon: "loading",
           disable: true,
-          onClick: () => {
-          },
+          onClick: () => {},
         };
       case ExecutionState.Running:
         return {
@@ -195,24 +197,21 @@ export class NavigationComponent implements OnInit {
           text: "Pausing",
           icon: "loading",
           disable: true,
-          onClick: () => {
-          },
+          onClick: () => {},
         };
       case ExecutionState.Resuming:
         return {
           text: "Resuming",
           icon: "loading",
           disable: true,
-          onClick: () => {
-          },
+          onClick: () => {},
         };
       case ExecutionState.Recovering:
         return {
           text: "Recovering",
           icon: "loading",
           disable: true,
-          onClick: () => {
-          },
+          onClick: () => {},
         };
     }
   }
@@ -381,7 +380,7 @@ export class NavigationComponent implements OnInit {
     const workflowContent: WorkflowContent = this.workflowActionService.getWorkflowContent();
     const workflowContentJson = JSON.stringify(workflowContent);
     const fileName = this.currentWorkflowName + ".json";
-    saveAs(new Blob([workflowContentJson], {type: "text/plain;charset=utf-8"}), fileName);
+    saveAs(new Blob([workflowContentJson], { type: "text/plain;charset=utf-8" }), fileName);
   }
 
   /**
@@ -423,8 +422,7 @@ export class NavigationComponent implements OnInit {
           untilDestroyed(this)
         )
         .subscribe(
-          () => {
-          },
+          () => {},
           (error: unknown) => {
             alert(error);
             this.isSaving = false;
@@ -459,12 +457,12 @@ export class NavigationComponent implements OnInit {
           this.workflowActionService.getWorkflowMetadata().lastModifiedTime === undefined
             ? ""
             : "Saved at " +
-            this.datePipe.transform(
-              this.workflowActionService.getWorkflowMetadata().lastModifiedTime,
-              "MM/dd/yyyy HH:mm:ss zzz",
-              Intl.DateTimeFormat().resolvedOptions().timeZone,
-              "en"
-            );
+              this.datePipe.transform(
+                this.workflowActionService.getWorkflowMetadata().lastModifiedTime,
+                "MM/dd/yyyy HH:mm:ss zzz",
+                Intl.DateTimeFormat().resolvedOptions().timeZone,
+                "en"
+              );
       });
   }
 
@@ -481,12 +479,12 @@ export class NavigationComponent implements OnInit {
           this.workflowActionService.getWorkflowMetadata().creationTime === undefined
             ? ""
             : "" +
-            this.datePipe.transform(
-              this.workflowActionService.getWorkflowMetadata().creationTime,
-              "MM/dd/yyyy HH:mm:ss zzz",
-              Intl.DateTimeFormat().resolvedOptions().timeZone,
-              "en"
-            );
+              this.datePipe.transform(
+                this.workflowActionService.getWorkflowMetadata().creationTime,
+                "MM/dd/yyyy HH:mm:ss zzz",
+                Intl.DateTimeFormat().resolvedOptions().timeZone,
+                "en"
+              );
         this.displayParticularWorkflowVersion = displayVersionFlag;
       });
   }

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -1,32 +1,32 @@
-import { DatePipe, Location } from "@angular/common";
-import { ChangeDetectorRef, Component, ElementRef, Input, OnInit, ViewChild } from "@angular/core";
-import { environment } from "../../../../environments/environment";
-import { UserService } from "../../../common/service/user/user.service";
+import {DatePipe, Location} from "@angular/common";
+import {ChangeDetectorRef, Component, ElementRef, Input, OnInit, ViewChild} from "@angular/core";
+import {environment} from "../../../../environments/environment";
+import {UserService} from "../../../common/service/user/user.service";
 import {
   DEFAULT_WORKFLOW_NAME,
   WorkflowPersistService,
 } from "../../../common/service/workflow-persist/workflow-persist.service";
-import { Workflow, WorkflowContent } from "../../../common/type/workflow";
-import { ExecuteWorkflowService } from "../../service/execute-workflow/execute-workflow.service";
-import { UndoRedoService } from "../../service/undo-redo/undo-redo.service";
-import { ValidationWorkflowService } from "../../service/validation/validation-workflow.service";
-import { JointGraphWrapper } from "../../service/workflow-graph/model/joint-graph-wrapper";
-import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
-import { ExecutionState } from "../../types/execute-workflow.interface";
-import { WorkflowWebsocketService } from "../../service/workflow-websocket/workflow-websocket.service";
-import { WorkflowResultExportService } from "../../service/workflow-result-export/workflow-result-export.service";
-import { debounceTime, map } from "rxjs/operators";
-import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
-import { WorkflowUtilService } from "../../service/workflow-graph/util/workflow-util.service";
-import { isSink } from "../../service/workflow-graph/model/workflow-graph";
-import { WorkflowVersionService } from "../../../dashboard/service/workflow-version/workflow-version.service";
-import { concatMap, catchError } from "rxjs/operators";
-import { UserProjectService } from "src/app/dashboard/service/user-project/user-project.service";
-import { NzUploadFile } from "ng-zorro-antd/upload";
-import { saveAs } from "file-saver";
-import { NotificationService } from "src/app/common/service/notification/notification.service";
-import { OperatorMenuService } from "../../service/operator-menu/operator-menu.service";
-import { CoeditorPresenceService } from "../../service/workflow-graph/model/coeditor-presence.service";
+import {Workflow, WorkflowContent} from "../../../common/type/workflow";
+import {ExecuteWorkflowService} from "../../service/execute-workflow/execute-workflow.service";
+import {UndoRedoService} from "../../service/undo-redo/undo-redo.service";
+import {ValidationWorkflowService} from "../../service/validation/validation-workflow.service";
+import {JointGraphWrapper} from "../../service/workflow-graph/model/joint-graph-wrapper";
+import {WorkflowActionService} from "../../service/workflow-graph/model/workflow-action.service";
+import {ExecutionState} from "../../types/execute-workflow.interface";
+import {WorkflowWebsocketService} from "../../service/workflow-websocket/workflow-websocket.service";
+import {WorkflowResultExportService} from "../../service/workflow-result-export/workflow-result-export.service";
+import {debounceTime, map, takeUntil} from "rxjs/operators";
+import {UntilDestroy, untilDestroyed} from "@ngneat/until-destroy";
+import {WorkflowUtilService} from "../../service/workflow-graph/util/workflow-util.service";
+import {isSink} from "../../service/workflow-graph/model/workflow-graph";
+import {WorkflowVersionService} from "../../../dashboard/service/workflow-version/workflow-version.service";
+import {concatMap, catchError} from "rxjs/operators";
+import {UserProjectService} from "src/app/dashboard/service/user-project/user-project.service";
+import {NzUploadFile} from "ng-zorro-antd/upload";
+import {saveAs} from "file-saver";
+import {NotificationService} from "src/app/common/service/notification/notification.service";
+import {OperatorMenuService} from "../../service/operator-menu/operator-menu.service";
+import {CoeditorPresenceService} from "../../service/workflow-graph/model/coeditor-presence.service";
 
 /**
  * NavigationComponent is the top level navigation bar that shows
@@ -54,6 +54,8 @@ export class NavigationComponent implements OnInit {
   public ExecutionState = ExecutionState; // make Angular HTML access enum definition
   public isWorkflowValid: boolean = true; // this will check whether the workflow error or not
   public isSaving: boolean = false;
+  public isWorkflowModifiable: boolean = false;
+  public workflowId?: number;
 
   @Input() private pid: number = 0;
   @Input() public autoSaveState: string = "";
@@ -73,7 +75,6 @@ export class NavigationComponent implements OnInit {
   public displayParticularWorkflowVersion: boolean = false;
   public onClickRunHandler: () => void;
 
-  public workflowIdChanged = this.workflowActionService.workflowMetaDataChanged().pipe(map(metadata => metadata.wid));
 
   constructor(
     public executeWorkflowService: ExecuteWorkflowService,
@@ -103,6 +104,9 @@ export class NavigationComponent implements OnInit {
     this.runDisable = initBehavior.disable;
     this.onClickRunHandler = initBehavior.onClick;
     // this.currentWorkflowName = this.workflowCacheService.getCachedWorkflow();
+    this.workflowActionService.getWorkflowModificationEnabledStream().pipe(untilDestroyed(this)).subscribe(a => this.isWorkflowModifiable = a);
+    this.workflowActionService.workflowMetaDataChanged().pipe(untilDestroyed(this)).subscribe(metadata => this.workflowId = metadata.wid);
+
   }
 
   public ngOnInit(): void {
@@ -149,7 +153,8 @@ export class NavigationComponent implements OnInit {
         text: "Error",
         icon: "exclamation-circle",
         disable: true,
-        onClick: () => {},
+        onClick: () => {
+        },
       };
     }
     switch (executionState) {
@@ -167,7 +172,8 @@ export class NavigationComponent implements OnInit {
           text: "Submitting",
           icon: "loading",
           disable: true,
-          onClick: () => {},
+          onClick: () => {
+          },
         };
       case ExecutionState.Running:
         return {
@@ -189,21 +195,24 @@ export class NavigationComponent implements OnInit {
           text: "Pausing",
           icon: "loading",
           disable: true,
-          onClick: () => {},
+          onClick: () => {
+          },
         };
       case ExecutionState.Resuming:
         return {
           text: "Resuming",
           icon: "loading",
           disable: true,
-          onClick: () => {},
+          onClick: () => {
+          },
         };
       case ExecutionState.Recovering:
         return {
           text: "Recovering",
           icon: "loading",
           disable: true,
-          onClick: () => {},
+          onClick: () => {
+          },
         };
     }
   }
@@ -372,7 +381,7 @@ export class NavigationComponent implements OnInit {
     const workflowContent: WorkflowContent = this.workflowActionService.getWorkflowContent();
     const workflowContentJson = JSON.stringify(workflowContent);
     const fileName = this.currentWorkflowName + ".json";
-    saveAs(new Blob([workflowContentJson], { type: "text/plain;charset=utf-8" }), fileName);
+    saveAs(new Blob([workflowContentJson], {type: "text/plain;charset=utf-8"}), fileName);
   }
 
   /**
@@ -414,7 +423,8 @@ export class NavigationComponent implements OnInit {
           untilDestroyed(this)
         )
         .subscribe(
-          () => {},
+          () => {
+          },
           (error: unknown) => {
             alert(error);
             this.isSaving = false;
@@ -449,12 +459,12 @@ export class NavigationComponent implements OnInit {
           this.workflowActionService.getWorkflowMetadata().lastModifiedTime === undefined
             ? ""
             : "Saved at " +
-              this.datePipe.transform(
-                this.workflowActionService.getWorkflowMetadata().lastModifiedTime,
-                "MM/dd/yyyy HH:mm:ss zzz",
-                Intl.DateTimeFormat().resolvedOptions().timeZone,
-                "en"
-              );
+            this.datePipe.transform(
+              this.workflowActionService.getWorkflowMetadata().lastModifiedTime,
+              "MM/dd/yyyy HH:mm:ss zzz",
+              Intl.DateTimeFormat().resolvedOptions().timeZone,
+              "en"
+            );
       });
   }
 
@@ -471,12 +481,12 @@ export class NavigationComponent implements OnInit {
           this.workflowActionService.getWorkflowMetadata().creationTime === undefined
             ? ""
             : "" +
-              this.datePipe.transform(
-                this.workflowActionService.getWorkflowMetadata().creationTime,
-                "MM/dd/yyyy HH:mm:ss zzz",
-                Intl.DateTimeFormat().resolvedOptions().timeZone,
-                "en"
-              );
+            this.datePipe.transform(
+              this.workflowActionService.getWorkflowMetadata().creationTime,
+              "MM/dd/yyyy HH:mm:ss zzz",
+              Intl.DateTimeFormat().resolvedOptions().timeZone,
+              "en"
+            );
         this.displayParticularWorkflowVersion = displayVersionFlag;
       });
   }

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -103,14 +103,8 @@ export class NavigationComponent implements OnInit {
     this.runDisable = initBehavior.disable;
     this.onClickRunHandler = initBehavior.onClick;
     // this.currentWorkflowName = this.workflowCacheService.getCachedWorkflow();
-    this.workflowActionService
-      .getWorkflowModificationEnabledStream()
-      .pipe(untilDestroyed(this))
-      .subscribe(a => (this.isWorkflowModifiable = a));
-    this.workflowActionService
-      .workflowMetaDataChanged()
-      .pipe(untilDestroyed(this))
-      .subscribe(metadata => (this.workflowId = metadata.wid));
+    this.registerWorkflowModifiableChangedHandler();
+    this.registerWorkflowIdUpdateHandler();
   }
 
   public ngOnInit(): void {
@@ -497,5 +491,19 @@ export class NavigationComponent implements OnInit {
     this.workflowVersionService.revertToVersion();
     // after swapping the workflows to point to the particular version, persist it in DB
     this.persistWorkflow();
+  }
+
+  private registerWorkflowModifiableChangedHandler(): void {
+    this.workflowActionService
+      .getWorkflowModificationEnabledStream()
+      .pipe(untilDestroyed(this))
+      .subscribe(modifiable => (this.isWorkflowModifiable = modifiable));
+  }
+
+  private registerWorkflowIdUpdateHandler(): void {
+    this.workflowActionService
+      .workflowMetaDataChanged()
+      .pipe(untilDestroyed(this))
+      .subscribe(metadata => (this.workflowId = metadata.wid));
   }
 }

--- a/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
@@ -1,13 +1,4 @@
-import {
-  ChangeDetectorRef,
-  Component,
-  ComponentFactoryResolver,
-  Input,
-  OnChanges,
-  OnDestroy,
-  OnInit,
-  SimpleChanges,
-} from "@angular/core";
+import { ChangeDetectorRef, Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges } from "@angular/core";
 import { ExecuteWorkflowService } from "../../../service/execute-workflow/execute-workflow.service";
 import { Subject } from "rxjs";
 import { AbstractControl, FormGroup } from "@angular/forms";
@@ -50,7 +41,6 @@ import Quill from "quill";
 import QuillCursors from "quill-cursors";
 import * as Y from "yjs";
 import { CollabWrapperComponent } from "../../../../common/formly/collab-wrapper/collab-wrapper/collab-wrapper.component";
-import { JSONSchema7Type } from "json-schema";
 
 export type PropertyDisplayComponent = TypeCastingDisplayComponent;
 
@@ -87,7 +77,7 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
   readonly ExecutionState = ExecutionState;
 
   // whether the editor can be edited
-  interactive: boolean = this.evaluateInteractivity();
+  interactive: boolean = false;
 
   // the source event stream of form change triggered by library at each user input
   sourceFormChangeEventStream = new Subject<Record<string, unknown>>();
@@ -277,14 +267,9 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
     // execute set interactivity immediately in another task because of a formly bug
     // whenever the form model is changed, formly can only disable it after the UI is rendered
     setTimeout(() => {
-      const interactive = this.evaluateInteractivity();
-      this.setInteractivity(interactive);
+      this.setInteractivity(this.interactive);
       this.changeDetectorRef.detectChanges();
     }, 0);
-  }
-
-  evaluateInteractivity(): boolean {
-    return this.workflowActionService.checkWorkflowModificationEnabled();
   }
 
   setInteractivity(interactive: boolean) {
@@ -389,8 +374,7 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
       .pipe(untilDestroyed(this))
       .subscribe(canModify => {
         if (this.currentOperatorId) {
-          const interactive = this.evaluateInteractivity();
-          this.setInteractivity(interactive);
+          this.setInteractivity(canModify);
           this.changeDetectorRef.detectChanges();
         }
       });

--- a/core/new-gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.html
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.html
@@ -14,7 +14,7 @@
     nz-menu-item
     *ngIf="(operatorMenu.effectivelyHighlightedOperators.value.length > 0 ||
   operatorMenu.effectivelyHighlightedCommentBoxes.value.length > 0) &&
-  this.workflowActionService.checkWorkflowModificationEnabled()"
+  isWorkflowModifiable"
     (click)="onCut()">
     <span
       nz-icon
@@ -26,7 +26,7 @@
     nz-menu-item
     *ngIf="(operatorMenu.effectivelyHighlightedOperators.value.length === 0 &&
   operatorMenu.effectivelyHighlightedCommentBoxes.value.length === 0) &&
-  this.workflowActionService.checkWorkflowModificationEnabled()"
+  isWorkflowModifiable"
     (click)="onPaste()">
     <span
       nz-icon
@@ -78,7 +78,7 @@
     nz-menu-item
     *ngIf="(operatorMenu.effectivelyHighlightedOperators.value.length > 0 ||
   operatorMenu.effectivelyHighlightedCommentBoxes.value.length > 0) &&
-  this.workflowActionService.checkWorkflowModificationEnabled()"
+  isWorkflowModifiable"
     (click)="onDelete()">
     <span
       nz-icon

--- a/core/new-gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.ts
@@ -1,8 +1,9 @@
 import { Component } from "@angular/core";
 import { OperatorMenuService } from "src/app/workspace/service/operator-menu/operator-menu.service";
 import { WorkflowActionService } from "src/app/workspace/service/workflow-graph/model/workflow-action.service";
-import { untilDestroyed } from "@ngneat/until-destroy";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 
+@UntilDestroy()
 @Component({
   selector: "texera-context-menu",
   templateUrl: "./context-menu.component.html",

--- a/core/new-gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.ts
@@ -1,6 +1,7 @@
 import { Component } from "@angular/core";
 import { OperatorMenuService } from "src/app/workspace/service/operator-menu/operator-menu.service";
 import { WorkflowActionService } from "src/app/workspace/service/workflow-graph/model/workflow-action.service";
+import { untilDestroyed } from "@ngneat/until-destroy";
 
 @Component({
   selector: "texera-context-menu",
@@ -8,7 +9,11 @@ import { WorkflowActionService } from "src/app/workspace/service/workflow-graph/
   styleUrls: ["./context-menu.component.scss"],
 })
 export class ContextMenuComponent {
-  constructor(public workflowActionService: WorkflowActionService, public operatorMenu: OperatorMenuService) {}
+  public isWorkflowModifiable: boolean = false;
+
+  constructor(public workflowActionService: WorkflowActionService, public operatorMenu: OperatorMenuService) {
+    this.registerWorkflowModifiableChangedHandler();
+  }
 
   public onCopy(): void {
     this.operatorMenu.saveHighlightedElements();
@@ -33,5 +38,12 @@ export class ContextMenuComponent {
     highlightedCommentBoxIDs.forEach(highlightedCommentBoxID =>
       this.workflowActionService.deleteCommentBox(highlightedCommentBoxID)
     );
+  }
+
+  private registerWorkflowModifiableChangedHandler() {
+    this.workflowActionService
+      .getWorkflowModificationEnabledStream()
+      .pipe(untilDestroyed(this))
+      .subscribe(modifiable => (this.isWorkflowModifiable = modifiable));
   }
 }


### PR DESCRIPTION
There are many instances of ExpressionChangedAfterItHasBeenCheckedError present in the navigation bar.
1. `workflowId` checked as null but then updated as `undefined` or an actual number.
2. `workflowActionService.checkWorkflowModificationEnabled()` checked as false but later updated as true.

There are more instances to be fixed in later PRs.