### PR TITLE
Fix missing paths in polyfills

### DIFF
--- a/core/new-gui/package.json
+++ b/core/new-gui/package.json
@@ -83,6 +83,7 @@
     "ngx-markdown": "13.1.0",
     "ngx-monaco-editor": "9.0.0",
     "ngx-popper": "7.0.0",
+    "path-browserify": "^1.0.1",
     "popper.js": "1.16.1",
     "quill": "1.3.7",
     "quill-cursors": "3.1.2",

--- a/core/new-gui/tsconfig.json
+++ b/core/new-gui/tsconfig.json
@@ -1,6 +1,11 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "paths": {
+      "path": [
+        "./node_modules/path-browserify"
+      ]
+    },
     "strict": true,
     "skipLibCheck": true,
     "outDir": "./dist/out-tsc",

--- a/core/new-gui/yarn.lock
+++ b/core/new-gui/yarn.lock
@@ -11065,6 +11065,11 @@ parseurl@~1.3.2, parseurl@~1.3.3:
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"
   integrity sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==
 
+path-browserify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/path-browserify/-/path-browserify-1.0.1.tgz#d98454a9c3753d5790860f16f68867b9e46be1fd"
+  integrity sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"


### PR DESCRIPTION
This PR fixes a typescript error where some js libraries are used in web browsers. The frontend console shows the following error:

```
BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
        - add a fallback 'resolve.fallback: { "path": require.resolve("path-browserify") }'
        - install 'path-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
        resolve.fallback: { "path": false }
```

The fix follows the instructions from [this comment](https://github.com/angular/angular-cli/issues/20819#issuecomment-900284913)