### PR TITLE
Fix buffering events in JointJS async context

### DIFF
--- a/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
@@ -225,8 +225,6 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
     if (!this.currentOperatorId) {
       return;
     }
-    console.log("re-rendered");
-    // console.trace()
     this.workflowActionService.getTexeraGraph().updateSharedModelAwareness("currentlyEditing", this.currentOperatorId);
     const operator = this.workflowActionService.getTexeraGraph().getOperator(this.currentOperatorId);
     // set the operator data needed


### PR DESCRIPTION
This PR fixes an issue when the JointJS paper is rendered in async mode. 
In async mode, the view is not available until it's completely rendered. Therefore, we need to buffer some UI events until we know it's completely rendered. We created a function `bufferWhileAsync` to do this.

The old `bufferWhileAsync` implementation has problems: for each input event, multiple duplicate output events (3 events) are emitted. This PR rewrites the implementation to make it correctly produce a single output event.