### PR TITLE
Fix upstream link for source UDF operator

### DIFF
--- a/core/amber/src/main/python/core/runnables/data_processor.py
+++ b/core/amber/src/main/python/core/runnables/data_processor.py
@@ -32,14 +32,19 @@ class DataProcessor(Runnable, Stoppable):
                 operator = self._context.operator_manager.operator
                 tuple_ = self._context.tuple_processing_manager.current_input_tuple
                 link = self._context.tuple_processing_manager.current_input_link
+                port: int
+                if link is None:
+                    # no upstream, special case for source operator.
+                    port = -1
 
-                # bind link with input index
-                if link not in self._context.tuple_processing_manager.input_link_map:
+                elif link in self._context.tuple_processing_manager.input_link_map:
+                    port = self._context.tuple_processing_manager.input_link_map[link]
+
+                else:
                     raise Exception(
                         f"Unexpected input link {link}, not in input mapping "
                         f"{self._context.tuple_processing_manager.input_link_map}"
                     )
-                port = self._context.tuple_processing_manager.input_link_map[link]
 
                 output_iterator = (
                     operator.process_tuple(tuple_, port)


### PR DESCRIPTION
This PR fixes an issue exposed by #1845, where the upstream link is shared and enforced on the Python side. However, it did not handle source operators properly as they do not have a valid upstream link. This bug caused source (1-out) UDF to fail to start.

This PR proposes a fix by recognizing the case where the upstream link is None and treating it as a special commendation for source operators.