### PR TITLE
Enable local user with googleId to login

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/AuthResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/AuthResource.scala
@@ -32,7 +32,7 @@ object AuthResource {
       SqlServer.createDSLContext
         .select()
         .from(USER)
-        .where(USER.NAME.eq(name).and(USER.GOOGLE_ID.isNull))
+        .where(USER.NAME.eq(name))
         .fetchOneInto(classOf[User])
     ).filter(user => new StrongPasswordEncryptor().checkPassword(password, user.getPassword))
   }


### PR DESCRIPTION
Enable local users with googleid to login. It might not be useful, but I don't see any reason to disallow users to login with local login and google login at the same time.