### PR TITLE
Enable lint tool scalafix

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -81,7 +81,7 @@ jobs:
       - uses: coursier/cache-action@v6
         with:
           extraSbtFiles: '["core/amber/*.sbt", "core/amber/project/**.{scala,sbt}", "core/amber/project/build.properties" ]'
-      - name: Lint
+      - name: Lint with scalafix & scalafmt
         run: cd core/amber && sbt "scalafixAll --check" && sbt scalafmtCheckAll
       - name: Compile with sbt
         run: cd core/amber && sbt clean package

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -81,8 +81,8 @@ jobs:
       - uses: coursier/cache-action@v6
         with:
           extraSbtFiles: '["core/amber/*.sbt", "core/amber/project/**.{scala,sbt}", "core/amber/project/build.properties" ]'
-      - name: Lint with scalafmt
-        run: cd core/amber && sbt scalafmtCheckAll
+      - name: Lint
+        run: cd core/amber sbt scalafixCheckAll && sbt scalafmtCheckAll
       - name: Compile with sbt
         run: cd core/amber && sbt clean package
       - name: Run backend tests

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           extraSbtFiles: '["core/amber/*.sbt", "core/amber/project/**.{scala,sbt}", "core/amber/project/build.properties" ]'
       - name: Lint
-        run: cd core/amber sbt scalafixCheckAll && sbt scalafmtCheckAll
+        run: cd core/amber && sbt scalafixCheckAll && sbt scalafmtCheckAll
       - name: Compile with sbt
         run: cd core/amber && sbt clean package
       - name: Run backend tests

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -82,7 +82,7 @@ jobs:
         with:
           extraSbtFiles: '["core/amber/*.sbt", "core/amber/project/**.{scala,sbt}", "core/amber/project/build.properties" ]'
       - name: Lint
-        run: cd core/amber && sbt scalafixCheckAll && sbt scalafmtCheckAll
+        run: cd core/amber && sbt "scalafixAll --check" && sbt scalafmtCheckAll
       - name: Compile with sbt
         run: cd core/amber && sbt clean package
       - name: Run backend tests

--- a/core/amber/.scalafix.conf
+++ b/core/amber/.scalafix.conf
@@ -1,3 +1,9 @@
 rules = [
   ProcedureSyntax,
+  RemoveUnused,
 ]
+RemoveUnused.imports = true
+RemoveUnused.privates = true
+RemoveUnused.locals = false
+RemoveUnused.patternvars = false
+RemoveUnused.params = false

--- a/core/amber/.scalafix.conf
+++ b/core/amber/.scalafix.conf
@@ -1,0 +1,3 @@
+rules = [
+  ProcedureSyntax,
+]

--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -4,6 +4,9 @@ version := "0.1-SNAPSHOT"
 
 scalaVersion := "2.12.15"
 
+semanticdbEnabled := true
+semanticdbVersion := scalafixSemanticdb.revision
+
 // to turn on, use: INFO
 // to turn off, use: WARNING
 scalacOptions ++= Seq("-Xelide-below", "WARNING")
@@ -12,6 +15,8 @@ scalacOptions ++= Seq("-Xelide-below", "WARNING")
 scalacOptions += "-feature"
 // to check deprecation warnings
 scalacOptions += "-deprecation"
+// to check unused variables
+scalacOptions += "-Ywarn-unused"
 
 conflictManager := ConflictManager.latestRevision
 
@@ -258,3 +263,5 @@ libraryDependencies += "org.jasypt" % "jasypt" % "1.9.3"
 // Jgit library for tracking operator version
 // https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.0.202109080827-r"
+
+

--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -15,8 +15,8 @@ scalacOptions ++= Seq("-Xelide-below", "WARNING")
 scalacOptions += "-feature"
 // to check deprecation warnings
 scalacOptions += "-deprecation"
-// to check unused variables
-scalacOptions += "-Ywarn-unused"
+// to check unused imports
+scalacOptions += "-Ywarn-unused-import"
 
 conflictManager := ConflictManager.latestRevision
 

--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -263,5 +263,3 @@ libraryDependencies += "org.jasypt" % "jasypt" % "1.9.3"
 // Jgit library for tracking operator version
 // https://mvnrepository.com/artifact/org.eclipse.jgit/org.eclipse.jgit
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit" % "5.13.0.202109080827-r"
-
-

--- a/core/amber/project/plugins.sbt
+++ b/core/amber/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.4.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.11.0")
 
 // for scalapb code gen
 addSbtPlugin("com.thesamet" % "sbt-protoc" % "1.0.3")

--- a/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
@@ -1,17 +1,15 @@
 package edu.uci.ics.amber.clustering
 
-import akka.actor.{Actor, ActorLogging, Address, ExtendedActorSystem}
+import akka.actor.{Actor, Address}
 import akka.cluster.ClusterEvent._
-import akka.cluster.{Cluster, Member}
+import akka.cluster.Cluster
 import com.twitter.util.{Await, Future}
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
-import edu.uci.ics.amber.engine.common.{AmberLogging, AmberUtils, Constants}
+import edu.uci.ics.amber.engine.common.{AmberLogging, Constants}
 import edu.uci.ics.texera.web.service.WorkflowService
 import edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState.ABORTED
 
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.duration.DurationInt
 
 object ClusterListener {
   final case class GetAvailableNodeAddresses()

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
@@ -1,13 +1,12 @@
 package edu.uci.ics.amber.engine.architecture.common
 
-import akka.actor.{Actor, ActorRef, Stash}
+import akka.actor.{Actor, Stash}
 import com.softwaremill.macwire.wire
 import edu.uci.ics.amber.engine.architecture.logging.storage.{
   DeterminantLogStorage,
-  EmptyLogStorage,
-  LocalFSLogStorage
+  EmptyLogStorage
 }
-import edu.uci.ics.amber.engine.architecture.logging.{AsyncLogWriter, LogManager}
+import edu.uci.ics.amber.engine.architecture.logging.LogManager
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor.{
   GetActorRef,
   NetworkSenderActorRef,
@@ -19,8 +18,8 @@ import edu.uci.ics.amber.engine.architecture.messaginglayer.{
   NetworkCommunicationActor,
   NetworkOutputPort
 }
-import edu.uci.ics.amber.engine.architecture.recovery.{LocalRecoveryManager, RecoveryQueue}
-import edu.uci.ics.amber.engine.common.{AmberLogging, AmberUtils}
+import edu.uci.ics.amber.engine.architecture.recovery.LocalRecoveryManager
+import edu.uci.ics.amber.engine.common.AmberLogging
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.ambermessage.{
   ControlPayload,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/EvaluatePythonExpressionHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/EvaluatePythonExpressionHandler.scala
@@ -7,7 +7,6 @@ import edu.uci.ics.amber.engine.architecture.pythonworker.promisehandlers.Evalua
 import edu.uci.ics.amber.engine.architecture.worker.controlreturns.EvaluatedValue
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.OperatorIdentity
-import edu.uci.ics.texera.web.model.websocket.response.python.PythonExpressionEvaluateResponse
 
 object EvaluatePythonExpressionHandler {
   final case class EvaluatePythonExpression(expression: String, operatorId: String)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/FatalErrorHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/FatalErrorHandler.scala
@@ -2,7 +2,6 @@ package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 
 import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.FatalErrorHandler.FatalError
-import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 
 object FatalErrorHandler {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LinkCompletedHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LinkCompletedHandler.scala
@@ -3,10 +3,8 @@ package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.LinkCompletedHandler.LinkCompleted
-import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.StartHandler.StartWorker
-import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
-import edu.uci.ics.amber.engine.common.virtualidentity.{LinkIdentity, OperatorIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 
 object LinkCompletedHandler {
   final case class LinkCompleted(linkID: LinkIdentity) extends ControlCommand[Unit]

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LinkWorkersHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LinkWorkersHandler.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.amber.engine.architecture.controller.promisehandlers
 import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.LinkWorkersHandler.LinkWorkers
-import edu.uci.ics.amber.engine.architecture.linksemantics.LinkStrategy
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.AddPartitioningHandler.AddPartitioning
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.UpdateInputLinkingHandler.UpdateInputLinking
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LocalBreakpointTriggeredHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LocalBreakpointTriggeredHandler.scala
@@ -13,7 +13,6 @@ import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 import edu.uci.ics.amber.engine.common.virtualidentity.util.CONTROLLER
 
-import scala.collection.convert.ImplicitConversions.`collection asJava`
 import scala.collection.mutable
 
 object LocalBreakpointTriggeredHandler {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/ModifyLogicHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/ModifyLogicHandler.scala
@@ -9,15 +9,8 @@ import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecConfig
 import edu.uci.ics.amber.engine.architecture.pythonworker.promisehandlers.ModifyPythonOperatorLogicHandler.ModifyPythonOperatorLogic
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.ModifyOperatorLogicHandler.WorkerModifyLogic
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
-import edu.uci.ics.amber.engine.common.virtualidentity.OperatorIdentity
-import edu.uci.ics.texera.workflow.common.operators.{OperatorDescriptor, StateTransferFunc}
-import edu.uci.ics.texera.workflow.common.operators.filter.FilterOpDesc
-import edu.uci.ics.texera.workflow.common.operators.map.MapOpDesc
-import edu.uci.ics.texera.workflow.operators.udf.pythonV2.{PythonUDFOpDescV2, PythonUDFOpExecV2}
-import edu.uci.ics.texera.workflow.operators.udf.pythonV2.source.{
-  PythonUDFSourceOpDescV2,
-  PythonUDFSourceOpExecV2
-}
+import edu.uci.ics.texera.workflow.common.operators.StateTransferFunc
+import edu.uci.ics.texera.workflow.operators.udf.pythonV2.source.PythonUDFSourceOpExecV2
 
 import scala.collection.mutable
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/PythonConsoleMessageHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/PythonConsoleMessageHandler.scala
@@ -4,7 +4,6 @@ import com.google.protobuf.timestamp.Timestamp
 import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.ConsoleMessageTriggered
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.PythonConsoleMessageHandler.PythonConsoleMessage
-import edu.uci.ics.amber.engine.architecture.worker.controlcommands.PythonConsoleMessageV2
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.texera.web.workflowruntimestate.ConsoleMessage
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/RegionsTimeSlotExpiredHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/RegionsTimeSlotExpiredHandler.scala
@@ -4,13 +4,8 @@ import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.controller.ControllerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.RegionsTimeSlotExpiredHandler.RegionsTimeSlotExpired
 import edu.uci.ics.amber.engine.architecture.scheduling.PipelinedRegion
-import edu.uci.ics.amber.engine.common.Constants
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
-
-import scala.concurrent.duration.{FiniteDuration, MILLISECONDS}
 
 object RegionsTimeSlotExpiredHandler {
   final case class RegionsTimeSlotExpired(regions: Set[PipelinedRegion])

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/deploystrategy/DeployStrategy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/deploystrategy/DeployStrategy.scala
@@ -4,7 +4,7 @@ import akka.actor.Address
 
 trait DeployStrategy extends Serializable {
 
-  def initialize(available: Array[Address])
+  def initialize(available: Array[Address]): Unit
 
   def next(): Address
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/OpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/OpExecConfig.scala
@@ -31,17 +31,9 @@ import edu.uci.ics.amber.engine.common.virtualidentity.{
   LinkIdentity,
   OperatorIdentity
 }
-import edu.uci.ics.amber.engine.common.{
-  Constants,
-  IOperatorExecutor,
-  ISinkOperatorExecutor,
-  ISourceOperatorExecutor
-}
+import edu.uci.ics.amber.engine.common.{Constants, IOperatorExecutor, ISourceOperatorExecutor}
 import edu.uci.ics.texera.web.workflowruntimestate.{OperatorRuntimeStats, WorkflowAggregatedState}
 import edu.uci.ics.texera.workflow.common.metadata.{InputPort, OperatorInfo, OutputPort}
-import edu.uci.ics.texera.workflow.common.operators.filter.FilterOpExec
-import edu.uci.ics.texera.workflow.common.operators.map.MapOpExec
-import edu.uci.ics.texera.workflow.common.operators.source.SourceOperatorExecutor
 import edu.uci.ics.texera.workflow.common.workflow.{HashPartition, PartitionInfo, SinglePartition}
 import edu.uci.ics.texera.workflow.operators.udf.pythonV2.PythonUDFOpExecV2
 import org.jgrapht.graph.{DefaultEdge, DirectedAcyclicGraph}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/logging/AsyncLogWriter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/logging/AsyncLogWriter.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.logging
 
 import com.google.common.collect.Queues
-import edu.uci.ics.amber.engine.architecture.logging.storage.DeterminantLogStorage
 import edu.uci.ics.amber.engine.architecture.logging.storage.DeterminantLogStorage.DeterminantLogWriter
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor.SendRequest
@@ -10,7 +9,6 @@ import edu.uci.ics.amber.engine.common.AmberUtils
 import java.util
 import java.util.concurrent.CompletableFuture
 import scala.collection.JavaConverters._
-import scala.util.control.Breaks.{break, breakable}
 
 class AsyncLogWriter(
     networkCommunicationActor: NetworkCommunicationActor.NetworkSenderActorRef,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/logging/LogManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/logging/LogManager.scala
@@ -1,15 +1,11 @@
 package edu.uci.ics.amber.engine.architecture.logging
 
 import edu.uci.ics.amber.engine.architecture.logging.storage.DeterminantLogStorage.DeterminantLogWriter
-import edu.uci.ics.amber.engine.architecture.logging.storage.{
-  DeterminantLogStorage,
-  LocalFSLogStorage
-}
+import edu.uci.ics.amber.engine.architecture.logging.storage.DeterminantLogStorage
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor.SendRequest
-import edu.uci.ics.amber.engine.common.AmberUtils
 import edu.uci.ics.amber.engine.common.ambermessage.ControlPayload
-import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LinkIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 
 //In-mem formats:
 sealed trait InMemDeterminant

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/logging/service/TimeService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/logging/service/TimeService.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.logging.service
 
-import edu.uci.ics.amber.engine.architecture.logging.{DeterminantLogger, LogManager, TimeStamp}
+import edu.uci.ics.amber.engine.architecture.logging.{DeterminantLogger, TimeStamp}
 
 class TimeService(determinantLogger: DeterminantLogger) {
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/logging/storage/LocalFSLogStorage.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/logging/storage/LocalFSLogStorage.scala
@@ -6,15 +6,7 @@ import edu.uci.ics.amber.engine.architecture.logging.storage.DeterminantLogStora
 }
 
 import java.io.{DataInputStream, DataOutputStream}
-import java.nio.file.{
-  CopyOption,
-  Files,
-  OpenOption,
-  Path,
-  Paths,
-  StandardCopyOption,
-  StandardOpenOption
-}
+import java.nio.file.{Files, Path, Paths, StandardCopyOption, StandardOpenOption}
 
 class LocalFSLogStorage(name: String) extends DeterminantLogStorage {
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/CongestionControl.scala
@@ -4,7 +4,6 @@ import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunication
 
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 class CongestionControl {
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/FlowControl.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/FlowControl.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.messaginglayer
 
 import akka.actor.Cancellable
-import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor.NetworkMessage
 import edu.uci.ics.amber.engine.common.Constants
 import edu.uci.ics.amber.engine.common.ambermessage.{WorkflowDataMessage, WorkflowMessage}
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkCommunicationActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkCommunicationActor.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.amber.engine.architecture.messaginglayer
 
 import akka.pattern.ask
-import akka.actor.{Actor, ActorLogging, ActorRef, Cancellable, Props}
+import akka.actor.{Actor, ActorRef, Cancellable, Props}
 import akka.pattern.StatusReply.Ack
 import akka.util.Timeout
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor._

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkInputPort.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkInputPort.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.messaginglayer
 
 import akka.actor.ActorRef
-import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor.NetworkAck
 import edu.uci.ics.amber.engine.common.AmberLogging
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OrderingEnforcer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OrderingEnforcer.scala
@@ -1,8 +1,5 @@
 package edu.uci.ics.amber.engine.architecture.messaginglayer
 
-import edu.uci.ics.amber.engine.common.AmberLogging
-import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
-
 import scala.collection.mutable
 
 /* The abstracted FIFO/exactly-once logic */

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OutputManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OutputManager.scala
@@ -8,7 +8,6 @@ import edu.uci.ics.amber.engine.architecture.messaginglayer.OutputManager.{
 }
 import edu.uci.ics.amber.engine.architecture.sendsemantics.partitioners._
 import edu.uci.ics.amber.engine.architecture.sendsemantics.partitionings._
-import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.InputEpochMarker
 import edu.uci.ics.amber.engine.common.Constants
 import edu.uci.ics.amber.engine.common.Constants.{
   adaptiveBufferingTimeoutMs,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/recovery/RecoveryQueue.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/recovery/RecoveryQueue.scala
@@ -16,7 +16,6 @@ import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.{
   InternalQueueElement
 }
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
-import lbmq.LinkedBlockingMultiQueue
 
 import java.util.concurrent.LinkedBlockingQueue
 import scala.collection.mutable

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/policies/SchedulingPolicy.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/policies/SchedulingPolicy.scala
@@ -4,11 +4,7 @@ import akka.actor.ActorContext
 import edu.uci.ics.amber.engine.architecture.controller.Workflow
 import edu.uci.ics.amber.engine.architecture.scheduling.PipelinedRegion
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
-import edu.uci.ics.amber.engine.common.virtualidentity.{
-  ActorVirtualIdentity,
-  LinkIdentity,
-  OperatorIdentity
-}
+import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LinkIdentity}
 import edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState
 import org.jgrapht.traverse.TopologicalOrderIterator
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/policies/SingleReadyRegionTimeInterleaved.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/policies/SingleReadyRegionTimeInterleaved.scala
@@ -5,7 +5,6 @@ import edu.uci.ics.amber.engine.architecture.controller.Workflow
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.RegionsTimeSlotExpiredHandler.RegionsTimeSlotExpired
 import edu.uci.ics.amber.engine.architecture.scheduling.PipelinedRegion
 import edu.uci.ics.amber.engine.common.Constants
-import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
 import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LinkIdentity}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/partitioners/Partitioner.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/partitioners/Partitioner.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.sendsemantics.partitioners
 
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkOutputPort
-import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.InputEpochMarker
 import edu.uci.ics.amber.engine.common.Constants
 import edu.uci.ics.amber.engine.common.ambermessage.{
   DataFrame,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -25,7 +25,7 @@ import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState.{
   UNINITIALIZED
 }
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
-import edu.uci.ics.amber.engine.common.ambermessage.{ControlPayload, EpochMarker}
+import edu.uci.ics.amber.engine.common.ambermessage.ControlPayload
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.{ControlInvocation, ReturnInvocation}
 import edu.uci.ics.amber.engine.common.rpc.{AsyncRPCClient, AsyncRPCServer}
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager
@@ -46,7 +46,6 @@ import edu.uci.ics.amber.engine.common.{
 import edu.uci.ics.amber.error.ErrorUtils.safely
 
 import java.util.concurrent.{ExecutorService, Executors, Future}
-import scala.collection.mutable
 
 class DataProcessor( // dependencies:
     val workerIndex: Int,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/UpstreamLinkStatus.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/UpstreamLinkStatus.scala
@@ -1,8 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.worker
 
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecConfig
-import edu.uci.ics.amber.engine.architecture.worker.WorkerInternalQueue.InputEpochMarker
-import edu.uci.ics.amber.engine.common.ambermessage.EpochMarker
 import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LinkIdentity}
 
 import scala.collection.mutable

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/BackpressureHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/BackpressureHandler.scala
@@ -2,7 +2,6 @@ package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
 import edu.uci.ics.amber.engine.architecture.worker.{
   BackpressurePause,
-  PauseType,
   WorkerAsyncRPCHandlerInitializer
 }
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.BackpressureHandler.Backpressure

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/MonitoringHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/MonitoringHandler.scala
@@ -8,7 +8,6 @@ import edu.uci.ics.amber.engine.architecture.worker.workloadmetrics.SelfWorkload
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 object MonitoringHandler {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/PauseHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/PauseHandler.scala
@@ -1,10 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
-import edu.uci.ics.amber.engine.architecture.worker.{
-  PauseType,
-  UserPause,
-  WorkerAsyncRPCHandlerInitializer
-}
+import edu.uci.ics.amber.engine.architecture.worker.{UserPause, WorkerAsyncRPCHandlerInitializer}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.PauseHandler.PauseWorker
 import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState
 import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState.{PAUSED, READY, RUNNING}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/QueryStatisticsHandler.scala
@@ -2,7 +2,7 @@ package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
 import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerStatistics
-import edu.uci.ics.amber.engine.architecture.worker.{WorkerAsyncRPCHandlerInitializer, WorkerResult}
+import edu.uci.ics.amber.engine.architecture.worker.WorkerAsyncRPCHandlerInitializer
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.{Constants, ISinkOperatorExecutor}
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ResumeHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ResumeHandler.scala
@@ -1,10 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
-import edu.uci.ics.amber.engine.architecture.worker.{
-  PauseType,
-  UserPause,
-  WorkerAsyncRPCHandlerInitializer
-}
+import edu.uci.ics.amber.engine.architecture.worker.{UserPause, WorkerAsyncRPCHandlerInitializer}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.ResumeHandler.ResumeWorker
 import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState
 import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState.{PAUSED, RUNNING}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/SchedulerTimeSlotEventHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/SchedulerTimeSlotEventHandler.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.worker.promisehandlers
 
 import edu.uci.ics.amber.engine.architecture.worker.{
-  PauseType,
   SchedulerTimeSlotExpiredPause,
   WorkerAsyncRPCHandlerInitializer
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/IOperatorExecutor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/IOperatorExecutor.scala
@@ -3,8 +3,6 @@ package edu.uci.ics.amber.engine.common
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
-import edu.uci.ics.texera.workflow.common.operators.OperatorContext
 
 case class InputExhausted()
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/ISinkOperatorExecutor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/ISinkOperatorExecutor.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.amber.engine.common
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 
 trait ISinkOperatorExecutor extends IOperatorExecutor {
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/ISourceOperatorExecutor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/ISourceOperatorExecutor.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.amber.engine.common
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 
 trait ISourceOperatorExecutor extends IOperatorExecutor {
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/TableMetadata.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/TableMetadata.scala
@@ -3,13 +3,13 @@ package edu.uci.ics.amber.engine.common
 import edu.uci.ics.amber.engine.common.amberfield.FieldType
 
 class TupleMetadata(val fields: Array[(String, FieldType.Value)]) {
-  def this(fieldsCount: Int) {
+  def this(fieldsCount: Int) = {
     this(Array.tabulate(fieldsCount)(i => ("_c" + i, FieldType.String)))
   }
-  def this(fieldTypes: Array[FieldType.Value]) {
+  def this(fieldTypes: Array[FieldType.Value]) = {
     this(Array.tabulate(fieldTypes.length)(i => ("_c" + i, fieldTypes(i))))
   }
-  def this(fieldNames: Array[String]) {
+  def this(fieldNames: Array[String]) = {
     this(Array.tabulate(fieldNames.length)(i => (fieldNames(i), FieldType.String)))
   }
   override def toString = s"TupleMataData: ${fields.mkString(", ")}"

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/amberexception/WorkflowRuntimeException.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/amberexception/WorkflowRuntimeException.scala
@@ -4,16 +4,16 @@ class WorkflowRuntimeException(message: String)
     extends RuntimeException(message)
     with Serializable {
 
-  def this(message: String, cause: Throwable) {
+  def this(message: String, cause: Throwable) = {
     this(message)
     initCause(cause)
   }
 
-  def this(cause: Throwable) {
+  def this(cause: Throwable) = {
     this(Option(cause).map(_.toString).orNull, cause)
   }
 
-  def this() {
+  def this() = {
     this(null: String)
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/ambermessage/DataPayload.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/ambermessage/DataPayload.scala
@@ -2,7 +2,6 @@ package edu.uci.ics.amber.engine.common.ambermessage
 
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.virtualidentity.LayerIdentity
 import edu.uci.ics.texera.workflow.common.workflow.PhysicalPlan
 
 sealed trait DataPayload extends Serializable {}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/client/AmberClient.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/client/AmberClient.scala
@@ -14,15 +14,14 @@ import edu.uci.ics.amber.engine.common.client.ClientActor.{
   ObservableRequest
 }
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
-import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 import edu.uci.ics.amber.engine.common.virtualidentity.util.CLIENT
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.Disposable
-import io.reactivex.rxjava3.subjects.{PublishSubject, Subject}
+import io.reactivex.rxjava3.subjects.PublishSubject
 
 import scala.collection.mutable
 import scala.concurrent.Await
-import scala.concurrent.duration.{Duration, DurationInt}
+import scala.concurrent.duration.DurationInt
 import scala.reflect.ClassTag
 
 class AmberClient(

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/client/ClientActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/client/ClientActor.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.amber.engine.common.client
 
-import akka.actor.{Actor, ActorRef, PoisonPill}
+import akka.actor.{Actor, ActorRef}
 import akka.pattern.StatusReply.Ack
 import com.twitter.util.Promise
 import edu.uci.ics.amber.engine.architecture.controller.{Controller, ControllerConfig, Workflow}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCHandlerInitializer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCHandlerInitializer.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.amber.engine.common.rpc
 
 import com.twitter.util.Future
-import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCServer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCServer.scala
@@ -2,7 +2,6 @@ package edu.uci.ics.amber.engine.common.rpc
 
 import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkOutputPort
-import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.AcceptImmutableStateHandler.AcceptImmutableState
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
 import edu.uci.ics.amber.engine.common.AmberLogging
 import edu.uci.ics.amber.engine.common.ambermessage.ControlPayload

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/tuple/amber/AmberTuple.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/tuple/amber/AmberTuple.scala
@@ -5,7 +5,7 @@ import edu.uci.ics.amber.engine.common.tuple.ITuple
 
 @Deprecated
 class AmberTuple(val data: Array[Any]) extends ITuple {
-  def this(fields: Array[String], fieldTypes: Array[FieldType.Value]) {
+  def this(fields: Array[String], fieldTypes: Array[FieldType.Value]) = {
     this({
       var i = 0
       val limit = Math.min(fields.length, fieldTypes.length)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/Utils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/Utils.scala
@@ -5,11 +5,10 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.noctordeser.NoCtorDeserModule
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState
-import org.apache.lucene.analysis.CharArraySet
 
 import java.nio.file.{Files, Path, Paths}
 import java.text.SimpleDateFormat
-import java.util.concurrent.locks.{Lock, ReentrantLock}
+import java.util.concurrent.locks.Lock
 import scala.annotation.tailrec
 
 object Utils {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/WebsocketInput.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/WebsocketInput.scala
@@ -4,7 +4,6 @@ import edu.uci.ics.texera.web.model.websocket.request.TexeraWebSocketRequest
 import io.reactivex.rxjava3.disposables.Disposable
 import io.reactivex.rxjava3.subjects.PublishSubject
 import org.jooq.types.UInteger
-import scala.compat.java8.FunctionConverters._
 
 import scala.reflect.{ClassTag, classTag}
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/WorkflowLifecycleManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/WorkflowLifecycleManager.scala
@@ -3,11 +3,11 @@ package edu.uci.ics.texera.web
 import java.time.{LocalDateTime, Duration => JDuration}
 import akka.actor.Cancellable
 import com.typesafe.scalalogging.LazyLogging
-import edu.uci.ics.texera.web.storage.{JobStateStore, WorkflowStateStore}
+import edu.uci.ics.texera.web.storage.JobStateStore
 import edu.uci.ics.texera.web.workflowruntimestate.{JobMetadataStore, WorkflowAggregatedState}
 import edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState.RUNNING
 
-import scala.concurrent.duration.{DurationInt, FiniteDuration}
+import scala.concurrent.duration.DurationInt
 
 class WorkflowLifecycleManager(id: String, cleanUpTimeout: Int, cleanUpCallback: () => Unit)
     extends LazyLogging {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/auth/GuestAuthFilter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/auth/GuestAuthFilter.scala
@@ -11,8 +11,6 @@ import javax.ws.rs.container.ContainerRequestContext
 import javax.ws.rs.container.PreMatching
 import javax.ws.rs.core.SecurityContext
 import java.io.IOException
-import java.security.Principal
-import java.util
 import java.util.Optional
 
 @PreMatching

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/websocket/request/CacheStatusUpdateRequest.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/websocket/request/CacheStatusUpdateRequest.scala
@@ -3,8 +3,6 @@ package edu.uci.ics.texera.web.model.websocket.request
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor
 import edu.uci.ics.texera.workflow.common.workflow.{BreakpointInfo, OperatorLink}
 
-import scala.collection.mutable
-
 case class CacheStatusUpdateRequest(
     operators: List[OperatorDescriptor],
     links: List[OperatorLink],

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/websocket/request/WorkflowExecuteRequest.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/websocket/request/WorkflowExecuteRequest.scala
@@ -3,8 +3,6 @@ package edu.uci.ics.texera.web.model.websocket.request
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor
 import edu.uci.ics.texera.workflow.common.workflow.{BreakpointInfo, OperatorLink}
 
-import scala.collection.mutable
-
 case class WorkflowExecuteRequest(
     executionName: String,
     engineVersion: String,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/websocket/response/python/PythonExpressionEvaluateResponse.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/websocket/response/python/PythonExpressionEvaluateResponse.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.texera.web.model.websocket.response.python
 
 import edu.uci.ics.amber.engine.architecture.worker.controlreturns.EvaluatedValue
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.texera.web.model.websocket.event.TexeraWebSocketEvent
 
 case class PythonExpressionEvaluateResponse(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -12,7 +12,7 @@ import edu.uci.ics.texera.web.model.websocket.event.{
 }
 import edu.uci.ics.texera.web.model.websocket.request._
 import edu.uci.ics.texera.web.model.websocket.response._
-import edu.uci.ics.texera.web.service.{WorkflowCacheService, WorkflowService}
+import edu.uci.ics.texera.web.service.WorkflowService
 import edu.uci.ics.texera.workflow.common.workflow.WorkflowCompiler.ConstraintViolationException
 
 import javax.websocket._

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
@@ -23,7 +23,6 @@ import javax.ws.rs._
 import javax.ws.rs.core.MediaType
 import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
 import scala.collection.mutable
-import scala.collection.mutable.Set
 
 /**
   * This file handles various request related to saved-workflows.

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobBreakpointService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobBreakpointService.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.web.service
 
-import com.twitter.util.{Duration, Future}
+import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.breakpoint.globalbreakpoint.{
   ConditionalGlobalBreakpoint,
   CountGlobalBreakpoint
@@ -10,14 +10,9 @@ import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.AssignBr
 import edu.uci.ics.amber.engine.common.client.AmberClient
 import edu.uci.ics.texera.web.SubscriptionManager
 import edu.uci.ics.texera.web.model.websocket.event.{BreakpointTriggeredEvent, TexeraWebSocketEvent}
-import edu.uci.ics.texera.web.storage.{JobStateStore, WorkflowStateStore}
+import edu.uci.ics.texera.web.storage.JobStateStore
 import edu.uci.ics.texera.web.workflowruntimestate.BreakpointFault.BreakpointTuple
-import edu.uci.ics.texera.web.workflowruntimestate.{
-  BreakpointFault,
-  OperatorBreakpoints,
-  OperatorRuntimeStats,
-  PythonOperatorInfo
-}
+import edu.uci.ics.texera.web.workflowruntimestate.{BreakpointFault, OperatorBreakpoints}
 import edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState.PAUSED
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.workflow.{

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobRuntimeService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobRuntimeService.scala
@@ -1,9 +1,7 @@
 package edu.uci.ics.texera.web.service
 
-import com.twitter.util.{Await, Duration}
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.WorkflowPaused
-import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.EvaluatePythonExpressionHandler.EvaluatePythonExpression
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.PauseHandler.PauseWorkflow
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.ResumeHandler.ResumeWorkflow
 import edu.uci.ics.amber.engine.common.client.AmberClient
@@ -15,13 +13,12 @@ import edu.uci.ics.texera.web.model.websocket.event.{
   WorkflowStateEvent
 }
 import edu.uci.ics.texera.web.model.websocket.request.{
-  RemoveBreakpointRequest,
   SkipTupleRequest,
   WorkflowKillRequest,
   WorkflowPauseRequest,
   WorkflowResumeRequest
 }
-import edu.uci.ics.texera.web.storage.{JobStateStore, WorkflowStateStore}
+import edu.uci.ics.texera.web.storage.JobStateStore
 import edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState._
 
 import scala.collection.mutable

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowCacheService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowCacheService.scala
@@ -2,7 +2,7 @@ package edu.uci.ics.texera.web.service
 
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.common.AmberUtils
-import edu.uci.ics.texera.web.model.websocket.event.{CacheStatusUpdateEvent, TexeraWebSocketEvent}
+import edu.uci.ics.texera.web.model.websocket.event.CacheStatusUpdateEvent
 import edu.uci.ics.texera.web.{SubscriptionManager, WebsocketInput}
 import edu.uci.ics.texera.web.model.websocket.request.CacheStatusUpdateRequest
 import edu.uci.ics.texera.web.storage.WorkflowStateStore

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/storage/JobReconfigurationStore.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/storage/JobReconfigurationStore.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.texera.web.storage
 
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecConfig
-import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LayerIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 import edu.uci.ics.texera.workflow.common.operators.StateTransferFunc
 
 case class JobReconfigurationStore(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OperatorExecutor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OperatorExecutor.scala
@@ -4,7 +4,6 @@ import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
 import edu.uci.ics.amber.engine.common.{IOperatorExecutor, InputExhausted}
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 
 trait OperatorExecutor extends IOperatorExecutor {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/PythonOperatorDescriptor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/PythonOperatorDescriptor.scala
@@ -2,7 +2,7 @@ package edu.uci.ics.texera.workflow.common.operators
 
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecConfig
 import edu.uci.ics.amber.engine.common.Constants
-import edu.uci.ics.texera.workflow.common.tuple.schema.{OperatorSchemaInfo, Schema}
+import edu.uci.ics.texera.workflow.common.tuple.schema.OperatorSchemaInfo
 import edu.uci.ics.texera.workflow.operators.udf.pythonV2.PythonUDFOpExecV2
 import edu.uci.ics.texera.workflow.operators.udf.pythonV2.source.PythonUDFSourceOpExecV2
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/aggregate/DistributedAggregation.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/aggregate/DistributedAggregation.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.texera.workflow.common.operators.aggregate
 
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
-import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
 
 /**
   * This class defines the necessary functions required by a distributed aggregation.

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/aggregate/FinalAggregateOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/aggregate/FinalAggregateOpExec.scala
@@ -3,14 +3,12 @@ package edu.uci.ics.texera.workflow.common.operators.aggregate
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.operators.aggregate.PartialAggregateOpExec.internalAggObjKey
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, OperatorSchemaInfo, Schema}
 
-import scala.collection.convert.ImplicitConversions.`collection AsScalaIterable`
-import scala.collection.{JavaConverters, mutable}
+import scala.collection.mutable
 
 class FinalAggregateOpExec(
     val aggFuncs: List[DistributedAggregation[Object]],

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/aggregate/PartialAggregateOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/aggregate/PartialAggregateOpExec.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.texera.workflow.common.operators.aggregate
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.operators.aggregate.PartialAggregateOpExec.internalAggObjKey
 import edu.uci.ics.texera.workflow.common.tuple.Tuple

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/filter/FilterOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/filter/FilterOpDesc.scala
@@ -2,7 +2,6 @@ package edu.uci.ics.texera.workflow.common.operators.filter
 
 import com.google.common.base.Preconditions
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecConfig
-import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo
 import edu.uci.ics.texera.workflow.common.operators.{OperatorDescriptor, StateTransferFunc}
 import edu.uci.ics.texera.workflow.common.tuple.schema.{OperatorSchemaInfo, Schema}
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/filter/FilterOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/filter/FilterOpExec.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.texera.workflow.common.operators.filter
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/flatmap/FlatMapOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/flatmap/FlatMapOpDesc.scala
@@ -1,6 +1,5 @@
 package edu.uci.ics.texera.workflow.common.operators.flatmap
 
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor
-import edu.uci.ics.texera.workflow.common.tuple.schema.OperatorSchemaInfo
 
 abstract class FlatMapOpDesc extends OperatorDescriptor {}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/flatmap/FlatMapOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/flatmap/FlatMapOpExec.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.texera.workflow.common.operators.flatmap
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/map/MapOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/map/MapOpDesc.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.texera.workflow.common.operators.map
 
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecConfig
-import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo
 import edu.uci.ics.texera.workflow.common.operators.{OperatorDescriptor, StateTransferFunc}
 import edu.uci.ics.texera.workflow.common.tuple.schema.OperatorSchemaInfo
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/map/MapOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/map/MapOpExec.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.texera.workflow.common.operators.map
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/mlmodel/MLModelOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/mlmodel/MLModelOpExec.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.texera.workflow.common.operators.mlmodel
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PartitionEnforcer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PartitionEnforcer.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.texera.workflow.common.workflow
 
 import edu.uci.ics.amber.engine.architecture.linksemantics._
-import edu.uci.ics.amber.engine.architecture.sendsemantics.partitioners.BroadcastPartitioner
 import edu.uci.ics.amber.engine.common.Constants.defaultBatchSize
 import edu.uci.ics.amber.engine.common.virtualidentity.{LayerIdentity, LinkIdentity}
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowRewriter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowRewriter.scala
@@ -6,12 +6,8 @@ import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor
 import edu.uci.ics.texera.workflow.common.storage.OpResultStorage
 import edu.uci.ics.texera.workflow.common.workflow.WorkflowRewriter.copyOperator
 import edu.uci.ics.texera.workflow.operators.source.cache.CacheSourceOpDesc
-import java.util.UUID
 
-import edu.uci.ics.texera.workflow.operators.sink.managed.{
-  ProgressiveSinkOpDesc,
-  ProgressiveSinkOpExec
-}
+import edu.uci.ics.texera.workflow.operators.sink.managed.ProgressiveSinkOpDesc
 
 import scala.collection.mutable
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpExec.scala
@@ -3,10 +3,8 @@ package edu.uci.ics.texera.workflow.operators.difference
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
-import org.apache.arrow.util.Preconditions
 
 import scala.collection.mutable
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/distinct/DistinctOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/distinct/DistinctOpExec.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.texera.workflow.operators.distinct
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpExec.scala
@@ -4,7 +4,6 @@ import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.Tuple.BuilderV2

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intervalJoin/IntervalJoinOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intervalJoin/IntervalJoinOpDesc.scala
@@ -95,7 +95,7 @@ class IntervalJoinOpDesc extends OperatorDescriptor {
       includeLeftBound: Boolean,
       includeRightBound: Boolean,
       timeIntervalType: TimeIntervalType
-  ) {
+  ) = {
     this() // Calling primary constructor, and it is first line
     this.leftAttributeName = leftTableAttributeName
     this.rightAttributeName = rightTableAttributeName

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intervalJoin/IntervalJoinOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intervalJoin/IntervalJoinOpExec.scala
@@ -4,7 +4,6 @@ import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.{

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/limit/LimitOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/limit/LimitOpExec.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.texera.workflow.operators.limit
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/projection/ProjectionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/projection/ProjectionOpDesc.scala
@@ -2,7 +2,6 @@ package edu.uci.ics.texera.workflow.operators.projection
 
 import com.google.common.base.Preconditions
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecConfig.oneToOneLayer
-import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecConfig
 import edu.uci.ics.texera.workflow.common.metadata._
 import edu.uci.ics.texera.workflow.common.operators.map.MapOpDesc
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, OperatorSchemaInfo, Schema}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/reservoirsampling/ReservoirSamplingOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/reservoirsampling/ReservoirSamplingOpExec.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.texera.workflow.operators.reservoirsampling
 import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sentiment/SentimentAnalysisOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sentiment/SentimentAnalysisOpDesc.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.texera.workflow.operators.sentiment
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.google.common.base.Preconditions
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecConfig
-import edu.uci.ics.amber.engine.common.Constants
 import edu.uci.ics.texera.workflow.common.metadata.{
   InputPort,
   OperatorGroupConstants,
@@ -13,10 +12,6 @@ import edu.uci.ics.texera.workflow.common.metadata.{
 import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.texera.workflow.common.operators.map.MapOpDesc
 import edu.uci.ics.texera.workflow.common.tuple.schema.{AttributeType, OperatorSchemaInfo, Schema}
-
-import java.util.Collections
-import java.util.Collections.singletonList
-import scala.collection.JavaConverters.{asScalaBuffer, mapAsScalaMap}
 
 class SentimentAnalysisOpDesc extends MapOpDesc {
   @JsonProperty(value = "attribute", required = true)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/managed/ProgressiveSinkOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/managed/ProgressiveSinkOpExec.scala
@@ -1,15 +1,12 @@
 package edu.uci.ics.texera.workflow.operators.sink.managed
 
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.amber.engine.common.{ISinkOperatorExecutor, InputExhausted}
 import edu.uci.ics.texera.workflow.common.IncrementalOutputMode._
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.OperatorSchemaInfo
 import edu.uci.ics.texera.workflow.common.{IncrementalOutputMode, ProgressiveUtils}
-import edu.uci.ics.texera.workflow.operators.sink.storage.{SinkStorageWriter, SinkStorageReader}
-
-import scala.collection.mutable
+import edu.uci.ics.texera.workflow.operators.sink.storage.SinkStorageWriter
 
 class ProgressiveSinkOpExec(
     val operatorSchemaInfo: OperatorSchemaInfo,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/storage/MongoDBSinkStorage.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/storage/MongoDBSinkStorage.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.texera.workflow.operators.sink.storage
 
 import com.mongodb.client.model.Sorts
-import com.mongodb.client.{MongoClient, MongoClients, MongoCollection, MongoCursor, MongoDatabase}
+import com.mongodb.client.MongoCursor
 import edu.uci.ics.amber.engine.common.AmberUtils
 import edu.uci.ics.texera.web.storage.{MongoCollectionManager, MongoDatabaseManager}
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
@@ -10,7 +10,6 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.Schema
 import org.bson.Document
 
 import scala.collection.mutable
-import collection.JavaConverters._
 
 class MongoDBSinkStorage(id: String, schema: Schema) extends SinkStorageReader {
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sortPartitions/SortPartitionOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sortPartitions/SortPartitionOpExec.scala
@@ -1,11 +1,8 @@
 package edu.uci.ics.texera.workflow.operators.sortPartitions
 
-import com.twitter.util.Future
-import edu.uci.ics.amber.engine.architecture.worker.{PauseManager, PauseType}
-import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
+import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
-import edu.uci.ics.amber.engine.common.{Constants, InputExhausted}
-import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LinkIdentity}
+import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.{AttributeType, OperatorSchemaInfo}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/fetcher/URLFetcherOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/fetcher/URLFetcherOpExec.scala
@@ -6,7 +6,6 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.OperatorSchemaInfo
 import edu.uci.ics.texera.workflow.operators.source.fetcher.URLFetchUtil.getInputStreamFromURL
 import org.apache.commons.io.IOUtils
 
-import java.io.InputStream
 import java.net.URL
 
 class URLFetcherOpExec(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpDesc.scala
@@ -5,8 +5,6 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import com.univocity.parsers.csv.{CsvFormat, CsvParser, CsvParserSettings}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecConfig
-import edu.uci.ics.amber.engine.common.virtualidentity.OperatorIdentity
-import edu.uci.ics.texera.workflow.common.WorkflowContext
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils.inferSchemaFromRows
 import edu.uci.ics.texera.workflow.common.tuple.schema.{
   Attribute,
@@ -15,7 +13,6 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.{
   Schema
 }
 import edu.uci.ics.texera.workflow.operators.source.scan.ScanSourceOpDesc
-import edu.uci.ics.texera.workflow.operators.udf.pythonV2.PythonUDFOpDescV2
 
 import java.io.{File, FileInputStream, IOException, InputStreamReader}
 import scala.jdk.CollectionConverters.asJavaIterableConverter

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/split/SplitOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/split/SplitOpExec.scala
@@ -4,11 +4,9 @@ import edu.uci.ics.amber.engine.architecture.worker.PauseManager
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
 import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.virtualidentity.LinkIdentity
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 
-import scala.collection.mutable
 import scala.util.Random
 
 class SplitOpExec(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/unneststring/UnnestStringOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/unneststring/UnnestStringOpExec.scala
@@ -2,11 +2,7 @@ package edu.uci.ics.texera.workflow.operators.unneststring
 
 import edu.uci.ics.texera.workflow.common.operators.flatmap.FlatMapOpExec
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
-import edu.uci.ics.texera.workflow.common.tuple.schema.{
-  Attribute,
-  AttributeType,
-  OperatorSchemaInfo
-}
+import edu.uci.ics.texera.workflow.common.tuple.schema.{AttributeType, OperatorSchemaInfo}
 
 class UnnestStringOpExec(opDesc: UnnestStringOpDesc, operatorSchemaInfo: OperatorSchemaInfo)
     extends FlatMapOpExec {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/barChart/BarChartOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/barChart/BarChartOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.visualization.barChart
 
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonPropertyDescription}
+import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecConfig
 import edu.uci.ics.amber.engine.common.virtualidentity.util.makeLayer
 import edu.uci.ics.texera.workflow.common.metadata.{
@@ -13,7 +13,6 @@ import edu.uci.ics.texera.workflow.common.metadata.annotations.{
   AutofillAttributeName,
   AutofillAttributeNameList
 }
-import edu.uci.ics.texera.workflow.common.operators.aggregate.DistributedAggregation
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils.parseTimestamp
 import edu.uci.ics.texera.workflow.common.tuple.schema.{
@@ -28,7 +27,6 @@ import edu.uci.ics.texera.workflow.operators.aggregate.{
   SpecializedAggregateOpDesc
 }
 import edu.uci.ics.texera.workflow.operators.visualization.{
-  AggregatedVizOpExecConfig,
   VisualizationConstants,
   VisualizationOperator
 }
@@ -114,16 +112,6 @@ class BarChartOpDesc extends VisualizationOperator {
       .add(getGroupByKeysSchema(schemas).getAttributes)
       .add(getFinalAggValueSchema.getAttributes)
       .build()
-  }
-
-  private def getNumericalValue(tuple: Tuple, attribute: String): Double = {
-    val value: Object = tuple.getField(attribute)
-    if (value == null)
-      return 0
-
-    if (tuple.getSchema.getAttribute(attribute).getType == AttributeType.TIMESTAMP)
-      parseTimestamp(value.toString).getTime.toDouble
-    else value.toString.toDouble
   }
 
   private def getGroupByKeysSchema(schemas: Array[Schema]): Schema = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/barChart/BarChartOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/barChart/BarChartOpDesc.scala
@@ -13,8 +13,6 @@ import edu.uci.ics.texera.workflow.common.metadata.annotations.{
   AutofillAttributeName,
   AutofillAttributeNameList
 }
-import edu.uci.ics.texera.workflow.common.tuple.Tuple
-import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils.parseTimestamp
 import edu.uci.ics.texera.workflow.common.tuple.schema.{
   Attribute,
   AttributeType,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/lineChart/LineChartOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/lineChart/LineChartOpDesc.scala
@@ -13,8 +13,6 @@ import edu.uci.ics.texera.workflow.common.metadata.{
   OperatorInfo,
   OutputPort
 }
-import edu.uci.ics.texera.workflow.common.tuple.Tuple
-import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils.parseTimestamp
 import edu.uci.ics.texera.workflow.common.tuple.schema.{
   Attribute,
   AttributeType,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/lineChart/LineChartOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/lineChart/LineChartOpDesc.scala
@@ -13,7 +13,6 @@ import edu.uci.ics.texera.workflow.common.metadata.{
   OperatorInfo,
   OutputPort
 }
-import edu.uci.ics.texera.workflow.common.operators.aggregate.DistributedAggregation
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils.parseTimestamp
 import edu.uci.ics.texera.workflow.common.tuple.schema.{
@@ -28,7 +27,6 @@ import edu.uci.ics.texera.workflow.operators.aggregate.{
   SpecializedAggregateOpDesc
 }
 import edu.uci.ics.texera.workflow.operators.visualization.{
-  AggregatedVizOpExecConfig,
   VisualizationConstants,
   VisualizationOperator
 }
@@ -117,16 +115,6 @@ class LineChartOpDesc extends VisualizationOperator {
       .add(getGroupByKeysSchema(schemas).getAttributes)
       .add(getFinalAggValueSchema.getAttributes)
       .build()
-  }
-
-  private def getNumericalValue(tuple: Tuple, attribute: String): Double = {
-    val value: Object = tuple.getField(attribute)
-    if (value == null)
-      return 0
-
-    if (tuple.getSchema.getAttribute(attribute).getType == AttributeType.TIMESTAMP)
-      parseTimestamp(value.toString).getTime.toDouble
-    else value.toString.toDouble
   }
 
   private def getGroupByKeysSchema(schemas: Array[Schema]): Schema = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/pieChart/PieChartOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/pieChart/PieChartOpDesc.scala
@@ -11,8 +11,6 @@ import edu.uci.ics.texera.workflow.common.metadata.{
   OperatorInfo,
   OutputPort
 }
-import edu.uci.ics.texera.workflow.common.tuple.Tuple
-import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils.parseTimestamp
 import edu.uci.ics.texera.workflow.common.tuple.schema.{
   Attribute,
   AttributeType,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/pieChart/PieChartOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/pieChart/PieChartOpDesc.scala
@@ -143,16 +143,6 @@ class PieChartOpDesc extends VisualizationOperator {
       .build()
   }
 
-  private def getNumericalValue(tuple: Tuple, attribute: String): Double = {
-    val value: Object = tuple.getField(attribute)
-    if (value == null)
-      return 0
-
-    if (tuple.getSchema.getAttribute(attribute).getType == AttributeType.TIMESTAMP)
-      parseTimestamp(value.toString).getTime.toDouble
-    else value.toString.toDouble
-  }
-
   private def getGroupByKeysSchema(schemas: Array[Schema]): Schema = {
     val groupByKeys = List(this.nameColumn)
     Schema

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/breakpoint/ExceptionBreakpointSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/breakpoint/ExceptionBreakpointSpec.scala
@@ -1,19 +1,14 @@
 package edu.uci.ics.amber.engine.architecture.breakpoint
 
-import edu.uci.ics.amber.clustering.SingleNodeListener
-import edu.uci.ics.amber.engine.architecture.controller.Controller
-import edu.uci.ics.amber.engine.common.tuple.ITuple
-import akka.actor.{ActorSystem, PoisonPill, Props}
+import akka.actor.ActorSystem
 import akka.event.LoggingAdapter
-import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 
-import scala.collection.mutable
-import scala.concurrent.{Await, ExecutionContextExecutor}
+import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
-import scala.util.Random
 
 class ExceptionBreakpointSpec
     extends TestKit(ActorSystem("PrincipalSpec"))

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/TrivialControlSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/TrivialControlSpec.scala
@@ -1,9 +1,7 @@
 package edu.uci.ics.amber.engine.architecture.control
 
 import akka.actor.{ActorRef, ActorSystem, PoisonPill, Props}
-import akka.pattern.ask
 import akka.testkit.{TestKit, TestProbe}
-import akka.util.Timeout
 import edu.uci.ics.amber.engine.architecture.control.utils.ChainHandler.Chain
 import edu.uci.ics.amber.engine.architecture.control.utils.CollectHandler.Collect
 import edu.uci.ics.amber.engine.architecture.control.utils.ErrorHandler.ErrorCommand
@@ -29,7 +27,6 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 
 import scala.collection.mutable
-import scala.concurrent.Await
 import scala.concurrent.duration._
 
 class TrivialControlSpec

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/ChainHandler.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/ChainHandler.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.control.utils
 
-import com.twitter.util.{Future, Promise}
+import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.control.utils.ChainHandler.Chain
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/CollectHandler.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/CollectHandler.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.control.utils
 
-import com.twitter.util.{Future, Promise}
+import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.control.utils.CollectHandler.{Collect, GenerateNumber}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/NestedHandler.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/NestedHandler.scala
@@ -1,6 +1,5 @@
 package edu.uci.ics.amber.engine.architecture.control.utils
 
-import com.twitter.util.Promise
 import edu.uci.ics.amber.engine.architecture.control.utils.NestedHandler.{Nested, Pass}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/PingPongHandler.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/PingPongHandler.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.control.utils
 
-import com.twitter.util.{Future, Promise}
+import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.control.utils.PingPongHandler.{Ping, Pong}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/RecursionHandler.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/RecursionHandler.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.control.utils
 
-import com.twitter.util.{Future, Promise}
+import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.control.utils.RecursionHandler.Recursion
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/TrivialControlTester.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/TrivialControlTester.scala
@@ -1,6 +1,5 @@
 package edu.uci.ics.amber.engine.architecture.control.utils
 
-import akka.actor.ActorRef
 import com.softwaremill.macwire.wire
 import edu.uci.ics.amber.engine.architecture.common.WorkflowActor
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkCommunicationActor.{

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerSpec.scala
@@ -1,17 +1,14 @@
 package edu.uci.ics.amber.engine.architecture.controller
 
 import edu.uci.ics.amber.clustering.SingleNodeListener
-import edu.uci.ics.amber.engine.common.tuple.ITuple
-import edu.uci.ics.amber.engine.common.Constants
-import akka.actor.{ActorSystem, PoisonPill, Props}
-import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import akka.actor.{ActorSystem, Props}
+import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 
-import scala.concurrent.{Await, ExecutionContextExecutor}
+import scala.concurrent.ExecutionContextExecutor
 import scala.concurrent.duration._
-import scala.util.Random
 
 class ControllerSpec
     extends TestKit(ActorSystem("ControllerSpec"))

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OutputManagerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OutputManagerSpec.scala
@@ -16,7 +16,7 @@ class OutputManagerSpec extends AnyFlatSpec with MockFactory {
   private val mockHandler =
     mock[(ActorVirtualIdentity, ActorVirtualIdentity, Long, DataPayload) => Unit]
   private val identifier = ActorVirtualIdentity("batch producer mock")
-  private val mockDataOutputPort: NetworkOutputPort[DataPayload] = // scalafix:ok; need it for wiring purpose
+  private val mockDataOutputPort = // scalafix:ok; need it for wiring purpose
     new NetworkOutputPort[DataPayload](identifier, mockHandler)
   var counter: Int = 0
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OutputManagerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OutputManagerSpec.scala
@@ -16,8 +16,7 @@ class OutputManagerSpec extends AnyFlatSpec with MockFactory {
   private val mockHandler =
     mock[(ActorVirtualIdentity, ActorVirtualIdentity, Long, DataPayload) => Unit]
   private val identifier = ActorVirtualIdentity("batch producer mock")
-  private val mockDataOutputPort: NetworkOutputPort[DataPayload] =
-    new NetworkOutputPort[DataPayload](identifier, mockHandler)
+  new NetworkOutputPort[DataPayload](identifier, mockHandler)
   var counter: Int = 0
 
   def layerID(): LayerIdentity = {

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OutputManagerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OutputManagerSpec.scala
@@ -16,7 +16,8 @@ class OutputManagerSpec extends AnyFlatSpec with MockFactory {
   private val mockHandler =
     mock[(ActorVirtualIdentity, ActorVirtualIdentity, Long, DataPayload) => Unit]
   private val identifier = ActorVirtualIdentity("batch producer mock")
-  new NetworkOutputPort[DataPayload](identifier, mockHandler)
+  private val mockDataOutputPort: NetworkOutputPort[DataPayload] = // scalafix:ok need it for wiring purpose
+    new NetworkOutputPort[DataPayload](identifier, mockHandler)
   var counter: Int = 0
 
   def layerID(): LayerIdentity = {

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OutputManagerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OutputManagerSpec.scala
@@ -16,7 +16,7 @@ class OutputManagerSpec extends AnyFlatSpec with MockFactory {
   private val mockHandler =
     mock[(ActorVirtualIdentity, ActorVirtualIdentity, Long, DataPayload) => Unit]
   private val identifier = ActorVirtualIdentity("batch producer mock")
-  private val mockDataOutputPort: NetworkOutputPort[DataPayload] = // scalafix:ok need it for wiring purpose
+  private val mockDataOutputPort: NetworkOutputPort[DataPayload] = // scalafix:ok; need it for wiring purpose
     new NetworkOutputPort[DataPayload](identifier, mockHandler)
   var counter: Int = 0
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/RangeBasedShuffleSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/RangeBasedShuffleSpec.scala
@@ -4,7 +4,7 @@ import edu.uci.ics.amber.engine.architecture.sendsemantics.partitioners.RangeBas
 import edu.uci.ics.amber.engine.architecture.sendsemantics.partitionings.RangeBasedShufflePartitioning
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
-import edu.uci.ics.texera.workflow.common.tuple.schema.{AttributeType, Schema}
+import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeType
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.flatspec.AnyFlatSpec
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowPipelinedRegionsBuilderSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowPipelinedRegionsBuilderSpec.scala
@@ -1,8 +1,7 @@
 package edu.uci.ics.amber.engine.architecture.scheduling
 
 import edu.uci.ics.amber.engine.architecture.controller.Workflow
-import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
-import edu.uci.ics.amber.engine.common.virtualidentity.{OperatorIdentity, WorkflowIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.WorkflowIdentity
 import edu.uci.ics.amber.engine.e2e.TestOperators
 import edu.uci.ics.texera.workflow.common.WorkflowContext
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor
@@ -22,7 +21,6 @@ import edu.uci.ics.texera.workflow.operators.udf.pythonV2.{
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.flatspec.AnyFlatSpec
 
-import scala.collection.mutable
 import scala.jdk.CollectionConverters.asScalaSetConverter
 
 class WorkflowPipelinedRegionsBuilderSpec extends AnyFlatSpec with MockFactory {

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.amber.engine.e2e
 
-import akka.actor.{ActorSystem, PoisonPill, Props}
-import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import akka.actor.{ActorSystem, Props}
+import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import ch.vorburger.mariadb4j.DB
 import edu.uci.ics.amber.clustering.SingleNodeListener
@@ -24,7 +24,6 @@ import edu.uci.ics.amber.engine.architecture.controller.ControllerEvent.Workflow
 import edu.uci.ics.amber.engine.common.client.AmberClient
 import edu.uci.ics.texera.workflow.common.storage.OpResultStorage
 
-import scala.collection.mutable
 import scala.concurrent.duration._
 
 class DataProcessingSpec

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/faulttolerance/RecoverySpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/faulttolerance/RecoverySpec.scala
@@ -24,7 +24,6 @@ import edu.uci.ics.amber.engine.architecture.worker.workloadmetrics.SelfWorkload
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ReturnInvocation
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
-import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
 

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
@@ -13,11 +13,7 @@ import edu.uci.ics.texera.Utils
 import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowResource.DashboardWorkflowEntry
 import org.jooq.Condition
 import org.jooq.impl.DSL.noCondition
-import edu.uci.ics.texera.web.model.jooq.generated.Tables.{
-  USER,
-  WORKFLOW,
-  WORKFLOW_OF_PROJECT
-}
+import edu.uci.ics.texera.web.model.jooq.generated.Tables.{USER, WORKFLOW, WORKFLOW_OF_PROJECT}
 
 import java.util.concurrent.TimeUnit
 import java.sql.Timestamp

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
@@ -7,26 +7,21 @@ import org.scalatest.flatspec.AnyFlatSpec
 import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.{User, Workflow}
 import org.jooq.types.UInteger
 import edu.uci.ics.texera.web.model.jooq.generated.enums.UserRole
-import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{UserDao, WorkflowDao}
+import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.UserDao
 import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowResource
 import edu.uci.ics.texera.Utils
 import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowResource.DashboardWorkflowEntry
 import org.jooq.Condition
 import org.jooq.impl.DSL.noCondition
 import edu.uci.ics.texera.web.model.jooq.generated.Tables.{
-  PROJECT,
   USER,
   WORKFLOW,
-  WORKFLOW_OF_PROJECT,
-  WORKFLOW_OF_USER,
-  WORKFLOW_USER_ACCESS
+  WORKFLOW_OF_PROJECT
 }
 
 import java.util.concurrent.TimeUnit
 import java.sql.Timestamp
 import java.text.{ParseException, SimpleDateFormat}
-import java.nio.file.Files
-import java.nio.charset.StandardCharsets
 import java.util
 import java.util.Collections
 

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowRewriterSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowRewriterSpec.scala
@@ -1,6 +1,5 @@
 package edu.uci.ics.texera.workflow.common.workflow
 
-import edu.uci.ics.texera.workflow.common.WorkflowContext
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor
 import edu.uci.ics.texera.workflow.common.storage.OpResultStorage
 import edu.uci.ics.texera.workflow.common.tuple.Tuple

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpExecSpec.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.difference
 
 import edu.uci.ics.amber.engine.common.InputExhausted
-import edu.uci.ics.amber.engine.common.virtualidentity.{LayerIdentity, LinkIdentity}
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
 import org.scalatest.BeforeAndAfter

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/symmetricDifference/SymmetricDifferenceOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/symmetricDifference/SymmetricDifferenceOpExecSpec.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.symmetricDifference
 
 import edu.uci.ics.amber.engine.common.InputExhausted
-import edu.uci.ics.amber.engine.common.virtualidentity.{LayerIdentity, LinkIdentity}
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
 import org.scalatest.BeforeAndAfter


### PR DESCRIPTION
This PR adds the lint plugin `scalafix` and uses it to check and fix code issues. Enabled rules:
1. [ProcedureSyntax](https://scalacenter.github.io/scalafix/docs/rules/ProcedureSyntax.html)
2. [RemoveUnused](https://scalacenter.github.io/scalafix/docs/rules/RemoveUnused.html)

The CI has added `scalafixAll --check` to validate those rules. Developers can use `sbt scalafixAll` to fix lint issues before executing `sbt scalafmtAll` to fix the format.