### PR TITLE
Add Backend Server API test framework

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/SqlServer.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/SqlServer.java
@@ -15,6 +15,7 @@ public final class SqlServer {
     public static final SQLDialect SQL_DIALECT = SQLDialect.MYSQL;
     private static final MysqlDataSource dataSource;
     public static Config jdbcConfig;
+    public static DSLContext context;
 
     static {
         // TODO: do not use hardcoded value
@@ -26,9 +27,14 @@ public final class SqlServer {
         dataSource.setUrl(jdbcConfig.getString("jdbc.url"));
         dataSource.setUser(jdbcConfig.getString("jdbc.username"));
         dataSource.setPassword(jdbcConfig.getString("jdbc.password"));
+        context = DSL.using(dataSource, SQL_DIALECT);
     }
 
     public static DSLContext createDSLContext() {
-        return DSL.using(dataSource, SQL_DIALECT);
+        return context;
+    }
+
+    public static void replaceDSLContext(DSLContext newContext){
+        context = newContext;
     }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/UserConfigResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/UserConfigResource.scala
@@ -22,7 +22,7 @@ import scala.jdk.CollectionConverters.asScalaBuffer
 @RolesAllowed(Array("REGULAR", "ADMIN"))
 @Consumes(Array(MediaType.TEXT_PLAIN))
 class UserConfigResource {
-  final private val userDictionaryDao = new UserConfigDao(
+  final private lazy val userDictionaryDao = new UserConfigDao(
     SqlServer.createDSLContext.configuration
   )
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/AuthResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/AuthResource.scala
@@ -18,7 +18,7 @@ import javax.ws.rs._
 import javax.ws.rs.core.MediaType
 object AuthResource {
 
-  final private val userDao = new UserDao(SqlServer.createDSLContext.configuration)
+  final private lazy val userDao = new UserDao(SqlServer.createDSLContext.configuration)
 
   /**
     * Retrieve exactly one User from databases with the given username and password.

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/GoogleAuthResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/GoogleAuthResource.scala
@@ -19,12 +19,13 @@ import java.util.Collections
 import javax.ws.rs._
 import javax.ws.rs.core.MediaType
 object GoogleAuthResource {
-  final private val userDao = new UserDao(SqlServer.createDSLContext.configuration)
-  private val verifier = new GoogleIdTokenVerifier.Builder(new NetHttpTransport, new JacksonFactory)
-    .setAudience(
-      Collections.singletonList(ConfigFactory.load("google_api").getString("google.clientId"))
-    )
-    .build()
+  final private lazy val userDao = new UserDao(SqlServer.createDSLContext.configuration)
+  private lazy val verifier =
+    new GoogleIdTokenVerifier.Builder(new NetHttpTransport, new JacksonFactory)
+      .setAudience(
+        Collections.singletonList(ConfigFactory.load("google_api").getString("google.clientId"))
+      )
+      .build()
 }
 
 @Path("/auth/google")

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
@@ -12,8 +12,8 @@ import javax.ws.rs._
 import javax.ws.rs.core.MediaType
 
 object AdminUserResource {
-  final private val context = SqlServer.createDSLContext()
-  final private val userDao = new UserDao(context.configuration)
+  final private lazy val context = SqlServer.createDSLContext()
+  final private lazy val userDao = new UserDao(context.configuration)
 }
 
 @Path("/admin/user")

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/file/UserFileResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/file/UserFileResource.scala
@@ -40,8 +40,8 @@ import java.net.URLDecoder
   */
 
 object UserFileResource {
-  private val context: DSLContext = SqlServer.createDSLContext
-  private val fileDao = new FileDao(context.configuration)
+  private lazy val context: DSLContext = SqlServer.createDSLContext
+  private lazy val fileDao = new FileDao(context.configuration)
 
   def saveUserFileSafe(
       uid: UInteger,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/file/UserFileUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/file/UserFileUtils.scala
@@ -11,10 +11,10 @@ import java.io._
 import java.nio.file.{Files, Path, Paths}
 
 object UserFileUtils {
-  private val FILE_CONTAINER_PATH: Path = {
+  private lazy val FILE_CONTAINER_PATH: Path = {
     Utils.amberHomePath.resolve("user-resources").resolve("files")
   }
-  private val fileDao = new FileDao(SqlServer.createDSLContext.configuration)
+  private lazy val fileDao = new FileDao(SqlServer.createDSLContext.configuration)
 
   def storeFile(fileStream: InputStream, fileName: String, userID: UInteger): Unit = {
     createFileDirectoryIfNotExist(UserFileUtils.getFileDirectory(userID))

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/project/ProjectResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/project/ProjectResource.scala
@@ -62,10 +62,10 @@ import javax.annotation.security.RolesAllowed
   */
 
 object ProjectResource {
-  final private val context = SqlServer.createDSLContext()
-  final private val userProjectDao = new ProjectDao(context.configuration)
-  final private val workflowOfProjectDao = new WorkflowOfProjectDao(context.configuration)
-  final private val fileOfProjectDao = new FileOfProjectDao(context.configuration)
+  final private lazy val context = SqlServer.createDSLContext()
+  final private lazy val userProjectDao = new ProjectDao(context.configuration)
+  final private lazy val workflowOfProjectDao = new WorkflowOfProjectDao(context.configuration)
+  final private lazy val fileOfProjectDao = new FileOfProjectDao(context.configuration)
 
   private def workflowOfProjectExists(wid: UInteger, pid: UInteger): Boolean = {
     workflowOfProjectDao.existsById(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowAccessResource.scala
@@ -42,7 +42,7 @@ import scala.collection.JavaConverters._
 object WorkflowAccessResource {
 
   private lazy val userDao = new UserDao(context.configuration())
-  private var context: DSLContext = SqlServer.createDSLContext
+  private lazy val context: DSLContext = SqlServer.createDSLContext
 
   /**
     * Identifies whether the given user has read-only access over the given workflow
@@ -169,11 +169,6 @@ class WorkflowAccessResource() {
   private val workflowUserAccessDao = new WorkflowUserAccessDao(
     context.configuration
   )
-
-  def this(dslContext: DSLContext) {
-    this()
-    context = dslContext
-  }
 
   /**
     * This method returns the owner of a workflow

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowResource.scala
@@ -44,11 +44,11 @@ import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 
 object WorkflowResource {
   final private lazy val context = SqlServer.createDSLContext()
-  final private val workflowDao = new WorkflowDao(context.configuration)
-  final private val workflowOfUserDao = new WorkflowOfUserDao(
+  final private lazy val workflowDao = new WorkflowDao(context.configuration)
+  final private lazy val workflowOfUserDao = new WorkflowOfUserDao(
     context.configuration
   )
-  final private val workflowUserAccessDao = new WorkflowUserAccessDao(
+  final private lazy val workflowUserAccessDao = new WorkflowUserAccessDao(
     context.configuration()
   )
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/workflow/WorkflowVersionResource.scala
@@ -31,14 +31,14 @@ import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 
 object WorkflowVersionResource {
   final private lazy val context = SqlServer.createDSLContext()
-  final private val workflowVersionDao = new WorkflowVersionDao(context.configuration)
-  final private val workflowDao = new WorkflowDao(context.configuration)
+  final private lazy val workflowVersionDao = new WorkflowVersionDao(context.configuration)
+  final private lazy val workflowDao = new WorkflowDao(context.configuration)
   // constant to indicate versions should be aggregated if they are within the specified time limit
-  private final val AGGREGATE_TIME_LIMIT_MILLSEC =
+  private final lazy val AGGREGATE_TIME_LIMIT_MILLSEC =
     AmberUtils.amberConfig.getInt("user-sys.version-time-limit-in-minutes") * 60000
   // list of Json keys in the diff patch that are considered UNimportant
-  private final val VERSION_UNIMPORTANCE_RULES = List("/operatorPositions/")
-  private final val SNAPSHOT_UNIMPORTANCE_RULES = List("replace")
+  private final lazy val VERSION_UNIMPORTANCE_RULES = List("/operatorPositions/")
+  private final lazy val SNAPSHOT_UNIMPORTANCE_RULES = List("replace")
 
   /**
     * This function retrieves the latest version of a workflow

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/MockTexeraDB.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/MockTexeraDB.scala
@@ -1,0 +1,64 @@
+package edu.uci.ics.texera.web
+
+import ch.vorburger.mariadb4j.DB
+import com.mysql.cj.jdbc.MysqlDataSource
+import org.jooq.DSLContext
+import org.jooq.impl.DSL
+import ch.vorburger.mariadb4j.{DB, DBConfigurationBuilder}
+
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, Path, Paths}
+
+trait MockTexeraDB {
+
+  private var dbInstance: Option[DB] = None
+  private var dslContext: Option[DSLContext] = None
+
+  def getDSLContext: DSLContext = {
+    dslContext match {
+      case Some(value) => value
+      case None =>
+        throw new RuntimeException("test database is not initialized. Did you call initialize()?")
+    }
+  }
+
+  def shutdownDB(): Unit = {
+    dbInstance match {
+      case Some(value) =>
+        value.stop()
+        dbInstance = None
+        dslContext = None
+      case None =>
+      // do nothing
+    }
+  }
+
+  def initializeDBAndReplaceDSLContext(): Unit = {
+    assert(dbInstance.isEmpty && dslContext.isEmpty)
+    val database: String = "texera_db"
+    val username: String = "root"
+    val password: String = ""
+    val ddlPath =
+      Paths.get("..").resolve("scripts").resolve("sql").resolve("texera_ddl.sql").toRealPath()
+    val content = new String(Files.readAllBytes(ddlPath), StandardCharsets.UTF_8)
+    val config = DBConfigurationBuilder.newBuilder
+      .setPort(0) // 0 => automatically detect free port
+      .addArg("--default-time-zone=+0:00")
+      .setSecurityDisabled(true)
+      .setDeletingTemporaryBaseAndDataDirsOnShutdown(true)
+      .build()
+
+    val db = DB.newEmbeddedDB(config)
+    db.start()
+    db.run(content)
+
+    val dataSource = new MysqlDataSource
+    dataSource.setUrl(config.getURL(database))
+    dataSource.setUser(username)
+    dataSource.setPassword(password)
+
+    dbInstance = Some(db)
+    dslContext = Some(DSL.using(dataSource, SqlServer.SQL_DIALECT))
+    SqlServer.replaceDSLContext(dslContext.get)
+  }
+}

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/file/UserFileResourceSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/file/UserFileResourceSpec.scala
@@ -1,0 +1,51 @@
+package edu.uci.ics.texera.web.resource.dashboard.file
+
+import edu.uci.ics.texera.web.{MockTexeraDB, SqlServer}
+import edu.uci.ics.texera.web.auth.SessionUser
+import edu.uci.ics.texera.web.model.jooq.generated.enums.UserRole
+import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.UserDao
+import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.User
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition
+import org.jooq.types.UInteger
+import org.scalatest.{BeforeAndAfter, BeforeAndAfterAll}
+import org.scalatest.flatspec.AnyFlatSpec
+
+class UserFileResourceSpec extends AnyFlatSpec with BeforeAndAfterAll with MockTexeraDB {
+
+  private val testUser: User = {
+    val user = new User
+    user.setUid(UInteger.valueOf(1))
+    user.setName("test_user")
+    user.setRole(UserRole.ADMIN)
+    user.setPassword("123")
+    user
+  }
+
+  override protected def beforeAll(): Unit = {
+    initializeDBAndReplaceDSLContext()
+    // add test user directly
+    val userDao = new UserDao(getDSLContext.configuration())
+    userDao.insert(testUser)
+  }
+
+  override protected def afterAll(): Unit = {
+    shutdownDB()
+  }
+
+  "user" should "be able to upload file" in {
+    val fileResource = new UserFileResource()
+    val source = "This is the content of the file"
+    val in = org.apache.commons.io.IOUtils.toInputStream(source, "UTF-8")
+    val fileDetail =
+      new FormDataContentDisposition("form-data; name=\"file\"; filename=\"example.txt\"")
+    val response = fileResource.uploadFile(
+      in,
+      fileDetail,
+      UInteger.valueOf(source.length),
+      "sample file for testing",
+      new SessionUser(testUser)
+    )
+    assert(response.getStatusInfo.getStatusCode == 200)
+  }
+
+}


### PR DESCRIPTION
This PR:
1. added a mock SQL database only for backend API testing. The database is in-memory, initialized with texera DDL, and contains no record.
2. change all global DAO objects to `lazy val` so that the unit test can have a chance to replace the DSL context they are using.
3. removed unused constructor in `WorkflowAccessResource`.