### PR TITLE
Use memory storage for HTML visualization sink operators

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -65,9 +65,7 @@ class WorkflowService(
 ) extends SubscriptionManager
     with LazyLogging {
   // state across execution:
-  var opResultStorage: OpResultStorage = new OpResultStorage(
-    AmberUtils.amberConfig.getString("storage.mode").toLowerCase
-  )
+  var opResultStorage: OpResultStorage = new OpResultStorage()
   private val errorSubject = BehaviorSubject.create[TexeraWebSocketEvent]().toSerialized
   val errorHandler: Throwable => Unit = { t =>
     {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/storage/OpResultStorage.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/storage/OpResultStorage.scala
@@ -2,6 +2,7 @@ package edu.uci.ics.texera.workflow.common.storage
 
 import java.util.concurrent.ConcurrentHashMap
 import com.typesafe.scalalogging.LazyLogging
+import edu.uci.ics.amber.engine.common.AmberUtils
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema
 import edu.uci.ics.texera.workflow.operators.sink.storage.{
   MemoryStorage,
@@ -9,10 +10,16 @@ import edu.uci.ics.texera.workflow.operators.sink.storage.{
   SinkStorageReader
 }
 
+object OpResultStorage {
+  val defaultStorageMode: String = AmberUtils.amberConfig.getString("storage.mode").toLowerCase
+  val MEMORY = "memory"
+  val MONGODB = "mongodb"
+}
+
 /**
   * Public class of operator result storage.
   */
-class OpResultStorage(mode: String = "memory") extends Serializable with LazyLogging {
+class OpResultStorage extends Serializable with LazyLogging {
 
   val cache: ConcurrentHashMap[String, SinkStorageReader] =
     new ConcurrentHashMap[String, SinkStorageReader]()
@@ -27,7 +34,7 @@ class OpResultStorage(mode: String = "memory") extends Serializable with LazyLog
     cache.get(key)
   }
 
-  def create(key: String, schema: Schema): SinkStorageReader = {
+  def create(key: String, schema: Schema, mode: String): SinkStorageReader = {
     val storage: SinkStorageReader =
       if (mode == "memory") {
         new MemoryStorage(schema)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/storage/OpResultStorage.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/storage/OpResultStorage.scala
@@ -18,6 +18,7 @@ object OpResultStorage {
 
 /**
   * Public class of operator result storage.
+  * One execution links one instance of OpResultStorage, both have the same lifecycle.
   */
 class OpResultStorage extends Serializable with LazyLogging {
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
@@ -200,7 +200,7 @@ case class LogicalPlan(
       case o @ (sink: ProgressiveSinkOpDesc) =>
         val storageKey = sink.getCachedUpstreamId.getOrElse(o.operatorID)
         // due to the size limit of single document in mongoDB (16MB)
-        // for sinks showing charts which could possibly be large in size, we always use the memory storage.
+        // for sinks visualizing HTMLs which could possibly be large in size, we always use the memory storage.
         val storageType =
           if (sink.getChartType.contains(VisualizationConstants.HTML_VIZ)) OpResultStorage.MEMORY
           else OpResultStorage.defaultStorageMode

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
@@ -12,6 +12,7 @@ import edu.uci.ics.texera.workflow.common.storage.OpResultStorage
 import edu.uci.ics.texera.workflow.common.tuple.schema.{OperatorSchemaInfo, Schema}
 import edu.uci.ics.texera.workflow.operators.sink.SinkOpDesc
 import edu.uci.ics.texera.workflow.operators.sink.managed.ProgressiveSinkOpDesc
+import edu.uci.ics.texera.workflow.operators.visualization.VisualizationConstants
 import org.jgrapht.graph.DirectedAcyclicGraph
 
 import scala.collection.mutable
@@ -201,7 +202,7 @@ case class LogicalPlan(
         // due to the size limit of single document in mongoDB (16MB)
         // for sinks showing charts which could possibly be large in size, we always use the memory storage.
         val storageType =
-          if (sink.getChartType.isDefined) OpResultStorage.MEMORY
+          if (sink.getChartType.contains(VisualizationConstants.HTML_VIZ)) OpResultStorage.MEMORY
           else OpResultStorage.defaultStorageMode
         sink.setStorage(
           opResultStorage.create(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/MaterializationRewriter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/MaterializationRewriter.scala
@@ -45,7 +45,11 @@ class MaterializationRewriter(
     val matWriterOutputSchema =
       materializationWriter.getOutputSchemas(Array(matWriterInputSchema))(0)
     materializationWriter.setStorage(
-      opResultStorage.create(materializationWriter.operatorID, matWriterOutputSchema)
+      opResultStorage.create(
+        materializationWriter.operatorID,
+        matWriterOutputSchema,
+        OpResultStorage.defaultStorageMode
+      )
     )
     val matWriterOpExecConfig =
       materializationWriter.operatorExecutor(


### PR DESCRIPTION
The visualization sink usually accepts an HTML that could be large in terms of size. If we use MongoDB as the sink storage, we cannot visualize the HTML since the record cannot be inserted into MongoDB due to a hard limit on the size of a single document (16MB). To fix this issue, HTML visualization sinks will always use memory storage after this PR as a quick solution.

In the future, we can break the HTML into multiple records and save them into MongoDB, then merge them back when we do the visualization.