### PR TITLE
Mitigate OOM by correctly turning off output message saving for fault tolerance

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
@@ -48,7 +48,11 @@ abstract class WorkflowActor(
   val networkCommunicationActor: NetworkSenderActorRef = NetworkSenderActorRef(
     // create a network communication actor on the same machine as the WorkflowActor itself
     context.actorOf(
-      NetworkCommunicationActor.props(parentNetworkCommunicationActorRef.ref, actorId)
+      NetworkCommunicationActor.props(
+        parentNetworkCommunicationActorRef.ref,
+        actorId,
+        supportFaultTolerance
+      )
     )
   )
   val logStorage: DeterminantLogStorage = {


### PR DESCRIPTION
This PR:
1. fixes a bug where the output messages are saved in the NetworkComminucationActor without fault tolerance being active.
With the default configuration, this can cause at most 400*10000 = 4M tuples to stay within each channel between a pair of operators during the whole execution. Which might lead to slowness or OOM.