### PR TITLE
Rollback some earlier changes in fault tolerance and sink storage

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowJobService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowJobService.scala
@@ -53,7 +53,7 @@ class WorkflowJobService(
         case other                              => false
       }
     ) {
-      conf.supportFaultTolerance = true
+      conf.supportFaultTolerance = false
     }
     conf
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/storage/MongoDBSinkStorage.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/storage/MongoDBSinkStorage.scala
@@ -14,6 +14,11 @@ import collection.JavaConverters._
 
 class MongoDBSinkStorage(id: String, schema: Schema) extends SinkStorageReader {
 
+  // For backward compatibility of old mongoDB(version < 5)
+  schema.getAttributeNames.stream.forEach(name =>
+    assert(!name.matches(".*[\\$\\.].*"), s"illegal attribute name '$name' for mongo DB")
+  )
+
   val commitBatchSize: Int = AmberUtils.amberConfig.getInt("storage.mongodb.commit-batch-size")
   MongoDatabaseManager.dropCollection(id)
   val collectionMgr: MongoCollectionManager = MongoDatabaseManager.getCollection(id)


### PR DESCRIPTION
This PR rolls back the fault tolerance setting for Python since that's only for the demo and the MongoDB field name assertion since the server uses old MongoDB that does not support dot in field names.