### PR TITLE
Change operator executor interface to use port index

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerLayer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerLayer.scala
@@ -33,7 +33,9 @@ class WorkerLayer(
     var initIOperatorExecutor: Int => IOperatorExecutor,
     var numWorkers: Int,
     val deploymentFilter: DeploymentFilter,
-    val deployStrategy: DeployStrategy
+    val deployStrategy: DeployStrategy,
+    val inputOrdinalMapping: Map[LinkIdentity, Int] = Map(),
+    val outputOrdinalMapping: mutable.Map[LinkIdentity, Int] = new mutable.HashMap()
 ) extends Serializable {
 
   private val startDependencies = mutable.HashSet[LinkIdentity]()
@@ -86,6 +88,8 @@ class WorkerLayer(
               .props(
                 workerId,
                 operatorExecutor,
+                this.inputOrdinalMapping,
+                this.outputOrdinalMapping,
                 parentNetworkCommunicationActorRef,
                 allUpstreamLinkIds
               )
@@ -95,6 +99,8 @@ class WorkerLayer(
               .props(
                 workerId,
                 operatorExecutor,
+                this.inputOrdinalMapping,
+                this.outputOrdinalMapping,
                 parentNetworkCommunicationActorRef,
                 allUpstreamLinkIds,
                 supportFaultTolerance

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonWorkflowWorker.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonWorkflowWorker.scala
@@ -18,26 +18,42 @@ import java.io.IOException
 import java.net.ServerSocket
 import java.nio.file.Path
 import java.util.concurrent.{ExecutorService, Executors}
+import scala.collection.mutable
 import scala.sys.process.{BasicIO, Process}
 
 object PythonWorkflowWorker {
   def props(
       id: ActorVirtualIdentity,
       op: IOperatorExecutor,
+      inputToOrdinalMapping: Map[LinkIdentity, Int],
+      outputToOrdinalMapping: mutable.Map[LinkIdentity, Int],
       parentNetworkCommunicationActorRef: NetworkSenderActorRef,
       allUpstreamLinkIds: Set[LinkIdentity]
   ): Props =
-    Props(new PythonWorkflowWorker(id, op, parentNetworkCommunicationActorRef, allUpstreamLinkIds))
+    Props(
+      new PythonWorkflowWorker(
+        id,
+        op,
+        inputToOrdinalMapping,
+        outputToOrdinalMapping,
+        parentNetworkCommunicationActorRef,
+        allUpstreamLinkIds
+      )
+    )
 }
 
 class PythonWorkflowWorker(
     actorId: ActorVirtualIdentity,
     operator: IOperatorExecutor,
+    inputToOrdinalMapping: Map[LinkIdentity, Int],
+    outputToOrdinalMapping: mutable.Map[LinkIdentity, Int],
     parentNetworkCommunicationActorRef: NetworkSenderActorRef,
     allUpstreamLinkIds: Set[LinkIdentity]
 ) extends WorkflowWorker(
       actorId,
       operator,
+      inputToOrdinalMapping,
+      outputToOrdinalMapping,
       parentNetworkCommunicationActorRef,
       allUpstreamLinkIds,
       false

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkflowWorker.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkflowWorker.scala
@@ -51,6 +51,8 @@ object WorkflowWorker {
   def props(
       id: ActorVirtualIdentity,
       op: IOperatorExecutor,
+      inputToOrdinalMapping: Map[LinkIdentity, Int],
+      outputToOrdinalMapping: mutable.Map[LinkIdentity, Int],
       parentNetworkCommunicationActorRef: NetworkSenderActorRef,
       allUpstreamLinkIds: Set[LinkIdentity],
       supportFaultTolerance: Boolean
@@ -59,6 +61,8 @@ object WorkflowWorker {
       new WorkflowWorker(
         id,
         op,
+        inputToOrdinalMapping,
+        outputToOrdinalMapping,
         parentNetworkCommunicationActorRef,
         allUpstreamLinkIds,
         supportFaultTolerance
@@ -71,6 +75,8 @@ object WorkflowWorker {
 class WorkflowWorker(
     actorId: ActorVirtualIdentity,
     operator: IOperatorExecutor,
+    inputToOrdinalMapping: Map[LinkIdentity, Int],
+    outputToOrdinalMapping: mutable.Map[LinkIdentity, Int],
     parentNetworkCommunicationActorRef: NetworkSenderActorRef,
     allUpstreamLinkIds: Set[LinkIdentity],
     supportFaultTolerance: Boolean

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/IOperatorExecutor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/IOperatorExecutor.scala
@@ -16,10 +16,10 @@ trait IOperatorExecutor {
 
   def processTuple(
       tuple: Either[ITuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
-  ): Iterator[(ITuple, Option[LinkIdentity])]
+  ): Iterator[(ITuple, Option[Int])]
 
   def getParam(query: String): String = { null }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/ISinkOperatorExecutor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/ISinkOperatorExecutor.scala
@@ -9,13 +9,13 @@ trait ISinkOperatorExecutor extends IOperatorExecutor {
 
   override def processTuple(
       tuple: Either[ITuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
-  ): Iterator[(ITuple, Option[LinkIdentity])] = {
+  ): Iterator[(ITuple, Option[Int])] = {
     consume(tuple, input)
     Iterator.empty
   }
 
-  def consume(tuple: Either[ITuple, InputExhausted], input: LinkIdentity): Unit
+  def consume(tuple: Either[ITuple, InputExhausted], input: Int): Unit
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/ISourceOperatorExecutor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/ISourceOperatorExecutor.scala
@@ -9,10 +9,10 @@ trait ISourceOperatorExecutor extends IOperatorExecutor {
 
   override def processTuple(
       tuple: Either[ITuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
-  ): Iterator[(ITuple, Option[LinkIdentity])] = {
+  ): Iterator[(ITuple, Option[Int])] = {
     // The input Tuple for source operator will always be InputExhausted.
     // Source and other operators can share the same processing logic.
     // produce() will be called only once.

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/ManyToOneOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/ManyToOneOpExecConfig.scala
@@ -33,7 +33,8 @@ class ManyToOneOpExecConfig(
           opExec,
           1,
           UseAll(),
-          RoundRobinDeployment()
+          RoundRobinDeployment(),
+          inputToOrdinalMapping.map(p => (p._1, p._2._1)).toMap
         )
       ),
       Array()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OneToOneOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OneToOneOpExecConfig.scala
@@ -33,7 +33,8 @@ class OneToOneOpExecConfig(
           opExec,
           numWorkers,
           FollowPrevious(),
-          RoundRobinDeployment()
+          RoundRobinDeployment(),
+          inputToOrdinalMapping.map(p => (p._1, p._2._1)).toMap
         )
       ),
       Array()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OperatorExecutor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OperatorExecutor.scala
@@ -11,10 +11,10 @@ trait OperatorExecutor extends IOperatorExecutor {
 
   override def processTuple(
       tuple: Either[ITuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
-  ): Iterator[(ITuple, Option[LinkIdentity])] = {
+  ): Iterator[(ITuple, Option[Int])] = {
     processTexeraTuple(
       tuple.asInstanceOf[Either[Tuple, InputExhausted]],
       input,
@@ -25,7 +25,7 @@ trait OperatorExecutor extends IOperatorExecutor {
 
   def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple]

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/aggregate/FinalAggregateOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/aggregate/FinalAggregateOpExec.scala
@@ -27,7 +27,7 @@ class FinalAggregateOpExec[Partial <: AnyRef](
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/aggregate/PartialAggregateOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/aggregate/PartialAggregateOpExec.scala
@@ -31,7 +31,7 @@ class PartialAggregateOpExec[Partial <: AnyRef](
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): scala.Iterator[Tuple] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/filter/FilterOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/filter/FilterOpExec.scala
@@ -21,7 +21,7 @@ abstract class FilterOpExec() extends OperatorExecutor with Serializable {
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/flatmap/FlatMapOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/flatmap/FlatMapOpExec.scala
@@ -42,7 +42,7 @@ class FlatMapOpExec(
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/map/MapOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/map/MapOpExec.scala
@@ -30,7 +30,7 @@ abstract class MapOpExec() extends OperatorExecutor with Serializable {
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/mlmodel/MLModelOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/mlmodel/MLModelOpExec.scala
@@ -28,7 +28,7 @@ abstract class MLModelOpExec() extends OperatorExecutor with Serializable {
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpExec.scala
@@ -22,7 +22,9 @@ class DifferenceOpExec() extends OperatorExecutor {
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {
-    assert(input < 2)
+    if (input >= 2) {
+      throw new IllegalArgumentException("input port should not be more than 2")
+    }
     tuple match {
       case Left(t) =>
         if (input == 1) { // right input

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpExec.scala
@@ -10,31 +10,24 @@ import org.apache.arrow.util.Preconditions
 
 import scala.collection.mutable
 
-class DifferenceOpExec(
-    val rightTable: LinkIdentity
-) extends OperatorExecutor {
+class DifferenceOpExec() extends OperatorExecutor {
 
-  private val linkIdentityHashSet: mutable.HashSet[LinkIdentity] = new mutable.HashSet()
   private val leftHashSet: mutable.HashSet[Tuple] = new mutable.HashSet()
   private val rightHashSet: mutable.HashSet[Tuple] = new mutable.HashSet()
   private var exhaustedCounter: Int = 0
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {
-    if (!linkIdentityHashSet.contains(input)) {
-      linkIdentityHashSet.add(input)
-    }
-    Preconditions.checkArgument(2 >= linkIdentityHashSet.size)
-
+    assert(input < 2)
     tuple match {
       case Left(t) =>
-        if (rightTable == input) {
+        if (input == 1) { // right input
           rightHashSet.add(t)
-        } else {
+        } else { // left input
           leftHashSet.add(t)
         }
         Iterator()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpExecConf.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpExecConf.scala
@@ -17,18 +17,16 @@ import edu.uci.ics.amber.engine.operators.OpExecConfig
 class DifferenceOpExecConf[K](
     id: OperatorIdentity
 ) extends OpExecConfig(id) {
-  def getRightLink(): LinkIdentity =
-    inputToOrdinalMapping.find({ case (_, (ordinal, _)) => ordinal == 1 }).get._1
-
   override lazy val topology: Topology = {
     new Topology(
       Array(
         new WorkerLayer(
           makeLayer(id, "main"),
-          _ => new DifferenceOpExec(getRightLink()),
+          _ => new DifferenceOpExec(),
           Constants.currentWorkerNum,
           UseAll(),
-          RoundRobinDeployment()
+          RoundRobinDeployment(),
+          inputToOrdinalMapping.map(p => (p._1, p._2._1)).toMap
         )
       ),
       Array()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/distinct/DistinctOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/distinct/DistinctOpExec.scala
@@ -13,7 +13,7 @@ class DistinctOpExec extends OperatorExecutor {
   private val hashset: mutable.HashSet[Tuple] = mutable.HashSet()
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpExec.scala
@@ -14,7 +14,6 @@ import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 class HashJoinOpExec[K](
-    val buildTable: LinkIdentity,
     val buildAttributeName: String,
     val probeAttributeName: String,
     val joinType: JoinType,
@@ -69,7 +68,7 @@ class HashJoinOpExec[K](
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {
@@ -79,7 +78,7 @@ class HashJoinOpExec[K](
         // small input port comes first. So, it is assigned the inputNum 0. Similarly
         // the large input is assigned the inputNum 1.
 
-        if (input == buildTable) {
+        if (input == 0) {
           // building phase
           building(tuple)
           Iterator()
@@ -106,7 +105,7 @@ class HashJoinOpExec[K](
 
         }
       case Right(_) =>
-        if (input == buildTable && !isBuildTableFinished) {
+        if (input == 0 && !isBuildTableFinished) {
           // the first input is exhausted, building phase finished
           isBuildTableFinished = true
           Iterator()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpExecConfig.scala
@@ -33,7 +33,6 @@ class HashJoinOpExecConfig[K](
           makeLayer(id, "main"),
           _ =>
             new HashJoinOpExec[K](
-              getBuildTableLinkId(),
               buildAttributeName,
               probeAttributeName,
               joinType,
@@ -41,7 +40,8 @@ class HashJoinOpExecConfig[K](
             ),
           Constants.currentWorkerNum,
           UseAll(),
-          RoundRobinDeployment()
+          RoundRobinDeployment(),
+          inputToOrdinalMapping.map(p => (p._1, p._2._1)).toMap
         )
       ),
       Array()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpExec.scala
@@ -20,6 +20,9 @@ class IntersectOpExec extends OperatorExecutor {
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {
+    if (input >= 2) {
+      throw new IllegalArgumentException("input port should not be more than 2")
+    }
     tuple match {
       case Left(t) =>
         // add the tuple to corresponding set

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpExec.scala
@@ -1,53 +1,36 @@
 package edu.uci.ics.texera.workflow.operators.intersect
 
-import com.google.common.base.Preconditions
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 
 import scala.collection.mutable
 
 class IntersectOpExec extends OperatorExecutor {
-  private val hashMap: mutable.HashMap[LinkIdentity, mutable.HashSet[Tuple]] =
-    new mutable.HashMap()
+  private val leftSet = new mutable.HashSet[Tuple]()
+  private val rightSet = new mutable.HashSet[Tuple]()
 
   private var exhaustedCounter: Int = 0
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {
     tuple match {
       case Left(t) =>
-        // for each input stream, initialize an empty set
-        if (!hashMap.contains(input)) {
-          hashMap.put(input, mutable.HashSet())
-        }
-
-        // should expect no more than 2 input streams, thus no more than 2 sets
-        Preconditions.checkArgument(hashMap.size <= 2)
-
         // add the tuple to corresponding set
-        hashMap(input) += t
+        if (input == 0) leftSet += t else rightSet += t
         Iterator()
 
       case Right(_) =>
-        // for empty input stream, initialize an empty set
-        if (!hashMap.contains(input)) {
-          hashMap.put(input, mutable.HashSet())
-        }
         exhaustedCounter += 1
         if (exhaustedCounter == 2) {
           // both streams are exhausted, take the intersect and return the results
-
-          hashMap.valuesIterator
-            .reduce((set1, set2) => { set1.intersect(set2) })
-            .iterator
+          leftSet.intersect(rightSet).iterator
         } else {
           // only one of the stream is exhausted, continue accepting tuples
           Iterator()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intervalJoin/IntervalJoinExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intervalJoin/IntervalJoinExecConfig.scala
@@ -35,12 +35,12 @@ class IntervalJoinExecConfig(
           _ =>
             new IntervalJoinOpExec(
               operatorSchemaInfo,
-              desc,
-              getLeftInputLink()
+              desc
             ),
           1,
           UseAll(),
-          RoundRobinDeployment()
+          RoundRobinDeployment(),
+          inputToOrdinalMapping.map(p => (p._1, p._2._1)).toMap
         )
       ),
       Array()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intervalJoin/IntervalJoinOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intervalJoin/IntervalJoinOpExec.scala
@@ -23,8 +23,7 @@ import scala.collection.mutable.ListBuffer
   */
 class IntervalJoinOpExec(
     val operatorSchemaInfo: OperatorSchemaInfo,
-    val desc: IntervalJoinOpDesc,
-    val leftInputLink: LinkIdentity
+    val desc: IntervalJoinOpDesc
 ) extends OperatorExecutor {
 
   val leftTableSchema: Schema = operatorSchemaInfo.inputSchemas(0)
@@ -34,13 +33,13 @@ class IntervalJoinOpExec(
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {
     tuple match {
       case Left(currentTuple) =>
-        if (input == leftInputLink) {
+        if (input == 0) {
           leftTable += currentTuple
           if (rightTable.nonEmpty) {
             removeTooSmallTupleInRightCache(leftTable.head)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/limit/LimitOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/limit/LimitOpExec.scala
@@ -12,7 +12,7 @@ class LimitOpExec(val limit: Int) extends OperatorExecutor {
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/reservoirsampling/ReservoirSamplingOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/reservoirsampling/ReservoirSamplingOpExec.scala
@@ -18,7 +18,7 @@ class ReservoirSamplingOpExec(val actor: Int, val opDesc: ReservoirSamplingOpDes
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/managed/ProgressiveSinkOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/managed/ProgressiveSinkOpExec.scala
@@ -23,7 +23,7 @@ class ProgressiveSinkOpExec(
 
   override def consume(
       tuple: Either[ITuple, InputExhausted],
-      input: LinkIdentity
+      input: Int
   ): Unit = {
     tuple match {
       case Left(t) =>

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sortPartitions/SortPartitionOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sortPartitions/SortPartitionOpExec.scala
@@ -107,7 +107,7 @@ class SortPartitionOpExec(
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/split/SplitOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/split/SplitOpExec.scala
@@ -24,24 +24,24 @@ class SplitOpExec(
 
   override def processTuple(
       tuple: Either[ITuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
-  ): Iterator[(ITuple, Option[LinkIdentity])] = {
+  ): Iterator[(ITuple, Option[Int])] = {
 
     if (tuple.isLeft) {
       val isTraining = random.nextInt(100) < opDesc.k
-      val port = if (isTraining) "training" else "testing"
-      val outLink = outputLinkMapping.get(port)
-      Iterator.single((tuple.left.get, outLink))
+      // training output port: 0, testing output port: 1
+      val port = if (isTraining) 0 else 1
+      Iterator.single((tuple.left.get, Some(port)))
     } else {
       Iterator.empty
     }
   }
 
-  def processTexeraTuple(
+  override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = ???

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/split/SplitOpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/split/SplitOpExecConfig.scala
@@ -32,7 +32,9 @@ class SplitOpExecConfig(
           i => new SplitOpExec(i, splitOpDesc, outputToOrdinalMapping),
           Constants.currentWorkerNum,
           FollowPrevious(),
-          RoundRobinDeployment()
+          RoundRobinDeployment(),
+          this.inputToOrdinalMapping.map(p => (p._1, p._2._1)).toMap,
+          this.outputToOrdinalMapping.map(p => (p._1, p._2._1))
         )
       ),
       Array()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/symmetricDifference/SymmetricDifferenceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/symmetricDifference/SymmetricDifferenceOpExec.scala
@@ -20,6 +20,9 @@ class SymmetricDifferenceOpExec extends OperatorExecutor {
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {
+    if (input >= 2) {
+      throw new IllegalArgumentException("input port should not be more than 2")
+    }
     tuple match {
       case Left(t) =>
         // add the tuple to corresponding set

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/symmetricDifference/SymmetricDifferenceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/symmetricDifference/SymmetricDifferenceOpExec.scala
@@ -3,56 +3,38 @@ package edu.uci.ics.texera.workflow.operators.symmetricDifference
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
-import org.apache.arrow.util.Preconditions
 
 import scala.collection.mutable
 
 class SymmetricDifferenceOpExec extends OperatorExecutor {
-  private val hashMap: mutable.HashMap[LinkIdentity, mutable.HashSet[Tuple]] =
-    new mutable.HashMap()
+  private val leftSet = new mutable.HashSet[Tuple]()
+  private val rightSet = new mutable.HashSet[Tuple]()
 
   private var exhaustedCounter: Int = 0
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {
     tuple match {
       case Left(t) =>
-        // for each input stream, initialize an empty set
-        if (!hashMap.contains(input)) {
-          hashMap.put(input, mutable.HashSet())
-        }
-
-        // should expect no more than 2 input streams, thus no more than 2 sets
-        Preconditions.checkArgument(hashMap.size <= 2)
-
         // add the tuple to corresponding set
-        hashMap(input) += t
+        if (input == 0) leftSet += t else rightSet += t
         Iterator()
 
       case Right(_) =>
-        // for empty input stream, initialize an empty set
-        if (!hashMap.contains(input)) {
-          hashMap.put(input, mutable.HashSet())
-        }
         exhaustedCounter += 1
         if (2 == exhaustedCounter) {
           // both streams are exhausted, take the intersect and return the results
-
-          hashMap.valuesIterator
-            .reduce((set1, set2) => { set1.union(set2).diff(set1.intersect(set2)) })
-            .iterator
+          leftSet.union(rightSet).diff(leftSet.intersect(rightSet)).iterator
         } else {
           // only one of the stream is exhausted, continue accepting tuples
           Iterator()
         }
-
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV1/PythonUDFOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV1/PythonUDFOpExec.java
@@ -369,7 +369,7 @@ public class PythonUDFOpExec implements OperatorExecutor {
     }
 
     @Override
-    public Iterator<Tuple> processTexeraTuple(Either<Tuple, InputExhausted> tuple, LinkIdentity input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
+    public Iterator<Tuple> processTexeraTuple(Either<Tuple, InputExhausted> tuple, int input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
         if (tuple.isLeft()) {
             Tuple inputTuple = tuple.left().get();
             if (globalInputSchema == null) {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/PythonUDFOpExecV2.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/PythonUDFOpExecV2.java
@@ -32,7 +32,7 @@ public class PythonUDFOpExecV2 implements OperatorExecutor {
 
 
     @Override
-    public Iterator<Tuple> processTexeraTuple(Either<Tuple, InputExhausted> tuple, LinkIdentity input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
+    public Iterator<Tuple> processTexeraTuple(Either<Tuple, InputExhausted> tuple, int input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
         // Will not be used. The real implementation is in the Python UDF.
         return null;
     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/source/PythonUDFSourceOpExecV2.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/source/PythonUDFSourceOpExecV2.java
@@ -23,7 +23,7 @@ public class PythonUDFSourceOpExecV2 extends PythonUDFOpExecV2 implements Source
 
 
     @Override
-    public Iterator<Tuple2<ITuple, Option<LinkIdentity>>> processTuple(Either<ITuple, InputExhausted> tuple, LinkIdentity input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
+    public Iterator<Tuple2<ITuple, Option<Object>>> processTuple(Either<ITuple, InputExhausted> tuple, int input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
         return SourceOperatorExecutor.super.processTuple(tuple, input, pauseManager, asyncRPCClient);
         // Will not be used. The real implementation is in the Python UDF.
     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/union/UnionOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/union/UnionOpExec.scala
@@ -3,14 +3,13 @@ package edu.uci.ics.texera.workflow.operators.union
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 
 class UnionOpExec extends OperatorExecutor {
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/htmlviz/HtmlVizOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/htmlviz/HtmlVizOpExec.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.texera.workflow.operators.visualization.htmlviz
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.{AttributeType, OperatorSchemaInfo}
@@ -23,7 +22,7 @@ class HtmlVizOpExec(htmlContentAttrName: String, operatorSchemaInfo: OperatorSch
 
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
-      input: LinkIdentity,
+      input: Int,
       pauseManager: PauseManager,
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/pieChart/PieChartOpFinalExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/pieChart/PieChartOpFinalExec.java
@@ -51,7 +51,7 @@ public class PieChartOpFinalExec implements OperatorExecutor {
     }
 
     @Override
-    public scala.collection.Iterator<Tuple> processTexeraTuple(Either<Tuple, InputExhausted> tuple, LinkIdentity input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
+    public scala.collection.Iterator<Tuple> processTexeraTuple(Either<Tuple, InputExhausted> tuple, int input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
         if (tuple.isLeft()) {
             if (noDataCol) {
                 sum += tuple.left().get().getInt(1);

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/pieChart/PieChartOpPartialExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/pieChart/PieChartOpPartialExec.java
@@ -47,7 +47,7 @@ public class PieChartOpPartialExec implements OperatorExecutor {
     }
 
     @Override
-    public Iterator<Tuple> processTexeraTuple(Either<Tuple, InputExhausted> tuple, LinkIdentity input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
+    public Iterator<Tuple> processTexeraTuple(Either<Tuple, InputExhausted> tuple, int input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
         if (tuple.isLeft()) {
             Tuple inputTuple = tuple.left().get();
             String name = inputTuple.getField(nameColumn);

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/scatterplot/ScatterplotOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/scatterplot/ScatterplotOpExec.java
@@ -74,7 +74,7 @@ public class ScatterplotOpExec implements OperatorExecutor {
     }
 
     @Override
-    public Iterator<Tuple> processTexeraTuple(Either<Tuple, InputExhausted> tuple, LinkIdentity input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
+    public Iterator<Tuple> processTexeraTuple(Either<Tuple, InputExhausted> tuple, int input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
         if (tuple.isLeft()) {
             return JavaConverters.asScalaIterator(processTuple(tuple.left().get()).iterator());
         } else { // input exhausted

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpFinalExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpFinalExec.java
@@ -77,7 +77,7 @@ public class WordCloudOpFinalExec implements OperatorExecutor {
     }
 
     @Override
-    public Iterator<Tuple> processTexeraTuple(Either<Tuple, InputExhausted> tuple, LinkIdentity input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
+    public Iterator<Tuple> processTexeraTuple(Either<Tuple, InputExhausted> tuple, int input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
         if (tuple.isLeft()) {
             String term = tuple.left().get().getString(0);
             int frequency = tuple.left().get().getInt(1);

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpPartialExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpPartialExec.java
@@ -86,7 +86,7 @@ public class WordCloudOpPartialExec implements OperatorExecutor {
     }
 
     @Override
-    public Iterator<Tuple> processTexeraTuple(Either<Tuple, InputExhausted> tuple, LinkIdentity input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
+    public Iterator<Tuple> processTexeraTuple(Either<Tuple, InputExhausted> tuple, int input, PauseManager pauseManager, AsyncRPCClient asyncRPCClient) {
         if (tuple.isLeft()) {
             textList.add(tuple.left().get().getField(textColumn).toString());
             boolean condition = System.currentTimeMillis() - lastUpdatedTime > UPDATE_INTERVAL_MS;

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -43,6 +43,7 @@ import org.scalamock.scalatest.MockFactory
 import org.scalatest.BeforeAndAfterEach
 import org.scalatest.flatspec.AnyFlatSpec
 
+import scala.collection.mutable
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 import scala.concurrent.{Await, ExecutionContext, Future}
 
@@ -137,6 +138,8 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     val recoveryQueue: RecoveryQueue = new RecoveryQueue(logStorage.getReader)
     val recoveryManager = new LocalRecoveryManager()
     val asyncRPCServer: AsyncRPCServer = null
+    val inputOrdinalMapping: Map[LinkIdentity, Int] = Map()
+    val outputOrdinalMapping: mutable.Map[LinkIdentity, Int] = new mutable.HashMap()
     val senderID = ActorVirtualIdentity("sender")
     val upstreamLinkStatus: UpstreamLinkStatus = new UpstreamLinkStatus(Set(linkID))
     upstreamLinkStatus.registerInput(senderID, linkID)
@@ -147,11 +150,11 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
       inSequence {
         (operator.open _).expects().once()
         tuples.foreach { x =>
-          (operator.processTuple _).expects(Left(x), linkID, pauseManager, asyncRPCClient)
+          (operator.processTuple _).expects(Left(x), 0, pauseManager, asyncRPCClient)
         }
         (operator.processTuple _).expects(
           Right(InputExhausted()),
-          linkID,
+          0,
           pauseManager,
           asyncRPCClient
         )
@@ -176,6 +179,8 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     val logStorage: DeterminantLogStorage = new EmptyLogStorage()
     val recoveryQueue: RecoveryQueue = new RecoveryQueue(logStorage.getReader)
     val recoveryManager = new LocalRecoveryManager()
+    val inputOrdinalMapping: Map[LinkIdentity, Int] = Map()
+    val outputOrdinalMapping: mutable.Map[LinkIdentity, Int] = new mutable.HashMap()
     val senderID = ActorVirtualIdentity("sender")
     val upstreamLinkStatus: UpstreamLinkStatus = new UpstreamLinkStatus(Set(linkID))
     upstreamLinkStatus.registerInput(senderID, linkID)
@@ -188,13 +193,13 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
         (operator.open _).expects().once()
         inAnyOrder {
           tuples.map { x =>
-            (operator.processTuple _).expects(Left(x), linkID, pauseManager, asyncRPCClient)
+            (operator.processTuple _).expects(Left(x), 0, pauseManager, asyncRPCClient)
           }
           (asyncRPCServer.receive _).expects(*, *).atLeastOnce() //process controls during execution
         }
         (operator.processTuple _).expects(
           Right(InputExhausted()),
-          linkID,
+          0,
           pauseManager,
           asyncRPCClient
         )
@@ -227,6 +232,8 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     val logStorage: DeterminantLogStorage = new EmptyLogStorage()
     val recoveryQueue: RecoveryQueue = new RecoveryQueue(logStorage.getReader)
     val recoveryManager = new LocalRecoveryManager()
+    val inputOrdinalMapping: Map[LinkIdentity, Int] = Map()
+    val outputOrdinalMapping: mutable.Map[LinkIdentity, Int] = new mutable.HashMap()
     val workerStateManager: WorkerStateManager = new WorkerStateManager(UNINITIALIZED)
     val senderID = ActorVirtualIdentity("sender")
     val upstreamLinkStatus: UpstreamLinkStatus = new UpstreamLinkStatus(Set(linkID))
@@ -259,6 +266,8 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     val logStorage: DeterminantLogStorage = new EmptyLogStorage()
     val recoveryQueue: RecoveryQueue = new RecoveryQueue(logStorage.getReader)
     val recoveryManager = new LocalRecoveryManager()
+    val inputOrdinalMapping: Map[LinkIdentity, Int] = Map()
+    val outputOrdinalMapping: mutable.Map[LinkIdentity, Int] = new mutable.HashMap()
     val workerStateManager: WorkerStateManager = new WorkerStateManager(UNINITIALIZED)
     val senderID = ActorVirtualIdentity("sender")
     val upstreamLinkStatus: UpstreamLinkStatus = new UpstreamLinkStatus(Set(linkID))
@@ -293,6 +302,8 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     val logStorage: DeterminantLogStorage = new EmptyLogStorage()
     val recoveryQueue: RecoveryQueue = new RecoveryQueue(logStorage.getReader)
     val recoveryManager = new LocalRecoveryManager()
+    val inputOrdinalMapping: Map[LinkIdentity, Int] = Map()
+    val outputOrdinalMapping: mutable.Map[LinkIdentity, Int] = new mutable.HashMap()
     val senderID = ActorVirtualIdentity("sender")
     val upstreamLinkStatus: UpstreamLinkStatus = new UpstreamLinkStatus(Set(linkID))
     upstreamLinkStatus.registerInput(senderID, linkID)
@@ -352,6 +363,8 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     val logStorage: DeterminantLogStorage = new EmptyLogStorage()
     val recoveryQueue: RecoveryQueue = new RecoveryQueue(logStorage.getReader)
     val recoveryManager = new LocalRecoveryManager()
+    val inputOrdinalMapping: Map[LinkIdentity, Int] = Map()
+    val outputOrdinalMapping: mutable.Map[LinkIdentity, Int] = new mutable.HashMap()
     val operator = new IOperatorExecutor {
       override def open(): Unit = {}
 
@@ -359,10 +372,10 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
 
       override def processTuple(
           tuple: Either[ITuple, InputExhausted],
-          input: LinkIdentity,
+          input: Int,
           pauseManager: PauseManager,
           asyncRPCClient: AsyncRPCClient
-      ): Iterator[(ITuple, Option[LinkIdentity])] = {
+      ): Iterator[(ITuple, Option[Int])] = {
         Await.result(
           Future {
             Thread.sleep(3000); 42

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
@@ -68,10 +68,10 @@ class WorkerSpec
 
       override def processTuple(
           tuple: Either[ITuple, InputExhausted],
-          input: LinkIdentity,
+          input: Int,
           pauseManager: PauseManager,
           asyncRPCClient: AsyncRPCClient
-      ): Iterator[(ITuple, Option[LinkIdentity])] = ???
+      ): Iterator[(ITuple, Option[Int])] = ???
     }
 
     val mockTag = LinkIdentity(null, null)
@@ -83,6 +83,8 @@ class WorkerSpec
         new WorkflowWorker(
           identifier1,
           mockOpExecutor,
+          Map[LinkIdentity, Int](),
+          new mutable.HashMap[LinkIdentity, Int](),
           NetworkSenderActorRef(null),
           Set(mockTag),
           false
@@ -115,16 +117,18 @@ class WorkerSpec
 
       override def processTuple(
           tuple: Either[ITuple, InputExhausted],
-          input: LinkIdentity,
+          input: Int,
           pauseManager: PauseManager,
           asyncRPCClient: AsyncRPCClient
-      ): Iterator[(ITuple, Option[LinkIdentity])] = { return Iterator() }
+      ): Iterator[(ITuple, Option[Int])] = { return Iterator() }
     }
 
     val worker = TestActorRef(
       new WorkflowWorker(
         identifier1,
         mockOpExecutor,
+        Map[LinkIdentity, Int](),
+        new mutable.HashMap[LinkIdentity, Int](),
         NetworkSenderActorRef(probe.ref),
         Set(),
         false

--- a/core/amber/src/test/scala/edu/uci/ics/texera/unittest/workflow/operators/visualization/scatterplot/ScatterplotVizOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/unittest/workflow/operators/visualization/scatterplot/ScatterplotVizOpExecSpec.scala
@@ -51,11 +51,11 @@ class ScatterplotVizOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
 
   it should "output the correct schema for geometric for the frontend to render it and process only one tuple because the other falls on the same pixel" in {
     val processedTuple: Tuple =
-      scatterplotOpExec.processTexeraTuple(Left(tuple), null, null, null).next()
+      scatterplotOpExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(processedTuple.getField("xColumn").asInstanceOf[Double] == 73.142)
     assert(processedTuple.getField("yColumn").asInstanceOf[Double] == 32.33)
     val outputTuples: List[Tuple] =
-      scatterplotOpExec.processTexeraTuple(Left(extratuple), null, null, null).toList
+      scatterplotOpExec.processTexeraTuple(Left(extratuple), 0, null, null).toList
     assert(outputTuples.size == 0)
   }
 
@@ -67,18 +67,18 @@ class ScatterplotVizOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     scatterplotOpExec = new ScatterplotOpExec(desc, operatorSchemaInfo)
     scatterplotOpExec.open()
     val processedTuple: Tuple =
-      scatterplotOpExec.processTexeraTuple(Left(tuple), null, null, null).next()
+      scatterplotOpExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(processedTuple.getField("field1").asInstanceOf[Double] == 73.142)
     assert(processedTuple.getField("field2").asInstanceOf[Double] == 32.33)
     val processedAnotherTuple: Tuple =
-      scatterplotOpExec.processTexeraTuple(Left(extratuple), null, null, null).next()
+      scatterplotOpExec.processTexeraTuple(Left(extratuple), 0, null, null).next()
     assert(processedAnotherTuple.getField("field1").asInstanceOf[Double] == 73.142)
     assert(processedAnotherTuple.getField("field2").asInstanceOf[Double] == 32.22)
   }
 
   it should "handle last tuple correctly" in {
     val outputTuples: List[Tuple] =
-      scatterplotOpExec.processTexeraTuple(Right(InputExhausted()), null, null, null).toList
+      scatterplotOpExec.processTexeraTuple(Right(InputExhausted()), 0, null, null).toList
     assert(outputTuples.size == 0)
   }
 

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/dictionary/DictionaryMatcherOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/dictionary/DictionaryMatcherOpExecSpec.scala
@@ -57,7 +57,7 @@ class DictionaryMatcherOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   it should "match a tuple if present in the given dictionary entry when matching type is SCANBASED" in {
     opDesc.matchingType = MatchingType.SCANBASED
     opExec.open()
-    val processedTuple = opExec.processTexeraTuple(Left(tuple), null, null, null).next()
+    val processedTuple = opExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(processedTuple.getField("matched"))
     opExec.close()
   }
@@ -65,7 +65,7 @@ class DictionaryMatcherOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   it should "match a tuple if present in the given dictionary entry when matching type is SUBSTRING" in {
     opDesc.matchingType = MatchingType.SUBSTRING
     opExec.open()
-    val processedTuple = opExec.processTexeraTuple(Left(tuple), null, null, null).next()
+    val processedTuple = opExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(processedTuple.getField("matched"))
     opExec.close()
   }
@@ -73,7 +73,7 @@ class DictionaryMatcherOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   it should "match a tuple if present in the given dictionary entry when matching type is CONJUNCTION_INDEXBASED" in {
     opDesc.matchingType = MatchingType.CONJUNCTION_INDEXBASED
     opExec.open()
-    val processedTuple = opExec.processTexeraTuple(Left(tuple), null, null, null).next()
+    val processedTuple = opExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(processedTuple.getField("matched"))
     opExec.close()
   }
@@ -85,7 +85,7 @@ class DictionaryMatcherOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.dictionary = dictionaryConjunction
     opDesc.matchingType = MatchingType.SCANBASED
     opExec.open()
-    val processedTuple = opExec.processTexeraTuple(Left(tuple), null, null, null).next()
+    val processedTuple = opExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(!processedTuple.getField("matched").asInstanceOf[Boolean])
     opExec.close()
   }
@@ -94,7 +94,7 @@ class DictionaryMatcherOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.dictionary = dictionaryConjunction
     opDesc.matchingType = MatchingType.SUBSTRING
     opExec.open()
-    val processedTuple = opExec.processTexeraTuple(Left(tuple), null, null, null).next()
+    val processedTuple = opExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(!processedTuple.getField("matched").asInstanceOf[Boolean])
     opExec.close()
   }
@@ -103,7 +103,7 @@ class DictionaryMatcherOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.dictionary = dictionaryConjunction
     opDesc.matchingType = MatchingType.CONJUNCTION_INDEXBASED
     opExec.open()
-    val processedTuple = opExec.processTexeraTuple(Left(tuple), null, null, null).next()
+    val processedTuple = opExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(processedTuple.getField("matched"))
     opExec.close()
   }
@@ -115,7 +115,7 @@ class DictionaryMatcherOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.dictionary = dictinarySubstring
     opDesc.matchingType = MatchingType.SCANBASED
     opExec.open()
-    val processedTuple = opExec.processTexeraTuple(Left(tuple), null, null, null).next()
+    val processedTuple = opExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(!processedTuple.getField("matched").asInstanceOf[Boolean])
     opExec.close()
   }
@@ -124,7 +124,7 @@ class DictionaryMatcherOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.dictionary = dictinarySubstring
     opDesc.matchingType = MatchingType.CONJUNCTION_INDEXBASED
     opExec.open()
-    val processedTuple = opExec.processTexeraTuple(Left(tuple), null, null, null).next()
+    val processedTuple = opExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(!processedTuple.getField("matched").asInstanceOf[Boolean])
     opExec.close()
   }
@@ -133,7 +133,7 @@ class DictionaryMatcherOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.dictionary = dictinarySubstring
     opDesc.matchingType = MatchingType.SUBSTRING
     opExec.open()
-    val processedTuple = opExec.processTexeraTuple(Left(tuple), null, null, null).next()
+    val processedTuple = opExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(processedTuple.getField("matched"))
     opExec.close()
   }

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/distinct/DistinctOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/distinct/DistinctOpExecSpec.scala
@@ -50,11 +50,11 @@ class DistinctOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
 
     opExec.open()
     (1 to 1000).map(_ => {
-      opExec.processTexeraTuple(Left(tuple()), null, null, null)
+      opExec.processTexeraTuple(Left(tuple()), 0, null, null)
     })
 
     val outputTuples: List[Tuple] =
-      opExec.processTexeraTuple(Right(InputExhausted()), null, null, null).toList
+      opExec.processTexeraTuple(Right(InputExhausted()), 0, null, null).toList
     assert(outputTuples.size == 1)
     assert(outputTuples.head.equals(tuple()))
     opExec.close()
@@ -64,17 +64,17 @@ class DistinctOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
 
     opExec.open()
     (1 to 1000).map(_ => {
-      opExec.processTexeraTuple(Left(tuple()), null, null, null)
+      opExec.processTexeraTuple(Left(tuple()), 0, null, null)
     })
     (1 to 1000).map(_ => {
-      opExec.processTexeraTuple(Left(tuple2()), null, null, null)
+      opExec.processTexeraTuple(Left(tuple2()), 0, null, null)
     })
     (1 to 1000).map(_ => {
-      opExec.processTexeraTuple(Left(tuple()), null, null, null)
+      opExec.processTexeraTuple(Left(tuple()), 0, null, null)
     })
 
     val outputTuples: List[Tuple] =
-      opExec.processTexeraTuple(Right(InputExhausted()), null, null, null).toList
+      opExec.processTexeraTuple(Right(InputExhausted()), 0, null, null).toList
     assert(outputTuples.size == 2)
     assert(outputTuples.head.equals(tuple()))
     assert(outputTuples.apply(1).equals(tuple2()))

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/filter/SpecializedFilterOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/filter/SpecializedFilterOpExecSpec.scala
@@ -1,25 +1,14 @@
 package edu.uci.ics.texera.workflow.operators.filter
 
-import edu.uci.ics.amber.engine.common.virtualidentity.{LayerIdentity, LinkIdentity}
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
-import edu.uci.ics.texera.workflow.operators.filter.{
-  ComparisonType,
-  FilterPredicate,
-  SpecializedFilterOpDesc,
-  SpecializedFilterOpExec
-}
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 
 import java.util.Arrays.asList
 
 class SpecializedFilterOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
-  val linkID: LinkIdentity =
-    LinkIdentity(
-      LayerIdentity(1.toString, 1.toString, 1.toString),
-      LayerIdentity(2.toString, 2.toString, 2.toString)
-    )
+  val inputPort: Int = 0
 
   val tuplesWithOneFieldNull: Iterable[Tuple] =
     AttributeType
@@ -67,7 +56,7 @@ class SpecializedFilterOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     val opExec = new SpecializedFilterOpExec(new SpecializedFilterOpDesc())
     opExec.open()
     assertThrows[NullPointerException] {
-      opExec.processTexeraTuple(Left(allNullTuple), linkID, null, null)
+      opExec.processTexeraTuple(Left(allNullTuple), inputPort, null, null)
     }
     opExec.close()
   }
@@ -77,7 +66,7 @@ class SpecializedFilterOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       predicates = asList()
     })
     opExec.open()
-    assert(opExec.processTexeraTuple(Left(allNullTuple), linkID, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Left(allNullTuple), inputPort, null, null).isEmpty)
     opExec.close()
   }
 
@@ -86,7 +75,7 @@ class SpecializedFilterOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       predicates = asList(new FilterPredicate("string", ComparisonType.IS_NULL, "value"))
     })
     opExec.open()
-    assert(!opExec.processTexeraTuple(Left(allNullTuple), linkID, null, null).isEmpty)
+    assert(!opExec.processTexeraTuple(Left(allNullTuple), inputPort, null, null).isEmpty)
     opExec.close()
   }
 
@@ -95,7 +84,7 @@ class SpecializedFilterOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       predicates = asList(new FilterPredicate("string", ComparisonType.IS_NOT_NULL, "value"))
     })
     opExec.open()
-    assert(opExec.processTexeraTuple(Left(allNullTuple), linkID, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Left(allNullTuple), inputPort, null, null).isEmpty)
     opExec.close()
   }
 
@@ -111,7 +100,7 @@ class SpecializedFilterOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
         })
 
         opExec.open()
-        assert(!opExec.processTexeraTuple(Left(nullTuple), linkID, null, null).isEmpty)
+        assert(!opExec.processTexeraTuple(Left(nullTuple), inputPort, null, null).isEmpty)
         opExec.close()
       })
   }
@@ -121,7 +110,7 @@ class SpecializedFilterOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       predicates = asList(new FilterPredicate("string", ComparisonType.IS_NULL, "value"))
     })
     opExec.open()
-    assert(opExec.processTexeraTuple(Left(nonNullTuple), linkID, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Left(nonNullTuple), inputPort, null, null).isEmpty)
     opExec.close()
   }
 
@@ -130,7 +119,7 @@ class SpecializedFilterOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       predicates = asList(new FilterPredicate("string", ComparisonType.IS_NOT_NULL, "value"))
     })
     opExec.open()
-    assert(!opExec.processTexeraTuple(Left(nonNullTuple), linkID, null, null).isEmpty)
+    assert(!opExec.processTexeraTuple(Left(nonNullTuple), inputPort, null, null).isEmpty)
     opExec.close()
   }
 
@@ -147,7 +136,7 @@ class SpecializedFilterOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
         })
 
         opExec.open()
-        assert(opExec.processTexeraTuple(Left(nullTuple), linkID, null, null).isEmpty)
+        assert(opExec.processTexeraTuple(Left(nullTuple), inputPort, null, null).isEmpty)
         opExec.close()
       })
   }

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpExecSpec.scala
@@ -13,8 +13,8 @@ import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 
 class HashJoinOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
-  val build: LinkIdentity = linkID()
-  val probe: LinkIdentity = linkID()
+  val build: Int = 0
+  val probe: Int = 1
 
   var opExec: HashJoinOpExec[String] = _
   var opDesc: HashJoinOpDesc[String] = _
@@ -54,7 +54,6 @@ class HashJoinOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     val outputSchema = opDesc.getOutputSchema(inputSchemas)
 
     opExec = new HashJoinOpExec[String](
-      build,
       "build_1",
       "probe_1",
       JoinType.INNER,
@@ -87,7 +86,6 @@ class HashJoinOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     val inputSchemas = Array(schema("same", 1), schema("same", 2))
     val outputSchema = opDesc.getOutputSchema(inputSchemas)
     opExec = new HashJoinOpExec[String](
-      build,
       "same",
       "same",
       JoinType.INNER,
@@ -122,7 +120,6 @@ class HashJoinOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     val inputSchemas = Array(schema("same", 1), schema("same", 2))
     val outputSchema = opDesc.getOutputSchema(inputSchemas)
     opExec = new HashJoinOpExec[String](
-      build,
       "same",
       "same",
       JoinType.FULL_OUTER,

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpExecSpec.scala
@@ -52,52 +52,25 @@ class IntersectOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   }
 
   it should "work with basic two input streams with no duplicates" in {
-    val linkID1 = linkID()
-    val linkID2 = linkID()
+    val input1 = 0
+    val input2 = 1
     opExec.open()
     counter = 0
     val commonTuples = (1 to 10).map(_ => tuple()).toList
 
     (0 to 7).map(i => {
-      opExec.processTexeraTuple(Left(commonTuples(i)), linkID1, null, null)
+      opExec.processTexeraTuple(Left(commonTuples(i)), input1, null, null)
     })
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID1, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), input1, null, null).isEmpty)
 
     (5 to 9).map(i => {
-      opExec.processTexeraTuple(Left(commonTuples(i)), linkID2, null, null)
+      opExec.processTexeraTuple(Left(commonTuples(i)), input2, null, null)
     })
 
     val outputTuples: Set[Tuple] =
-      opExec.processTexeraTuple(Right(InputExhausted()), linkID2, null, null).toSet
+      opExec.processTexeraTuple(Right(InputExhausted()), input2, null, null).toSet
     assert(outputTuples.equals(commonTuples.slice(5, 8).toSet))
 
-    opExec.close()
-  }
-
-  it should "work with two random input upstreams" in {
-    val links = (0 to 1).map(_ => linkID()).toList
-    opExec.open()
-    counter = 0
-    val commonTuples = (1 to 10).map(_ => tuple()).toList
-
-    (1 to 10).map(_ => {
-
-      opExec.processTexeraTuple(Left(tuple()), links(Random.nextInt(links.size)), null, null)
-      opExec.processTexeraTuple(
-        Left(commonTuples(Random.nextInt(commonTuples.size))),
-        links(Random.nextInt(links.size)),
-        null,
-        null
-      )
-    })
-
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), links.head, null, null).isEmpty)
-
-    val outputTuples: Set[Tuple] =
-      opExec.processTexeraTuple(Right(InputExhausted()), links(1), null, null).toSet
-    assert(outputTuples.size <= 10)
-    assert(outputTuples.subsetOf(commonTuples.toSet))
-    outputTuples.foreach(tuple => assert(tuple.getField[Int]("field2") <= 10))
     opExec.close()
   }
 
@@ -108,17 +81,17 @@ class IntersectOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     val commonTuples = (1 to 10).map(_ => tuple()).toList
     assertThrows[IllegalArgumentException] {
       (1 to 100).map(_ => {
-        opExec.processTexeraTuple(Left(tuple()), linkID(), null, null)
+        opExec.processTexeraTuple(Left(tuple()), 2, null, null)
         opExec.processTexeraTuple(
           Left(commonTuples(Random.nextInt(commonTuples.size))),
-          linkID(),
+          3,
           null,
           null
         )
       })
 
       val outputTuples: Set[Tuple] =
-        opExec.processTexeraTuple(Right(InputExhausted()), null, null, null).toSet
+        opExec.processTexeraTuple(Right(InputExhausted()), 0, null, null).toSet
       assert(outputTuples.size <= 10)
       assert(outputTuples.subsetOf(commonTuples.toSet))
       outputTuples.foreach(tuple => assert(tuple.getField[Int]("field2") <= 10))
@@ -127,99 +100,99 @@ class IntersectOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   }
 
   it should "work with one empty input upstream after a data stream" in {
-    val linkID1 = linkID()
-    val linkID2 = linkID()
+    val input0 = 0
+    val input1 = 1
     opExec.open()
     counter = 0
     val commonTuples = (1 to 10).map(_ => tuple()).toList
 
     (1 to 100).map(_ => {
-      opExec.processTexeraTuple(Left(tuple()), linkID1, null, null)
+      opExec.processTexeraTuple(Left(tuple()), input0, null, null)
       opExec.processTexeraTuple(
         Left(commonTuples(Random.nextInt(commonTuples.size))),
-        linkID1,
+        input0,
         null,
         null
       )
     })
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID1, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), input0, null, null).isEmpty)
 
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID2, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), input1, null, null).isEmpty)
     opExec.close()
   }
 
   it should "work with one empty input upstream after a data stream - other order" in {
-    val linkID1 = linkID()
-    val linkID2 = linkID()
+    val input1 = 0
+    val input2 = 1
     opExec.open()
     counter = 0
     val commonTuples = (1 to 10).map(_ => tuple()).toList
 
     (1 to 100).map(_ => {
-      opExec.processTexeraTuple(Left(tuple()), linkID1, null, null)
+      opExec.processTexeraTuple(Left(tuple()), input1, null, null)
       opExec.processTexeraTuple(
         Left(commonTuples(Random.nextInt(commonTuples.size))),
-        linkID1,
+        input1,
         null,
         null
       )
     })
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID2, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), input2, null, null).isEmpty)
 
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID1, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), input1, null, null).isEmpty)
     opExec.close()
   }
 
   it should "work with one empty input upstream before a data stream" in {
-    val linkID1 = linkID()
-    val linkID2 = linkID()
+    val input1 = 0
+    val input2 = 1
     opExec.open()
     counter = 0
     val commonTuples = (1 to 10).map(_ => tuple()).toList
 
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID2, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), input2, null, null).isEmpty)
     (1 to 100).map(_ => {
-      opExec.processTexeraTuple(Left(tuple()), linkID1, null, null)
+      opExec.processTexeraTuple(Left(tuple()), input1, null, null)
       opExec.processTexeraTuple(
         Left(commonTuples(Random.nextInt(commonTuples.size))),
-        linkID1,
+        input1,
         null,
         null
       )
     })
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID1, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), input1, null, null).isEmpty)
 
     opExec.close()
   }
 
   it should "work with one empty input upstream during a data stream" in {
-    val linkID1 = linkID()
-    val linkID2 = linkID()
+    val input1 = 0
+    val input2 = 1
     opExec.open()
     counter = 0
     val commonTuples = (1 to 10).map(_ => tuple()).toList
 
     (1 to 100).map(_ => {
-      opExec.processTexeraTuple(Left(tuple()), linkID1, null, null)
+      opExec.processTexeraTuple(Left(tuple()), input1, null, null)
       opExec.processTexeraTuple(
         Left(commonTuples(Random.nextInt(commonTuples.size))),
-        linkID1,
+        input1,
         null,
         null
       )
     })
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID2, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), input2, null, null).isEmpty)
 
     (1 to 100).map(_ => {
-      opExec.processTexeraTuple(Left(tuple()), linkID1, null, null)
+      opExec.processTexeraTuple(Left(tuple()), input1, null, null)
       opExec.processTexeraTuple(
         Left(commonTuples(Random.nextInt(commonTuples.size))),
-        linkID1,
+        input1,
         null,
         null
       )
     })
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID1, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), input1, null, null).isEmpty)
 
     opExec.close()
   }
@@ -227,8 +200,8 @@ class IntersectOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   it should "work with two empty input upstreams" in {
 
     opExec.open()
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID(), null, null).isEmpty)
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID(), null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), 0, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), 1, null, null).isEmpty)
     opExec.close()
   }
 

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/intervalJoin/IntervalOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/intervalJoin/IntervalOpExecSpec.scala
@@ -18,8 +18,8 @@ import scala.collection.mutable.ArrayBuffer
 import scala.util.Random.{nextInt, nextLong}
 
 class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
-  val left: LinkIdentity = linkID()
-  val right: LinkIdentity = linkID()
+  val left: Int = 0
+  val right: Int = 1
 
   var opDesc: IntervalJoinOpDesc = _
   var counter: Int = 0
@@ -220,8 +220,7 @@ class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     val outputSchema = opDesc.getOutputSchema(inputSchemas)
     val opExec = new IntervalJoinOpExec(
       OperatorSchemaInfo(inputSchemas, Array(outputSchema)),
-      opDesc,
-      left
+      opDesc
     )
     opExec.open()
     counter = 0
@@ -416,8 +415,7 @@ class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     val outputSchema = opDesc.getOutputSchema(inputSchemas)
     val opExec = new IntervalJoinOpExec(
       OperatorSchemaInfo(inputSchemas, Array(outputSchema)),
-      opDesc,
-      left
+      opDesc
     )
 
     opExec.open()

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/projection/ProjectionOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/projection/ProjectionOpExecSpec.scala
@@ -52,7 +52,7 @@ class ProjectionOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
 
     projectionOpExec.open()
 
-    val processedTuple = projectionOpExec.processTexeraTuple(Left(tuple), null, null, null).next()
+    val processedTuple = projectionOpExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(processedTuple.length() == 2)
     assert(processedTuple.getField("f1").asInstanceOf[String] == "hello")
     assert(processedTuple.getField("f2").asInstanceOf[Int] == 1)
@@ -75,7 +75,7 @@ class ProjectionOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
 
     projectionOpExec.open()
 
-    val processedTuple = projectionOpExec.processTexeraTuple(Left(tuple), null, null, null).next()
+    val processedTuple = projectionOpExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(processedTuple.length() == 2)
     assert(processedTuple.getField("f3").asInstanceOf[Boolean])
     assert(processedTuple.getField("f1").asInstanceOf[String] == "hello")
@@ -90,7 +90,7 @@ class ProjectionOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       new AttributeUnit("field---6", "f6")
     )
     assertThrows[RuntimeException] {
-      projectionOpExec.processTexeraTuple(Left(tuple), null, null, null).next()
+      projectionOpExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     }
 
   }
@@ -98,7 +98,7 @@ class ProjectionOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   it should "raise IllegalArgumentException on empty attributes" in {
     val projectionOpExec = new ProjectionOpExec(List(), null)
     assertThrows[IllegalArgumentException] {
-      projectionOpExec.processTexeraTuple(Left(tuple), null, null, null).next()
+      projectionOpExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     }
 
   }
@@ -110,7 +110,7 @@ class ProjectionOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       new AttributeUnit("field2", "f")
     )
     assertThrows[RuntimeException] {
-      projectionOpExec.processTexeraTuple(Left(tuple), null, null, null).next()
+      projectionOpExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     }
 
   }
@@ -130,7 +130,7 @@ class ProjectionOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
 
     projectionOpExec.open()
 
-    val processedTuple = projectionOpExec.processTexeraTuple(Left(tuple), null, null, null).next()
+    val processedTuple = projectionOpExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(processedTuple.length() == 2)
     assert(processedTuple.getField("field1").asInstanceOf[String] == "hello")
     assert(processedTuple.getField("f2").asInstanceOf[Int] == 1)

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/sortPartitions/SortPartitionsOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/sortPartitions/SortPartitionsOpExecSpec.scala
@@ -51,13 +51,13 @@ class SortPartitionsOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   it should "output in order" in {
 
     opExec.open()
-    opExec.processTexeraTuple(Left(tuple(3)), null, null, null)
-    opExec.processTexeraTuple(Left(tuple(1)), null, null, null)
-    opExec.processTexeraTuple(Left(tuple(2)), null, null, null)
-    opExec.processTexeraTuple(Left(tuple(5)), null, null, null)
+    opExec.processTexeraTuple(Left(tuple(3)), 0, null, null)
+    opExec.processTexeraTuple(Left(tuple(1)), 0, null, null)
+    opExec.processTexeraTuple(Left(tuple(2)), 0, null, null)
+    opExec.processTexeraTuple(Left(tuple(5)), 0, null, null)
 
     val outputTuples: List[Tuple] =
-      opExec.processTexeraTuple(Right(InputExhausted()), null, null, null).toList
+      opExec.processTexeraTuple(Right(InputExhausted()), 0, null, null).toList
     assert(outputTuples.size == 4)
     assert(outputTuples(0).equals(tuple(1)))
     assert(outputTuples(1).equals(tuple(2)))

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/symmetricDifference/SymmetricDifferenceOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/symmetricDifference/SymmetricDifferenceOpExecSpec.scala
@@ -13,13 +13,6 @@ class SymmetricDifferenceOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   var opExec: SymmetricDifferenceOpExec = _
   var counter: Int = 0
 
-  def layerID(): LayerIdentity = {
-    counter += 1
-    LayerIdentity("" + counter, "" + counter, "" + counter)
-  }
-
-  def linkID(): LinkIdentity = LinkIdentity(layerID(), layerID())
-
   def tuple(): Tuple = {
     counter += 1
     val schema = Schema
@@ -47,23 +40,23 @@ class SymmetricDifferenceOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   }
 
   it should "work with basic two input streams with no duplicates" in {
-    val linkID1 = linkID()
-    val linkID2 = linkID()
+    val input1 = 0
+    val input2 = 1
     opExec.open()
     counter = 0
     val commonTuples = (1 to 10).map(_ => tuple()).toList
 
     (0 to 7).map(i => {
-      opExec.processTexeraTuple(Left(commonTuples(i)), linkID1, null, null)
+      opExec.processTexeraTuple(Left(commonTuples(i)), input1, null, null)
     })
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID1, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), input1, null, null).isEmpty)
 
     (5 to 9).map(i => {
-      opExec.processTexeraTuple(Left(commonTuples(i)), linkID2, null, null)
+      opExec.processTexeraTuple(Left(commonTuples(i)), input2, null, null)
     })
 
     val outputTuples: Set[Tuple] =
-      opExec.processTexeraTuple(Right(InputExhausted()), linkID2, null, null).toSet
+      opExec.processTexeraTuple(Right(InputExhausted()), input2, null, null).toSet
     assert(
       outputTuples.equals(commonTuples.slice(0, 5).toSet.union(commonTuples.slice(8, 10).toSet))
     )
@@ -78,17 +71,17 @@ class SymmetricDifferenceOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     val commonTuples = (1 to 10).map(_ => tuple()).toList
     assertThrows[IllegalArgumentException] {
       (1 to 100).map(_ => {
-        opExec.processTexeraTuple(Left(tuple()), linkID(), null, null)
+        opExec.processTexeraTuple(Left(tuple()), 2, null, null)
         opExec.processTexeraTuple(
           Left(commonTuples(Random.nextInt(commonTuples.size))),
-          linkID(),
+          3,
           null,
           null
         )
       })
 
       val outputTuples: Set[Tuple] =
-        opExec.processTexeraTuple(Right(InputExhausted()), null, null, null).toSet
+        opExec.processTexeraTuple(Right(InputExhausted()), 0, null, null).toSet
       assert(outputTuples.size <= 10)
       assert(outputTuples.subsetOf(commonTuples.toSet))
       outputTuples.foreach(tuple => assert(tuple.getField[Int]("field2") <= 10))
@@ -97,76 +90,76 @@ class SymmetricDifferenceOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   }
 
   it should "work with one empty input upstream after a data stream" in {
-    val linkID1 = linkID()
-    val linkID2 = linkID()
+    val input1 = 0
+    val input2 = 1
     opExec.open()
     counter = 0
     val commonTuples = (1 to 10).map(_ => tuple()).toList
 
     (0 to 9).map(i => {
-      opExec.processTexeraTuple(Left(commonTuples(i)), linkID1, null, null)
+      opExec.processTexeraTuple(Left(commonTuples(i)), input1, null, null)
     })
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID1, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), input1, null, null).isEmpty)
 
     val outputTuples: Set[Tuple] =
-      opExec.processTexeraTuple(Right(InputExhausted()), linkID2, null, null).toSet
+      opExec.processTexeraTuple(Right(InputExhausted()), input2, null, null).toSet
     assert(outputTuples.equals(commonTuples.toSet))
     opExec.close()
   }
 
   it should "work with one empty input upstream after a data stream - other order" in {
-    val linkID1 = linkID()
-    val linkID2 = linkID()
+    val input1 = 0
+    val input2 = 1
     opExec.open()
     counter = 0
     val commonTuples = (1 to 10).map(_ => tuple()).toList
 
     (0 to 9).map(i => {
-      opExec.processTexeraTuple(Left(commonTuples(i)), linkID2, null, null)
+      opExec.processTexeraTuple(Left(commonTuples(i)), input2, null, null)
     })
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID2, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), input2, null, null).isEmpty)
 
     val outputTuples: Set[Tuple] =
-      opExec.processTexeraTuple(Right(InputExhausted()), linkID1, null, null).toSet
+      opExec.processTexeraTuple(Right(InputExhausted()), input1, null, null).toSet
     assert(outputTuples.equals(commonTuples.toSet))
     opExec.close()
   }
 
   it should "work with one empty input upstream before a data stream" in {
-    val linkID1 = linkID()
-    val linkID2 = linkID()
+    val input1 = 0
+    val input2 = 1
     opExec.open()
     counter = 0
     val commonTuples = (1 to 10).map(_ => tuple()).toList
 
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID2, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), input2, null, null).isEmpty)
     (0 to 9).map(i => {
-      opExec.processTexeraTuple(Left(commonTuples(i)), linkID1, null, null)
+      opExec.processTexeraTuple(Left(commonTuples(i)), input1, null, null)
     })
 
     val outputTuples: Set[Tuple] =
-      opExec.processTexeraTuple(Right(InputExhausted()), linkID1, null, null).toSet
+      opExec.processTexeraTuple(Right(InputExhausted()), input1, null, null).toSet
     assert(outputTuples.equals(commonTuples.toSet))
     opExec.close()
   }
 
   it should "work with one empty input upstream during a data stream" in {
-    val linkID1 = linkID()
-    val linkID2 = linkID()
+    val input1 = 0
+    val input2 = 1
     opExec.open()
     counter = 0
     val commonTuples = (1 to 10).map(_ => tuple()).toList
 
     (0 to 5).map(i => {
-      opExec.processTexeraTuple(Left(commonTuples(i)), linkID1, null, null)
+      opExec.processTexeraTuple(Left(commonTuples(i)), input1, null, null)
     })
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID2, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), input2, null, null).isEmpty)
     (6 to 9).map(i => {
-      opExec.processTexeraTuple(Left(commonTuples(i)), linkID1, null, null)
+      opExec.processTexeraTuple(Left(commonTuples(i)), input1, null, null)
     })
 
     val outputTuples: Set[Tuple] =
-      opExec.processTexeraTuple(Right(InputExhausted()), linkID1, null, null).toSet
+      opExec.processTexeraTuple(Right(InputExhausted()), input1, null, null).toSet
     assert(outputTuples.equals(commonTuples.toSet))
     opExec.close()
   }
@@ -174,8 +167,8 @@ class SymmetricDifferenceOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   it should "work with two empty input upstreams" in {
 
     opExec.open()
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID(), null, null).isEmpty)
-    assert(opExec.processTexeraTuple(Right(InputExhausted()), linkID(), null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), 0, null, null).isEmpty)
+    assert(opExec.processTexeraTuple(Right(InputExhausted()), 1, null, null).isEmpty)
     opExec.close()
   }
 

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/typecasting/TypeCastingOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/typecasting/TypeCastingOpExecSpec.scala
@@ -48,7 +48,7 @@ class TypeCastingOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
 
     typeCastingOpExec.open()
 
-    val processedTuple = typeCastingOpExec.processTexeraTuple(Left(tuple), null, null, null).next()
+    val processedTuple = typeCastingOpExec.processTexeraTuple(Left(tuple), 0, null, null).next()
     assert(processedTuple.length() == 4)
     assert(processedTuple.getField("field1").asInstanceOf[String] == "hello")
     assert(processedTuple.getField("field2").asInstanceOf[String] == "1")

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/unneststring/UnnestStringOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/unneststring/UnnestStringOpExecSpec.scala
@@ -42,7 +42,7 @@ class UnnestStringOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
 
   it should "split value in the given attribute and output the split result in the result attribute, one for each tuple" in {
     opExec.open()
-    val processedTuple = opExec.processTexeraTuple(Left(tuple), null, null, null)
+    val processedTuple = opExec.processTexeraTuple(Left(tuple), 0, null, null)
     assert(processedTuple.next().getField("split").equals("a"))
     assert(processedTuple.next().getField("split").equals("b"))
     assert(processedTuple.next().getField("split").equals("c"))
@@ -53,7 +53,7 @@ class UnnestStringOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   it should "generate the correct tuple when there is no delimiter in the value" in {
     opDesc.attribute = "field3"
     opExec.open()
-    val processedTuple = opExec.processTexeraTuple(Left(tuple), null, null, null)
+    val processedTuple = opExec.processTexeraTuple(Left(tuple), 0, null, null)
     assert(processedTuple.next().getField("split").equals("a"))
     assertThrows[java.util.NoSuchElementException](processedTuple.next().getField("split"))
     opExec.close()
@@ -69,7 +69,7 @@ class UnnestStringOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       .build()
 
     opExec.open()
-    val processedTuple = opExec.processTexeraTuple(Left(tuple), null, null, null)
+    val processedTuple = opExec.processTexeraTuple(Left(tuple), 0, null, null)
     assert(processedTuple.next().getField("split").equals("a"))
     assert(processedTuple.next().getField("split").equals("b"))
     assertThrows[java.util.NoSuchElementException](processedTuple.next().getField("split"))
@@ -86,7 +86,7 @@ class UnnestStringOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       .build()
 
     opExec.open()
-    val processedTuple = opExec.processTexeraTuple(Left(tuple), null, null, null)
+    val processedTuple = opExec.processTexeraTuple(Left(tuple), 0, null, null)
     assert(processedTuple.next().getField("split").equals("a"))
     assert(processedTuple.next().getField("split").equals("b"))
     assertThrows[java.util.NoSuchElementException](processedTuple.next().getField("split"))

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/visualization/htmlviz/HtmlVizOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/visualization/htmlviz/HtmlVizOpExecSpec.scala
@@ -31,7 +31,7 @@ class HtmlVizOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     val htmlVizOpExec = new HtmlVizOpExec("field1", operatorSchemaInfo)
     htmlVizOpExec.open()
     val processedTuple: Tuple =
-      htmlVizOpExec.processTexeraTuple(Left(tuple()), null, null, null).next()
+      htmlVizOpExec.processTexeraTuple(Left(tuple()), 0, null, null).next()
 
     assert(processedTuple.getField("html-content").asInstanceOf[String] == "hello")
 
@@ -42,7 +42,7 @@ class HtmlVizOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     val htmlVizOpExec = new HtmlVizOpExec("field2", operatorSchemaInfo)
     htmlVizOpExec.open()
     val processedTuple: Tuple =
-      htmlVizOpExec.processTexeraTuple(Left(tuple()), null, null, null).next()
+      htmlVizOpExec.processTexeraTuple(Left(tuple()), 0, null, null).next()
 
     assert(processedTuple.getField("html-content").asInstanceOf[String] == "<html></html>")
 


### PR DESCRIPTION
In this PR, we changed the operator executor interface to use input/output port index instead of link to other operators.

original interface:
```
  def processTuple(
      tuple: Either[ITuple, InputExhausted],
      input: LinkIdentity,
      pauseManager: PauseManager,
      asyncRPCClient: AsyncRPCClient
  ): Iterator[(ITuple, Option[LinkIdentity])]

// LinkIdentity contains fromOperatorID and toOperatorID
```

new interafce:
```
  def processTuple(
      tuple: Either[ITuple, InputExhausted],
      input: Int,
      pauseManager: PauseManager,
      asyncRPCClient: AsyncRPCClient
  ): Iterator[(ITuple, Option[Int])]
```

The motivation for this change is to make each operator more independent: an operator should independently run on its own and do not care which operator it's connected to. 

Before this change, an operator is aware of the specific input and output operators, which violates this independence principle. 

After the change, an operator only cares if an input data is coming from a specific port (for multi-input operators such as join), and the output data is sent to a specific port (for multi-output operators such as split)