### PR TITLE
Fix error overriding issue on the webserver

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/SchemaPropagationResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/SchemaPropagationResource.scala
@@ -31,10 +31,13 @@ class SchemaPropagationResource {
 
       val texeraWorkflowCompiler = new WorkflowCompiler(LogicalPlan(workflow), context)
 
-      val schemaPropagationResult = texeraWorkflowCompiler.logicalPlan
-        .propagateWorkflowSchema()
-        .map(e => (e._1.operator, e._2.map(s => s.map(o => o.getAttributesScala))))
-      SchemaPropagationResponse(0, schemaPropagationResult, null)
+      // ignore errors during propagation.
+      val (schemaPropagationResult, _) =
+        texeraWorkflowCompiler.logicalPlan.propagateWorkflowSchema()
+      val responseContent = schemaPropagationResult.map(e =>
+        (e._1.operator, e._2.map(s => s.map(o => o.getAttributesScala)))
+      )
+      SchemaPropagationResponse(0, responseContent, null)
     } catch {
       case e: Throwable =>
         e.printStackTrace()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
@@ -65,7 +65,7 @@ case class LogicalPlan(
   lazy val inputSchemaMap: Map[OperatorIdentity, List[Option[Schema]]] = {
     val (schemaMap, errorList) = propagateWorkflowSchema()
     if (errorList.nonEmpty) {
-      throw new RuntimeException(s"${errorList.size} error(s) occurred during schema propagation.")
+      throw new RuntimeException(s"${errorList.size} error(s) occurred in schema propagation.")
     }
     schemaMap
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
@@ -127,7 +127,7 @@ case class LogicalPlan(
             Option.empty
           } else {
             // op's input schema is complete, try to infer its output schema
-            // if inference failed, print an exception message, but still continue the process
+            // if inference failed, print an exception message then abort
             Option.apply(
               op.getOutputSchemas(inputSchemaMap(op.operatorIdentifier).map(s => s.get).toArray)
             )
@@ -135,7 +135,7 @@ case class LogicalPlan(
         } catch {
           case e: Throwable =>
             e.printStackTrace()
-            Option.empty
+            throw e
         }
       }
       // exception: if op is a source operator, use its output schema as input schema for autocomplete

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
@@ -13,6 +13,7 @@ import edu.uci.ics.texera.workflow.operators.sink.managed.ProgressiveSinkOpDesc
 import org.jgrapht.graph.DirectedAcyclicGraph
 
 import scala.collection.mutable
+import scala.collection.mutable.ArrayBuffer
 
 case class BreakpointInfo(operatorID: String, breakpoint: Breakpoint)
 
@@ -61,8 +62,13 @@ case class LogicalPlan(
       .filter(op => operatorMap(op).isInstanceOf[SinkOpDesc])
       .toList
 
-  lazy val inputSchemaMap: Map[OperatorIdentity, List[Option[Schema]]] =
-    propagateWorkflowSchema()
+  lazy val inputSchemaMap: Map[OperatorIdentity, List[Option[Schema]]] = {
+    val (schemaMap, errorList) = propagateWorkflowSchema()
+    if (errorList.nonEmpty) {
+      throw new RuntimeException(s"${errorList.size} error(s) occurred during schema propagation.")
+    }
+    schemaMap
+  }
 
   lazy val outputSchemaMap: Map[OperatorIdentity, List[Schema]] =
     operatorMap.values
@@ -98,7 +104,7 @@ case class LogicalPlan(
     downstream.toList
   }
 
-  def propagateWorkflowSchema(): Map[OperatorIdentity, List[Option[Schema]]] = {
+  def propagateWorkflowSchema(): (Map[OperatorIdentity, List[Option[Schema]]], List[Throwable]) = {
     // a map from an operator to the list of its input schema
     val inputSchemaMap =
       new mutable.HashMap[OperatorIdentity, mutable.MutableList[Option[Schema]]]()
@@ -106,7 +112,7 @@ case class LogicalPlan(
           mutable.MutableList
             .fill(operatorMap(op.operator).operatorInfo.inputPorts.size)(Option.empty)
         )
-
+    val errorsDuringPropagation = new ArrayBuffer[Throwable]()
     // propagate output schema following topological order
     val topologicalOrderIterator = jgraphtDag.iterator()
     topologicalOrderIterator.forEachRemaining(opID => {
@@ -127,15 +133,15 @@ case class LogicalPlan(
             Option.empty
           } else {
             // op's input schema is complete, try to infer its output schema
-            // if inference failed, print an exception message then abort
+            // if inference failed, print an exception message, but still continue the process
             Option.apply(
               op.getOutputSchemas(inputSchemaMap(op.operatorIdentifier).map(s => s.get).toArray)
             )
           }
         } catch {
           case e: Throwable =>
-            e.printStackTrace()
-            throw e
+            errorsDuringPropagation.append(e)
+            Option.empty
         }
       }
       // exception: if op is a source operator, use its output schema as input schema for autocomplete
@@ -164,10 +170,13 @@ case class LogicalPlan(
       })
     })
 
-    inputSchemaMap
-      .filter(e => !(e._2.exists(s => s.isEmpty) || e._2.isEmpty))
-      .map(e => (e._1, e._2.toList))
-      .toMap
+    (
+      inputSchemaMap
+        .filter(e => !(e._2.exists(s => s.isEmpty) || e._2.isEmpty))
+        .map(e => (e._1, e._2.toList))
+        .toMap,
+      errorsDuringPropagation.toList
+    )
   }
 
   def toPhysicalPlan(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
@@ -61,7 +61,12 @@ class WorkflowCompiler(val logicalPlan: LogicalPlan, val context: WorkflowContex
     })
 
     // create and save OpExecConfigs for the operators
-    val inputSchemaMap = logicalPlan.propagateWorkflowSchema()
+    val (inputSchemaMap, errorList) = logicalPlan.propagateWorkflowSchema()
+    if (errorList.nonEmpty) {
+      throw new RuntimeException(
+        s"${errorList.size} error(s) occurred during submitting the workflow: \n ${errorList.mkString("\n")}"
+      )
+    }
     val amberOperators: mutable.Map[OperatorIdentity, OpExecConfig] = mutable.Map()
     logicalPlan.operators.foreach(o => {
       val inputSchemas: Array[Schema] =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
@@ -64,7 +64,7 @@ class WorkflowCompiler(val logicalPlan: LogicalPlan, val context: WorkflowContex
     val (inputSchemaMap, errorList) = logicalPlan.propagateWorkflowSchema()
     if (errorList.nonEmpty) {
       throw new RuntimeException(
-        s"${errorList.size} error(s) occurred during submitting the workflow: \n ${errorList.mkString("\n")}"
+        s"${errorList.size} error(s) occurred in workflow submission: \n ${errorList.mkString("\n")}"
       )
     }
     val amberOperators: mutable.Map[OperatorIdentity, OpExecConfig] = mutable.Map()

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/common/workflow/SchemaPropagationSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/common/workflow/SchemaPropagationSpec.scala
@@ -141,7 +141,7 @@ class SchemaPropagationSpec extends AnyFlatSpec with BeforeAndAfter {
     val logicalPlan = LogicalPlan(operators, links, List())
     val workflowCompiler = new WorkflowCompiler(logicalPlan, new WorkflowContext())
 
-    val schemaResult = workflowCompiler.logicalPlan.propagateWorkflowSchema()
+    val schemaResult = workflowCompiler.logicalPlan.propagateWorkflowSchema()._1
 
     assert(schemaResult(mlTrainingOp.operatorIdentifier).head.get.equals(dataSchema))
     assert(schemaResult(mlTrainingOp.operatorIdentifier)(1).get.equals(dataSchema))


### PR DESCRIPTION
This PR fixes an issue where the actual error is overridden by the "Key not found" error thrown from `LogicalPlan`. When the schema propagation of one operator throws an exception, earlier we silently printed the error and returned None. Now we return a list of errors that occurred during schema propagation and handle this list case by case.