### PR TITLE
Initialize MockTexeraDB using JDBC

### DIFF
--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -179,7 +179,7 @@ Test / PB.protoSources += PB.externalSourcePath.value
 // https://mvnrepository.com/artifact/org.scalamock/scalamock
 libraryDependencies += "org.scalamock" %% "scalamock" % "4.4.0" % Test
 // https://mvnrepository.com/artifact/ch.vorburger.mariaDB4j/mariaDB4j
-libraryDependencies += "ch.vorburger.mariaDB4j" % "mariaDB4j" % "2.3.0" % Test
+libraryDependencies += "ch.vorburger.mariaDB4j" % "mariaDB4j" % "2.4.0" % Test
 // https://www.scalatest.org/getting_started_with_fun_suite
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.9" % Test
 

--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -179,7 +179,7 @@ Test / PB.protoSources += PB.externalSourcePath.value
 // https://mvnrepository.com/artifact/org.scalamock/scalamock
 libraryDependencies += "org.scalamock" %% "scalamock" % "4.4.0" % Test
 // https://mvnrepository.com/artifact/ch.vorburger.mariaDB4j/mariaDB4j
-libraryDependencies += "ch.vorburger.mariaDB4j" % "mariaDB4j" % "2.4.0" % Test
+libraryDependencies += "ch.vorburger.mariaDB4j" % "mariaDB4j" % "2.3.0" % Test
 // https://www.scalatest.org/getting_started_with_fun_suite
 libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.9" % Test
 

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/MockTexeraDB.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/MockTexeraDB.scala
@@ -5,21 +5,30 @@ import com.mysql.cj.jdbc.MysqlDataSource
 import org.jooq.DSLContext
 import org.jooq.impl.DSL
 import ch.vorburger.mariadb4j.{DB, DBConfigurationBuilder}
-import edu.uci.ics.amber.engine.common.AmberUtils
 import edu.uci.ics.texera.Utils
 
 import java.io.{File, FileInputStream, InputStream}
-import java.nio.charset.StandardCharsets
-import java.nio.file.{Files, Path, Paths}
-import java.sql.{Connection, DriverManager, PreparedStatement, Statement}
+import java.nio.file.Path
+import java.sql.{Connection, DriverManager, SQLException, Statement}
 import java.util.Scanner
 
 trait MockTexeraDB {
 
   private var dbInstance: Option[DB] = None
   private var dslContext: Option[DSLContext] = None
+  private val database: String = "texera_db"
+  private val username: String = "root"
+  private val password: String = ""
 
-  import java.sql.SQLException
+
+  def executeScriptInJDBC(path:Path): Unit ={
+    assert(dbInstance.nonEmpty)
+    val sqlFile = new File(path.toString)
+    val in = new FileInputStream(sqlFile)
+    val conn = DriverManager.getConnection(dbInstance.get.getConfiguration.getURL(""), username, password)
+    importSQL(conn, in)
+    conn.close()
+  }
 
   @throws[SQLException]
   private def importSQL(conn: Connection, in: InputStream): Unit = {
@@ -74,14 +83,6 @@ trait MockTexeraDB {
 
   def initializeDBAndReplaceDSLContext(): Unit = {
     assert(dbInstance.isEmpty && dslContext.isEmpty)
-    val database: String = "texera_db"
-    val username: String = "root"
-    val password: String = ""
-    val ddlPath = {
-      Utils.amberHomePath.resolve("../scripts/sql/texera_ddl.sql").toRealPath()
-    }
-    val sqlFile = new File(ddlPath.toString)
-    val in = new FileInputStream(sqlFile)
 
     val config = DBConfigurationBuilder.newBuilder
       .setPort(0) // 0 => automatically detect free port
@@ -92,8 +93,6 @@ trait MockTexeraDB {
 
     val db = DB.newEmbeddedDB(config)
     db.start()
-    val conn = DriverManager.getConnection(config.getURL(""), username, password)
-    importSQL(conn, in)
 
     val dataSource = new MysqlDataSource
     dataSource.setUrl(config.getURL(database))
@@ -102,6 +101,12 @@ trait MockTexeraDB {
 
     dbInstance = Some(db)
     dslContext = Some(DSL.using(dataSource, SqlServer.SQL_DIALECT))
+
+    val ddlPath = {
+      Utils.amberHomePath.resolve("../scripts/sql/texera_ddl.sql").toRealPath()
+    }
+    executeScriptInJDBC(ddlPath)
+
     SqlServer.replaceDSLContext(dslContext.get)
   }
 }

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/MockTexeraDB.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/MockTexeraDB.scala
@@ -10,6 +10,7 @@ import edu.uci.ics.texera.Utils
 
 import java.nio.charset.StandardCharsets
 import java.nio.file.{Files, Path, Paths}
+import java.sql.{DriverManager, PreparedStatement}
 
 trait MockTexeraDB {
 
@@ -66,6 +67,7 @@ trait MockTexeraDB {
 
     val db = DB.newEmbeddedDB(config)
     db.start()
+    Runtime.getRuntime.exec(db.getConfiguration.getBaseDir+"/bin/mysqld -u root < "+ddlPath.toString)
     db.run(content)
 
     val dataSource = new MysqlDataSource

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/MockTexeraDB.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/MockTexeraDB.scala
@@ -20,12 +20,12 @@ trait MockTexeraDB {
   private val username: String = "root"
   private val password: String = ""
 
-
-  def executeScriptInJDBC(path:Path): Unit ={
+  def executeScriptInJDBC(path: Path): Unit = {
     assert(dbInstance.nonEmpty)
     val sqlFile = new File(path.toString)
     val in = new FileInputStream(sqlFile)
-    val conn = DriverManager.getConnection(dbInstance.get.getConfiguration.getURL(""), username, password)
+    val conn =
+      DriverManager.getConnection(dbInstance.get.getConfiguration.getURL(""), username, password)
     importSQL(conn, in)
     conn.close()
   }

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/MockTexeraDB.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/MockTexeraDB.scala
@@ -67,7 +67,9 @@ trait MockTexeraDB {
 
     val db = DB.newEmbeddedDB(config)
     db.start()
-    Runtime.getRuntime.exec(db.getConfiguration.getBaseDir+"/bin/mysqld -u root < "+ddlPath.toString)
+    Runtime.getRuntime.exec(
+      db.getConfiguration.getBaseDir + "/bin/mysqld -u root < " + ddlPath.toString
+    )
     db.run(content)
 
     val dataSource = new MysqlDataSource

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
@@ -113,14 +113,11 @@ class WorkflowResourceSpec
 
   override protected def beforeAll(): Unit = {
     initializeDBAndReplaceDSLContext()
-    val db = getDBInstance
     // build fulltext indexes
     val fulltextIndexPath = {
       Utils.amberHomePath.resolve("../scripts/sql/update/fulltext_indexes.sql").toRealPath()
     }
-    val buildFulltextIndex =
-      new String(Files.readAllBytes(fulltextIndexPath), StandardCharsets.UTF_8)
-    db.run(buildFulltextIndex)
+    executeScriptInJDBC(fulltextIndexPath)
 
     // add test user directly
     val userDao = new UserDao(getDSLContext.configuration())

--- a/core/scripts/sql/texera_ddl.sql
+++ b/core/scripts/sql/texera_ddl.sql
@@ -15,7 +15,7 @@ DROP TABLE IF EXISTS `file_of_workflow`;
 DROP TABLE IF EXISTS `file_of_project`;
 DROP TABLE IF EXISTS `workflow_executions`;
 
-SET GLOBAL time_zone = '+00:00'; # this line is mandatory
+SET GLOBAL time_zone = '+00:00'; -- this line is mandatory
 
 CREATE TABLE IF NOT EXISTS user
 (
@@ -155,8 +155,8 @@ CREATE TABLE IF NOT EXISTS workflow_executions
     `vid`             INT UNSIGNED NOT NULL,
     `uid`             INT UNSIGNED NOT NULL,
     `status`          TINYINT NOT NULL DEFAULT 1,
-    `result`          TEXT, #pointer to volume
-    `starting_time`   TIMESTAMP                   NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `result`          TEXT, /* pointer to volume */
+    `starting_time`   TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `last_update_time`   TIMESTAMP,
     `bookmarked`      BOOLEAN DEFAULT FALSE,
     `name`				VARCHAR(128) NOT NULL DEFAULT 'Untitled Execution',


### PR DESCRIPTION
This PR addresses the issue of frequent test failures that started occurring after commit #1912. The failure is caused by the initialization of the mock Texera DB. Upon running the Texera DDL script, the DB exits due to a known issue in the MariaDB4j library, as documented in this GitHub issue: https://github.com/MariaDB4j/MariaDB4j/issues/233.

To resolve this problem, I have identified several potential solutions:

1. Upgrade the library to version 3.0.0. However, this requires Java 17, and migrating our codebase to Java 17 would involve a substantial effort.
2. Downgrade the library to version 2.3.0. However, many of the functionalities we rely on are not yet available in this version.
3. Upon further investigation, I discovered that the error comes from a managed process in MariaDB4j which executes the SQL. To solve this issue, we can execute the SQL script through JDBC, thereby avoiding the usage of the managed process.