### PR TITLE
[Compiler Refactor #4] Introduce new APIs in OperatorDescriptor to support new OpExecConfig interface

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OperatorDescriptor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OperatorDescriptor.scala
@@ -2,11 +2,13 @@ package edu.uci.ics.texera.workflow.common.operators
 
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonSubTypes, JsonTypeInfo}
+import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.NewOpExecConfig.NewOpExecConfig
 import edu.uci.ics.amber.engine.common.virtualidentity.OperatorIdentity
 import edu.uci.ics.amber.engine.operators.OpExecConfig
 import edu.uci.ics.texera.web.OPversion
 import edu.uci.ics.texera.workflow.common.metadata.{OperatorInfo, PropertyNameConstants}
 import edu.uci.ics.texera.workflow.common.tuple.schema.{OperatorSchemaInfo, Schema}
+import edu.uci.ics.texera.workflow.common.workflow.PhysicalPlan
 import edu.uci.ics.texera.workflow.common.{ConstraintViolation, WorkflowContext}
 import edu.uci.ics.texera.workflow.operators.aggregate.SpecializedAverageOpDesc
 import edu.uci.ics.texera.workflow.operators.dictionary.DictionaryMatcherOpDesc
@@ -133,7 +135,22 @@ abstract class OperatorDescriptor extends Serializable {
   var operatorVersion: String = getOperatorVersion()
   def operatorIdentifier: OperatorIdentity = OperatorIdentity(context.jobId, operatorID)
 
-  def operatorExecutor(operatorSchemaInfo: OperatorSchemaInfo): OpExecConfig
+  def operatorExecutor(operatorSchemaInfo: OperatorSchemaInfo): OpExecConfig = {
+    throw new UnsupportedOperationException(
+      "operator " + operatorIdentifier + " does not implement its executor"
+    )
+  }
+
+  def newOperatorExecutor(operatorSchemaInfo: OperatorSchemaInfo): NewOpExecConfig = {
+    throw new UnsupportedOperationException(
+      "operator " + operatorIdentifier + " is not migrated to new OpExec API"
+    )
+  }
+
+  // a logical operator corresponds multiple physical operators (a small DAG)
+  def operatorExecutorMultiLayer(operatorSchemaInfo: OperatorSchemaInfo): PhysicalPlan = {
+    new PhysicalPlan(List(newOperatorExecutor(operatorSchemaInfo)), List())
+  }
 
   def operatorInfo: OperatorInfo
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/aggregate/AggregateOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/aggregate/AggregateOpDesc.scala
@@ -1,10 +1,13 @@
 package edu.uci.ics.texera.workflow.common.operators.aggregate
 
+import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.NewOpExecConfig.NewOpExecConfig
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor
 import edu.uci.ics.texera.workflow.common.tuple.schema.OperatorSchemaInfo
 
 abstract class AggregateOpDesc extends OperatorDescriptor {
 
-  override def operatorExecutor(operatorSchemaInfo: OperatorSchemaInfo): AggregateOpExecConfig[_]
+  override def newOperatorExecutor(operatorSchemaInfo: OperatorSchemaInfo): NewOpExecConfig = {
+    throw new UnsupportedOperationException("multi-layer op should use operatorExecutorMultiLayer")
+  }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/filter/FilterOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/filter/FilterOpDesc.scala
@@ -11,6 +11,4 @@ abstract class FilterOpDesc extends OperatorDescriptor {
     schemas(0)
   }
 
-  override def operatorExecutor(operatorSchemaInfo: OperatorSchemaInfo): OneToOneOpExecConfig
-
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/flatmap/FlatMapOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/flatmap/FlatMapOpDesc.scala
@@ -3,8 +3,4 @@ package edu.uci.ics.texera.workflow.common.operators.flatmap
 import edu.uci.ics.texera.workflow.common.operators.{OneToOneOpExecConfig, OperatorDescriptor}
 import edu.uci.ics.texera.workflow.common.tuple.schema.OperatorSchemaInfo
 
-abstract class FlatMapOpDesc extends OperatorDescriptor {
-
-  override def operatorExecutor(operatorSchemaInfo: OperatorSchemaInfo): OneToOneOpExecConfig
-
-}
+abstract class FlatMapOpDesc extends OperatorDescriptor {}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/map/MapOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/map/MapOpDesc.scala
@@ -3,8 +3,4 @@ package edu.uci.ics.texera.workflow.common.operators.map
 import edu.uci.ics.texera.workflow.common.operators.{OneToOneOpExecConfig, OperatorDescriptor}
 import edu.uci.ics.texera.workflow.common.tuple.schema.OperatorSchemaInfo
 
-abstract class MapOpDesc extends OperatorDescriptor {
-
-  override def operatorExecutor(operatorSchemaInfo: OperatorSchemaInfo): OneToOneOpExecConfig
-
-}
+abstract class MapOpDesc extends OperatorDescriptor {}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
@@ -1,0 +1,30 @@
+package edu.uci.ics.texera.workflow.common.workflow
+
+import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.NewOpExecConfig.NewOpExecConfig
+import edu.uci.ics.amber.engine.architecture.linksemantics.LinkStrategy
+import edu.uci.ics.amber.engine.architecture.scheduling.PipelinedRegion
+import edu.uci.ics.amber.engine.common.virtualidentity.{LinkIdentity, OperatorIdentity}
+import org.jgrapht.graph.{DefaultEdge, DirectedAcyclicGraph}
+
+object PhysicalPlan {
+
+  def apply(operatorList: Array[NewOpExecConfig], links: Array[LinkIdentity]): PhysicalPlan = {
+    new PhysicalPlan(operatorList.toList, links.toList)
+  }
+
+  def toOutLinks(
+      allLinks: Iterable[(OperatorIdentity, OperatorIdentity)]
+  ): Map[OperatorIdentity, Set[OperatorIdentity]] = {
+    allLinks
+      .groupBy(link => link._1)
+      .mapValues(links => links.map(link => link._2).toSet)
+  }
+
+}
+
+case class PhysicalPlan(
+    operators: List[NewOpExecConfig],
+    links: List[LinkIdentity],
+    linkStrategies: Map[LinkIdentity, LinkStrategy] = Map(),
+    pipelinedRegionsDAG: DirectedAcyclicGraph[PipelinedRegion, DefaultEdge] = null
+) {}


### PR DESCRIPTION
This PR is a follow-up of #1791 , where a new `OpExecConfig` interface is introduced for the new workflow compiler layer. This PR changes the `OperatorDescriptor` interface to use the new `OpExecConfig`. Currently, the old and new interfaces exist in parallel. After all migrations are completed, the old interface will be removed.

New interfaces:
```
  def newOperatorExecutor(operatorSchemaInfo: OperatorSchemaInfo): NewOpExecConfig = {
    throw new UnsupportedOperationException(
      "operator " + operatorIdentifier + " is not migrated to new OpExec API"
    )
  }

  // a logical operator corresponds multiple physical operators (a small DAG)
  def operatorExecutorMultiLayer(operatorSchemaInfo: OperatorSchemaInfo): PhysicalPlan = {
    new PhysicalPlan(List(newOperatorExecutor(operatorSchemaInfo)), List())
```

Logical operators that correpond to a single physical operator will implement `newOperatorExecutor` interface.
Logical operators that correpond to a **multiple** physical operator (such as aggregate) will implement `operatorExecutorMultiLayer` interface.