### PR TITLE
[1/2] Passing wid from Frontend to Backend

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/SchemaPropagationResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/SchemaPropagationResource.scala
@@ -6,10 +6,11 @@ import edu.uci.ics.texera.web.model.websocket.request.LogicalPlanPojo
 import edu.uci.ics.texera.workflow.common.WorkflowContext
 import edu.uci.ics.texera.workflow.common.workflow.{LogicalPlan, WorkflowCompiler}
 import io.dropwizard.auth.Auth
+import org.jooq.types.UInteger
 
 import javax.annotation.security.RolesAllowed
 import javax.ws.rs.core.MediaType
-import javax.ws.rs.{Consumes, POST, Path, Produces}
+import javax.ws.rs.{Consumes, POST, Path, PathParam, Produces}
 
 @Consumes(Array(MediaType.APPLICATION_JSON))
 @Produces(Array(MediaType.APPLICATION_JSON))
@@ -17,10 +18,11 @@ import javax.ws.rs.{Consumes, POST, Path, Produces}
 class SchemaPropagationResource {
 
   @POST
-  @Path("/autocomplete")
+  @Path("/autocomplete/{wid}")
   @RolesAllowed(Array("REGULAR", "ADMIN"))
   def suggestAutocompleteSchema(
       workflowStr: String,
+      @PathParam("wid") wid: UInteger,
       @Auth sessionUser: SessionUser
   ): SchemaPropagationResponse = {
     try {
@@ -28,6 +30,7 @@ class SchemaPropagationResource {
 
       val context = new WorkflowContext
       context.userId = Option(sessionUser.getUser.getUid)
+      context.wId = wid
 
       val texeraWorkflowCompiler = new WorkflowCompiler(LogicalPlan(workflow), context)
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionsMetadataPersistService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionsMetadataPersistService.scala
@@ -51,20 +51,19 @@ object ExecutionsMetadataPersistService extends LazyLogging {
     */
 
   def insertNewExecution(
-      wid: Long,
+      wid: UInteger,
       uid: Option[UInteger],
       executionName: String,
       environmentVersion: String
   ): Long = {
     // first retrieve the latest version of this workflow
-    val uint = UInteger.valueOf(wid)
-    val vid = getLatestVersion(uint)
+    val vid = getLatestVersion(wid)
     val newExecution = new WorkflowExecutions()
     if (executionName != "") {
       newExecution.setName(executionName)
     }
     newExecution.setVid(vid)
-    newExecution.setUid(uid.getOrElse(null))
+    newExecution.setUid(uid.orNull)
     newExecution.setStartingTime(new Timestamp(System.currentTimeMillis()))
     newExecution.setEnvironmentVersion(environmentVersion)
     workflowExecutionsDao.insert(newExecution)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowJobService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowJobService.scala
@@ -2,15 +2,12 @@ package edu.uci.ics.texera.web.service
 
 import com.twitter.util.{Await, Duration}
 import com.typesafe.scalalogging.LazyLogging
-import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.ModifyLogicHandler.ModifyLogic
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.StartWorkflowHandler.StartWorkflow
 import edu.uci.ics.amber.engine.architecture.controller.{ControllerConfig, Workflow}
 import edu.uci.ics.amber.engine.common.client.AmberClient
 import edu.uci.ics.amber.engine.common.virtualidentity.WorkflowIdentity
-import edu.uci.ics.texera.web.model.websocket.event.TexeraWebSocketEvent
-import edu.uci.ics.texera.web.model.websocket.request.{ModifyLogicRequest, WorkflowExecuteRequest}
-import edu.uci.ics.texera.web.model.websocket.response.ModifyLogicResponse
-import edu.uci.ics.texera.web.storage.{JobReconfigurationStore, JobStateStore, WorkflowStateStore}
+import edu.uci.ics.texera.web.model.websocket.request.WorkflowExecuteRequest
+import edu.uci.ics.texera.web.storage.JobStateStore
 import edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState.{READY, RUNNING}
 import edu.uci.ics.texera.web.{SubscriptionManager, TexeraWebApplication, WebsocketInput}
 import edu.uci.ics.texera.workflow.common.WorkflowContext
@@ -19,11 +16,8 @@ import edu.uci.ics.texera.workflow.common.workflow.{LogicalPlan, WorkflowCompile
 import edu.uci.ics.texera.workflow.operators.udf.pythonV2.source.PythonUDFSourceOpDescV2
 import edu.uci.ics.texera.workflow.operators.udf.pythonV2.{
   DualInputPortsPythonUDFOpDescV2,
-  PythonUDFOpDescV2,
-  PythonUDFOpExecV2
+  PythonUDFOpDescV2
 }
-
-import scala.util.{Failure, Success}
 
 class WorkflowJobService(
     workflowContext: WorkflowContext,
@@ -126,7 +120,7 @@ class WorkflowJobService(
       logicalPlan = newWorkflowInfo
       logicalPlan.cachedOperatorIds = oldWorkflowInfo.cachedOperatorIds
       logger.info(
-        s"Rewrite the original workflow: ${oldWorkflowInfo} to be: ${logicalPlan}"
+        s"Rewrite the original workflow: $oldWorkflowInfo to be: $logicalPlan"
       )
     }
     logicalPlan

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -4,20 +4,10 @@ import java.util.concurrent.ConcurrentHashMap
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.common.AmberUtils
 import scala.collection.JavaConverters._
-import edu.uci.ics.texera.web.model.websocket.event.{
-  TexeraWebSocketEvent,
-  WorkflowErrorEvent,
-  WorkflowExecutionErrorEvent
-}
-import edu.uci.ics.texera.web.{
-  SubscriptionManager,
-  TexeraWebApplication,
-  WebsocketInput,
-  WorkflowLifecycleManager
-}
+import edu.uci.ics.texera.web.model.websocket.event.{TexeraWebSocketEvent, WorkflowErrorEvent}
+import edu.uci.ics.texera.web.{SubscriptionManager, WebsocketInput, WorkflowLifecycleManager}
 import edu.uci.ics.texera.web.model.websocket.request.{
   CacheStatusUpdateRequest,
-  TexeraWebSocketRequest,
   WorkflowExecuteRequest,
   WorkflowKillRequest
 }
@@ -27,7 +17,7 @@ import edu.uci.ics.texera.web.storage.WorkflowStateStore
 import edu.uci.ics.texera.workflow.common.WorkflowContext
 import edu.uci.ics.texera.workflow.common.storage.OpResultStorage
 import io.reactivex.rxjava3.disposables.{CompositeDisposable, Disposable}
-import io.reactivex.rxjava3.subjects.{BehaviorSubject, Subject}
+import io.reactivex.rxjava3.subjects.BehaviorSubject
 import org.jooq.types.UInteger
 import play.api.libs.json.Json
 
@@ -148,7 +138,7 @@ class WorkflowService(
         )
       )
     }
-    new WorkflowContext(jobID, uidOpt, wId)
+    new WorkflowContext(jobID, uidOpt, UInteger.valueOf(wId))
   }
 
   def initJobService(req: WorkflowExecuteRequest, uidOpt: Option[UInteger]): Unit = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/WorkflowContext.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/WorkflowContext.scala
@@ -4,6 +4,6 @@ import org.jooq.types.UInteger
 class WorkflowContext(
     var jobId: String = null,
     var userId: Option[UInteger] = None,
-    var wId: Int = -1,
+    var wId: UInteger = UInteger.valueOf(0),
     var executionID: Long = -1
 )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/ScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/ScanSourceOpDesc.scala
@@ -12,10 +12,8 @@ import edu.uci.ics.texera.workflow.common.metadata.{
 }
 import edu.uci.ics.texera.workflow.common.operators.source.SourceOperatorDescriptor
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema
-
 import java.util.Collections.singletonList
 import scala.collection.JavaConverters.asScalaBuffer
-import scala.collection.immutable.List
 
 abstract class ScanSourceOpDesc extends SourceOperatorDescriptor {
 

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/download/BulkDownloaderOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/download/BulkDownloaderOpExecSpec.scala
@@ -38,7 +38,7 @@ class BulkDownloaderOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   var opExec: BulkDownloaderOpExec = _
   before {
     opExec = new BulkDownloaderOpExec(
-      new WorkflowContext("job1", Some(UInteger.valueOf(1)), 1, 1),
+      new WorkflowContext("job1", Some(UInteger.valueOf(1)), UInteger.valueOf(1), 1),
       "url",
       "url result",
       OperatorSchemaInfo(Array(tupleSchema), Array(resultSchema))

--- a/core/new-gui/src/app/workspace/service/dynamic-schema/auto-attribute-correction/auto-attribute-correction.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/auto-attribute-correction/auto-attribute-correction.service.spec.ts
@@ -1,35 +1,30 @@
 import { HttpClient } from "@angular/common/http";
 import { HttpClientTestingModule, HttpTestingController } from "@angular/common/http/testing";
-import { fakeAsync, inject, TestBed, tick, flush, discardPeriodicTasks } from "@angular/core/testing";
+import { discardPeriodicTasks, fakeAsync, flush, inject, TestBed, tick } from "@angular/core/testing";
 import { environment } from "../../../../../environments/environment";
 import { OperatorMetadataService } from "../../operator-metadata/operator-metadata.service";
-import {
-  mockPoint,
-  mockScanPredicate,
-  mockScanSentimentLink,
-  mockSentimentPredicate,
-} from "../../workflow-graph/model/mock-workflow-data";
+import { mockPoint } from "../../workflow-graph/model/mock-workflow-data";
 import { StubOperatorMetadataService } from "../../operator-metadata/stub-operator-metadata.service";
 import { WorkflowActionService } from "../../workflow-graph/model/workflow-action.service";
 import { DynamicSchemaService } from "../dynamic-schema.service";
 import { AutoAttributeCorrectionService } from "./auto-attribute-correction.service";
 import {
+  mockLinkAtoB,
+  mockLinkBtoC,
   mockSchemaPropagationResponse1,
   mockSchemaPropagationResponse2,
   mockSchemaPropagationResponse3,
-  mockSentimentOperatorA,
-  mockSentimentOperatorB,
-  mockLinkAtoB,
-  mockLinkBtoC,
-  mockSentimentOperatorC,
   mockSchemaPropagationResponse4,
   mockSchemaPropagationResponse5,
+  mockSentimentOperatorA,
+  mockSentimentOperatorB,
+  mockSentimentOperatorC,
 } from "./mock-auto-attribute-correction.data";
 import { AppSettings } from "src/app/common/app-setting";
 import {
-  SchemaPropagationService,
   SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS,
   SCHEMA_PROPAGATION_ENDPOINT,
+  SchemaPropagationService,
 } from "../schema-propagation/schema-propagation.service";
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
@@ -63,26 +58,28 @@ describe("AttributeChangePropagationService", () => {
 
   it("should propagate new attribute name when atteibute is renamed", fakeAsync(() => {
     const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
-    const autoAttributeCorrectionService: AutoAttributeCorrectionService =
-      TestBed.inject(AutoAttributeCorrectionService);
-
+    TestBed.inject(SchemaPropagationService);
+    TestBed.inject(AutoAttributeCorrectionService);
     workflowActionService.addOperator(mockSentimentOperatorA, mockPoint);
     workflowActionService.addOperator(mockSentimentOperatorB, mockPoint);
     workflowActionService.addLink(mockLinkAtoB);
 
-    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    const req1 = httpTestingController.expectOne(
+      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`
+    );
     expect(req1.request.method === "POST");
-    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     req1.flush(mockSchemaPropagationResponse1);
     httpTestingController.verify();
 
     // trigger inputSchemaChangeStream
     workflowActionService.setOperatorProperty(mockSentimentOperatorA.operatorID, { testAttr: "test" });
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
-    const req2 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    const req2 = httpTestingController.expectOne(
+      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`
+    );
     expect(req2.request.method === "POST");
-    expect(req2.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    expect(req2.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     req2.flush(mockSchemaPropagationResponse2);
     httpTestingController.verify();
 
@@ -95,26 +92,28 @@ describe("AttributeChangePropagationService", () => {
 
   it("should delete attribute in succeeding operators when attribute is deleted", fakeAsync(() => {
     const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
-    const autoAttributeCorrectionService: AutoAttributeCorrectionService =
-      TestBed.inject(AutoAttributeCorrectionService);
-
+    TestBed.inject(SchemaPropagationService);
+    TestBed.inject(AutoAttributeCorrectionService);
     workflowActionService.addOperator(mockSentimentOperatorA, mockPoint);
     workflowActionService.addOperator(mockSentimentOperatorB, mockPoint);
     workflowActionService.addLink(mockLinkAtoB);
 
-    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    const req1 = httpTestingController.expectOne(
+      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`
+    );
     expect(req1.request.method === "POST");
-    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     req1.flush(mockSchemaPropagationResponse1);
     httpTestingController.verify();
 
     // trigger inputSchemaChangeStream
     workflowActionService.setOperatorProperty(mockSentimentOperatorA.operatorID, { testAttr: "test" });
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS + 1);
-    const req2 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    const req2 = httpTestingController.expectOne(
+      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`
+    );
     expect(req2.request.method === "POST");
-    expect(req2.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    expect(req2.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     req2.flush(mockSchemaPropagationResponse3);
     httpTestingController.verify();
 
@@ -128,29 +127,31 @@ describe("AttributeChangePropagationService", () => {
 
   it("should propagate new attribute name in three consecutive operators", fakeAsync(() => {
     const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
-    const autoAttributeCorrectionService: AutoAttributeCorrectionService =
-      TestBed.inject(AutoAttributeCorrectionService);
-
+    TestBed.inject(SchemaPropagationService);
+    TestBed.inject(AutoAttributeCorrectionService);
     workflowActionService.addOperator(mockSentimentOperatorA, mockPoint);
     workflowActionService.addOperator(mockSentimentOperatorB, mockPoint);
     workflowActionService.addOperator(mockSentimentOperatorC, mockPoint);
     workflowActionService.addLink(mockLinkAtoB);
-    httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     workflowActionService.addLink(mockLinkBtoC);
 
-    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    const req1 = httpTestingController.expectOne(
+      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`
+    );
     expect(req1.request.method === "POST");
-    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     req1.flush(mockSchemaPropagationResponse4);
     httpTestingController.verify();
 
     // trigger inputSchemaChangeStream
     workflowActionService.setOperatorProperty(mockSentimentOperatorA.operatorID, { testAttr: "test" });
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
-    const req2 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    const req2 = httpTestingController.expectOne(
+      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`
+    );
     expect(req2.request.method === "POST");
-    expect(req2.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    expect(req2.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     req2.flush(mockSchemaPropagationResponse5);
     httpTestingController.verify();
 

--- a/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.spec.ts
@@ -67,33 +67,33 @@ describe("SchemaPropagationService", () => {
 
   it("should invoke schema propagation API on link changes, property changes, and disable status changes", fakeAsync(() => {
     const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
+    TestBed.inject(SchemaPropagationService);
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
     workflowActionService.addOperator(mockSentimentPredicate, mockPoint);
 
     // add link
     workflowActionService.addLink(mockScanSentimentLink);
-    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     httpTestingController.verify();
 
     // delete link
     workflowActionService.deleteLinkWithID(mockScanSentimentLink.linkID);
-    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     httpTestingController.verify();
 
     // add link again
     workflowActionService.addLink(mockScanSentimentLink);
-    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     httpTestingController.verify();
 
     // disable opeator
     workflowActionService.getTexeraGraph().disableOperator(mockScanPredicate.operatorID);
-    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     httpTestingController.verify();
 
     // enable operator
     workflowActionService.getTexeraGraph().disableOperator(mockScanPredicate.operatorID);
-    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     httpTestingController.verify();
 
     // change operator property
@@ -103,22 +103,23 @@ describe("SchemaPropagationService", () => {
     // verify debounce time: no request before debounce time ticks
     httpTestingController.verify();
     // reqeuest should be made after debounce time
-    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    httpTestingController.match(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     httpTestingController.verify();
     discardPeriodicTasks();
   }));
 
   it("should invoke schema propagation API when a operator property is changed", fakeAsync(() => {
     const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
-
+    TestBed.inject(SchemaPropagationService);
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
     workflowActionService.setOperatorProperty(mockScanPredicate.operatorID, {
       tableName: "test",
     });
 
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
-    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    const req1 = httpTestingController.expectOne(
+      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`
+    );
     expect(req1.request.method).toEqual("POST");
     req1.flush(mockSchemaPropagationResponse);
     httpTestingController.verify();
@@ -127,15 +128,16 @@ describe("SchemaPropagationService", () => {
 
   it("should handle error responses from server gracefully", fakeAsync(() => {
     const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
-
+    TestBed.inject(SchemaPropagationService);
     workflowActionService.addOperator(mockScanPredicate, mockPoint);
     workflowActionService.setOperatorProperty(mockScanPredicate.operatorID, {
       tableName: "test",
     });
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
 
-    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    const req1 = httpTestingController.expectOne(
+      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`
+    );
     expect(req1.request.method).toEqual("POST");
 
     // return error response from server
@@ -148,7 +150,9 @@ describe("SchemaPropagationService", () => {
     });
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
 
-    const req2 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    const req2 = httpTestingController.expectOne(
+      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`
+    );
     expect(req2.request.method).toEqual("POST");
     req2.flush(mockSchemaPropagationResponse);
     httpTestingController.verify();
@@ -158,8 +162,7 @@ describe("SchemaPropagationService", () => {
   it("should modify `attribute` of operator schema", fakeAsync(() => {
     const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
     const dynamicSchemaService: DynamicSchemaService = TestBed.inject(DynamicSchemaService);
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
-
+    TestBed.inject(SchemaPropagationService);
     const mockOperator = {
       ...mockSentimentPredicate,
       operatorID: mockSchemaPropagationOperatorID,
@@ -173,16 +176,12 @@ describe("SchemaPropagationService", () => {
 
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
     // flush mock response
-    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    const req1 = httpTestingController.expectOne(
+      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`
+    );
     expect(req1.request.method === "POST");
-    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     req1.flush(mockSchemaPropagationResponse);
-
-    // const req2 = httpTestingController.match(
-    //   request => request.method === 'POST'
-    // );
-    // expect(req2[0].request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
-    // req2[0].flush(mockSchemaPropagationResponse);
 
     httpTestingController.verify();
 
@@ -203,8 +202,7 @@ describe("SchemaPropagationService", () => {
   it("should restore `attribute` to original schema if input attributes no longer exists", fakeAsync(() => {
     const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
     const dynamicSchemaService: DynamicSchemaService = TestBed.inject(DynamicSchemaService);
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
-
+    TestBed.inject(SchemaPropagationService);
     const mockOperator = {
       ...mockSentimentPredicate,
       operatorID: mockSchemaPropagationOperatorID,
@@ -218,18 +216,14 @@ describe("SchemaPropagationService", () => {
 
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
 
-    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    const req1 = httpTestingController.expectOne(
+      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`
+    );
     expect(req1.request.method === "POST");
-    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
 
     // flush mock response
     req1.flush(mockSchemaPropagationResponse);
-
-    // const req2 = httpTestingController.match(
-    //   request => request.method === 'POST'
-    // );
-    // expect(req2[0].request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
-    // req2[0].flush(mockSchemaPropagationResponse);
 
     httpTestingController.verify();
 
@@ -251,9 +245,11 @@ describe("SchemaPropagationService", () => {
     });
 
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
-    const req3 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    const req3 = httpTestingController.expectOne(
+      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`
+    );
     expect(req3.request.method === "POST");
-    expect(req3.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    expect(req3.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
 
     // flush mock response, however, this time response is empty, which means input attrs no longer exists
     req3.flush(mockEmptySchemaPropagationResponse);
@@ -279,8 +275,7 @@ describe("SchemaPropagationService", () => {
   it("should modify `attributes` of operator schema", fakeAsync(() => {
     const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
     const dynamicSchemaService: DynamicSchemaService = TestBed.inject(DynamicSchemaService);
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
-
+    TestBed.inject(SchemaPropagationService);
     const mockKeywordSearchOperator: OperatorPredicate = {
       operatorID: mockSchemaPropagationOperatorID,
       operatorType: mockKeywordSearchSchema.operatorType,
@@ -297,17 +292,13 @@ describe("SchemaPropagationService", () => {
     workflowActionService.setOperatorProperty(mockKeywordSearchOperator.operatorID, { testAttr: "test" });
 
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
-    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    const req1 = httpTestingController.expectOne(
+      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`
+    );
     expect(req1.request.method === "POST");
-    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
     // flush mock response
     req1.flush(mockSchemaPropagationResponse);
-
-    // const req2 = httpTestingController.match(
-    //   request => request.method === 'POST'
-    // );
-    // expect(req2[0].request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
-    // req2[0].flush(mockSchemaPropagationResponse);
 
     httpTestingController.verify();
 
@@ -334,8 +325,7 @@ describe("SchemaPropagationService", () => {
   it("should modify nested deep `attribute` of operator schema", fakeAsync(() => {
     const workflowActionService: WorkflowActionService = TestBed.inject(WorkflowActionService);
     const dynamicSchemaService: DynamicSchemaService = TestBed.inject(DynamicSchemaService);
-    const schemaPropagationService: SchemaPropagationService = TestBed.inject(SchemaPropagationService);
-
+    TestBed.inject(SchemaPropagationService);
     // to match the operator ID of mockSchemaPropagationResponse
     const mockAggregationPredicate: OperatorPredicate = {
       operatorID: mockSchemaPropagationOperatorID,
@@ -353,18 +343,14 @@ describe("SchemaPropagationService", () => {
     workflowActionService.setOperatorProperty(mockAggregationPredicate.operatorID, { testAttr: "test" });
     tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
 
-    const req1 = httpTestingController.expectOne(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    const req1 = httpTestingController.expectOne(
+      `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`
+    );
     expect(req1.request.method === "POST");
-    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
+    expect(req1.request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/undefined`);
 
     // flush mock response
     req1.flush(mockSchemaPropagationResponse);
-
-    // const req2 = httpTestingController.match(
-    //   request => request.method === 'POST'
-    // );
-    // expect(req2[0].request.url).toEqual(`${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`);
-    // req2[0].flush(mockSchemaPropagationResponse);
 
     httpTestingController.verify();
 

--- a/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.ts
@@ -126,7 +126,9 @@ export class SchemaPropagationService {
     // make a http post request to the API endpoint with the logical plan object
     return this.httpClient
       .post<SchemaPropagationResponse>(
-        `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}`,
+        `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/${
+          this.workflowActionService.getWorkflow().wid
+        }`,
         JSON.stringify(body),
         { headers: { "Content-Type": "application/json" } }
       )


### PR DESCRIPTION
The 'wid' on the Backend is a dummy placeholder before this PR. The JSON string passed to the compiler doesn't contain the 'wid'. The actual 'wid' is needed for the 'file_of_workflow' table in PR #1883, so the 'wid' will be passed from the Frontend.