### PR TITLE
Show resource types in fulltext search result

### DIFF
--- a/core/new-gui/src/app/dashboard/user/component/dashboard.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/dashboard.component.html
@@ -65,7 +65,7 @@
         routerLink="/dashboard/search">
         <span
           nz-icon
-          nzType="search"></span>
+          nzType="file-search"></span>
         <span>Search</span>
       </li>
 

--- a/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.html
@@ -8,22 +8,52 @@
     class="virtual-scroll-container">
     <nz-list>
       <ng-container *cdkVirtualFor="let entry of entries">
-        <texera-user-project-list-item
-          *ngIf="entry.type === 'project'"
-          [editable]="editable"
-          [entry]="entry.project"></texera-user-project-list-item>
-        <texera-user-workflow-list-item
-          (deleted)="deleted.emit(entry)"
-          (duplicated)="duplicated.emit(entry)"
-          [editable]="editable"
-          [pid]="pid"
-          *ngIf="entry.type === 'workflow'"
-          [entry]="entry"></texera-user-workflow-list-item>
-        <texera-user-file-list-item
-          *ngIf="entry.type === 'file'"
-          [editable]="editable"
-          [entry]="entry.file">
-        </texera-user-file-list-item>
+        <nz-layout *ngIf="entry.type === 'project'">
+          <nz-sider *ngIf="showResourceTypes"
+                    [nzWidth]="40"
+            ><i
+              class="resource-type-icon"
+              nz-icon
+              nzTheme="outline"
+              nzType="container"></i
+          ></nz-sider>
+          <nz-content>
+            <texera-user-project-list-item
+              [editable]="editable"
+              [entry]="entry.project"></texera-user-project-list-item> </nz-content
+        ></nz-layout>
+        <nz-layout *ngIf="entry.type === 'workflow'">
+          <nz-sider *ngIf="showResourceTypes"
+                    [nzWidth]="40"
+            ><i
+              class="resource-type-icon"
+              nz-icon
+              nzTheme="outline"
+              nzType="project"></i
+          ></nz-sider>
+          <nz-content>
+            <texera-user-workflow-list-item
+              (deleted)="deleted.emit(entry)"
+              (duplicated)="duplicated.emit(entry)"
+              [editable]="editable"
+              [pid]="pid"
+              [entry]="entry"></texera-user-workflow-list-item> </nz-content
+        ></nz-layout>
+        <nz-layout *ngIf="entry.type === 'file'">
+          <nz-sider *ngIf="showResourceTypes"
+                    [nzWidth]="40"
+            ><i
+              class="resource-type-icon"
+              nz-icon
+              nzTheme="outline"
+              nzType="folder-open"></i
+          ></nz-sider>
+          <nz-content>
+            <texera-user-file-list-item
+              [editable]="editable"
+              [entry]="entry.file">
+            </texera-user-file-list-item> </nz-content
+        ></nz-layout>
       </ng-container>
     </nz-list>
     <div

--- a/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.html
@@ -9,8 +9,9 @@
     <nz-list>
       <ng-container *cdkVirtualFor="let entry of entries">
         <nz-layout *ngIf="entry.type === 'project'">
-          <nz-sider *ngIf="showResourceTypes"
-                    [nzWidth]="40"
+          <nz-sider
+            *ngIf="showResourceTypes"
+            [nzWidth]="40"
             ><i
               class="resource-type-icon"
               nz-icon
@@ -23,8 +24,9 @@
               [entry]="entry.project"></texera-user-project-list-item> </nz-content
         ></nz-layout>
         <nz-layout *ngIf="entry.type === 'workflow'">
-          <nz-sider *ngIf="showResourceTypes"
-                    [nzWidth]="40"
+          <nz-sider
+            *ngIf="showResourceTypes"
+            [nzWidth]="40"
             ><i
               class="resource-type-icon"
               nz-icon
@@ -40,8 +42,9 @@
               [entry]="entry"></texera-user-workflow-list-item> </nz-content
         ></nz-layout>
         <nz-layout *ngIf="entry.type === 'file'">
-          <nz-sider *ngIf="showResourceTypes"
-                    [nzWidth]="40"
+          <nz-sider
+            *ngIf="showResourceTypes"
+            [nzWidth]="40"
             ><i
               class="resource-type-icon"
               nz-icon

--- a/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.scss
+++ b/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.scss
@@ -7,3 +7,17 @@
   height: 32px;
   line-height: 32px;
 }
+
+nz-sider {
+  background: rgb(255, 255, 255);
+}
+
+nz-content {
+  background: rgb(255, 255, 255);
+}
+
+.resource-type-icon {
+  font-size: 30px;
+  margin-top: 10px;
+  margin-left: 5px;
+}

--- a/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.ts
@@ -14,6 +14,7 @@ export class SearchResultsComponent {
   more = false;
   entries: ReadonlyArray<DashboardEntry> = [];
   private resetCounter = 0;
+  @Input() showResourceTypes = false;
   @Input() public pid: number = 0;
   @Input() editable = false;
   @Output() deleted = new EventEmitter<DashboardEntry>();

--- a/core/new-gui/src/app/dashboard/user/component/search/search.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/search/search.component.html
@@ -24,5 +24,5 @@
     </nz-select>
   </div>
 
-  <texera-search-results></texera-search-results>
+  <texera-search-results [showResourceTypes]="true"></texera-search-results>
 </div>

--- a/core/new-gui/src/app/dashboard/user/component/search/search.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/search/search.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ViewChild } from "@angular/core";
+import { Component, ViewChild } from "@angular/core";
 import { DashboardEntry } from "../../type/dashboard-entry";
 import { SearchService } from "../../service/search.service";
 import { FiltersComponent } from "../filters/filters.component";

--- a/core/new-gui/src/app/dashboard/user/component/search/search.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/search/search.component.ts
@@ -1,4 +1,4 @@
-import { Component, ViewChild } from "@angular/core";
+import { Component, Input, ViewChild } from "@angular/core";
 import { DashboardEntry } from "../../type/dashboard-entry";
 import { SearchService } from "../../service/search.service";
 import { FiltersComponent } from "../filters/filters.component";

--- a/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.html
@@ -45,7 +45,7 @@
       </nz-upload>
 
       <button
-        *ngIf="pid !== null"
+        *ngIf="pid !== undefined"
         (click)="onClickOpenAddWorkflow()"
         nz-button
         title="Add workflow(s) to project"
@@ -58,7 +58,7 @@
           nzType="plus-square"></i>
       </button>
       <button
-        *ngIf="pid !== null"
+        *ngIf="pid !== undefined"
         (click)="onClickOpenRemoveWorkflow()"
         nz-button
         title="Remove workflow(s) from project"


### PR DESCRIPTION
This PR refined the frontend of full-text search:
1. showed icons for each resource type in the search result for the user to better distinguish between different resources.
2. updated the icon for the search tab on the dashboard to make it align with other icons.
3. fixed a minor issue on unchanged code where it was supposed to be changed in #2008.

the UI before this change:
<img width="1810" alt="before" src="https://github.com/Texera/texera/assets/13672781/ba33d7b3-aace-4f64-bd0c-76cbf8543975">
the UI after this change:
<img width="1827" alt="after" src="https://github.com/Texera/texera/assets/13672781/2bf4f686-60c3-4519-b93d-bb7e6022f9a7">
