### PR TITLE
Clean up frontend google configs

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/GoogleAuthResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/GoogleAuthResource.scala
@@ -31,7 +31,7 @@ class GoogleAuthResource {
   def getClientId: String = {
     clientId
   }
-  
+
   @POST
   @Consumes(Array(MediaType.TEXT_PLAIN))
   @Produces(Array(MediaType.APPLICATION_JSON))

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/GoogleAuthResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/GoogleAuthResource.scala
@@ -32,6 +32,12 @@ object GoogleAuthResource {
 
 @Path("/auth/google")
 class GoogleAuthResource {
+  final private lazy val clientId = AmberUtils.amberConfig.getString("user-sys.googleClientId")
+  @GET
+  @Path("/clientid")
+  def getClientId: String = {
+    clientId
+  }
   @POST
   @Consumes(Array(MediaType.TEXT_PLAIN))
   @Produces(Array(MediaType.APPLICATION_JSON))

--- a/core/new-gui/src/app/dashboard/user/component/user-avatar/user-avatar.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-avatar/user-avatar.component.ts
@@ -26,7 +26,7 @@ export class UserAvatarComponent implements OnInit {
   @Input() googleId?: string;
   @Input() userName?: string;
   @Input() userColor?: string;
-  private publicKey = environment.google.publicKey;
+  private googleApiKey = environment.googleApiKey;
 
   constructor(private http: HttpClient) {}
 
@@ -35,7 +35,7 @@ export class UserAvatarComponent implements OnInit {
       throw new Error("google Id or user name should be provided");
     } else if (this.googleId) {
       // get the avatar of the google user
-      const googlePeopleAPIUrl = `https://people.googleapis.com/v1/people/${this.googleId}?personFields=names%2Cphotos&key=${this.publicKey}`;
+      const googlePeopleAPIUrl = `https://people.googleapis.com/v1/people/${this.googleId}?personFields=names%2Cphotos&key=${this.googleApiKey}`;
       this.http
         .get<GooglePeopleApiResponse>(googlePeopleAPIUrl)
         .pipe(untilDestroyed(this))

--- a/core/new-gui/src/app/home/component/home.component.spec.ts
+++ b/core/new-gui/src/app/home/component/home.component.spec.ts
@@ -4,7 +4,7 @@ import { UserService } from "../../common/service/user/user.service";
 import { StubUserService } from "../../common/service/user/stub-user.service";
 import { GoogleService } from "../service/google.service";
 import { RouterTestingModule } from "@angular/router/testing";
-import { HttpClientModule } from "@angular/common/http";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
 
 describe("HomeComponent", () => {
   let component: HomeComponent;
@@ -14,7 +14,7 @@ describe("HomeComponent", () => {
     TestBed.configureTestingModule({
       declarations: [HomeComponent],
       providers: [{ provide: UserService, useClass: StubUserService }, GoogleService],
-      imports: [HttpClientModule, RouterTestingModule.withRoutes([{ path: "home", component: HomeComponent }])],
+      imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([{ path: "home", component: HomeComponent }])],
     }).compileComponents();
   }));
 

--- a/core/new-gui/src/app/home/component/home.component.spec.ts
+++ b/core/new-gui/src/app/home/component/home.component.spec.ts
@@ -22,8 +22,4 @@ describe("HomeComponent", () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
   });
-
-  it("should create", () => {
-    expect(component).toBeTruthy();
-  });
 });

--- a/core/new-gui/src/app/home/component/home.component.spec.ts
+++ b/core/new-gui/src/app/home/component/home.component.spec.ts
@@ -4,6 +4,7 @@ import { UserService } from "../../common/service/user/user.service";
 import { StubUserService } from "../../common/service/user/stub-user.service";
 import { GoogleService } from "../service/google.service";
 import { RouterTestingModule } from "@angular/router/testing";
+import { HttpClientModule } from "@angular/common/http";
 
 describe("HomeComponent", () => {
   let component: HomeComponent;
@@ -13,7 +14,7 @@ describe("HomeComponent", () => {
     TestBed.configureTestingModule({
       declarations: [HomeComponent],
       providers: [{ provide: UserService, useClass: StubUserService }, GoogleService],
-      imports: [RouterTestingModule.withRoutes([{ path: "home", component: HomeComponent }])],
+      imports: [HttpClientModule, RouterTestingModule.withRoutes([{ path: "home", component: HomeComponent }])],
     }).compileComponents();
   }));
 
@@ -21,5 +22,9 @@ describe("HomeComponent", () => {
     fixture = TestBed.createComponent(HomeComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
+  });
+
+  it("should create", () => {
+    expect(component).toBeTruthy();
   });
 });

--- a/core/new-gui/src/app/home/service/google.service.ts
+++ b/core/new-gui/src/app/home/service/google.service.ts
@@ -18,9 +18,8 @@ export class GoogleService {
   constructor(private http: HttpClient) {}
 
   public googleInit(parent: HTMLElement | null) {
-    this.http
-      .get(`${AppSettings.getApiEndpoint()}/auth/google/clientid`, { responseType: "text" })
-      .subscribe(response => {
+    this.http.get(`${AppSettings.getApiEndpoint()}/auth/google/clientid`, { responseType: "text" }).subscribe({
+      next: response => {
         window.onGoogleLibraryLoad = () => {
           window.google.accounts.id.initialize({
             client_id: response,
@@ -31,7 +30,11 @@ export class GoogleService {
           window.google.accounts.id.renderButton(parent, { width: "270" });
           window.google.accounts.id.prompt();
         };
-      });
+      },
+      error: (err: unknown) => {
+        console.error(err);
+      },
+    });
   }
 
   get googleCredentialResponse() {

--- a/core/new-gui/src/app/home/service/google.service.ts
+++ b/core/new-gui/src/app/home/service/google.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@angular/core";
 import { Subject } from "rxjs";
-import { environment } from "../../../environments/environment";
+import { HttpClient } from "@angular/common/http";
+import { AppSettings } from "../../common/app-setting";
 declare var window: any;
 
 export interface credentialRes {
@@ -14,17 +15,23 @@ export interface credentialRes {
 export class GoogleService {
   private _googleCredentialResponse = new Subject<credentialRes>();
 
+  constructor(private http: HttpClient) {}
+
   public googleInit(parent: HTMLElement | null) {
-    window.onGoogleLibraryLoad = () => {
-      window.google.accounts.id.initialize({
-        client_id: environment.google.clientID,
-        callback: (auth: credentialRes) => {
-          this._googleCredentialResponse.next(auth);
-        },
+    this.http
+      .get(`${AppSettings.getApiEndpoint()}/auth/google/clientid`, { responseType: "text" })
+      .subscribe(response => {
+        window.onGoogleLibraryLoad = () => {
+          window.google.accounts.id.initialize({
+            client_id: response,
+            callback: (auth: credentialRes) => {
+              this._googleCredentialResponse.next(auth);
+            },
+          });
+          window.google.accounts.id.renderButton(parent, { width: "270" });
+          window.google.accounts.id.prompt();
+        };
       });
-      window.google.accounts.id.renderButton(parent, { width: "270" });
-      window.google.accounts.id.prompt();
-    };
   }
 
   get googleCredentialResponse() {

--- a/core/new-gui/src/environments/environment.default.ts
+++ b/core/new-gui/src/environments/environment.default.ts
@@ -55,6 +55,11 @@ export const defaultEnvironment = {
   inviteOnly: false,
 
   /**
+   * Google Api Key for Google icons
+   */
+  googleApiKey: "",
+
+  /**
    * whether user preset feature is enabled, requires user system to be enabled
    */
   userPresetEnabled: false,
@@ -88,14 +93,6 @@ export const defaultEnvironment = {
    */
   mapbox: {
     accessToken: "",
-  },
-
-  /**
-   * all google-related configs
-   */
-  google: {
-    clientID: "",
-    publicKey: "",
   },
 
   /**


### PR DESCRIPTION
Clean up google related configurations.

Renamed `publicKey` to `googleApiKey` to match the name on the Google website. 
The `googleApiKey` is used to request user icons.
The 'googleClientId' is no longer needed on the frontend configs.
The only config needed for Google login is 'googleClientId' on the backend. 

As a follow-up of #1977.

Reference(post from google staff):
https://www.googlecloudcommunity.com/gc/Apigee/Client-Id-vs-Client-Secret/m-p/13501#:~:text=Client%20ID%20is%20publicly%20available,securely%20%26%20not%20available%20to%20public.