### PR TITLE
Refactored each project list item into its own component

### DIFF
--- a/core/new-gui/src/app/app.module.ts
+++ b/core/new-gui/src/app/app.module.ts
@@ -119,7 +119,7 @@ import { MarkdownModule } from "ngx-markdown";
 import { FileSaverService } from "./dashboard/user/service/user-file/file-saver.service";
 import { DragDropModule } from "@angular/cdk/drag-drop";
 import { AuthInterceptor } from "./common/service/user/auth.interceptor";
-import { UserProjectListItemComponent } from './dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component';
+import { UserProjectListItemComponent } from "./dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component";
 
 registerLocaleData(en);
 

--- a/core/new-gui/src/app/app.module.ts
+++ b/core/new-gui/src/app/app.module.ts
@@ -119,6 +119,7 @@ import { MarkdownModule } from "ngx-markdown";
 import { FileSaverService } from "./dashboard/user/service/user-file/file-saver.service";
 import { DragDropModule } from "@angular/cdk/drag-drop";
 import { AuthInterceptor } from "./common/service/user/auth.interceptor";
+import { UserProjectListItemComponent } from './dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component';
 
 registerLocaleData(en);
 
@@ -179,6 +180,7 @@ registerLocaleData(en);
     InputAutoCompleteComponent,
     CollabWrapperComponent,
     HomeComponent,
+    UserProjectListItemComponent,
   ],
   imports: [
     BrowserModule,

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.css
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.css
@@ -1,0 +1,34 @@
+.project-name {
+    font-size: 20px;
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+    text-align: center;
+  }
+  
+  .project-name:hover {
+    cursor: pointer;
+  }
+  
+  .project-avatar-container {
+    text-align: center;
+  }
+  
+  button {
+    border-radius: 5px;
+    border: none;
+  }
+  
+  .edit-name-icon:hover,
+  .edit-description-icon:hover {
+    color: skyblue;
+  }
+  
+  .description-container {
+    border: 1px solid gainsboro;
+    border-radius: 10px;
+    padding: 2.5%;
+  }
+  
+  .character-count {
+    text-align: right;
+  }
+  

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.html
@@ -1,175 +1,172 @@
-
 <nz-list-item>
-    <nz-list-item-meta>
-      <nz-list-item-meta-avatar>
-        <div class="project-avatar-container">
-          <nz-avatar
-            (colorPickerSelect)="updateProjectColor()"
-            [(colorPicker)]="color"
-            [(cpToggle)]="editingColor"
-            [cpExtraTemplate]="colorMenuTemplate"
-            [cpPresetColors]="['#ff85c0', '#ff8c50', '#bae637', '#36cfc9', '#9254de', '#808080']"
-            [cpSaveClickOutside]="false"
-            [ngStyle]="{ 'background-color': entry?.color === null ? 'grey' : '#' + entry?.color, 'color' : lightColor ? 'black' : 'white'}"
-            [nzGap]="4"
-            [nzText]="'' + entry?.pid"
-            nzSize="default"></nz-avatar>
-          <ng-template #colorMenuTemplate>
-            <div style="display: flex; padding: 0 16px 16px; justify-content: space-between">
-              <button
-                (click)="removeProjectColor()"
-                [disabled]="entry?.color === null"
-                class="btn btn-outline-danger btn-xs">
-                Delete
-              </button>
-              <button
-                (click)="updateProjectColor()"
-                class="btn btn-primary btn-xs">
-                Save
-              </button>
-            </div>
-          </ng-template>
-        </div>
-      </nz-list-item-meta-avatar>
-
-      <!-- editable name of saved workflow -->
-      <nz-list-item-meta-title>
-        <ng-container
-          *ngIf="!editingName; else editingProject">
-          <a
-            [routerLink]="ROUTER_USER_PROJECT_BASE_URL + '/' + entry?.pid"
-            class="project-name">
-            {{entry?.name}}</a
-          >
-          <button
-            (click)="editingName = true"
-            nz-button
-            title="Edit Project Name"
-            nz-tooltip="Edit Project Name"
-            nzSize="small"
-            nzTooltipPlacement="top"
-            nzType="text">
-            <i
-              class="edit-name-icon"
-              nz-icon
-              nzTheme="outline"
-              nzType="edit"></i>
-          </button>
-          <button
-            (click)="editingDescription = true"
-            nz-button
-            title="Add / Edit Description"
-            nz-tooltip="Add / Edit Description"
-            nzSize="small"
-            nzTooltipPlacement="top"
-            nzType="text">
-            <i
-              class="edit-description-icon"
-              nz-icon
-              nzTheme="outline"
-              nzType="plus-square"></i>
-          </button>
-          <button
-            (click)="descriptionCollapsed = true"
-            *ngIf="entry?.description && entry?.description?.trim() && !descriptionCollapsed"
-            nz-button
-            title="Collapse Description"
-            nz-tooltip="Collapse Description"
-            nzSize="small"
-            nzTooltipPlacement="top"
-            nzType="text">
-            <i
-              nz-icon
-              nzTheme="outline"
-              nzType="up-square"></i>
-          </button>
-          <button
-            (click)="descriptionCollapsed = false"
-            *ngIf="entry?.description && entry?.description?.trim() && descriptionCollapsed"
-            nz-button
-            title="Expand Description"
-            nz-tooltip="Expand Description"
-            nzSize="small"
-            nzTooltipPlacement="top"
-            nzType="text">
-            <i
-              nz-icon
-              nzTheme="outline"
-              nzType="down-square"></i>
-          </button>
-        </ng-container>
-
-        <ng-template #editingProject>
-          <input
-            #editedName
-            (focusout)="editingName = false"
-            (keyup.enter)="saveProjectName(editedName.value)"
-            placeholder="{{ entry?.name }}"
-            value="{{ entry?.name }}" />
-        </ng-template>
-      </nz-list-item-meta-title>
-
-      <!-- editable project description -->
-      <nz-list-item-meta-description>
-        <ng-container
-          *ngIf="!editingDescription;else editDescriptionTemplate">
-          <div
-            *ngIf="entry?.description && entry?.description?.trim() && !descriptionCollapsed"
-            class="description-container">
-            <markdown [data]="entry?.description"></markdown>
+  <nz-list-item-meta>
+    <nz-list-item-meta-avatar>
+      <div class="project-avatar-container">
+        <nz-avatar
+          (colorPickerSelect)="updateProjectColor()"
+          [(colorPicker)]="color"
+          [(cpToggle)]="editingColor"
+          [cpExtraTemplate]="colorMenuTemplate"
+          [cpPresetColors]="['#ff85c0', '#ff8c50', '#bae637', '#36cfc9', '#9254de', '#808080']"
+          [cpSaveClickOutside]="false"
+          [ngStyle]="{ 'background-color': entry?.color === null ? 'grey' : '#' + entry?.color, 'color' : lightColor ? 'black' : 'white'}"
+          [nzGap]="4"
+          [nzText]="'' + entry?.pid"
+          nzSize="default"></nz-avatar>
+        <ng-template #colorMenuTemplate>
+          <div style="display: flex; padding: 0 16px 16px; justify-content: space-between">
+            <button
+              (click)="removeProjectColor()"
+              [disabled]="entry?.color === null"
+              class="btn btn-outline-danger btn-xs">
+              Delete
+            </button>
+            <button
+              (click)="updateProjectColor()"
+              class="btn btn-primary btn-xs">
+              Save
+            </button>
           </div>
-        </ng-container>
-
-        <ng-template #editDescriptionTemplate>
-          <nz-input-group
-            [nzSuffix]="saveDescriptionIcon"
-            class="ant-input-affix-wrapper-textarea-with-clear-btn">
-            <textarea
-              #descriptionBox
-              (focusout)="saveProjectDescription(descriptionBox.value)"
-              [attr.maxlength]="MAX_PROJECT_DESCRIPTION_CHAR_COUNT"
-              nz-input
-              nzAutosize
-              placeholder="Enter project description">
-{{entry?.description}}</textarea
-            >
-          </nz-input-group>
-          <div class="character-count">{{descriptionBox.value.length}}/{{MAX_PROJECT_DESCRIPTION_CHAR_COUNT}}</div>
-          <ng-template #saveDescriptionIcon>
-            <span
-              (click)="editingDescription = false"
-              *ngIf="descriptionBox.value !== entry?.description"
-              class="ant-input-clear-icon"
-              nz-icon
-              nz-tooltip="Save"
-              nzTheme="fill"
-              nzTooltipPlacement="top"
-              nzType="check-circle"></span>
-          </ng-template>
         </ng-template>
-      </nz-list-item-meta-description>
+      </div>
+    </nz-list-item-meta-avatar>
 
-      <!-- created time of project -->
-      <nz-list-item-meta-description>
-        <p>Created: {{entry?.creationTime | date: "yyyy-MM-dd HH:mm"}}</p>
-      </nz-list-item-meta-description>
-    </nz-list-item-meta>
-
-    <ul nz-list-item-actions>
-      <nz-list-item-action>
+    <!-- editable name of saved workflow -->
+    <nz-list-item-meta-title>
+      <ng-container *ngIf="!editingName; else editingProject">
+        <a
+          [routerLink]="ROUTER_USER_PROJECT_BASE_URL + '/' + entry?.pid"
+          class="project-name">
+          {{entry?.name}}</a
+        >
         <button
-          (nzOnConfirm)="deleted.emit()"
+          (click)="editingName = true"
           nz-button
-          nz-popconfirm
-          title="Delete the project {{entry?.name}}"
-          nz-tooltip="Delete the project {{entry?.name}}"
-          nzPopconfirmTitle="Confirm to delete this project."
-          nzTooltipPlacement="bottom">
+          title="Edit Project Name"
+          nz-tooltip="Edit Project Name"
+          nzSize="small"
+          nzTooltipPlacement="top"
+          nzType="text">
+          <i
+            class="edit-name-icon"
+            nz-icon
+            nzTheme="outline"
+            nzType="edit"></i>
+        </button>
+        <button
+          (click)="editingDescription = true"
+          nz-button
+          title="Add / Edit Description"
+          nz-tooltip="Add / Edit Description"
+          nzSize="small"
+          nzTooltipPlacement="top"
+          nzType="text">
+          <i
+            class="edit-description-icon"
+            nz-icon
+            nzTheme="outline"
+            nzType="plus-square"></i>
+        </button>
+        <button
+          (click)="descriptionCollapsed = true"
+          *ngIf="entry?.description && entry?.description?.trim() && !descriptionCollapsed"
+          nz-button
+          title="Collapse Description"
+          nz-tooltip="Collapse Description"
+          nzSize="small"
+          nzTooltipPlacement="top"
+          nzType="text">
           <i
             nz-icon
             nzTheme="outline"
-            nzType="delete"></i>
+            nzType="up-square"></i>
         </button>
-      </nz-list-item-action>
-    </ul>
-  </nz-list-item>
+        <button
+          (click)="descriptionCollapsed = false"
+          *ngIf="entry?.description && entry?.description?.trim() && descriptionCollapsed"
+          nz-button
+          title="Expand Description"
+          nz-tooltip="Expand Description"
+          nzSize="small"
+          nzTooltipPlacement="top"
+          nzType="text">
+          <i
+            nz-icon
+            nzTheme="outline"
+            nzType="down-square"></i>
+        </button>
+      </ng-container>
+
+      <ng-template #editingProject>
+        <input
+          #editedName
+          (focusout)="editingName = false"
+          (keyup.enter)="saveProjectName(editedName.value)"
+          placeholder="{{ entry?.name }}"
+          value="{{ entry?.name }}" />
+      </ng-template>
+    </nz-list-item-meta-title>
+
+    <!-- editable project description -->
+    <nz-list-item-meta-description>
+      <ng-container *ngIf="!editingDescription;else editDescriptionTemplate">
+        <div
+          *ngIf="entry?.description && entry?.description?.trim() && !descriptionCollapsed"
+          class="description-container">
+          <markdown [data]="entry?.description"></markdown>
+        </div>
+      </ng-container>
+
+      <ng-template #editDescriptionTemplate>
+        <nz-input-group
+          [nzSuffix]="saveDescriptionIcon"
+          class="ant-input-affix-wrapper-textarea-with-clear-btn">
+          <textarea
+            #descriptionBox
+            (focusout)="saveProjectDescription(descriptionBox.value)"
+            [attr.maxlength]="MAX_PROJECT_DESCRIPTION_CHAR_COUNT"
+            nz-input
+            nzAutosize
+            placeholder="Enter project description">
+{{entry?.description}}</textarea
+          >
+        </nz-input-group>
+        <div class="character-count">{{descriptionBox.value.length}}/{{MAX_PROJECT_DESCRIPTION_CHAR_COUNT}}</div>
+        <ng-template #saveDescriptionIcon>
+          <span
+            (click)="editingDescription = false"
+            *ngIf="descriptionBox.value !== entry?.description"
+            class="ant-input-clear-icon"
+            nz-icon
+            nz-tooltip="Save"
+            nzTheme="fill"
+            nzTooltipPlacement="top"
+            nzType="check-circle"></span>
+        </ng-template>
+      </ng-template>
+    </nz-list-item-meta-description>
+
+    <!-- created time of project -->
+    <nz-list-item-meta-description>
+      <p>Created: {{entry?.creationTime | date: "yyyy-MM-dd HH:mm"}}</p>
+    </nz-list-item-meta-description>
+  </nz-list-item-meta>
+
+  <ul nz-list-item-actions>
+    <nz-list-item-action>
+      <button
+        (nzOnConfirm)="deleted.emit()"
+        nz-button
+        nz-popconfirm
+        title="Delete the project {{entry?.name}}"
+        nz-tooltip="Delete the project {{entry?.name}}"
+        nzPopconfirmTitle="Confirm to delete this project."
+        nzTooltipPlacement="bottom">
+        <i
+          nz-icon
+          nzTheme="outline"
+          nzType="delete"></i>
+      </button>
+    </nz-list-item-action>
+  </ul>
+</nz-list-item>

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.html
@@ -1,0 +1,175 @@
+
+<nz-list-item>
+    <nz-list-item-meta>
+      <nz-list-item-meta-avatar>
+        <div class="project-avatar-container">
+          <nz-avatar
+            (colorPickerSelect)="updateProjectColor()"
+            [(colorPicker)]="color"
+            [(cpToggle)]="editingColor"
+            [cpExtraTemplate]="colorMenuTemplate"
+            [cpPresetColors]="['#ff85c0', '#ff8c50', '#bae637', '#36cfc9', '#9254de', '#808080']"
+            [cpSaveClickOutside]="false"
+            [ngStyle]="{ 'background-color': entry?.color === null ? 'grey' : '#' + entry?.color, 'color' : lightColor ? 'black' : 'white'}"
+            [nzGap]="4"
+            [nzText]="'' + entry?.pid"
+            nzSize="default"></nz-avatar>
+          <ng-template #colorMenuTemplate>
+            <div style="display: flex; padding: 0 16px 16px; justify-content: space-between">
+              <button
+                (click)="removeProjectColor()"
+                [disabled]="entry?.color === null"
+                class="btn btn-outline-danger btn-xs">
+                Delete
+              </button>
+              <button
+                (click)="updateProjectColor()"
+                class="btn btn-primary btn-xs">
+                Save
+              </button>
+            </div>
+          </ng-template>
+        </div>
+      </nz-list-item-meta-avatar>
+
+      <!-- editable name of saved workflow -->
+      <nz-list-item-meta-title>
+        <ng-container
+          *ngIf="!editingName; else editingProject">
+          <a
+            [routerLink]="ROUTER_USER_PROJECT_BASE_URL + '/' + entry?.pid"
+            class="project-name">
+            {{entry?.name}}</a
+          >
+          <button
+            (click)="editingName = true"
+            nz-button
+            title="Edit Project Name"
+            nz-tooltip="Edit Project Name"
+            nzSize="small"
+            nzTooltipPlacement="top"
+            nzType="text">
+            <i
+              class="edit-name-icon"
+              nz-icon
+              nzTheme="outline"
+              nzType="edit"></i>
+          </button>
+          <button
+            (click)="editingDescription = true"
+            nz-button
+            title="Add / Edit Description"
+            nz-tooltip="Add / Edit Description"
+            nzSize="small"
+            nzTooltipPlacement="top"
+            nzType="text">
+            <i
+              class="edit-description-icon"
+              nz-icon
+              nzTheme="outline"
+              nzType="plus-square"></i>
+          </button>
+          <button
+            (click)="descriptionCollapsed = true"
+            *ngIf="entry?.description && entry?.description?.trim() && !descriptionCollapsed"
+            nz-button
+            title="Collapse Description"
+            nz-tooltip="Collapse Description"
+            nzSize="small"
+            nzTooltipPlacement="top"
+            nzType="text">
+            <i
+              nz-icon
+              nzTheme="outline"
+              nzType="up-square"></i>
+          </button>
+          <button
+            (click)="descriptionCollapsed = false"
+            *ngIf="entry?.description && entry?.description?.trim() && descriptionCollapsed"
+            nz-button
+            title="Expand Description"
+            nz-tooltip="Expand Description"
+            nzSize="small"
+            nzTooltipPlacement="top"
+            nzType="text">
+            <i
+              nz-icon
+              nzTheme="outline"
+              nzType="down-square"></i>
+          </button>
+        </ng-container>
+
+        <ng-template #editingProject>
+          <input
+            #editedName
+            (focusout)="editingName = false"
+            (keyup.enter)="saveProjectName(editedName.value)"
+            placeholder="{{ entry?.name }}"
+            value="{{ entry?.name }}" />
+        </ng-template>
+      </nz-list-item-meta-title>
+
+      <!-- editable project description -->
+      <nz-list-item-meta-description>
+        <ng-container
+          *ngIf="!editingDescription;else editDescriptionTemplate">
+          <div
+            *ngIf="entry?.description && entry?.description?.trim() && !descriptionCollapsed"
+            class="description-container">
+            <markdown [data]="entry?.description"></markdown>
+          </div>
+        </ng-container>
+
+        <ng-template #editDescriptionTemplate>
+          <nz-input-group
+            [nzSuffix]="saveDescriptionIcon"
+            class="ant-input-affix-wrapper-textarea-with-clear-btn">
+            <textarea
+              #descriptionBox
+              (focusout)="saveProjectDescription(descriptionBox.value)"
+              [attr.maxlength]="MAX_PROJECT_DESCRIPTION_CHAR_COUNT"
+              nz-input
+              nzAutosize
+              placeholder="Enter project description">
+{{entry?.description}}</textarea
+            >
+          </nz-input-group>
+          <div class="character-count">{{descriptionBox.value.length}}/{{MAX_PROJECT_DESCRIPTION_CHAR_COUNT}}</div>
+          <ng-template #saveDescriptionIcon>
+            <span
+              (click)="editingDescription = false"
+              *ngIf="descriptionBox.value !== entry?.description"
+              class="ant-input-clear-icon"
+              nz-icon
+              nz-tooltip="Save"
+              nzTheme="fill"
+              nzTooltipPlacement="top"
+              nzType="check-circle"></span>
+          </ng-template>
+        </ng-template>
+      </nz-list-item-meta-description>
+
+      <!-- created time of project -->
+      <nz-list-item-meta-description>
+        <p>Created: {{entry?.creationTime | date: "yyyy-MM-dd HH:mm"}}</p>
+      </nz-list-item-meta-description>
+    </nz-list-item-meta>
+
+    <ul nz-list-item-actions>
+      <nz-list-item-action>
+        <button
+          (nzOnConfirm)="deleted.emit()"
+          nz-button
+          nz-popconfirm
+          title="Delete the project {{entry?.name}}"
+          nz-tooltip="Delete the project {{entry?.name}}"
+          nzPopconfirmTitle="Confirm to delete this project."
+          nzTooltipPlacement="bottom">
+          <i
+            nz-icon
+            nzTheme="outline"
+            nzType="delete"></i>
+        </button>
+      </nz-list-item-action>
+    </ul>
+  </nz-list-item>

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { UserProjectListItemComponent } from './user-project-list-item.component';
+
+describe('UserProjectListItemComponent', () => {
+  let component: UserProjectListItemComponent;
+  let fixture: ComponentFixture<UserProjectListItemComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ UserProjectListItemComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(UserProjectListItemComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.spec.ts
@@ -1,19 +1,34 @@
 import { ComponentFixture, TestBed } from "@angular/core/testing";
 import { UserProjectListItemComponent } from "./user-project-list-item.component";
+import { HttpClient, HttpHandler } from "@angular/common/http";
+import { NotificationService } from "src/app/common/service/notification/notification.service";
+import { UserProjectService } from "../../../service/user-project/user-project.service";
+import { UserProject } from "../../../type/user-project";
 
 describe("UserProjectListItemComponent", () => {
   let component: UserProjectListItemComponent;
   let fixture: ComponentFixture<UserProjectListItemComponent>;
+  const januaryFirst1970 = 28800000; // 1970-01-01 in PST
+  const testProject: UserProject = {
+    color: null,
+    creationTime: januaryFirst1970,
+    description: "description",
+    name: "project1",
+    ownerID: 1,
+    pid: 1,
+  };
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       declarations: [UserProjectListItemComponent],
+      providers: [HttpClient, HttpHandler, NotificationService, UserProjectService],
     }).compileComponents();
   });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(UserProjectListItemComponent);
     component = fixture.componentInstance;
+    component.entry = testProject;
     fixture.detectChanges();
   });
 

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.spec.ts
@@ -1,15 +1,14 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { UserProjectListItemComponent } from './user-project-list-item.component';
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { UserProjectListItemComponent } from "./user-project-list-item.component";
 
-describe('UserProjectListItemComponent', () => {
+describe("UserProjectListItemComponent", () => {
   let component: UserProjectListItemComponent;
   let fixture: ComponentFixture<UserProjectListItemComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ UserProjectListItemComponent ]
-    })
-    .compileComponents();
+      declarations: [UserProjectListItemComponent],
+    }).compileComponents();
   });
 
   beforeEach(() => {
@@ -18,7 +17,7 @@ describe('UserProjectListItemComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  it("should create", () => {
     expect(component).toBeTruthy();
   });
 });

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.ts
@@ -13,8 +13,17 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 export class UserProjectListItemComponent implements OnInit {
   public readonly ROUTER_USER_PROJECT_BASE_URL = "/dashboard/user-project";
   public readonly MAX_PROJECT_DESCRIPTION_CHAR_COUNT = 10000;
-
-  @Input() entry?: UserProject;
+  private _entry?: UserProject;
+  @Input()
+  get entry(): UserProject {
+    if (!this._entry) {
+      throw new Error("entry property must be provided to UserProjectListItemComponent.");
+    }
+    return this._entry;
+  }
+  set entry(value: UserProject) {
+    this._entry = value;
+  }
   /**
    * Whether edit is enabled globally. It is possible to only edit this entry by setting
    * this.editingName = true or this.editingDescription = true.
@@ -35,18 +44,12 @@ export class UserProjectListItemComponent implements OnInit {
   constructor(private userProjectService: UserProjectService, private notificationService: NotificationService) {}
 
   ngOnInit(): void {
-    if (!this.entry) {
-      throw new Error("entry property must be provided to UserProjectListItemComponent.");
-    }
     if (this.entry.color) {
       this.color = this.entry.color;
     }
   }
 
   updateProjectColor(): void {
-    if (!this.entry) {
-      throw new Error("entry property must be provided to UserProjectListItemComponent.");
-    }
     const color = this.color.substring(1);
     this.editingColor = false;
     // validate that color is in proper HEX format
@@ -67,9 +70,6 @@ export class UserProjectListItemComponent implements OnInit {
       .subscribe({
         next: () => {
           this.color = color;
-          if (!this.entry) {
-            throw new Error("entry property must be provided to UserProjectListItemComponent.");
-          }
           this.entry = { ...this.entry, color: color };
         },
         error: (err: unknown) => {
@@ -80,10 +80,6 @@ export class UserProjectListItemComponent implements OnInit {
   }
 
   removeProjectColor(): void {
-    if (!this.entry) {
-      throw new Error("entry property must be provided to UserProjectListItemComponent.");
-    }
-
     this.editingColor = false;
 
     this.userProjectService
@@ -92,9 +88,6 @@ export class UserProjectListItemComponent implements OnInit {
       .subscribe({
         next: _ => {
           this.color = "#ffffff"; // reset color wheel
-          if (!this.entry) {
-            throw new Error("entry property must be provided to UserProjectListItemComponent.");
-          }
           this.entry = { ...this.entry, color: null };
         },
         error: (err: unknown) => {
@@ -105,9 +98,6 @@ export class UserProjectListItemComponent implements OnInit {
   }
 
   saveProjectName(name: string): void {
-    if (!this.entry) {
-      throw new Error("entry property must be provided to UserProjectListItemComponent.");
-    }
     // nothing happens if name is the same
     if (this.entry.name === name) {
       this.editingName = false;
@@ -132,9 +122,6 @@ export class UserProjectListItemComponent implements OnInit {
   }
 
   saveProjectDescription(description: string): void {
-    if (!this.entry) {
-      throw new Error("entry property must be provided to UserProjectListItemComponent.");
-    }
     // nothing happens if description is the same
     if (this.entry.description === description) {
       this.editingDescription = false;
@@ -147,9 +134,6 @@ export class UserProjectListItemComponent implements OnInit {
       .pipe(untilDestroyed(this))
       .subscribe({
         next: () => {
-          if (!this.entry) {
-            throw new Error("entry property must be provided to UserProjectListItemComponent.");
-          }
           this.entry.description = description;
           this.notificationService.success(`Saved description for project: "${this.entry.name}".`);
         },

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.ts
@@ -1,0 +1,165 @@
+import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
+import { UserProject } from "../../../type/user-project";
+import { UserProjectService } from "../../../service/user-project/user-project.service";
+import { NotificationService } from "src/app/common/service/notification/notification.service";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+
+@UntilDestroy()
+@Component({
+  selector: "texera-user-project-list-item",
+  templateUrl: "./user-project-list-item.component.html",
+  styleUrls: ["./user-project-list-item.component.css"],
+})
+export class UserProjectListItemComponent implements OnInit {
+  public readonly ROUTER_USER_PROJECT_BASE_URL = "/dashboard/user-project";
+  public readonly MAX_PROJECT_DESCRIPTION_CHAR_COUNT = 10000;
+
+  @Input() entry?: UserProject;
+  /**
+   * Whether edit is enabled globally. It is possible to only edit this entry by setting
+   * this.editingName = true or this.editingDescription = true.
+   */
+  @Input() editing = false;
+  @Output() deleted = new EventEmitter<void>();
+
+  editingColor = false;
+  editingName = false;
+  editingDescription = false;
+  descriptionCollapsed = false;
+  color = "#ffffff";
+  /** To make sure info remains visible against white background */
+  get lightColor() {
+    return this.userProjectService.isLightColor(this.color);
+  }
+
+  constructor(private userProjectService: UserProjectService, private notificationService: NotificationService) {}
+
+  ngOnInit(): void {
+    if (!this.entry) {
+      throw new Error("entry property must be provided to UserProjectListItemComponent.");
+    }
+    if (this.entry.color) {
+      this.color = this.entry.color;
+    }
+  }
+
+  updateProjectColor(): void {
+    if (!this.entry) {
+      throw new Error("entry property must be provided to UserProjectListItemComponent.");
+    }
+    const color = this.color.substring(1);
+    this.editingColor = false;
+    // validate that color is in proper HEX format
+    if (this.userProjectService.isInvalidColorFormat(color)) {
+      this.notificationService.error(
+        `Cannot update color for project: "${this.entry.name}".  It must be a valid HEX color format`
+      );
+      return;
+    }
+
+    if (color === this.entry.color) {
+      return;
+    }
+
+    this.userProjectService
+      .updateProjectColor(this.entry.pid, color)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: () => {
+          this.color = color;
+          if (!this.entry) {
+            throw new Error("entry property must be provided to UserProjectListItemComponent.");
+          }
+          this.entry = { ...this.entry, color: color };
+        },
+        error: (err: unknown) => {
+          // @ts-ignore
+          this.notificationService.error(err.error.message);
+        },
+      });
+  }
+
+  removeProjectColor(): void {
+    if (!this.entry) {
+      throw new Error("entry property must be provided to UserProjectListItemComponent.");
+    }
+
+    this.editingColor = false;
+
+    this.userProjectService
+      .deleteProjectColor(this.entry.pid)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: _ => {
+          this.color = "#ffffff"; // reset color wheel
+          if (!this.entry) {
+            throw new Error("entry property must be provided to UserProjectListItemComponent.");
+          }
+          this.entry = { ...this.entry, color: null };
+        },
+        error: (err: unknown) => {
+          // @ts-ignore
+          this.notificationService.error(err.error.message);
+        },
+      });
+  }
+
+  saveProjectName(name: string): void {
+    if (!this.entry) {
+      throw new Error("entry property must be provided to UserProjectListItemComponent.");
+    }
+    // nothing happens if name is the same
+    if (this.entry.name === name) {
+      this.editingName = false;
+    } else {
+      this.userProjectService
+        .updateProjectName(this.entry.pid, name)
+        .pipe(untilDestroyed(this))
+        .subscribe({
+          next: () => {
+            if (!this.entry) {
+              throw new Error("entry property must be provided to UserProjectListItemComponent.");
+            }
+            this.editingName = false;
+            this.entry.name = name;
+          },
+          error: (err: unknown) => {
+            // @ts-ignore
+            this.notificationService.error(err.error.message);
+          },
+        });
+    }
+  }
+
+  saveProjectDescription(description: string): void {
+    if (!this.entry) {
+      throw new Error("entry property must be provided to UserProjectListItemComponent.");
+    }
+    // nothing happens if description is the same
+    if (this.entry.description === description) {
+      this.editingDescription = false;
+      return;
+    }
+
+    // update the project's description
+    this.userProjectService
+      .updateProjectDescription(this.entry.pid, description)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: () => {
+          if (!this.entry) {
+            throw new Error("entry property must be provided to UserProjectListItemComponent.");
+          }
+          this.entry.description = description;
+          this.notificationService.success(`Saved description for project: "${this.entry.name}".`);
+        },
+        error: (err: unknown) => {
+          // @ts-ignore
+          this.notificationService.error(err.error.message);
+        },
+      })
+      .add(() => {
+        this.editingDescription = false;
+      });
+  }
+}

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.html
@@ -4,7 +4,7 @@
     <a
       [nzDropdownMenu]="menu"
       nz-dropdown>
-      <button nz-button>
+      <button nz-button title="sort">
         <i
           nz-icon
           nzTheme="outline"
@@ -35,6 +35,7 @@
     <button
       (click)="clickCreateButton()"
       nz-button
+      title="Create a new project"
       nz-tooltip="Create a new project"
       nzTooltipPlacement="bottom"
       type="button">
@@ -54,175 +55,11 @@
 
   <nz-card>
     <nz-list>
-      <nz-list-item *ngFor="let dashboardUserProjectEntry of userProjectEntries; let i = index">
-        <nz-list-item-meta>
-          <nz-list-item-meta-avatar>
-            <div class="project-avatar-container">
-              <nz-avatar
-                (colorPickerSelect)="updateProjectColor(dashboardUserProjectEntry, i)"
-                [(colorPicker)]="userProjectInputColors[userProjectToColorInputIndexMap.get(dashboardUserProjectEntry.pid)!]"
-                [(cpToggle)]="colorInputToggleArray[i]"
-                [cpExtraTemplate]="colorMenuTemplate"
-                [cpPresetColors]="['#ff85c0', '#ff8c50', '#bae637', '#36cfc9', '#9254de', '#808080']"
-                [cpSaveClickOutside]="false"
-                [ngStyle]="{ 'background-color': dashboardUserProjectEntry.color === null ? 'grey' : '#' + dashboardUserProjectEntry.color, 'color' : colorBrightnessMap.get(dashboardUserProjectEntry.pid) ? 'black' : 'white'}"
-                [nzGap]="4"
-                [nzText]="'' + dashboardUserProjectEntry.pid"
-                nzSize="default"></nz-avatar>
-              <ng-template #colorMenuTemplate>
-                <div style="display: flex; padding: 0 16px 16px; justify-content: space-between">
-                  <button
-                    (click)="removeProjectColor(dashboardUserProjectEntry, i)"
-                    [disabled]="dashboardUserProjectEntry.color === null"
-                    class="btn btn-outline-danger btn-xs">
-                    Delete
-                  </button>
-                  <button
-                    (click)="updateProjectColor(dashboardUserProjectEntry, i)"
-                    class="btn btn-primary btn-xs">
-                    Save
-                  </button>
-                </div>
-              </ng-template>
-            </div>
-          </nz-list-item-meta-avatar>
-
-          <!-- editable name of saved workflow -->
-          <nz-list-item-meta-title>
-            <ng-container
-              *ngIf="userProjectEntriesIsEditingName.indexOf(dashboardUserProjectEntry.pid) === -1;else editingProject">
-              <a
-                [routerLink]="ROUTER_USER_PROJECT_BASE_URL + '/' + dashboardUserProjectEntry.pid"
-                class="project-name">
-                {{dashboardUserProjectEntry.name}}</a
-              >
-              <button
-                (click)="userProjectEntriesIsEditingName.push(dashboardUserProjectEntry.pid)"
-                nz-button
-                nz-tooltip="Edit Project Name"
-                nzSize="small"
-                nzTooltipPlacement="top"
-                nzType="text">
-                <i
-                  class="edit-name-icon"
-                  nz-icon
-                  nzTheme="outline"
-                  nzType="edit"></i>
-              </button>
-              <button
-                (click)="userProjectEntriesIsEditingDescription.push(dashboardUserProjectEntry.pid)"
-                nz-button
-                nz-tooltip="Add / Edit Description"
-                nzSize="small"
-                nzTooltipPlacement="top"
-                nzType="text">
-                <i
-                  class="edit-description-icon"
-                  nz-icon
-                  nzTheme="outline"
-                  nzType="plus-square"></i>
-              </button>
-              <button
-                (click)="collapsedProjectDescriptions.push(dashboardUserProjectEntry.pid)"
-                *ngIf="dashboardUserProjectEntry.description && dashboardUserProjectEntry.description.trim() && collapsedProjectDescriptions.indexOf(dashboardUserProjectEntry.pid) === -1"
-                nz-button
-                nz-tooltip="Collapse Description"
-                nzSize="small"
-                nzTooltipPlacement="top"
-                nzType="text">
-                <i
-                  nz-icon
-                  nzTheme="outline"
-                  nzType="up-square"></i>
-              </button>
-              <button
-                (click)="removeCollapsedProjectDescriptionStatus(dashboardUserProjectEntry.pid)"
-                *ngIf="dashboardUserProjectEntry.description && dashboardUserProjectEntry.description.trim() && collapsedProjectDescriptions.indexOf(dashboardUserProjectEntry.pid) !== -1"
-                nz-button
-                nz-tooltip="Expand Description"
-                nzSize="small"
-                nzTooltipPlacement="top"
-                nzType="text">
-                <i
-                  nz-icon
-                  nzTheme="outline"
-                  nzType="down-square"></i>
-              </button>
-            </ng-container>
-
-            <ng-template #editingProject>
-              <input
-                #editedName
-                (focusout)="removeEditNameStatus(dashboardUserProjectEntry.pid)"
-                (keyup.enter)="saveProjectName(dashboardUserProjectEntry, editedName.value)"
-                placeholder="{{ dashboardUserProjectEntry.name }}"
-                value="{{ dashboardUserProjectEntry.name }}" />
-            </ng-template>
-          </nz-list-item-meta-title>
-
-          <!-- editable project description -->
-          <nz-list-item-meta-description>
-            <ng-container
-              *ngIf="userProjectEntriesIsEditingDescription.indexOf(dashboardUserProjectEntry.pid) === -1;else editingDescription">
-              <div
-                *ngIf="dashboardUserProjectEntry.description && dashboardUserProjectEntry.description.trim() && collapsedProjectDescriptions.indexOf(dashboardUserProjectEntry.pid) === -1"
-                class="description-container">
-                <markdown [data]="dashboardUserProjectEntry.description"></markdown>
-              </div>
-            </ng-container>
-
-            <ng-template #editingDescription>
-              <nz-input-group
-                [nzSuffix]="saveDescriptionIcon"
-                class="ant-input-affix-wrapper-textarea-with-clear-btn">
-                <textarea
-                  #descriptionBox
-                  (focusout)="saveProjectDescription(dashboardUserProjectEntry, descriptionBox.value, i)"
-                  [attr.maxlength]="MAX_PROJECT_DESCRIPTION_CHAR_COUNT"
-                  nz-input
-                  nzAutosize
-                  placeholder="Enter project description">
-{{dashboardUserProjectEntry.description}}</textarea
-                >
-              </nz-input-group>
-              <div class="character-count">{{descriptionBox.value.length}}/{{MAX_PROJECT_DESCRIPTION_CHAR_COUNT}}</div>
-              <ng-template #saveDescriptionIcon>
-                <span
-                  (click)="removeEditDescriptionStatus(dashboardUserProjectEntry.pid)"
-                  *ngIf="descriptionBox.value !== dashboardUserProjectEntry.description"
-                  class="ant-input-clear-icon"
-                  nz-icon
-                  nz-tooltip="Save"
-                  nzTheme="fill"
-                  nzTooltipPlacement="top"
-                  nzType="check-circle"></span>
-              </ng-template>
-            </ng-template>
-          </nz-list-item-meta-description>
-
-          <!-- created time of project -->
-          <nz-list-item-meta-description>
-            <p>Created: {{dashboardUserProjectEntry.creationTime | date: "yyyy-MM-dd HH:mm"}}</p>
-          </nz-list-item-meta-description>
-        </nz-list-item-meta>
-
-        <ul nz-list-item-actions>
-          <nz-list-item-action>
-            <button
-              (nzOnConfirm)="deleteProject(dashboardUserProjectEntry.pid)"
-              nz-button
-              nz-popconfirm
-              nz-tooltip="Delete the project {{dashboardUserProjectEntry.name}}"
-              nzPopconfirmTitle="Confirm to delete this project."
-              nzTooltipPlacement="bottom">
-              <i
-                nz-icon
-                nzTheme="outline"
-                nzType="delete"></i>
-            </button>
-          </nz-list-item-action>
-        </ul>
-      </nz-list-item>
+      <texera-user-project-list-item 
+        *ngFor="let dashboardUserProjectEntry of userProjectEntries" 
+        [entry]="dashboardUserProjectEntry"
+        (deleted)="deleteProject(dashboardUserProjectEntry.pid)">
+      </texera-user-project-list-item>
     </nz-list>
   </nz-card>
 </div>

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.html
@@ -4,7 +4,9 @@
     <a
       [nzDropdownMenu]="menu"
       nz-dropdown>
-      <button nz-button title="sort">
+      <button
+        nz-button
+        title="sort">
         <i
           nz-icon
           nzTheme="outline"
@@ -55,8 +57,8 @@
 
   <nz-card>
     <nz-list>
-      <texera-user-project-list-item 
-        *ngFor="let dashboardUserProjectEntry of userProjectEntries" 
+      <texera-user-project-list-item
+        *ngFor="let dashboardUserProjectEntry of userProjectEntries"
         [entry]="dashboardUserProjectEntry"
         (deleted)="deleteProject(dashboardUserProjectEntry.pid)">
       </texera-user-project-list-item>

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.scss
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.scss
@@ -1,33 +1,4 @@
-.project-name {
-  font-size: 20px;
-  font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-  text-align: center;
-}
-
-.project-name:hover {
-  cursor: pointer;
-}
-
-.project-avatar-container {
-  text-align: center;
-}
-
 button {
   border-radius: 5px;
   border: none;
-}
-
-.edit-name-icon:hover,
-.edit-description-icon:hover {
-  color: skyblue;
-}
-
-.description-container {
-  border: 1px solid gainsboro;
-  border-radius: 10px;
-  padding: 2.5%;
-}
-
-.character-count {
-  text-align: right;
 }

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.ts
@@ -25,10 +25,7 @@ export class UserProjectComponent implements OnInit {
   public colorBrightnessMap: Map<number, boolean> = new Map(); // tracks brightness of each project's color, to make sure info remains visible against white background
   public colorInputToggleArray: boolean[] = []; // tracks which project's color wheel is toggled on or off
 
-  constructor(
-    private userProjectService: UserProjectService,
-    private notificationService: NotificationService
-  ) {}
+  constructor(private userProjectService: UserProjectService, private notificationService: NotificationService) {}
 
   ngOnInit(): void {
     this.getUserProjectArray();

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.ts
@@ -1,7 +1,6 @@
 import { Component, OnInit } from "@angular/core";
 import { UserProjectService } from "../../service/user-project/user-project.service";
 import { UserProject } from "../../type/user-project";
-import { Router } from "@angular/router";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { NotificationService } from "../../../../common/service/notification/notification.service";
 
@@ -26,12 +25,8 @@ export class UserProjectComponent implements OnInit {
   public colorBrightnessMap: Map<number, boolean> = new Map(); // tracks brightness of each project's color, to make sure info remains visible against white background
   public colorInputToggleArray: boolean[] = []; // tracks which project's color wheel is toggled on or off
 
-  public readonly ROUTER_USER_PROJECT_BASE_URL = "/dashboard/user-project";
-  public readonly MAX_PROJECT_DESCRIPTION_CHAR_COUNT = 10000;
-
   constructor(
     private userProjectService: UserProjectService,
-    private router: Router,
     private notificationService: NotificationService
   ) {}
 
@@ -39,77 +34,9 @@ export class UserProjectComponent implements OnInit {
     this.getUserProjectArray();
   }
 
-  public removeEditNameStatus(pid: number) {
-    this.userProjectEntriesIsEditingName = this.userProjectEntriesIsEditingName.filter(index => index != pid);
-  }
-
-  public removeEditDescriptionStatus(pid: number) {
-    this.userProjectEntriesIsEditingDescription = this.userProjectEntriesIsEditingDescription.filter(
-      index => index != pid
-    );
-  }
-
-  public removeCollapsedProjectDescriptionStatus(pid: number) {
-    this.collapsedProjectDescriptions = this.collapsedProjectDescriptions.filter(index => index != pid);
-  }
-
-  public saveProjectDescription(project: UserProject, newDescr: string, index: number): void {
-    // nothing happens if description is the same
-    if (project.description === newDescr) {
-      this.removeEditDescriptionStatus(project.pid);
-      return;
-    }
-
-    // update the project's description
-    this.userProjectService
-      .updateProjectDescription(project.pid, newDescr)
-      .pipe(untilDestroyed(this))
-      .subscribe(
-        () => {
-          let updatedProjectEntry = { ...project };
-          updatedProjectEntry.description = newDescr;
-          const newEntries = this.userProjectEntries.slice();
-          newEntries[index] = updatedProjectEntry;
-          this.userProjectEntries = newEntries;
-          this.notificationService.success(`Saved description for project: "${project.name}".`);
-        },
-        (err: unknown) => {
-          // @ts-ignore
-          this.notificationService.error(err.error.message);
-        }
-      )
-      .add(() => {
-        this.removeEditDescriptionStatus(project.pid);
-      });
-  }
-
-  public saveProjectName(project: UserProject, newName: string): void {
-    // nothing happens if name is the same
-    if (project.name === newName) {
-      this.removeEditNameStatus(project.pid);
-    } else if (this.isValidNewProjectName(newName, project)) {
-      this.userProjectService
-        .updateProjectName(project.pid, newName)
-        .pipe(untilDestroyed(this))
-        .subscribe(
-          () => {
-            this.removeEditNameStatus(project.pid);
-            this.getUserProjectArray(); // refresh list of projects, name is read only property so cannot edit
-          },
-          (err: unknown) => {
-            // @ts-ignore
-            this.notificationService.error(err.error.message);
-          }
-        );
-    } else {
-      // show error message and do not call backend
-      this.notificationService.error(`Cannot create project named: "${newName}".  It must be a non-empty, unique name`);
-    }
-  }
-
   public deleteProject(pid: number): void {
     if (pid == undefined) {
-      return;
+      throw new Error("pid is undefined in deleteProject().");
     }
     this.userProjectService
       .deleteProject(pid)
@@ -131,8 +58,8 @@ export class UserProjectComponent implements OnInit {
       this.userProjectService
         .createProject(this.createProjectName)
         .pipe(untilDestroyed(this))
-        .subscribe(
-          createdProject => {
+        .subscribe({
+          next: createdProject => {
             this.userProjectEntries.push(createdProject); // update local list of projects
 
             // add color wheel input record for the newly created, colorless project
@@ -142,89 +69,17 @@ export class UserProjectComponent implements OnInit {
 
             this.unclickCreateButton();
           },
-          (err: unknown) => {
+          error: (err: unknown) => {
             // @ts-ignore
             this.notificationService.error(err.error.message);
-          }
-        );
+          },
+        });
     } else {
       // show error message and don't call backend
       this.notificationService.error(
         `Cannot create project named: "${this.createProjectName}".  It must be a non-empty, unique name`
       );
     }
-  }
-
-  public updateProjectColor(dashboardProjectEntry: UserProject, index: number) {
-    let color: string =
-      this.userProjectInputColors[this.userProjectToColorInputIndexMap.get(dashboardProjectEntry.pid)!].substring(1);
-    this.colorInputToggleArray[index] = false;
-
-    // validate that color is in proper HEX format
-    if (this.userProjectService.isInvalidColorFormat(color)) {
-      this.notificationService.error(
-        `Cannot update color for project: "${dashboardProjectEntry.name}".  It must be a valid HEX color format`
-      );
-      return;
-    }
-
-    if (color === this.userProjectEntries[index].color) {
-      return;
-    }
-
-    this.userProjectService
-      .updateProjectColor(dashboardProjectEntry.pid, color)
-      .pipe(untilDestroyed(this))
-      .subscribe({
-        next: () => {
-          // update local cache of project entries
-          let updatedDashboardProjectEntry = { ...dashboardProjectEntry };
-          updatedDashboardProjectEntry.color = color;
-          const newProjectEntries = this.userProjectEntries.slice();
-          newProjectEntries[index] = updatedDashboardProjectEntry;
-          this.userProjectEntries = newProjectEntries;
-
-          // update color brightness record for this project
-          this.colorBrightnessMap.set(dashboardProjectEntry.pid, this.userProjectService.isLightColor(color));
-        },
-        error: (err: unknown) => {
-          // @ts-ignore
-          this.notificationService.error(err.error.message);
-        },
-      });
-  }
-
-  public removeProjectColor(dashboardProjectEntry: UserProject, index: number) {
-    this.colorInputToggleArray[index] = false;
-
-    if (dashboardProjectEntry.color == null) {
-      this.notificationService.error(`There is no color to delete for project: "${dashboardProjectEntry.name}"`);
-      return;
-    }
-
-    this.userProjectService
-      .deleteProjectColor(dashboardProjectEntry.pid)
-      .pipe(untilDestroyed(this))
-      .subscribe({
-        next: _ => {
-          // update local cache of project entries
-          let updatedDashboardProjectEntry = { ...dashboardProjectEntry };
-          updatedDashboardProjectEntry.color = null;
-          const newProjectEntries = this.userProjectEntries.slice();
-          newProjectEntries[index] = updatedDashboardProjectEntry;
-          this.userProjectEntries = newProjectEntries;
-
-          // remove records of this project from color data structures
-          if (this.colorBrightnessMap.has(dashboardProjectEntry.pid)) {
-            this.colorBrightnessMap.delete(dashboardProjectEntry.pid);
-          }
-          this.userProjectInputColors[index] = "#ffffff"; // reset color wheel
-        },
-        error: (err: unknown) => {
-          // @ts-ignore
-          this.notificationService.error(err.error.message);
-        },
-      });
   }
 
   public sortByCreationTime(): void {
@@ -247,21 +102,6 @@ export class UserProjectComponent implements OnInit {
       .pipe(untilDestroyed(this))
       .subscribe(projectEntries => {
         this.userProjectEntries = projectEntries;
-
-        // map each pid to important color information, for access in HTML template
-        let index = 0;
-        for (var project of projectEntries) {
-          // used to store each project's updated color (via color wheel)
-          this.userProjectToColorInputIndexMap.set(project.pid, index);
-          this.userProjectInputColors.push(project.color == null ? "#ffffff" : "#" + project.color);
-          this.colorInputToggleArray.push(false);
-
-          // determine whether each project's color is light or dark
-          if (project.color != null) {
-            this.colorBrightnessMap.set(project.pid, this.userProjectService.isLightColor(project.color));
-          }
-          index++;
-        }
       });
   }
 

--- a/core/new-gui/src/app/dashboard/user/type/user-project.ts
+++ b/core/new-gui/src/app/dashboard/user/type/user-project.ts
@@ -1,9 +1,8 @@
-export interface UserProject
-  extends Readonly<{
-    pid: number;
-    name: string;
-    description: string;
-    ownerID: number;
-    creationTime: number;
-    color: string | null;
-  }> {}
+export interface UserProject {
+  pid: number;
+  name: string;
+  description: string;
+  ownerID: number;
+  creationTime: number;
+  color: string | null;
+}


### PR DESCRIPTION
Refactored each project list item into its own component. This is in preparation of the displaying projects for universal search so that it can be re-used in the new code.

Previously, all the logics for what you can see in the screenshot was in `UserProjectComponent`. After the refactoring, the red box portion is moved to `UserProjectListItemComponent`.
In the universal search UI, the new `UserProjectListItemComponent` will be re-used.
![image](https://github.com/Texera/texera/assets/9412032/6dae80ab-77ff-49d7-be3d-d2933cc8d19d)
