### PR TITLE
Fix the redirect after login

### DIFF
--- a/core/new-gui/src/app/common/service/user/auth-guard.service.ts
+++ b/core/new-gui/src/app/common/service/user/auth-guard.service.ts
@@ -14,7 +14,7 @@ export class AuthGuardService implements CanActivate {
     if (this.userService.isLogin() || !environment.userSystemEnabled) {
       return true;
     } else {
-      this.router.navigate(["home"], { queryParams: { returnUrl: state.url } });
+      this.router.navigate(["home"], { queryParams: { returnUrl: state.url === "/" ? null : state.url } });
       return false;
     }
   }


### PR DESCRIPTION
This PR fixes the bug that the user can be redirected to an empty workflow after login instead of the user-workflow page in some cases. 
