### PR TITLE
Fix workflow scheduling for python dual input ports

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/OpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/OpExecConfig.scala
@@ -129,6 +129,9 @@ case class OpExecConfig(
     isOneToManyOp: Boolean = false
 ) {
 
+  // all the "dependee" links are also blocking inputs
+  lazy val realBlockingInputs: List[Int] = (blockingInputs ++ dependency.values).distinct
+
   // return the runtime class of the corresponding OperatorExecutor
   lazy private val tempOperatorInstance: IOperatorExecutor = initIOperatorExecutor((0, this))
   lazy val opExecClass: Class[_ <: IOperatorExecutor] =
@@ -224,7 +227,7 @@ case class OpExecConfig(
     * outputs all its tuples
     */
   def isInputBlocking(input: LinkIdentity): Boolean = {
-    inputToOrdinalMapping.get(input).exists(port => blockingInputs.contains(port))
+    inputToOrdinalMapping.get(input).exists(port => realBlockingInputs.contains(port))
   }
 
   /**

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/DualInputPortsPythonUDFOpDescV2.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/pythonV2/DualInputPortsPythonUDFOpDescV2.scala
@@ -71,6 +71,7 @@ class DualInputPortsPythonUDFOpDescV2 extends OperatorDescriptor {
         )
         .copy(
           numWorkers = workers,
+          blockingInputs = List(0),
           dependency = Map(1 -> 0),
           derivePartition = _ => UnknownPartition()
         )
@@ -80,7 +81,11 @@ class DualInputPortsPythonUDFOpDescV2 extends OperatorDescriptor {
           operatorIdentifier,
           _ => new PythonUDFOpExecV2(code, operatorSchemaInfo.outputSchemas.head)
         )
-        .copy(dependency = Map(1 -> 0), derivePartition = _ => UnknownPartition())
+        .copy(
+          blockingInputs = List(0),
+          dependency = Map(1 -> 0),
+          derivePartition = _ => UnknownPartition()
+        )
   }
 
   override def operatorInfo: OperatorInfo =


### PR DESCRIPTION
This PR fixes a wrong configuration for python dual input ports. This operator doesn't specify the `blocking` property.

This PR also updates the definition of "blocking" inputs. All the dependee input ports should also be blocking.