### PR TITLE
Fix project section displaying all workflows incorrectly

### DIFF
--- a/core/new-gui/src/app/dashboard/user/component/filters/filters.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/filters/filters.component.html
@@ -163,6 +163,7 @@
   </nz-dropdown-menu>
 
   <a
+    *ngIf="pid === null"
     [nzDropdownMenu]="projectSearchOptions"
     nz-dropdown
     nzTrigger="click"

--- a/core/new-gui/src/app/dashboard/user/component/filters/filters.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/filters/filters.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, OnInit, Output } from "@angular/core";
+import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 import { OperatorMetadataService } from "src/app/workspace/service/operator-metadata/operator-metadata.service";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { Observable } from "rxjs";
@@ -17,6 +17,8 @@ import { SearchFilterParameters } from "../../type/search-filter-parameters";
 })
 export class FiltersComponent implements OnInit {
   private _masterFilterList: ReadonlyArray<string> = [];
+  // receive input from parent components (UserProjectSection), if any
+  @Input() public pid: number | null = null;
   @Output()
   public masterFilterListChange = new EventEmitter<typeof this._masterFilterList>();
   public get masterFilterList(): ReadonlyArray<string> {

--- a/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.html
@@ -45,7 +45,7 @@
       </nz-upload>
 
       <button
-        *ngIf="pid !== 0"
+        *ngIf="pid !== null"
         (click)="onClickOpenAddWorkflow()"
         nz-button
         title="Add workflow(s) to project"
@@ -58,7 +58,7 @@
           nzType="plus-square"></i>
       </button>
       <button
-        *ngIf="pid !== 0"
+        *ngIf="pid !== null"
         (click)="onClickOpenRemoveWorkflow()"
         nz-button
         title="Remove workflow(s) from project"
@@ -71,7 +71,9 @@
           nzType="minus-square"></i>
       </button>
     </nz-button-group>
-    <texera-filters #filters></texera-filters>
+    <texera-filters
+      [pid]="pid"
+      #filters></texera-filters>
   </nz-card>
 
   <div class="section-search-bar workflow-search-bar">

--- a/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
@@ -33,11 +33,8 @@ import { SearchService } from "../../service/search.service";
 import { SortMethod } from "../../type/sort-method";
 
 export const ROUTER_WORKFLOW_CREATE_NEW_URL = "/";
-export const ROUTER_USER_PROJECT_BASE_URL = "/dashboard/user-project";
 
 export const WORKFLOW_BASE_URL = "workflow";
-export const WORKFLOW_OWNER_URL = WORKFLOW_BASE_URL + "/owners";
-export const WORKFLOW_ID_URL = WORKFLOW_BASE_URL + "/workflow-ids";
 
 /**
  * Saved-workflow-section component contains information and functionality
@@ -95,11 +92,10 @@ export class UserWorkflowComponent implements AfterViewInit, OnChanges {
   }
   private masterFilterList: ReadonlyArray<string> | null = null;
   // receive input from parent components (UserProjectSection), if any
-  @Input() public pid: number = 0;
+  @Input() public pid: number | null = null;
   public sortMethod = SortMethod.EditTimeDesc;
   lastSortMethod: SortMethod | null = null;
   public dashboardWorkflowEntriesIsEditingName: number[] = [];
-  public dashboardWorkflowEntriesIsEditingDescription: number[] = [];
   public owners = this.workflowPersistService.retrieveOwners().pipe(
     map((owners: string[]) => {
       return owners.map((user: string) => {
@@ -111,9 +107,6 @@ export class UserWorkflowComponent implements AfterViewInit, OnChanges {
     })
   );
   public projectFilterList: number[] = []; // for filter by project mode, track which projects are selected
-
-  public ROUTER_WORKFLOW_BASE_URL = "/workflow";
-  public ROUTER_USER_PROJECT_BASE_URL = "/dashboard/user-project";
 
   constructor(
     private userService: UserService,
@@ -143,7 +136,6 @@ export class UserWorkflowComponent implements AfterViewInit, OnChanges {
       if (propName === "pid" && changes[propName].currentValue) {
         // listen to see if component is to be re-rendered inside a different project
         this.pid = changes[propName].currentValue;
-        this.search();
       }
     }
   }
@@ -158,7 +150,8 @@ export class UserWorkflowComponent implements AfterViewInit, OnChanges {
     // retrieve updated values from modal via promise
     modalRef.result.then(result => {
       if (result) {
-        this.search();
+        // force the search to update the workflow list.
+        this.search(true);
       }
     });
   }
@@ -173,7 +166,8 @@ export class UserWorkflowComponent implements AfterViewInit, OnChanges {
     // retrieve updated values from modal via promise
     modalRef.result.then(result => {
       if (result) {
-        this.search();
+        // force the search to update the workflow list.
+        this.search(true);
       }
     });
   }
@@ -182,22 +176,27 @@ export class UserWorkflowComponent implements AfterViewInit, OnChanges {
    * Searches workflows with keywords and filters given in the masterFilterList.
    * @returns
    */
-  async search(): Promise<void> {
+  async search(forced: Boolean = false): Promise<void> {
     const sameList =
       this.masterFilterList !== null &&
       this.filters.masterFilterList.length === this.masterFilterList.length &&
       this.filters.masterFilterList.every((v, i) => v === this.masterFilterList![i]);
-    if (sameList && this.sortMethod === this.lastSortMethod) {
+    if (!forced && sameList && this.sortMethod === this.lastSortMethod) {
       // If the filter lists are the same, do no make the same request again.
       return;
     }
     this.lastSortMethod = this.sortMethod;
     this.masterFilterList = this.filters.masterFilterList;
+    let filterParams = this.filters.getSearchFilterParameters();
+    if (this.pid) {
+      // force the project id in the search query to be the current pid.
+      filterParams.projectIds = [this.pid];
+    }
     this.searchResultsComponent.reset(async (start, count) => {
       const results = await firstValueFrom(
         this.searchService.search(
           this.filters.getSearchKeywords(),
-          this.filters.getSearchFilterParameters(),
+          filterParams,
           start,
           count,
           "workflow",
@@ -258,7 +257,7 @@ export class UserWorkflowComponent implements AfterViewInit, OnChanges {
                 ...this.searchResultsComponent.entries,
                 new DashboardEntry(duplicatedWorkflowInfo),
               ];
-              return this.userProjectService.addWorkflowToProject(this.pid, duplicatedWorkflowInfo.workflow.wid!);
+              return this.userProjectService.addWorkflowToProject(this.pid!, duplicatedWorkflowInfo.workflow.wid!);
             }),
             catchError((err: unknown) => {
               throw err;

--- a/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
@@ -131,15 +131,6 @@ export class UserWorkflowComponent implements AfterViewInit {
     this.registerDashboardWorkflowEntriesRefresh();
   }
 
-  // ngOnChanges(changes: SimpleChanges) {
-  //   for (const propName in changes) {
-  //     if (propName === "pid" && changes[propName].currentValue) {
-  //       // listen to see if component is to be re-rendered inside a different project
-  //       this.pid = changes[propName].currentValue;
-  //     }
-  //   }
-  // }
-
   /**
    * open the Modal to add workflow(s) to project
    */

--- a/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
@@ -68,7 +68,7 @@ export const WORKFLOW_BASE_URL = "workflow";
   templateUrl: "user-workflow.component.html",
   styleUrls: ["user-workflow.component.scss"],
 })
-export class UserWorkflowComponent implements AfterViewInit, OnChanges {
+export class UserWorkflowComponent implements AfterViewInit {
   private _searchResultsComponent?: SearchResultsComponent;
   @ViewChild(SearchResultsComponent) get searchResultsComponent(): SearchResultsComponent {
     if (this._searchResultsComponent) {
@@ -131,14 +131,14 @@ export class UserWorkflowComponent implements AfterViewInit, OnChanges {
     this.registerDashboardWorkflowEntriesRefresh();
   }
 
-  ngOnChanges(changes: SimpleChanges) {
-    for (const propName in changes) {
-      if (propName === "pid" && changes[propName].currentValue) {
-        // listen to see if component is to be re-rendered inside a different project
-        this.pid = changes[propName].currentValue;
-      }
-    }
-  }
+  // ngOnChanges(changes: SimpleChanges) {
+  //   for (const propName in changes) {
+  //     if (propName === "pid" && changes[propName].currentValue) {
+  //       // listen to see if component is to be re-rendered inside a different project
+  //       this.pid = changes[propName].currentValue;
+  //     }
+  //   }
+  // }
 
   /**
    * open the Modal to add workflow(s) to project


### PR DESCRIPTION
This PR:
1. Fixed a bug that led to a particular project displaying all workflows.
2. Hide the project filter in the project section because it does not make sense to filter by project inside a project.
3. Removed some unused code and an unnecessary callback for `pid` to change during the lifecycle of a workflow component. For now, we assume `pid` is fixed in the whole lifecycle.