### PR TITLE
Fix the mongoDB storage for binary field type

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/TupleUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/TupleUtils.scala
@@ -2,7 +2,10 @@ package edu.uci.ics.texera.workflow.common.tuple
 
 import com.fasterxml.jackson.databind.JsonNode
 import edu.uci.ics.texera.Utils.objectMapper
-import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils.{inferSchemaFromRows, parseField}
+import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils.{
+  inferSchemaFromRows,
+  parseField
+}
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, Schema}
 import edu.uci.ics.texera.workflow.operators.source.scan.json.JSONUtil.JSONToMap
 import org.bson.Document
@@ -72,10 +75,10 @@ object TupleUtils {
   def document2Tuple(doc: Document, schema: Schema): Tuple = {
     val builder = Tuple.newBuilder(schema)
     schema.getAttributes.forEach(attr =>
-      if(attr.getType == BINARY){
+      if (attr.getType == BINARY) {
         // special care for converting MongoDB's binary type to byte[] in our schema
         builder.add(attr, doc.get(attr.getName).asInstanceOf[Binary].getData)
-      }else{
+      } else {
         builder.add(attr, parseField(doc.get(attr.getName), attr.getType))
       }
     )


### PR DESCRIPTION
This PR converts the internal representation of binary data in MongoDB to a byte array in JVM, to resolve the error when we read binary data from MongoDB. The symptom is shown in the screenshot below. After this PR, the error should be fixed.

![image (1)](https://github.com/Texera/texera/assets/13672781/d5882178-0b16-48cb-8203-0c6ec72d2686)
