### PR TITLE
Fix minor issue with Fault tolerance and enable demo scenario

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/recovery/RecoveryQueue.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/recovery/RecoveryQueue.scala
@@ -45,7 +45,7 @@ class RecoveryQueue(logReader: DeterminantLogReader) {
   }
 
   def isReplayCompleted: Boolean = {
-    val res = !records.hasNext
+    val res = !records.hasNext && nextRecordToEmit == null
     if (res && !endCallbackTriggered) {
       endCallbackTriggered = true
       callbacksOnEnd.foreach(callback => callback())
@@ -132,6 +132,7 @@ class RecoveryQueue(logReader: DeterminantLogReader) {
         .take()
     } else {
       val res = nextRecordToEmit
+      nextRecordToEmit = null
       processInternalEventsTillNextControl()
       res
     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowJobService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowJobService.scala
@@ -53,7 +53,7 @@ class WorkflowJobService(
         case other                              => false
       }
     ) {
-      conf.supportFaultTolerance = false
+      conf.supportFaultTolerance = true
     }
     conf
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpDesc.java
@@ -76,7 +76,7 @@ public class WordCloudOpDesc extends VisualizationOperator {
         OpExecConfig partialLayer = OpExecConfig.oneToOneLayer(
                 this.operatorIdentifier(),
                 (OpExecFunc & Serializable) i -> new WordCloudOpPartialExec(textColumn)
-        ).withId(partialId).withIsOneToManyOp(true);
+        ).withId(partialId).withIsOneToManyOp(true).withNumWorkers(1);
 
         LayerIdentity finalId = util.makeLayer(operatorIdentifier(), "global");
         OpExecConfig finalLayer = OpExecConfig.manyToOneLayer(


### PR DESCRIPTION
This PR:
1. fixed one minor bug with fault tolerance where the last control message is not replayed correctly.
2. enforce the word cloud operator to use one worker on the partial layer.
3. set fault tolerance config for workflows with PythonUDF always to true.