### PR TITLE
Fix non-source operator being recognized as source in ModifyOperatorLogic

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/ModifyLogicHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/ModifyLogicHandler.scala
@@ -34,7 +34,7 @@ trait ModifyLogicHandler {
       val workerCommand = if (operator.isPythonOperator) {
         ModifyPythonOperatorLogic(
           msg.newOp.getPythonCode,
-          isSource = operator.opExecClass.isAssignableFrom(classOf[PythonUDFSourceOpExecV2])
+          isSource = operator.opExecClass.isInstance(classOf[PythonUDFSourceOpExecV2])
         )
       } else {
         WorkerModifyLogic(msg.newOp, msg.stateTransferFunc)


### PR DESCRIPTION
There is a bug that non-source Python UDF would be recognized as source operator, because of the check used `isAssignableFrom(classOf[PythonUDFSourceOpExecV2])` instead of `isInstance(classOf[PythonUDFSourceOpExecV2])`, which gives wrong evaluation result. This is happening in the ModifyOperatorLogic handler where it could register a non-source UDF as a source UDF.