### PR TITLE
Fix Random Line Break Inserted Bug in Collaborative Text Editors

### DIFF
--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/coeditor-presence.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/coeditor-presence.service.ts
@@ -96,11 +96,6 @@ export class CoeditorPresenceService {
     this.texeraGraph.sharedModel.awareness.on(
       "change",
       (change: { added: number[]; updated: number[]; removed: number[] }) => {
-        this.getCoeditorStatesArray().filter(
-          userState =>
-            userState.user.clientId && this.getLocalClientId() && userState.user.clientId !== this.getLocalClientId()
-        );
-
         for (const clientId of change.added) {
           const coeditorState = this.getCoeditorStatesMap().get(clientId);
           if (coeditorState && coeditorState.user.clientId !== this.getLocalClientId()) this.addCoeditor(coeditorState);


### PR DESCRIPTION
This PR fixes the bug reported in #1808. The issue is not about running a workflow. It happens after creating a new workflow. , and immediately editing a textual field that uses a collaborative text editor. The "random line break" is caused by interrupted text insertion for the text editor, as whenever it inserts texts, this error happens:
<img width="644" alt="image" src="https://user-images.githubusercontent.com/36582710/214925700-f4ca204a-79f1-4b29-8a2f-04948c5bc5c7.png">.

This is actually caused by an erroneous piece of code in `CoeditorPresenceService`, which was not useful and left there by mistake. It has wrong assumptions about `userState`, because it assumes `userState` will only be changed by our custom presence updates. (Since it was written before the introduction of collaborative textual editors). When a new workflow is created, when editing a textual field, the text editor also updates `userState`, and at this moment there is no `user` object yet, which causes the exception.

Deleting this piece of code will fix the error.