### PR TITLE
Change front-end to use SQLite-based /search API

### DIFF
--- a/core/new-gui/src/app/app.module.ts
+++ b/core/new-gui/src/app/app.module.ts
@@ -118,6 +118,7 @@ import { NzLayoutModule } from "ng-zorro-antd/layout";
 import { AuthGuardService } from "./common/service/user/auth-guard.service";
 import { LocalLoginComponent } from "./home/component/login/local-login/local-login.component";
 import { MarkdownModule } from "ngx-markdown";
+import { FileSaverService } from "./dashboard/service/user-file/file-saver.service";
 
 registerLocaleData(en);
 
@@ -254,6 +255,7 @@ registerLocaleData(en);
     UserService,
     UserFileService,
     UserFileUploadService,
+    FileSaverService,
     { provide: NZ_I18N, useValue: en_US },
     {
       provide: HTTP_INTERCEPTORS,

--- a/core/new-gui/src/app/common/service/workflow-persist/stub-workflow-persist.service.ts
+++ b/core/new-gui/src/app/common/service/workflow-persist/stub-workflow-persist.service.ts
@@ -1,0 +1,36 @@
+import { Injectable } from "@angular/core";
+
+import { Observable } from "rxjs";
+import { Workflow } from "../../type/workflow";
+import { DashboardWorkflowEntry } from "../../../dashboard/type/dashboard-workflow-entry";
+
+export const WORKFLOW_BASE_URL = "workflow";
+export const WORKFLOW_SEARCH_URL = WORKFLOW_BASE_URL + "/search";
+
+@Injectable()
+export class StubWorkflowPersistService {
+  constructor(private testWorkflows: DashboardWorkflowEntry[]) {}
+
+  public retrieveWorkflowByOperator(operator: string): Observable<string[]> {
+    if (operator === "NlpSentiment,SimpleSink" || operator === "Aggregation") {
+      return new Observable(observer => observer.next(["1", "2", "3"]));
+    }
+    if (operator === "NlpSentiment") {
+      return new Observable(observer => observer.next(["3"]));
+    }
+    return new Observable(observer => observer.next([]));
+  }
+
+  public retrieveWorkflow(wid: number): Observable<Workflow> {
+    return new Observable(observer => observer.next(this.testWorkflows.find(e => e.workflow.wid == wid)?.workflow));
+  }
+
+  public searchWorkflowsBySessionUser(keywords: string[]): Observable<DashboardWorkflowEntry[]> {
+    return new Observable(observer => {
+      if (keywords.length == 0) {
+        return observer.next([]);
+      }
+      return observer.next(this.testWorkflows.filter(e => keywords.some(k => e.workflow.name.indexOf(k) !== -1)));
+    });
+  }
+}

--- a/core/new-gui/src/app/common/service/workflow-persist/workflow-persist.service.ts
+++ b/core/new-gui/src/app/common/service/workflow-persist/workflow-persist.service.ts
@@ -11,10 +11,12 @@ import { NotificationService } from "../notification/notification.service";
 export const WORKFLOW_BASE_URL = "workflow";
 export const WORKFLOW_PERSIST_URL = WORKFLOW_BASE_URL + "/persist";
 export const WORKFLOW_LIST_URL = WORKFLOW_BASE_URL + "/list";
+export const WORKFLOW_SEARCH_URL = WORKFLOW_BASE_URL + "/search";
 export const WORKFLOW_CREATE_URL = WORKFLOW_BASE_URL + "/create";
 export const WORKFLOW_DUPLICATE_URL = WORKFLOW_BASE_URL + "/duplicate";
 export const WORKFLOW_UPDATENAME_URL = WORKFLOW_BASE_URL + "/update/name";
 export const WORKFLOW_UPDATEDESCRIPTION_URL = WORKFLOW_BASE_URL + "/update/description";
+export const WORKFLOW_OPERATOR_URL = WORKFLOW_BASE_URL + "/search-by-operators";
 
 export const DEFAULT_WORKFLOW_NAME = "Untitled workflow";
 
@@ -83,11 +85,8 @@ export class WorkflowPersistService {
     );
   }
 
-  /**
-   * retrieves a list of workflows from backend database that belongs to the user in the session.
-   */
-  public retrieveWorkflowsBySessionUser(): Observable<DashboardWorkflowEntry[]> {
-    return this.http.get<DashboardWorkflowEntry[]>(`${AppSettings.getApiEndpoint()}/${WORKFLOW_LIST_URL}`).pipe(
+  private retrieveWorkflowsBySessionUserInternal(url: string): Observable<DashboardWorkflowEntry[]> {
+    return this.http.get<DashboardWorkflowEntry[]>(url).pipe(
       map((dashboardWorkflowEntries: DashboardWorkflowEntry[]) =>
         dashboardWorkflowEntries.map((workflowEntry: DashboardWorkflowEntry) => {
           return {
@@ -96,6 +95,30 @@ export class WorkflowPersistService {
           };
         })
       )
+    );
+  }
+
+  /**
+   * retrieves a list of workflows from backend database that belongs to the user in the session.
+   */
+  public retrieveWorkflowsBySessionUser(): Observable<DashboardWorkflowEntry[]> {
+    return this.retrieveWorkflowsBySessionUserInternal(`${AppSettings.getApiEndpoint()}/${WORKFLOW_LIST_URL}`);
+  }
+
+  /**
+   * retrieves the workflow ids of workflows with the operator(s) specified
+   */
+  public retrieveWorkflowByOperator(operator: string): Observable<string[]> {
+    return this.http.get<string[]>(`${AppSettings.getApiEndpoint()}/${WORKFLOW_OPERATOR_URL}?operator=${operator}`);
+  }
+
+  /**
+   * Search workflows by a text query from backend database that belongs to the user in the session.
+   */
+  public searchWorkflowsBySessionUser(keywords: string[]): Observable<DashboardWorkflowEntry[]> {
+    const query = keywords.map(q => `query=${encodeURIComponent(q)}`).join("&");
+    return this.retrieveWorkflowsBySessionUserInternal(
+      `${AppSettings.getApiEndpoint()}/${WORKFLOW_SEARCH_URL}?${query}`
     );
   }
 

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.spec.ts
@@ -3,10 +3,8 @@ import { RouterTestingModule } from "@angular/router/testing";
 import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
 import { FormsModule, ReactiveFormsModule } from "@angular/forms";
 import { SavedWorkflowSectionComponent } from "./saved-workflow-section.component";
-import {
-  WORKFLOW_BASE_URL,
-  WorkflowPersistService,
-} from "../../../../common/service/workflow-persist/workflow-persist.service";
+import { WorkflowPersistService } from "../../../../common/service/workflow-persist/workflow-persist.service";
+import { StubWorkflowPersistService } from "../../../../common/service/workflow-persist/stub-workflow-persist.service";
 import { MatDividerModule } from "@angular/material/divider";
 import { MatListModule } from "@angular/material/list";
 import { MatCardModule } from "@angular/material/card";
@@ -40,6 +38,7 @@ import { animationFrameScheduler } from "rxjs";
 import { ScrollingModule } from "@angular/cdk/scrolling";
 import { NzAvatarModule } from "ng-zorro-antd/avatar";
 import { NzToolTipModule } from "ng-zorro-antd/tooltip";
+import { FileSaverService } from "src/app/dashboard/service/user-file/file-saver.service";
 
 describe("SavedWorkflowSectionComponent", () => {
   let component: SavedWorkflowSectionComponent;
@@ -190,12 +189,14 @@ describe("SavedWorkflowSectionComponent", () => {
     },
   });
 
+  const fileSaverServiceSpy = jasmine.createSpyObj<FileSaverService>(["saveAs"]);
+
   // must use waitForAsync for configureTestingModule in components with virtual scroll
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [SavedWorkflowSectionComponent, NgbdModalWorkflowShareAccessComponent],
       providers: [
-        WorkflowPersistService,
+        { provide: WorkflowPersistService, useValue: new StubWorkflowPersistService(testWorkflowEntries) },
         NgbActiveModal,
         HttpClient,
         NgbActiveModal,
@@ -203,6 +204,7 @@ describe("SavedWorkflowSectionComponent", () => {
         { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
         { provide: UserService, useClass: StubUserService },
         { provide: NZ_I18N, useValue: en_US },
+        { provide: FileSaverService, useValue: fileSaverServiceSpy },
       ],
       imports: [
         MatDividerModule,
@@ -300,44 +302,44 @@ describe("SavedWorkflowSectionComponent", () => {
     expect(SortedCase).toEqual(["workflow 5", "workflow 4", "workflow 3", "workflow 2", "workflow 1"]);
   });
 
-  it("searchNoInput", () => {
+  it("searchNoInput", async () => {
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
     component.masterFilterList = [];
     component.fuse.setCollection(component.allDashboardWorkflowEntries);
-    component.searchWorkflow();
+    await component.searchWorkflow();
     const SortedCase = component.dashboardWorkflowEntries.map(workflow => workflow.workflow.name);
     expect(SortedCase).toEqual(["workflow 1", "workflow 2", "workflow 3", "workflow 4", "workflow 5"]);
     expect(component.masterFilterList).toEqual([]);
   });
 
-  it("searchByWorkflowName", () => {
+  it("searchByWorkflowName", async () => {
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
-    component.masterFilterList = ["5"];
+    component.masterFilterList = ["workflow 5"];
     component.fuse.setCollection(component.allDashboardWorkflowEntries);
-    component.searchWorkflow();
+    await component.searchWorkflow();
     const SortedCase = component.dashboardWorkflowEntries.map(workflow => workflow.workflow.name);
     expect(SortedCase).toEqual(["workflow 5"]);
-    expect(component.masterFilterList).toEqual(["5"]);
+    expect(component.masterFilterList).toEqual(["workflow 5"]);
   });
 
-  it("searchByOwners", () => {
+  it("searchByOwners", async () => {
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
     component.masterFilterList = [];
     component.fuse.setCollection(component.allDashboardWorkflowEntries);
     component.owners[0].checked = true;
-    component.updateSelectedOwners(); // calls searchWorkflow()
+    await component.updateSelectedOwners(); // calls searchWorkflow()
     const SortedCase = component.dashboardWorkflowEntries.map(workflow => workflow.workflow.name);
     expect(SortedCase).toEqual(["workflow 1", "workflow 2"]);
     expect(component.masterFilterList).toEqual(["owner: Texera"]);
   });
 
-  it("searchByIDs", () => {
+  it("searchByIDs", async () => {
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
@@ -346,46 +348,46 @@ describe("SavedWorkflowSectionComponent", () => {
     component.wids[0].checked = true;
     component.wids[1].checked = true;
     component.wids[2].checked = true;
-    component.updateSelectedIDs(); // calls searchWorkflow()
+    await component.updateSelectedIDs(); // calls searchWorkflow()
     const SortedCase = component.dashboardWorkflowEntries.map(workflow => workflow.workflow.name);
     expect(SortedCase).toEqual(["workflow 1", "workflow 2", "workflow 3"]);
     expect(component.masterFilterList).toEqual(["id: 1", "id: 2", "id: 3"]);
   });
 
-  it("searchByProjects", () => {
+  it("searchByProjects", async () => {
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
     component.masterFilterList = [];
     component.fuse.setCollection(component.allDashboardWorkflowEntries);
     component.userProjectsDropdown[0].checked = true;
-    component.updateSelectedProjects(); // calls searchWorkflow()
+    await component.updateSelectedProjects(); // calls searchWorkflow()
     const SortedCase = component.dashboardWorkflowEntries.map(workflow => workflow.workflow.name);
     expect(SortedCase).toEqual(["workflow 1", "workflow 2", "workflow 3"]);
     expect(component.masterFilterList).toEqual(["project: Project1"]);
   });
 
-  it("searchByCreationTime", () => {
+  it("searchByCreationTime", async () => {
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
     component.masterFilterList = [];
     component.fuse.setCollection(component.allDashboardWorkflowEntries);
     component.selectedCtime = [new Date(1970, 0, 3), new Date(1981, 2, 13)];
-    component.searchWorkflow();
+    await component.searchWorkflow();
     const SortedCase = component.dashboardWorkflowEntries.map(workflow => workflow.workflow.name);
     expect(SortedCase).toEqual(["workflow 4", "workflow 5"]);
     expect(component.masterFilterList).toEqual(["ctime: 1970-01-03 ~ 1981-03-13"]);
   });
 
-  it("searchByModifyTime", () => {
+  it("searchByModifyTime", async () => {
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
     component.masterFilterList = [];
     component.fuse.setCollection(component.allDashboardWorkflowEntries);
     component.selectedMtime = [new Date(1970, 0, 3), new Date(1981, 2, 13)];
-    component.searchWorkflow();
+    await component.searchWorkflow();
     const SortedCase = component.dashboardWorkflowEntries.map(workflow => workflow.workflow.name);
     expect(SortedCase).toEqual(["workflow 4", "workflow 5"]);
     expect(component.masterFilterList).toEqual(["mtime: 1970-01-03 ~ 1981-03-13"]);
@@ -402,7 +404,7 @@ describe("SavedWorkflowSectionComponent", () => {
    *
    *   - See searchByManyOperators test
    */
-  it("searchByOperators", () => {
+  it("searchByOperators", async () => {
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
@@ -410,19 +412,15 @@ describe("SavedWorkflowSectionComponent", () => {
     component.fuse.setCollection(component.allDashboardWorkflowEntries);
     const operatorGroup = component.operators.get("Analysis");
     if (operatorGroup) {
-      const operatorSelectionList = []; // list of operators for query
       operatorGroup[2].checked = true; // sentiment analysis
-      component.updateSelectedOperators(); // calls searchWorkflow()
-      operatorSelectionList.push(operatorGroup[2].operatorType);
-      const req = httpTestingController.match(`api/workflow/search-by-operators?operator=${operatorSelectionList}`);
-      req[0].flush(["3"]);
+      await component.updateSelectedOperators();
     }
     const SortedCase = component.dashboardWorkflowEntries.map(workflow => workflow.workflow.name);
     expect(SortedCase).toEqual(["workflow 3"]);
     expect(component.masterFilterList).toEqual(["operator: Sentiment Analysis"]); // userFriendlyName
   });
 
-  it("searchByManyOperators", () => {
+  it("searchByManyOperators", async () => {
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
@@ -432,21 +430,16 @@ describe("SavedWorkflowSectionComponent", () => {
     const operatorGroup2 = component.operators.get("View Results");
     if (operatorGroup && operatorGroup2) {
       console.log(component.operators);
-      const operatorSelectionList = []; // list of operators for query
       operatorGroup[2].checked = true; // sentiment analysis
       operatorGroup2[0].checked = true;
-      component.updateSelectedOperators(); // calls searchWorkflow()
-      operatorSelectionList.push(operatorGroup[2].operatorType);
-      operatorSelectionList.push(operatorGroup2[0].operatorType);
-      const req = httpTestingController.match(`api/workflow/search-by-operators?operator=${operatorSelectionList}`);
-      req[0].flush(["1", "2", "3"]);
+      await component.updateSelectedOperators(); // calls searchWorkflow()
     }
     const SortedCase = component.dashboardWorkflowEntries.map(workflow => workflow.workflow.name);
     expect(SortedCase).toEqual(["workflow 1", "workflow 2", "workflow 3"]);
     expect(component.masterFilterList).toEqual(["operator: Sentiment Analysis", "operator: View Results"]); // userFriendlyName
   });
 
-  it("searchByManyParameters", () => {
+  it("searchByManyParameters", async () => {
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
@@ -455,10 +448,8 @@ describe("SavedWorkflowSectionComponent", () => {
 
     const operatorGroup = component.operators.get("Analysis");
     if (operatorGroup) {
-      const operatorSelectionList = []; // list of operators for query
-      operatorGroup[2].checked = true; // sentiment analysis
-      component.updateSelectedOperators();
-      operatorSelectionList.push(operatorGroup[2].operatorType);
+      operatorGroup[3].checked = true; // Aggregation operator
+      await component.updateSelectedOperators();
 
       component.owners[0].checked = true; //Texera
       component.owners[1].checked = true; //Angular
@@ -471,14 +462,9 @@ describe("SavedWorkflowSectionComponent", () => {
       component.masterFilterList.push("1");
       //add/select new search parameter here
 
-      component.updateSelectedProjects();
-      component.updateSelectedIDs();
-      component.updateSelectedOwners();
-      // if adding parameters, add its respective update function here
-
-      const req = httpTestingController.match(`api/workflow/search-by-operators?operator=${operatorSelectionList}`);
-      req[0].flush(["1", "2", "3"]);
-      //triggers backend call
+      await component.updateSelectedProjects();
+      await component.updateSelectedIDs();
+      await component.updateSelectedOwners();
     }
     const SortedCase = component.dashboardWorkflowEntries.map(workflow => workflow.workflow.name);
     expect(SortedCase).toEqual(["workflow 1"]);
@@ -489,7 +475,7 @@ describe("SavedWorkflowSectionComponent", () => {
       "id: 1",
       "id: 2",
       "id: 3",
-      "operator: Sentiment Analysis",
+      "operator: Aggregation",
       "project: Project1",
       "ctime: 1970-01-01 ~ 1973-03-11",
       "mtime: 1970-01-01 ~ 1982-04-14",
@@ -498,8 +484,10 @@ describe("SavedWorkflowSectionComponent", () => {
 
   it("sends http request to backend to retrieve export json", () => {
     component.onClickDownloadWorkfllow(testWorkflowEntries[0]);
-    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${WORKFLOW_BASE_URL}/${testWorkflowEntries[0]}`);
-    httpTestingController.expectOne("api/workflow/1");
+    expect(fileSaverServiceSpy.saveAs).toHaveBeenCalledOnceWith(
+      new Blob([JSON.stringify(testWorkflowEntries[0].workflow.content)], { type: "text/plain;charset=utf-8" }),
+      "workflow 1.json"
+    );
   });
 
   it("adds selected workflow to the downloadListWorkflow", () => {

--- a/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/component/feature-container/saved-workflow-section/saved-workflow-section.component.spec.ts
@@ -303,6 +303,7 @@ describe("SavedWorkflowSectionComponent", () => {
   });
 
   it("searchNoInput", async () => {
+    // When no search input is provided, it should show all workflows.
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
@@ -315,6 +316,8 @@ describe("SavedWorkflowSectionComponent", () => {
   });
 
   it("searchByWorkflowName", async () => {
+    // If the name "workflow 5" is entered as a single phrase, only workflow 5 should be returned, rather
+    // than all containing the keyword "workflow".
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
@@ -327,6 +330,7 @@ describe("SavedWorkflowSectionComponent", () => {
   });
 
   it("searchByOwners", async () => {
+    // If the owner filter is applied, only those workflow ownered by that user should be returned.
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
@@ -340,6 +344,7 @@ describe("SavedWorkflowSectionComponent", () => {
   });
 
   it("searchByIDs", async () => {
+    // If the ID filter is applied, only those workflows should be returned.
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
@@ -355,6 +360,7 @@ describe("SavedWorkflowSectionComponent", () => {
   });
 
   it("searchByProjects", async () => {
+    // If the project filter is applied, only those workflows belonging to those projects should be returned.
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
@@ -368,6 +374,7 @@ describe("SavedWorkflowSectionComponent", () => {
   });
 
   it("searchByCreationTime", async () => {
+    // If the creation time filter is applied, only those workflows matching the date range should be returned.
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
@@ -381,6 +388,7 @@ describe("SavedWorkflowSectionComponent", () => {
   });
 
   it("searchByModifyTime", async () => {
+    // If the modified time filter is applied, only those workflows matching the date range should be returned.
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
@@ -405,6 +413,7 @@ describe("SavedWorkflowSectionComponent", () => {
    *   - See searchByManyOperators test
    */
   it("searchByOperators", async () => {
+    // If a single operator filter is provided, only the workflows containing that operator should be returned.
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
@@ -421,6 +430,7 @@ describe("SavedWorkflowSectionComponent", () => {
   });
 
   it("searchByManyOperators", async () => {
+    // If a multiple operator filters are provided, workflows containing any of the provided operators should be returned.
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
@@ -440,6 +450,7 @@ describe("SavedWorkflowSectionComponent", () => {
   });
 
   it("searchByManyParameters", async () => {
+    // Apply the project, ID, owner, and operator filter all at once.
     component.dashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = [];
     component.allDashboardWorkflowEntries = component.allDashboardWorkflowEntries.concat(testWorkflowEntries);
@@ -483,6 +494,7 @@ describe("SavedWorkflowSectionComponent", () => {
   });
 
   it("sends http request to backend to retrieve export json", () => {
+    // Test the workflow download button.
     component.onClickDownloadWorkfllow(testWorkflowEntries[0]);
     expect(fileSaverServiceSpy.saveAs).toHaveBeenCalledOnceWith(
       new Blob([JSON.stringify(testWorkflowEntries[0].workflow.content)], { type: "text/plain;charset=utf-8" }),
@@ -491,6 +503,7 @@ describe("SavedWorkflowSectionComponent", () => {
   });
 
   it("adds selected workflow to the downloadListWorkflow", () => {
+    // Test workflow download with multiple workflows selected.
     component.dashboardWorkflowEntries = [];
     component.dashboardWorkflowEntries = component.dashboardWorkflowEntries.concat(testWorkflowEntries);
     component.onClickAddToDownload(testWorkflowEntries[0], checked);
@@ -500,6 +513,7 @@ describe("SavedWorkflowSectionComponent", () => {
   });
 
   it("remove unchecked workflow from the downloadListWorkflow", () => {
+    // Allow removal of items in the pending download list.
     component.dashboardWorkflowEntries = [];
     component.dashboardWorkflowEntries = component.dashboardWorkflowEntries.concat(testWorkflowEntries);
     component.onClickAddToDownload(testWorkflowEntries[0], checked);
@@ -511,6 +525,7 @@ describe("SavedWorkflowSectionComponent", () => {
   });
 
   it("detects conflict filename and resolves it", () => {
+    // If multiple workflows in a single batch download have name conflicts, rename them as workflow-1, workflow-2, etc.
     component.dashboardWorkflowEntries = [];
     component.dashboardWorkflowEntries = component.dashboardWorkflowEntries.concat(testWorkflowFileNameConflictEntries);
     component.onClickAddToDownload(testWorkflowFileNameConflictEntries[0], checked);
@@ -586,8 +601,7 @@ describe("SavedWorkflowSectionComponent", () => {
   }));
 
   function sendInput(editableDescriptionInput: HTMLInputElement, text: string) {
-    // editableDescriptionInput.dispatchEvent(new Event("focus"));
-    // fixture.detectChanges();
+    // Helper function to change the workflow description textbox.
     editableDescriptionInput.value = text;
     editableDescriptionInput.dispatchEvent(new Event("input"));
     fixture.detectChanges();

--- a/core/new-gui/src/app/dashboard/service/user-file/file-saver.service.ts
+++ b/core/new-gui/src/app/dashboard/service/user-file/file-saver.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from "@angular/core";
+import * as FileSaver from "file-saver";
+
+@Injectable({
+  providedIn: "root",
+})
+export class FileSaverService {
+  constructor() {}
+  saveAs(data: Blob | string, filename?: string, options?: FileSaver.FileSaverOptions): void {
+    FileSaver.saveAs(data, filename, options);
+  }
+}


### PR DESCRIPTION
1. Updated `saved-workflow-section` component to make use of the `/search` endpoint added by #1879 
2. Added a mock `WorkflowPersistService` for unit tests. Previously, no API call to the server was made and it is therefore not mocked.
3. Added a FileSaverService to intercept calls to `file-saver`. I was not able mock this using jest. Details are [here](https://stackoverflow.com/questions/59281306/angular-7-mocking-filesaver-saveas-in-unittest)
4. Note that all workflows for a user or project is loaded fully in the beginning. Then, for each search query, the server returns the full details of a list of workflows. Only the ID is used to filter the workflows to display. The server doesn't simply return the list of IDs in anticipation of adding pagination. In a future PR, only the top 20 results will be loaded and when the user searches by keywords, we will fully utilize the returned workflow object for display.