### PR TITLE
Fix Aggregation Attribute Type Rule, Add Timestamp Type

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/aggregate/AggregationOperation.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/aggregate/AggregationOperation.scala
@@ -22,7 +22,7 @@ import java.sql.Timestamp
             }
           },
           "then": {
-            "enum": ["integer", "long", "double"]
+            "enum": ["integer", "long", "double", "timestamp"]
           }
         },
         {


### PR DESCRIPTION
The `sum`, `average`, `min`, and `max` aggregation functions in the Aggregation operator should support all numeric types (integer, double, long, and timestamp). The code does support these types, but the `attributeTypeRules` injected did not include the timestamp type. This PR adds the timestamp type for these aggregation functions.