### PR TITLE
Fix Python returnInvocation type of Unit

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/controlcommands/ControlCommandConvertUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/controlcommands/ControlCommandConvertUtils.scala
@@ -99,7 +99,7 @@ object ControlCommandConvertUtils {
       controlReturnV2: ControlReturnV2
   ): Any = {
     controlReturnV2.value match {
-      case Empty                                                        => Unit
+      case Empty                                                        => ()
       case _: ControlReturnV2.Value.CurrentInputTupleInfo               => null
       case selfWorkloadReturn: ControlReturnV2.Value.SelfWorkloadReturn =>
         // TODO: convert real samples back from PythonUDF.


### PR DESCRIPTION
This PR fixes a type mismatching issue. When returning an empty message from Python, we previously converted it to the object `Unit`. However, this `Unit` is a type not an instance. The instance of `Unit` should be `()` ([BoxedUnit](https://stackoverflow.com/questions/32289511/boxedunit-vs-unit-in-scala)). 

