### PR TITLE
Fix the binary mode in Text Scan Operator

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextScanSourceOpDesc.scala
@@ -86,7 +86,8 @@ class TextScanSourceOpDesc extends ScanSourceOpDesc with TextSourceOpDesc {
         new Attribute(
           if (attributeName.isEmpty || attributeName.get.isEmpty) defaultAttributeName
           else attributeName.get,
-          AttributeType.STRING
+          if (outputAsBinary) AttributeType.BINARY
+          else AttributeType.STRING
         )
       )
       .build()


### PR DESCRIPTION
Fix the type mismatch for binary mode in Text Scan Operator

![image](https://github.com/Texera/texera/assets/11544314/066eacb5-ba56-45cd-838a-718d642d6ffc)
