### PR TITLE
Add Option To Name Output Attribute In Text Source Operators

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextInputSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextInputSourceOpDesc.scala
@@ -36,21 +36,36 @@ class TextInputSourceOpDesc extends SourceOperatorDescriptor with TextSourceOpDe
   override def operatorExecutor(operatorSchemaInfo: OperatorSchemaInfo): OpExecConfig = {
     val offsetValue: Int = offsetHideable.getOrElse(0)
     val count: Int = countNumLines(textInput.linesIterator, offsetValue)
+    val defaultAttributeName: String = if (outputAsSingleTuple) "text" else "line"
 
     OpExecConfig.localLayer(
       operatorIdentifier,
       _ => {
         val startOffset: Int = offsetValue
         val endOffset: Int = offsetValue + count
-        new TextInputSourceOpExec(this, startOffset, endOffset)
+        new TextInputSourceOpExec(
+          this,
+          startOffset,
+          endOffset,
+          if (attributeName.isEmpty || attributeName.get.isEmpty) defaultAttributeName
+          else attributeName.get
+        )
       }
     )
   }
 
   override def sourceSchema(): Schema = {
+    val defaultAttributeName: String = if (outputAsSingleTuple) "text" else "line"
+
     Schema
       .newBuilder()
-      .add(new Attribute(if (outputAsSingleTuple) "text" else "line", AttributeType.STRING))
+      .add(
+        new Attribute(
+          if (attributeName.isEmpty || attributeName.get.isEmpty) defaultAttributeName
+          else attributeName.get,
+          AttributeType.STRING
+        )
+      )
       .build()
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextInputSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextInputSourceOpExec.scala
@@ -7,17 +7,23 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.Schema
 class TextInputSourceOpExec private[text] (
     val desc: TextInputSourceOpDesc,
     val startOffset: Int,
-    val endOffset: Int
+    val endOffset: Int,
+    val outputAttributeName: String
 ) extends SourceOperatorExecutor {
   private var schema: Schema = _
   private var rows: Iterator[String] = _
 
   override def produceTexeraTuple(): Iterator[Tuple] = {
     if (desc.outputAsSingleTuple) {
-      Iterator(Tuple.newBuilder(schema).add(schema.getAttribute("text"), desc.textInput).build())
+      Iterator(
+        Tuple
+          .newBuilder(schema)
+          .add(schema.getAttribute(outputAttributeName), desc.textInput)
+          .build()
+      )
     } else {
       rows.map(line => {
-        Tuple.newBuilder(schema).add(schema.getAttribute("line"), line).build()
+        Tuple.newBuilder(schema).add(schema.getAttribute(outputAttributeName), line).build()
       })
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextScanSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextScanSourceOpExec.scala
@@ -12,7 +12,8 @@ import scala.jdk.CollectionConverters.asScalaIteratorConverter
 class TextScanSourceOpExec private[text] (
     val desc: TextScanSourceOpDesc,
     val startOffset: Int,
-    val endOffset: Int
+    val endOffset: Int,
+    val outputAttributeName: String
 ) extends SourceOperatorExecutor {
   private var schema: Schema = _
   private var reader: BufferedReader = _
@@ -26,7 +27,7 @@ class TextScanSourceOpExec private[text] (
         Tuple
           .newBuilder(schema)
           .add(
-            schema.getAttribute("file"),
+            schema.getAttribute(outputAttributeName),
             new String(Files.readAllBytes(path), StandardCharsets.UTF_8)
             // currently using UTF_8 encoding, which will support all files
             // that can be represented using Unicode characters
@@ -37,7 +38,7 @@ class TextScanSourceOpExec private[text] (
       )
     } else { // normal text file scan mode
       rows.map(line => {
-        Tuple.newBuilder(schema).add(schema.getAttribute("line"), line).build()
+        Tuple.newBuilder(schema).add(schema.getAttribute(outputAttributeName), line).build()
       })
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextSourceOpDesc.scala
@@ -43,6 +43,13 @@ trait TextSourceOpDesc {
   )
   var offsetHideable: Option[Int] = None
 
+  // optional field allowing users to specify name of resulting output tuple attribute
+  @JsonProperty()
+  @JsonSchemaTitle("Output Attribute Name")
+  @JsonPropertyDescription("optionally specify name of output attribute")
+  @JsonDeserialize(contentAs = classOf[java.lang.String])
+  var attributeName: Option[String] = None
+
   @JsonProperty(defaultValue = "false")
   @JsonPropertyDescription(
     "scan entire text into single output tuple, ignoring any offsets and limits"

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextInputSourceOpDescSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextInputSourceOpDescSpec.scala
@@ -37,13 +37,24 @@ class TextInputSourceOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
     assert(inferredSchema.getAttribute("text").getType == AttributeType.STRING)
   }
 
+  it should "infer schema with user-specified output schema attribute" in {
+    val outputAsSingleTuple: Boolean = false
+    textInputSourceOpDesc.outputAsSingleTuple = outputAsSingleTuple
+    val customOutputAttributeName: String = "testing"
+    textInputSourceOpDesc.attributeName = Option(customOutputAttributeName)
+    val inferredSchema: Schema = textInputSourceOpDesc.sourceSchema()
+
+    assert(inferredSchema.getAttributes.length == 1)
+    assert(inferredSchema.getAttribute("testing").getType == AttributeType.STRING)
+  }
+
   it should "read first 5 lines of the input text into corresponding output tuples" in {
     val outputAsSingleTuple: Boolean = false
     val inputString: String = readFileIntoString(TestTextFilePath)
     textInputSourceOpDesc.textInput = inputString
     textInputSourceOpDesc.outputAsSingleTuple = outputAsSingleTuple
     val textScanSourceOpExec =
-      new TextInputSourceOpExec(textInputSourceOpDesc, StartOffset, EndOffset)
+      new TextInputSourceOpExec(textInputSourceOpDesc, StartOffset, EndOffset, "line")
     textScanSourceOpExec.open()
     val processedTuple: Iterator[Tuple] = textScanSourceOpExec.produceTexeraTuple()
 
@@ -62,7 +73,7 @@ class TextInputSourceOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
     textInputSourceOpDesc.textInput = inputString
     textInputSourceOpDesc.outputAsSingleTuple = outputAsSingleTuple
     val textScanSourceOpExec =
-      new TextInputSourceOpExec(textInputSourceOpDesc, StartOffset, EndOffset)
+      new TextInputSourceOpExec(textInputSourceOpDesc, StartOffset, EndOffset, "line")
     textScanSourceOpExec.open()
     val processedTuple: Iterator[Tuple] = textScanSourceOpExec.produceTexeraTuple()
 
@@ -81,7 +92,7 @@ class TextInputSourceOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
     textInputSourceOpDesc.textInput = inputString
     textInputSourceOpDesc.outputAsSingleTuple = outputAsSingleTuple
     val textScanSourceOpExec =
-      new TextInputSourceOpExec(textInputSourceOpDesc, StartOffset, EndOffset)
+      new TextInputSourceOpExec(textInputSourceOpDesc, StartOffset, EndOffset, "text")
     textScanSourceOpExec.open()
     val processedTuple: Iterator[Tuple] = textScanSourceOpExec.produceTexeraTuple()
 

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextScanSourceOpDescSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextScanSourceOpDescSpec.scala
@@ -36,10 +36,22 @@ class TextScanSourceOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
     assert(inferredSchema.getAttribute("file").getType == AttributeType.STRING)
   }
 
+  it should "infer schema with user-specified output schema attribute" in {
+    val outputAsSingleTuple: Boolean = false
+    textScanSourceOpDesc.outputAsSingleTuple = outputAsSingleTuple
+    val customOutputAttributeName: String = "testing"
+    textScanSourceOpDesc.attributeName = Option(customOutputAttributeName)
+    val inferredSchema: Schema = textScanSourceOpDesc.inferSchema()
+
+    assert(inferredSchema.getAttributes.length == 1)
+    assert(inferredSchema.getAttribute("testing").getType == AttributeType.STRING)
+  }
+
   it should "read first 5 lines of the input text file into corresponding output tuples" in {
     val outputAsSingleTuple: Boolean = false
+    textScanSourceOpDesc.outputAsSingleTuple = outputAsSingleTuple
     val textScanSourceOpExec =
-      new TextScanSourceOpExec(textScanSourceOpDesc, StartOffset, EndOffset)
+      new TextScanSourceOpExec(textScanSourceOpDesc, StartOffset, EndOffset, "line")
     textScanSourceOpExec.open()
     val processedTuple: Iterator[Tuple] = textScanSourceOpExec.produceTexeraTuple()
 
@@ -55,8 +67,9 @@ class TextScanSourceOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
   it should "read first 5 lines of the input text file with CRLF separators into corresponding output tuples" in {
     textScanSourceOpDesc.filePath = Some(TestCRLFTextFilePath)
     val outputAsSingleTuple: Boolean = false
+    textScanSourceOpDesc.outputAsSingleTuple = outputAsSingleTuple
     val textScanSourceOpExec =
-      new TextScanSourceOpExec(textScanSourceOpDesc, StartOffset, EndOffset)
+      new TextScanSourceOpExec(textScanSourceOpDesc, StartOffset, EndOffset, "line")
     textScanSourceOpExec.open()
     val processedTuple: Iterator[Tuple] = textScanSourceOpExec.produceTexeraTuple()
 
@@ -73,7 +86,7 @@ class TextScanSourceOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
     val outputAsSingleTuple: Boolean = true
     textScanSourceOpDesc.outputAsSingleTuple = outputAsSingleTuple
     val textScanSourceOpExec =
-      new TextScanSourceOpExec(textScanSourceOpDesc, StartOffset, EndOffset)
+      new TextScanSourceOpExec(textScanSourceOpDesc, StartOffset, EndOffset, "file")
     textScanSourceOpExec.open()
     val processedTuple: Iterator[Tuple] = textScanSourceOpExec.produceTexeraTuple()
 


### PR DESCRIPTION
Introduction 
---
Enhances the Text File Scan Operator #1846  and Text Input Source Operator #1868 by enabling users to optionally specify the name of the output attribute.  This is convenient for the Alteryx Migration effort where a specific name for the output attribute is desired and avoids having to use an extra Projection operator.

Demo
---
https://github.com/Texera/texera/assets/57075492/0910fab7-f4b3-4c2f-bbbe-36b02530e49b

