### PR TITLE
Fix Arrow's alert about DoAction calls

### DIFF
--- a/core/amber/src/main/python/core/proxy/proxy_client.py
+++ b/core/amber/src/main/python/core/proxy/proxy_client.py
@@ -13,13 +13,13 @@ from pyarrow.flight import (
 
 class ProxyClient(FlightClient):
     def __init__(
-            self,
-            scheme: str = "grpc+tcp",
-            host: str = "localhost",
-            port: int = 5005,
-            timeout=1000,
-            *args,
-            **kwargs,
+        self,
+        scheme: str = "grpc+tcp",
+        host: str = "localhost",
+        port: int = 5005,
+        timeout=1000,
+        *args,
+        **kwargs,
     ):
         location = f"{scheme}://{host}:{port}"
         super().__init__(location, *args, **kwargs)
@@ -28,10 +28,10 @@ class ProxyClient(FlightClient):
 
     @logger.catch(reraise=True)
     def call_action(
-            self,
-            action_name: str,
-            payload: bytes = bytes(),
-            options: Optional[FlightCallOptions] = None,
+        self,
+        action_name: str,
+        payload: bytes = bytes(),
+        options: Optional[FlightCallOptions] = None,
     ) -> bytes:
         """
         Call a specific remote action specified by the name, pass along a payload.


### PR DESCRIPTION
This PR fixes a missing part of #1900, which we did not "consume" all results from the DoAction call on the Python client side.