### PR TITLE
Fix a misleading log entry in enforce FIFO logic

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkInputPort.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkInputPort.scala
@@ -35,8 +35,7 @@ class NetworkInputPort[T](
       case Some(iterable) =>
         iterable.foreach(v => handler.apply(from, v))
       case None =>
-        // discard duplicate
-        logger.info(s"receive duplicated: $payload from $from")
+          // could be stashed or deduplicated
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkInputPort.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkInputPort.scala
@@ -35,7 +35,7 @@ class NetworkInputPort[T](
       case Some(iterable) =>
         iterable.foreach(v => handler.apply(from, v))
       case None =>
-          // could be stashed or deduplicated
+      // could be stashed or deduplicated
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkInputPort.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkInputPort.scala
@@ -27,10 +27,12 @@ class NetworkInputPort[T](
     sender ! NetworkAck(messageID, Some(senderCredits))
     val entry = idToOrderingEnforcers.getOrElseUpdate(from, new OrderingEnforcer[T]())
     if (entry.isDuplicated(sequenceNumber)) { // discard duplicate
-      logger.info(s"receive a duplicated message: $payload from $sender")
+      logger.info(
+        s"receive a duplicated message: $payload from $sender with seqNum = $sequenceNumber while current = ${entry.current}"
+      )
     } else if (entry.isAhead(sequenceNumber)) {
       logger.info(
-        s"receive a message that is ahead of the current, stashing: $payload from $sender"
+        s"receive a message that is ahead of the current, stashing: $payload from $sender with seqNum = $sequenceNumber"
       )
       entry.stash(sequenceNumber, payload)
     } else {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OrderingEnforcer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OrderingEnforcer.scala
@@ -5,7 +5,7 @@ import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 
 import scala.collection.mutable
 
-object OrderingEnforcer  extends AmberLogging {
+object OrderingEnforcer extends AmberLogging {
   def reorderMessage[V](
       seqMap: mutable.AnyRefMap[ActorVirtualIdentity, OrderingEnforcer[V]],
       sender: ActorVirtualIdentity,
@@ -17,7 +17,9 @@ object OrderingEnforcer  extends AmberLogging {
       logger.info(s"receive a duplicated message: $payload from $sender")
       None
     } else if (entry.isAhead(seq)) {
-      logger.info(s"receive a message that is ahead of the current, stashing: $payload from $sender")
+      logger.info(
+        s"receive a message that is ahead of the current, stashing: $payload from $sender"
+      )
       entry.stash(seq, payload)
       None
     } else {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OrderingEnforcer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OrderingEnforcer.scala
@@ -1,10 +1,11 @@
 package edu.uci.ics.amber.engine.architecture.messaginglayer
 
+import edu.uci.ics.amber.engine.common.AmberLogging
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 
 import scala.collection.mutable
 
-object OrderingEnforcer {
+object OrderingEnforcer  extends AmberLogging {
   def reorderMessage[V](
       seqMap: mutable.AnyRefMap[ActorVirtualIdentity, OrderingEnforcer[V]],
       sender: ActorVirtualIdentity,
@@ -12,9 +13,11 @@ object OrderingEnforcer {
       payload: V
   ): Option[Iterable[V]] = {
     val entry = seqMap.getOrElseUpdate(sender, new OrderingEnforcer[V]())
-    if (entry.isDuplicated(seq)) {
+    if (entry.isDuplicated(seq)) { // discard duplicate
+      logger.info(s"receive a duplicated message: $payload from $sender")
       None
     } else if (entry.isAhead(seq)) {
+      logger.info(s"receive a message that is ahead of the current, stashing: $payload from $sender")
       entry.stash(seq, payload)
       None
     } else {


### PR DESCRIPTION
This PR:
1. refactored part of the enforcing FIFO logic from `OrderingEnforcer` into`NetworkInputPort`.
2. fixed the misleading log statement.