### PR TITLE
Replace import all syntax with explicit import

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/DualInputPortsPythonUDFOpDescV2.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/DualInputPortsPythonUDFOpDescV2.scala
@@ -22,25 +22,27 @@ class DualInputPortsPythonUDFOpDescV2 extends OperatorDescriptor {
     defaultValue =
       "# Choose from the following templates:\n" +
         "# \n" +
-        "# from pytexera import *\n" +
+        "# import pytexera as pt\n" +
+        "# from overrides import overrides\n" +
+        "# from typing import Iterator, Optional\n" +
         "# \n" +
-        "# class ProcessTupleOperator(UDFOperatorV2):\n" +
+        "# class ProcessTupleOperator(pt.UDFOperatorV2):\n" +
         "#     \n" +
         "#     @overrides\n" +
-        "#     def process_tuple(self, tuple_: Tuple, port: int) -> Iterator[Optional[TupleLike]]:\n" +
+        "#     def process_tuple(self, tuple_: pt.Tuple, port: int) -> Iterator[Optional[pt.TupleLike]]:\n" +
         "#         yield tuple_\n" +
         "# \n" +
-        "# class ProcessBatchOperator(UDFBatchOperator):\n" +
+        "# class ProcessBatchOperator(pt.UDFBatchOperator):\n" +
         "#     BATCH_SIZE = 10 # must be a positive integer\n" +
         "# \n" +
         "#     @overrides\n" +
-        "#     def process_batch(self, batch: Batch, port: int) -> Iterator[Optional[BatchLike]]:\n" +
+        "#     def process_batch(self, batch: pt.Batch, port: int) -> Iterator[Optional[pt.BatchLike]]:\n" +
         "#         yield batch\n" +
         "# \n" +
-        "# class ProcessTableOperator(UDFTableOperator):\n" +
+        "# class ProcessTableOperator(pt.UDFTableOperator):\n" +
         "# \n" +
         "#     @overrides\n" +
-        "#     def process_table(self, table: Table, port: int) -> Iterator[Optional[TableLike]]:\n" +
+        "#     def process_table(self, table: pt.Table, port: int) -> Iterator[Optional[pt.TableLike]]:\n" +
         "#         yield table\n"
   )
   @JsonSchemaTitle("Python script")

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/DualInputPortsPythonUDFOpDescV2.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/DualInputPortsPythonUDFOpDescV2.scala
@@ -26,6 +26,7 @@ class DualInputPortsPythonUDFOpDescV2 extends OperatorDescriptor {
         "# from overrides import overrides\n" +
         "# from typing import Iterator, Optional\n" +
         "# \n" +
+        "# \n" +
         "# class ProcessTupleOperator(pt.UDFOperatorV2):\n" +
         "#     \n" +
         "#     @overrides\n" +

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonUDFOpDescV2.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonUDFOpDescV2.scala
@@ -27,25 +27,27 @@ class PythonUDFOpDescV2 extends OperatorDescriptor with PortDescriptor {
     defaultValue =
       "# Choose from the following templates:\n" +
         "# \n" +
-        "# from pytexera import *\n" +
+        "# import pytexera as pt\n" +
+        "# from overrides import overrides\n" +
+        "# from typing import Iterator, Optional\n" +
         "# \n" +
-        "# class ProcessTupleOperator(UDFOperatorV2):\n" +
+        "# class ProcessTupleOperator(pt.UDFOperatorV2):\n" +
         "#     \n" +
         "#     @overrides\n" +
-        "#     def process_tuple(self, tuple_: Tuple, port: int) -> Iterator[Optional[TupleLike]]:\n" +
+        "#     def process_tuple(self, tuple_: pt.Tuple, port: int) -> Iterator[Optional[pt.TupleLike]]:\n" +
         "#         yield tuple_\n" +
         "# \n" +
-        "# class ProcessBatchOperator(UDFBatchOperator):\n" +
+        "# class ProcessBatchOperator(pt.UDFBatchOperator):\n" +
         "#     BATCH_SIZE = 10 # must be a positive integer\n" +
         "# \n" +
         "#     @overrides\n" +
-        "#     def process_batch(self, batch: Batch, port: int) -> Iterator[Optional[BatchLike]]:\n" +
+        "#     def process_batch(self, batch: pt.Batch, port: int) -> Iterator[Optional[pt.BatchLike]]:\n" +
         "#         yield batch\n" +
         "# \n" +
-        "# class ProcessTableOperator(UDFTableOperator):\n" +
+        "# class ProcessTableOperator(pt.UDFTableOperator):\n" +
         "# \n" +
         "#     @overrides\n" +
-        "#     def process_table(self, table: Table, port: int) -> Iterator[Optional[TableLike]]:\n" +
+        "#     def process_table(self, table: pt.Table, port: int) -> Iterator[Optional[pt.TableLike]]:\n" +
         "#         yield table\n"
   )
   @JsonSchemaTitle("Python script")

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonUDFOpDescV2.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonUDFOpDescV2.scala
@@ -31,6 +31,7 @@ class PythonUDFOpDescV2 extends OperatorDescriptor with PortDescriptor {
         "# from overrides import overrides\n" +
         "# from typing import Iterator, Optional\n" +
         "# \n" +
+        "# \n" +
         "# class ProcessTupleOperator(pt.UDFOperatorV2):\n" +
         "#     \n" +
         "#     @overrides\n" +

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/source/PythonUDFSourceOpDescV2.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/source/PythonUDFSourceOpDescV2.java
@@ -24,7 +24,7 @@ import static scala.collection.JavaConverters.asScalaBuffer;
 public class PythonUDFSourceOpDescV2 extends SourceOperatorDescriptor {
 
     @JsonProperty(required = true, defaultValue =
-                    "import pytexera as pt\n" +
+            "import pytexera as pt\n" +
                     "from overrides import overrides\n" +
                     "from typing import Iterator, Union\n" +
                     "\n" +

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/source/PythonUDFSourceOpDescV2.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/source/PythonUDFSourceOpDescV2.java
@@ -25,15 +25,15 @@ import static scala.collection.JavaConverters.asScalaBuffer;
 public class PythonUDFSourceOpDescV2 extends SourceOperatorDescriptor {
 
     @JsonProperty(required = true, defaultValue =
-            "# Choose from the following templates:\n" +
-                    "# \n" +
-                    "# from pytexera import *\n" +
-                    "# \n" +
-                    "# class GenerateOperator(UDFSourceOperator):\n" +
-                    "# \n" +
-                    "#     @overrides\n" +
-                    "#     def produce(self) -> Iterator[Union[TupleLike, TableLike, None]]:\n" +
-                    "#         yield\n")
+                    "import pytexera as pt\n" +
+                    "from overrides import overrides\n" +
+                    "from typing import Iterator, Union\n" +
+                    "\n" +
+                    "class GenerateOperator(pt.UDFSourceOperator):\n" +
+                    "\n" +
+                    "    @overrides\n" +
+                    "    def produce(self) -> Iterator[Union[pt.TupleLike, pt.TableLike, None]]:\n" +
+                    "        yield\n")
     @JsonSchemaTitle("Python script")
     @JsonPropertyDescription("Input your code here")
     public String code;

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/source/PythonUDFSourceOpDescV2.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/source/PythonUDFSourceOpDescV2.java
@@ -28,6 +28,7 @@ public class PythonUDFSourceOpDescV2 extends SourceOperatorDescriptor {
                     "from overrides import overrides\n" +
                     "from typing import Iterator, Union\n" +
                     "\n" +
+                    "\n" +
                     "class GenerateOperator(pt.UDFSourceOperator):\n" +
                     "\n" +
                     "    @overrides\n" +

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/source/PythonUDFSourceOpDescV2.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/source/PythonUDFSourceOpDescV2.java
@@ -6,7 +6,6 @@ import com.google.common.base.Preconditions;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecConfig;
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecFunc;
-import edu.uci.ics.texera.workflow.common.metadata.InputPort;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorGroupConstants;
 import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
 import edu.uci.ics.texera.workflow.common.metadata.OutputPort;


### PR DESCRIPTION
It is not recommended to use `import *` statements per [PEP 8](https://peps.python.org/pep-0008/).  It was generally [a bad idea](https://stackoverflow.com/questions/2386714/why-is-import-bad) to expose the namespace with a wildcard. In our case, pyflakes complains about `from pytexera import *` and raises a warning in the UI.

This PR uses `import pytexera as pt` and explicit `pt.Tuple`, `py.UDFOperatorV2` which is a better practice. This change is backward compatible so existing UDFs will not be affected.