### PR TITLE
Fix project list not being refreshed when navigating to it a second time

### DIFF
--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.ts
@@ -94,6 +94,7 @@ export class UserProjectComponent implements OnInit {
   }
 
   private getUserProjectArray() {
+    this.userProjectService.refreshProjectList();
     this.userProjectService
       .retrieveProjectList()
       .pipe(untilDestroyed(this))

--- a/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
@@ -278,7 +278,7 @@ export class UserWorkflowComponent implements OnInit, OnChanges {
       .subscribe(() => {
         if (this.userService.isLogin()) {
           this.refreshDashboardWorkflowEntries();
-          this.userProjectService.retrieveProjectList();
+          this.userProjectService.refreshProjectList();
         } else {
           this.clearDashboardWorkflowEntries();
         }

--- a/core/new-gui/src/app/dashboard/user/service/user-project/stub-user-project.service.ts
+++ b/core/new-gui/src/app/dashboard/user/service/user-project/stub-user-project.service.ts
@@ -5,6 +5,10 @@ import { DashboardFile } from "../../type/dashboard-file.interface";
 import { UserProjectService } from "./user-project.service";
 
 export class StubUserProjectService {
+  public refreshProjectList(): Observable<UserProject[]> {
+    return this.retrieveProjectList();
+  }
+  
   public retrieveProjectList(): Observable<UserProject[]> {
     return new Observable(observer =>
       observer.next([

--- a/core/new-gui/src/app/dashboard/user/service/user-project/user-project.service.ts
+++ b/core/new-gui/src/app/dashboard/user/service/user-project/user-project.service.ts
@@ -23,9 +23,17 @@ export class UserProjectService {
 
   constructor(private http: HttpClient) {}
 
+  public refreshProjectList(): Observable<UserProject[]> {
+    this.http
+      .get<UserProject[]>(`${USER_PROJECT_LIST_URL}`)
+      .pipe()
+      // Pass through the result but without completing the long-lived BehaviorSubject.
+      .subscribe({ next: p => this.projects.next(p), error: (p: unknown) => this.projects.error(p), complete: () => {} });
+    return this.retrieveProjectList();
+  }
+
   public retrieveProjectList(): Observable<UserProject[]> {
-    this.http.get<UserProject[]>(`${USER_PROJECT_LIST_URL}`).subscribe(this.projects);
-    return this.projects;
+    return this.projects.asObservable();
   }
 
   public retrieveWorkflowsOfProject(pid: number): Observable<DashboardWorkflowEntry[]> {


### PR DESCRIPTION
An issue introduced by #1953.
Turns out, the observable returned by Angular `HttpClient` completes the long-lived `BehaviorSubject` and subsequent navigations were trying to obtain the project list from an Observable that has already completed.