### PR TITLE
Allow users to cascade the sharing

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DashboardResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DashboardResource.scala
@@ -620,10 +620,12 @@ class DashboardResource {
             if (resourceType == "file") {
               DashboardFile(
                 record.into(USER).getEmail,
-                record.get(
-                  "user_file_access",
-                  classOf[UserFileAccessPrivilege]
-                ) == UserFileAccessPrivilege.WRITE,
+                record
+                  .get(
+                    "user_file_access",
+                    classOf[UserFileAccessPrivilege]
+                  )
+                  .toString,
                 record.into(FILE).into(classOf[File])
               )
             } else {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/file/UserFileAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/file/UserFileAccessResource.scala
@@ -141,7 +141,7 @@ class UserFileAccessResource {
   @GET
   @Path("list/{fid}")
   def getAccessList(
-      @PathParam("fid") fid: UInteger,
+      @PathParam("fid") fid: UInteger
   ): util.List[AccessEntry] = {
     context
       .select(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/file/UserFileAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/file/UserFileAccessResource.scala
@@ -129,8 +129,7 @@ class UserFileAccessResource {
   @GET
   @Path("/owner/{fid}")
   def getOwner(@PathParam("fid") fid: UInteger): String = {
-    val uid = fileDao.fetchOneByFid(fid).getOwnerUid
-    userDao.fetchOneByUid(uid).getEmail
+    userDao.fetchOneByUid(fileDao.fetchOneByFid(fid).getOwnerUid).getEmail
   }
 
   /**
@@ -143,7 +142,6 @@ class UserFileAccessResource {
   @Path("list/{fid}")
   def getAccessList(
       @PathParam("fid") fid: UInteger,
-      @Auth user: SessionUser
   ): util.List[AccessEntry] = {
     context
       .select(
@@ -157,7 +155,7 @@ class UserFileAccessResource {
       .where(
         USER_FILE_ACCESS.FID
           .eq(fid)
-          .and(USER_FILE_ACCESS.UID.notEqual(user.getUid))
+          .and(USER_FILE_ACCESS.UID.notEqual(fileDao.fetchOneByFid(fid).getOwnerUid))
       )
       .fetchInto(classOf[AccessEntry])
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/file/UserFileAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/file/UserFileAccessResource.scala
@@ -130,7 +130,7 @@ class UserFileAccessResource {
   def grantAccess(
       @PathParam("fid") fid: UInteger,
       @PathParam("email") email: String,
-      @PathParam("privilege") privilege: String,
+      @PathParam("privilege") privilege: String
   ): Unit = {
     userFileAccessDao.merge(
       new UserFileAccess(
@@ -152,7 +152,7 @@ class UserFileAccessResource {
   @Path("/revoke/{fid}/{email}")
   def revokeAccess(
       @PathParam("fid") fid: UInteger,
-      @PathParam("email") email: String,
+      @PathParam("email") email: String
   ): Unit = {
     context
       .delete(USER_FILE_ACCESS)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/file/UserFileResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/file/UserFileResource.scala
@@ -7,10 +7,6 @@ import edu.uci.ics.texera.web.model.jooq.generated.Tables._
 import edu.uci.ics.texera.web.model.jooq.generated.enums.UserFileAccessPrivilege
 import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{FileDao, UserFileAccessDao}
 import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.{File, User, UserFileAccess}
-import edu.uci.ics.texera.web.resource.dashboard.user.file.UserFileAccessResource.{
-  checkReadAccess,
-  checkWriteAccess
-}
 import edu.uci.ics.texera.web.resource.dashboard.user.file.UserFileResource.{
   DashboardFile,
   context,
@@ -183,7 +179,6 @@ class UserFileResource {
       @PathParam("fid") fid: UInteger,
       @Auth user: SessionUser
   ): Unit = {
-    checkWriteAccess(fid, user.getUid)
     Files.deleteIfExists(Paths.get(fileDao.fetchOneByFid(fid).getPath))
     fileDao.deleteById(fid)
   }
@@ -194,7 +189,6 @@ class UserFileResource {
       @PathParam("fid") fid: UInteger,
       @Auth user: SessionUser
   ): Response = {
-    checkReadAccess(fid, user.getUid)
     Response
       .ok(
         new StreamingOutput() {
@@ -220,7 +214,6 @@ class UserFileResource {
       @PathParam("name") name: String,
       @Auth user: SessionUser
   ): Unit = {
-    checkWriteAccess(fid, user.getUid)
     val validationRes = this.validateFileName(name, user.getUid)
     if (!validationRes.getLeft) {
       throw new BadRequestException(validationRes.getRight)
@@ -236,9 +229,7 @@ class UserFileResource {
   def changeFileDescription(
       @PathParam("fid") fid: UInteger,
       @PathParam("description") description: String,
-      @Auth user: SessionUser
   ): Unit = {
-    checkWriteAccess(fid, user.getUid)
     val userFile = fileDao.fetchOneByFid(fid)
     userFile.setDescription(description)
     fileDao.update(userFile)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/file/UserFileResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/file/UserFileResource.scala
@@ -62,7 +62,7 @@ object UserFileResource {
 
   case class DashboardFile(
       ownerEmail: String,
-      writeAccess: Boolean,
+      accessLevel: String,
       file: File
   )
 }
@@ -112,7 +112,7 @@ class UserFileResource {
         fids += fileRecord.into(FILE).getFid
         fileEntries += DashboardFile(
           fileRecord.into(USER).getEmail,
-          fileRecord.into(USER_FILE_ACCESS).getPrivilege == UserFileAccessPrivilege.WRITE,
+          fileRecord.into(USER_FILE_ACCESS).getPrivilege.toString,
           fileRecord.into(FILE).into(classOf[File])
         )
       })
@@ -132,7 +132,7 @@ class UserFileResource {
         if (!fileEntries.exists(file => { file.file.getFid == fileRecord.into(FILE).getFid })) {
           fileEntries += DashboardFile(
             fileRecord.into(USER).getEmail,
-            writeAccess = false,
+            "READ",
             fileRecord.into(FILE).into(classOf[File])
           )
         }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/file/UserFileResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/file/UserFileResource.scala
@@ -228,7 +228,7 @@ class UserFileResource {
   @Path("/description/{fid}/{description}")
   def changeFileDescription(
       @PathParam("fid") fid: UInteger,
-      @PathParam("description") description: String,
+      @PathParam("description") description: String
   ): Unit = {
     val userFile = fileDao.fetchOneByFid(fid)
     userFile.setDescription(description)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/project/ProjectAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/project/ProjectAccessResource.scala
@@ -1,6 +1,5 @@
 package edu.uci.ics.texera.web.resource.dashboard.user.project
 import edu.uci.ics.texera.web.SqlServer
-import edu.uci.ics.texera.web.auth.SessionUser
 import edu.uci.ics.texera.web.model.common.AccessEntry
 import edu.uci.ics.texera.web.model.jooq.generated.Tables.{PROJECT_USER_ACCESS, USER}
 import edu.uci.ics.texera.web.model.jooq.generated.enums.ProjectUserAccessPrivilege
@@ -10,7 +9,6 @@ import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{
   UserDao
 }
 import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.ProjectUserAccess
-import io.dropwizard.auth.Auth
 import org.jooq.DSLContext
 import org.jooq.types.UInteger
 import java.util

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/project/ProjectAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/project/ProjectAccessResource.scala
@@ -47,7 +47,6 @@ class ProjectAccessResource() {
   @Path("/list/{pid}")
   def getAccessList(
       @PathParam("pid") pid: UInteger,
-      @Auth user: SessionUser
   ): util.List[AccessEntry] = {
     context
       .select(
@@ -58,7 +57,7 @@ class ProjectAccessResource() {
       .from(PROJECT_USER_ACCESS)
       .join(USER)
       .on(USER.UID.eq(PROJECT_USER_ACCESS.UID))
-      .where(PROJECT_USER_ACCESS.PID.eq(pid).and(PROJECT_USER_ACCESS.UID.notEqual(user.getUid)))
+      .where(PROJECT_USER_ACCESS.PID.eq(pid).and(PROJECT_USER_ACCESS.UID.notEqual(projectDao.fetchOneByPid(pid).getOwnerId)))
       .fetchInto(classOf[AccessEntry])
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/project/ProjectAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/project/ProjectAccessResource.scala
@@ -46,7 +46,7 @@ class ProjectAccessResource() {
   @GET
   @Path("/list/{pid}")
   def getAccessList(
-      @PathParam("pid") pid: UInteger,
+      @PathParam("pid") pid: UInteger
   ): util.List[AccessEntry] = {
     context
       .select(
@@ -57,7 +57,11 @@ class ProjectAccessResource() {
       .from(PROJECT_USER_ACCESS)
       .join(USER)
       .on(USER.UID.eq(PROJECT_USER_ACCESS.UID))
-      .where(PROJECT_USER_ACCESS.PID.eq(pid).and(PROJECT_USER_ACCESS.UID.notEqual(projectDao.fetchOneByPid(pid).getOwnerId)))
+      .where(
+        PROJECT_USER_ACCESS.PID
+          .eq(pid)
+          .and(PROJECT_USER_ACCESS.UID.notEqual(projectDao.fetchOneByPid(pid).getOwnerId))
+      )
       .fetchInto(classOf[AccessEntry])
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/project/ProjectResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/project/ProjectResource.scala
@@ -105,7 +105,7 @@ object ProjectResource {
       ownerID: UInteger,
       creationTime: Timestamp,
       color: String,
-      writeAccess: Boolean
+      accessLevel: String
   )
 }
 
@@ -141,8 +141,7 @@ class ProjectResource {
         PROJECT.OWNER_ID,
         PROJECT.CREATION_TIME,
         PROJECT.COLOR,
-        case_()
-          .when(PROJECT_USER_ACCESS.PRIVILEGE.eq(ProjectUserAccessPrivilege.WRITE), "true")
+        PROJECT_USER_ACCESS.PRIVILEGE
       )
       .from(PROJECT)
       .leftJoin(PROJECT_USER_ACCESS)
@@ -221,7 +220,7 @@ class ProjectResource {
       .map(fileRecord =>
         DashboardFile(
           fileRecord.into(USER).getName,
-          fileRecord.into(USER_FILE_ACCESS).getPrivilege == UserFileAccessPrivilege.WRITE,
+          fileRecord.into(USER_FILE_ACCESS).getPrivilege.toString,
           fileRecord.into(FILE).into(classOf[File])
         )
       )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/project/ProjectResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/project/ProjectResource.scala
@@ -3,10 +3,7 @@ package edu.uci.ics.texera.web.resource.dashboard.user.project
 import edu.uci.ics.texera.web.SqlServer
 import edu.uci.ics.texera.web.auth.SessionUser
 import edu.uci.ics.texera.web.model.jooq.generated.Tables._
-import edu.uci.ics.texera.web.model.jooq.generated.enums.{
-  ProjectUserAccessPrivilege,
-  UserFileAccessPrivilege
-}
+import edu.uci.ics.texera.web.model.jooq.generated.enums.ProjectUserAccessPrivilege
 import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{
   FileOfProjectDao,
   ProjectDao,
@@ -21,7 +18,6 @@ import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowResource.
 
 import io.dropwizard.auth.Auth
 import org.apache.commons.lang3.StringUtils
-import org.jooq.impl.DSL.case_
 import org.jooq.types.UInteger
 import java.sql.Timestamp
 import java.util

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowAccessResource.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.texera.web.resource.dashboard.user.workflow
 
 import edu.uci.ics.texera.web.SqlServer
-import edu.uci.ics.texera.web.auth.SessionUser
 import edu.uci.ics.texera.web.model.common.AccessEntry
 import edu.uci.ics.texera.web.model.jooq.generated.Tables.{
   PROJECT_USER_ACCESS,
@@ -16,14 +15,9 @@ import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{
   WorkflowUserAccessDao
 }
 import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.WorkflowUserAccess
-import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowAccessResource.{
-  context,
-  hasWriteAccess
-}
-import io.dropwizard.auth.Auth
+import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowAccessResource.context
 import org.jooq.DSLContext
 import org.jooq.types.UInteger
-
 import java.util
 import javax.annotation.security.RolesAllowed
 import javax.ws.rs._
@@ -143,11 +137,7 @@ class WorkflowAccessResource() {
       @PathParam("wid") wid: UInteger,
       @PathParam("email") email: String,
       @PathParam("privilege") privilege: String,
-      @Auth user: SessionUser
   ): Unit = {
-    if (!hasWriteAccess(wid, user.getUid)) {
-      throw new ForbiddenException("No sufficient access privilege.")
-    }
     workflowUserAccessDao.merge(
       new WorkflowUserAccess(
         userDao.fetchOneByEmail(email).getUid,
@@ -169,11 +159,7 @@ class WorkflowAccessResource() {
   def revokeAccess(
       @PathParam("wid") wid: UInteger,
       @PathParam("email") email: String,
-      @Auth user: SessionUser
   ): Unit = {
-    if (!hasWriteAccess(wid, user.getUid)) {
-      throw new ForbiddenException("No sufficient access privilege.")
-    }
     context
       .delete(WORKFLOW_USER_ACCESS)
       .where(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowAccessResource.scala
@@ -98,8 +98,7 @@ class WorkflowAccessResource() {
   @GET
   @Path("/owner/{wid}")
   def getOwner(@PathParam("wid") wid: UInteger): String = {
-    val uid = workflowOfUserDao.fetchByWid(wid).get(0).getUid
-    userDao.fetchOneByUid(uid).getEmail
+    userDao.fetchOneByUid(workflowOfUserDao.fetchByWid(wid).get(0).getUid).getEmail
   }
 
   /**
@@ -112,7 +111,6 @@ class WorkflowAccessResource() {
   @Path("/list/{wid}")
   def getAccessList(
       @PathParam("wid") wid: UInteger,
-      @Auth sessionUser: SessionUser
   ): util.List[AccessEntry] = {
     context
       .select(
@@ -126,7 +124,7 @@ class WorkflowAccessResource() {
       .where(
         WORKFLOW_USER_ACCESS.WID
           .eq(wid)
-          .and(WORKFLOW_USER_ACCESS.UID.notEqual(sessionUser.getUser.getUid))
+          .and(WORKFLOW_USER_ACCESS.UID.notEqual(workflowOfUserDao.fetchByWid(wid).get(0).getUid))
       )
       .fetchInto(classOf[AccessEntry])
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowAccessResource.scala
@@ -136,7 +136,7 @@ class WorkflowAccessResource() {
   def grantAccess(
       @PathParam("wid") wid: UInteger,
       @PathParam("email") email: String,
-      @PathParam("privilege") privilege: String,
+      @PathParam("privilege") privilege: String
   ): Unit = {
     workflowUserAccessDao.merge(
       new WorkflowUserAccess(
@@ -158,7 +158,7 @@ class WorkflowAccessResource() {
   @Path("/revoke/{wid}/{email}")
   def revokeAccess(
       @PathParam("wid") wid: UInteger,
-      @PathParam("email") email: String,
+      @PathParam("email") email: String
   ): Unit = {
     context
       .delete(WORKFLOW_USER_ACCESS)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowAccessResource.scala
@@ -110,7 +110,7 @@ class WorkflowAccessResource() {
   @GET
   @Path("/list/{wid}")
   def getAccessList(
-      @PathParam("wid") wid: UInteger,
+      @PathParam("wid") wid: UInteger
   ): util.List[AccessEntry] = {
     context
       .select(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
@@ -242,7 +242,7 @@ class WorkflowResource {
     * @return WorkflowID[]
     */
   @GET
-  @Path("/userWorkflowIDs")
+  @Path("/user-workflow-ids")
   def retrieveIDs(@Auth user: SessionUser): util.List[String] = {
     context
       .select(WORKFLOW_USER_ACCESS.WID)
@@ -257,7 +257,7 @@ class WorkflowResource {
     * @return OwnerName[]
     */
   @GET
-  @Path("/userWorkflowOwners")
+  @Path("/user-workflow-owners")
   def retrieveOwners(@Auth user: SessionUser): util.List[String] = {
     context
       .selectDistinct(USER.EMAIL)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
@@ -232,6 +232,7 @@ object WorkflowResource {
 
 }
 @Produces(Array(MediaType.APPLICATION_JSON))
+@RolesAllowed(Array("REGULAR", "ADMIN"))
 @Path("/workflow")
 class WorkflowResource {
 
@@ -241,8 +242,7 @@ class WorkflowResource {
     * @return WorkflowID[]
     */
   @GET
-  @Path("/workflow-ids")
-  @RolesAllowed(Array("REGULAR", "ADMIN"))
+  @Path("/userWorkflowIDs")
   def retrieveIDs(@Auth user: SessionUser): util.List[String] = {
     context
       .select(WORKFLOW_USER_ACCESS.WID)
@@ -257,8 +257,7 @@ class WorkflowResource {
     * @return OwnerName[]
     */
   @GET
-  @Path("/owners")
-  @RolesAllowed(Array("REGULAR", "ADMIN"))
+  @Path("/userWorkflowOwners")
   def retrieveOwners(@Auth user: SessionUser): util.List[String] = {
     context
       .selectDistinct(USER.EMAIL)
@@ -278,7 +277,6 @@ class WorkflowResource {
     */
   @GET
   @Path("/search-by-operators")
-  @RolesAllowed(Array("REGULAR", "ADMIN"))
   def searchWorkflowByOperator(
       @QueryParam("operator") operator: String,
       @Auth sessionUser: SessionUser
@@ -330,7 +328,6 @@ class WorkflowResource {
     */
   @GET
   @Path("/list")
-  @RolesAllowed(Array("REGULAR", "ADMIN"))
   def retrieveWorkflowsBySessionUser(
       @Auth sessionUser: SessionUser
   ): List[DashboardWorkflow] = {
@@ -388,7 +385,6 @@ class WorkflowResource {
     */
   @GET
   @Path("/{wid}")
-  @RolesAllowed(Array("REGULAR", "ADMIN"))
   def retrieveWorkflow(
       @PathParam("wid") wid: UInteger,
       @Auth sessionUser: SessionUser
@@ -413,7 +409,6 @@ class WorkflowResource {
   @POST
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Path("/persist")
-  @RolesAllowed(Array("REGULAR", "ADMIN"))
   def persistWorkflow(workflow: Workflow, @Auth sessionUser: SessionUser): Workflow = {
     val user = sessionUser.getUser
 
@@ -448,7 +443,6 @@ class WorkflowResource {
   @POST
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Path("/duplicate")
-  @RolesAllowed(Array("REGULAR", "ADMIN"))
   def duplicateWorkflow(
       workflow: Workflow,
       @Auth sessionUser: SessionUser
@@ -487,7 +481,6 @@ class WorkflowResource {
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Produces(Array(MediaType.APPLICATION_JSON))
   @Path("/create")
-  @RolesAllowed(Array("REGULAR", "ADMIN"))
   def createWorkflow(workflow: Workflow, @Auth sessionUser: SessionUser): DashboardWorkflow = {
     val user = sessionUser.getUser
     if (workflow.getWid != null) {
@@ -513,7 +506,6 @@ class WorkflowResource {
     */
   @DELETE
   @Path("/{wid}")
-  @RolesAllowed(Array("REGULAR", "ADMIN"))
   def deleteWorkflow(@PathParam("wid") wid: UInteger, @Auth sessionUser: SessionUser): Unit = {
     val user = sessionUser.getUser
     if (workflowOfUserExists(wid, user.getUid)) {
@@ -532,7 +524,6 @@ class WorkflowResource {
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Produces(Array(MediaType.APPLICATION_JSON))
   @Path("/update/name")
-  @RolesAllowed(Array("REGULAR", "ADMIN"))
   def updateWorkflowName(
       workflow: Workflow,
       @Auth sessionUser: SessionUser

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
@@ -4,7 +4,11 @@ import edu.uci.ics.texera.web.SqlServer
 import edu.uci.ics.texera.web.auth.SessionUser
 import edu.uci.ics.texera.web.model.jooq.generated.Tables._
 import edu.uci.ics.texera.web.model.jooq.generated.enums.WorkflowUserAccessPrivilege
-import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{WorkflowDao, WorkflowOfUserDao, WorkflowUserAccessDao}
+import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{
+  WorkflowDao,
+  WorkflowOfUserDao,
+  WorkflowUserAccessDao
+}
 import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos._
 import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowResource._
 import io.dropwizard.auth.Auth

--- a/core/new-gui/src/app/common/service/workflow-persist/workflow-persist.service.ts
+++ b/core/new-gui/src/app/common/service/workflow-persist/workflow-persist.service.ts
@@ -17,9 +17,8 @@ export const WORKFLOW_CREATE_URL = WORKFLOW_BASE_URL + "/create";
 export const WORKFLOW_DUPLICATE_URL = WORKFLOW_BASE_URL + "/duplicate";
 export const WORKFLOW_UPDATENAME_URL = WORKFLOW_BASE_URL + "/update/name";
 export const WORKFLOW_UPDATEDESCRIPTION_URL = WORKFLOW_BASE_URL + "/update/description";
-export const WORKFLOW_OPERATOR_URL = WORKFLOW_BASE_URL + "/search-by-operators";
-export const WORKFLOW_OWNER_URL = WORKFLOW_BASE_URL + "/owners";
-export const WORKFLOW_ID_URL = WORKFLOW_BASE_URL + "/workflow-ids";
+export const WORKFLOW_OWNER_URL = WORKFLOW_BASE_URL + "/userWorkflowOwners";
+export const WORKFLOW_ID_URL = WORKFLOW_BASE_URL + "/userWorkflowIDs";
 
 export const DEFAULT_WORKFLOW_NAME = "Untitled workflow";
 

--- a/core/new-gui/src/app/common/service/workflow-persist/workflow-persist.service.ts
+++ b/core/new-gui/src/app/common/service/workflow-persist/workflow-persist.service.ts
@@ -17,8 +17,8 @@ export const WORKFLOW_CREATE_URL = WORKFLOW_BASE_URL + "/create";
 export const WORKFLOW_DUPLICATE_URL = WORKFLOW_BASE_URL + "/duplicate";
 export const WORKFLOW_UPDATENAME_URL = WORKFLOW_BASE_URL + "/update/name";
 export const WORKFLOW_UPDATEDESCRIPTION_URL = WORKFLOW_BASE_URL + "/update/description";
-export const WORKFLOW_OWNER_URL = WORKFLOW_BASE_URL + "/userWorkflowOwners";
-export const WORKFLOW_ID_URL = WORKFLOW_BASE_URL + "/userWorkflowIDs";
+export const WORKFLOW_OWNER_URL = WORKFLOW_BASE_URL + "/user-workflow-owners";
+export const WORKFLOW_ID_URL = WORKFLOW_BASE_URL + "/user-workflow-ids";
 
 export const DEFAULT_WORKFLOW_NAME = "Untitled workflow";
 

--- a/core/new-gui/src/app/dashboard/user/component/share-access/share-access.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/share-access/share-access.component.html
@@ -51,7 +51,7 @@
         <div
           nz-col
           [nzSpan]="24">
-          <nz-card nzTitle="Share">
+            <nz-card nzTitle="Share">
             <div style="height: 50px">
               Access Level:
               <select formControlName="accessLevel">

--- a/core/new-gui/src/app/dashboard/user/component/share-access/share-access.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/share-access/share-access.component.html
@@ -60,6 +60,7 @@
               </select>
             </div>
             <button
+              [disabled]="!writeAccess"
               style="width: 100%"
               nz-button
               nzType="primary"
@@ -92,6 +93,7 @@
       {{ entry.email }} ({{ entry.name }})
       <span class="badge badge-primary">{{ entry.privilege }}</span>
       <button
+        [disabled]="!writeAccess && entry.email !== currentEmail"
         (click)="revokeAccess(entry.email)"
         nz-button
         nz-tooltip="revoke access"

--- a/core/new-gui/src/app/dashboard/user/component/share-access/share-access.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/share-access/share-access.component.html
@@ -51,7 +51,7 @@
         <div
           nz-col
           [nzSpan]="24">
-            <nz-card nzTitle="Share">
+          <nz-card nzTitle="Share">
             <div style="height: 50px">
               Access Level:
               <select formControlName="accessLevel">

--- a/core/new-gui/src/app/dashboard/user/component/share-access/share-access.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/user/component/share-access/share-access.component.spec.ts
@@ -4,6 +4,8 @@ import { HttpClient, HttpHandler } from "@angular/common/http";
 import { ShareAccessService } from "../../service/share-access/share-access.service";
 import { NgbActiveModal } from "@ng-bootstrap/ng-bootstrap";
 import { ShareAccessComponent } from "./share-access.component";
+import { UserService } from "../../../../common/service/user/user.service";
+import { StubUserService } from "../../../../common/service/user/stub-user.service";
 
 describe("NgbdModalShareAccessComponent", () => {
   let component: ShareAccessComponent;
@@ -14,6 +16,7 @@ describe("NgbdModalShareAccessComponent", () => {
       imports: [ReactiveFormsModule, FormsModule],
       declarations: [ShareAccessComponent],
       providers: [
+        { provide: UserService, useClass: StubUserService },
         NgbActiveModal,
         HttpClient,
         HttpHandler,

--- a/core/new-gui/src/app/dashboard/user/component/share-access/share-access.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/share-access/share-access.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, Validators } from "@angular/forms";
 import { ShareAccessService } from "../../service/share-access/share-access.service";
 import { ShareAccess } from "../../type/share-access.interface";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
+import { UserService } from "../../../../common/service/user/user.service";
 
 @UntilDestroy()
 @Component({
@@ -12,6 +13,7 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
   providers: [{ provide: "type", useValue: "workflow" }],
 })
 export class ShareAccessComponent implements OnInit {
+  @Input() writeAccess!: boolean;
   @Input() type!: string;
   @Input() id!: number;
   @Input() allOwners!: string[];
@@ -25,11 +27,15 @@ export class ShareAccessComponent implements OnInit {
   public owner: string = "";
   public filteredOwners: Array<string> = [];
   public ownerSearchValue?: string;
+  currentEmail: string | undefined = "";
   constructor(
     public activeModal: NgbActiveModal,
     private accessService: ShareAccessService,
-    private formBuilder: FormBuilder
-  ) {}
+    private formBuilder: FormBuilder,
+    private userService: UserService
+  ) {
+    this.currentEmail = this.userService.getCurrentUser()?.email;
+  }
 
   ngOnInit(): void {
     this.accessService

--- a/core/new-gui/src/app/dashboard/user/component/user-dashboard-test-fixtures.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-dashboard-test-fixtures.ts
@@ -159,7 +159,7 @@ export const testWorkflowEntries: DashboardEntry[] = [
 ];
 
 export const testUserProjects: DashboardProject[] = [
-  { pid: 1, name: "Project1", description: "p1", ownerID: 1, color: "#ffffff", creationTime: 0, writeAccess: true },
-  { pid: 2, name: "Project2", description: "p1", ownerID: 1, color: "#ffffff", creationTime: 0, writeAccess: true },
-  { pid: 3, name: "Project3", description: "p1", ownerID: 1, color: "#ffffff", creationTime: 0, writeAccess: true },
+  { pid: 1, name: "Project1", description: "p1", ownerID: 1, color: "#ffffff", creationTime: 0, accessLevel: "WRITE" },
+  { pid: 2, name: "Project2", description: "p1", ownerID: 1, color: "#ffffff", creationTime: 0, accessLevel: "WRITE" },
+  { pid: 3, name: "Project3", description: "p1", ownerID: 1, color: "#ffffff", creationTime: 0, accessLevel: "WRITE" },
 ];

--- a/core/new-gui/src/app/dashboard/user/component/user-dashboard-test-fixtures.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-dashboard-test-fixtures.ts
@@ -159,7 +159,7 @@ export const testWorkflowEntries: DashboardEntry[] = [
 ];
 
 export const testUserProjects: DashboardProject[] = [
-  { pid: 1, name: "Project1", description: "p1", ownerID: 1, color: "#ffffff", creationTime: 0 },
-  { pid: 2, name: "Project2", description: "p1", ownerID: 1, color: "#ffffff", creationTime: 0 },
-  { pid: 3, name: "Project3", description: "p1", ownerID: 1, color: "#ffffff", creationTime: 0 },
+  { pid: 1, name: "Project1", description: "p1", ownerID: 1, color: "#ffffff", creationTime: 0, writeAccess: true },
+  { pid: 2, name: "Project2", description: "p1", ownerID: 1, color: "#ffffff", creationTime: 0, writeAccess: true },
+  { pid: 3, name: "Project3", description: "p1", ownerID: 1, color: "#ffffff", creationTime: 0, writeAccess: true },
 ];

--- a/core/new-gui/src/app/dashboard/user/component/user-file/user-file-list-item/user-file-list-item.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-file/user-file-list-item/user-file-list-item.component.html
@@ -20,7 +20,6 @@
           (click)="editingName = true"
           nz-button
           nz-tooltip="Customize File Name"
-          title="Customize File Name"
           nzSize="small"
           nzTooltipPlacement="bottom"
           nzType="text">
@@ -35,7 +34,6 @@
           class="add-description-btn"
           nz-button
           nz-tooltip="Add Description"
-          title="Add Description"
           nzSize="small"
           nzTooltipPlacement="bottom"
           nzType="text">
@@ -92,12 +90,9 @@
     <nz-list-item-action>
       <button
         (click)="onClickOpenShareAccess()"
-        [disabled]="entry.file.ownerUid !== uid"
+        [disabled]="!entry.writeAccess"
         nz-button
         nz-tooltip="Share the file {{
-                      entry.file.name
-                  }} to others"
-        title="Share the file {{
                       entry.file.name
                   }} to others"
         nzTooltipPlacement="bottom"
@@ -117,9 +112,6 @@
         nz-tooltip="Delete the file {{
                       entry.file.name
                   }}"
-        title="Delete the file {{
-                      entry.file.name
-                  }}"
         nzPopconfirmTitle="Confirm to delete this file."
         nzTooltipPlacement="bottom"
         type="button">
@@ -134,7 +126,6 @@
         (click)="downloadFile()"
         nz-button
         nz-tooltip="Download the {{ entry.file.name }}"
-        title="Download the {{ entry.file.name }}"
         nzTooltipPlacement="bottom">
         <i
           nz-icon

--- a/core/new-gui/src/app/dashboard/user/component/user-file/user-file-list-item/user-file-list-item.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-file/user-file-list-item/user-file-list-item.component.html
@@ -105,7 +105,7 @@
     <nz-list-item-action *ngIf="editable">
       <button
         (nzOnConfirm)="deleted.emit()"
-        [disabled]="!entry.writeAccess"
+        [disabled]="entry.accessLevel==='READ'"
         nz-button
         nz-popconfirm
         nz-tooltip="Delete the file {{

--- a/core/new-gui/src/app/dashboard/user/component/user-file/user-file-list-item/user-file-list-item.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-file/user-file-list-item/user-file-list-item.component.html
@@ -90,7 +90,6 @@
     <nz-list-item-action>
       <button
         (click)="onClickOpenShareAccess()"
-        [disabled]="!entry.writeAccess"
         nz-button
         nz-tooltip="Share the file {{
                       entry.file.name

--- a/core/new-gui/src/app/dashboard/user/component/user-file/user-file-list-item/user-file-list-item.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-file/user-file-list-item/user-file-list-item.component.ts
@@ -15,7 +15,7 @@ import { ShareAccessComponent } from "../../share-access/share-access.component"
 export class UserFileListItemComponent {
   private _entry?: DashboardFile = {
     ownerEmail: "jingchf@uci.edu",
-    writeAccess: true,
+    accessLevel: "WRITE",
     file: {
       ownerUid: 1,
       fid: 2,
@@ -87,7 +87,7 @@ export class UserFileListItemComponent {
 
   public onClickOpenShareAccess(): void {
     const modalRef = this.modalService.open(ShareAccessComponent);
-    modalRef.componentInstance.writeAccess = this.entry.writeAccess;
+    modalRef.componentInstance.writeAccess = this.entry.accessLevel === "WRITE";
     modalRef.componentInstance.type = "file";
     modalRef.componentInstance.id = this.entry.file.fid;
   }

--- a/core/new-gui/src/app/dashboard/user/component/user-file/user-file-list-item/user-file-list-item.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-file/user-file-list-item/user-file-list-item.component.ts
@@ -87,6 +87,7 @@ export class UserFileListItemComponent {
 
   public onClickOpenShareAccess(): void {
     const modalRef = this.modalService.open(ShareAccessComponent);
+    modalRef.componentInstance.writeAccess = this.entry.writeAccess;
     modalRef.componentInstance.type = "file";
     modalRef.componentInstance.id = this.entry.file.fid;
   }

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.html
@@ -44,7 +44,6 @@
           *ngIf="editable"
           (click)="editingName = true"
           nz-button
-          title="Edit Project Name"
           nz-tooltip="Edit Project Name"
           nzSize="small"
           nzTooltipPlacement="top"
@@ -59,7 +58,6 @@
           *ngIf="editable"
           (click)="editingDescription = true"
           nz-button
-          title="Add / Edit Description"
           nz-tooltip="Add / Edit Description"
           nzSize="small"
           nzTooltipPlacement="top"
@@ -74,7 +72,6 @@
           (click)="descriptionCollapsed = true"
           *ngIf="entry.description && entry.description?.trim() && !descriptionCollapsed"
           nz-button
-          title="Collapse Description"
           nz-tooltip="Collapse Description"
           nzSize="small"
           nzTooltipPlacement="top"
@@ -88,7 +85,6 @@
           (click)="descriptionCollapsed = false"
           *ngIf="entry.description && entry.description?.trim() && descriptionCollapsed"
           nz-button
-          title="Expand Description"
           nz-tooltip="Expand Description"
           nzSize="small"
           nzTooltipPlacement="top"
@@ -161,7 +157,7 @@
     <nz-list-item-action>
       <button
         (click)="onClickOpenShareAccess(entry.pid)"
-        [disabled]="entry.ownerID !== uid"
+        [disabled]="!entry.writeAccess"
         nz-button
         nz-tooltip="Share the project {{
 								entry.name
@@ -179,7 +175,6 @@
         (nzOnConfirm)="deleted.emit()"
         nz-button
         nz-popconfirm
-        title="Delete the project {{entry.name}}"
         nz-tooltip="Delete the project {{entry.name}}"
         nzPopconfirmTitle="Confirm to delete this project."
         nzTooltipPlacement="bottom">

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.html
@@ -156,8 +156,7 @@
     *ngIf="editable">
     <nz-list-item-action>
       <button
-        (click)="onClickOpenShareAccess(entry.pid)"
-        [disabled]="!entry.writeAccess"
+        (click)="onClickOpenShareAccess()"
         nz-button
         nz-tooltip="Share the project {{
 								entry.name

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.spec.ts
@@ -16,7 +16,7 @@ describe("UserProjectListItemComponent", () => {
     name: "project1",
     ownerID: 1,
     pid: 1,
-    writeAccess: true,
+    accessLevel: "WRITE",
   };
 
   beforeEach(async () => {

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.spec.ts
@@ -16,6 +16,7 @@ describe("UserProjectListItemComponent", () => {
     name: "project1",
     ownerID: 1,
     pid: 1,
+    writeAccess: true,
   };
 
   beforeEach(async () => {

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.ts
@@ -157,7 +157,7 @@ export class UserProjectListItemComponent implements OnInit {
    */
   public onClickOpenShareAccess(): void {
     const modalRef = this.modalService.open(ShareAccessComponent);
-    modalRef.componentInstance.writeAccess = this.entry.writeAccess;
+    modalRef.componentInstance.writeAccess = this.entry.accessLevel === "WRITE";
     modalRef.componentInstance.type = "project";
     modalRef.componentInstance.id = this.entry.pid;
   }

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-list-item/user-project-list-item.component.ts
@@ -155,9 +155,10 @@ export class UserProjectListItemComponent implements OnInit {
   /**
    * open the Modal based on the workflow clicked on
    */
-  public onClickOpenShareAccess(id: number): void {
+  public onClickOpenShareAccess(): void {
     const modalRef = this.modalService.open(ShareAccessComponent);
+    modalRef.componentInstance.writeAccess = this.entry.writeAccess;
     modalRef.componentInstance.type = "project";
-    modalRef.componentInstance.id = id;
+    modalRef.componentInstance.id = this.entry.pid;
   }
 }

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project-section/user-project-section.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project-section/user-project-section.component.html
@@ -148,9 +148,8 @@
           <nz-list-item-action>
             <button
               (click)="deleteUserFileEntry(file)"
-              [disabled]="!file.writeAccess"
+              [disabled]="file.accessLevel==='READ'"
               nz-button
-              title="Delete the file {{file.file.name}}"
               nz-tooltip="Delete the file {{file.file.name}}"
               nzTooltipPlacement="bottom"
               type="button">

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.ts
@@ -20,7 +20,6 @@ export class UserProjectComponent implements OnInit {
   // used to manage setting project colors
   public userProjectToColorInputIndexMap: Map<number, number> = new Map(); // maps each project to its color wheel input index, even after reordering / sorting of projects
   public userProjectInputColors: string[] = []; // stores the color wheel input for each project, each color string must start with '#'
-  public colorBrightnessMap: Map<number, boolean> = new Map(); // tracks brightness of each project's color, to make sure info remains visible against white background
   public colorInputToggleArray: boolean[] = []; // tracks which project's color wheel is toggled on or off
   public uid: number | undefined;
 

--- a/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-project/user-project.component.ts
@@ -16,11 +16,6 @@ export class UserProjectComponent implements OnInit {
   public userProjectEntries: DashboardProject[] = [];
   public createButtonIsClicked: boolean = false;
   public createProjectName: string = "";
-
-  // used to manage setting project colors
-  public userProjectToColorInputIndexMap: Map<number, number> = new Map(); // maps each project to its color wheel input index, even after reordering / sorting of projects
-  public userProjectInputColors: string[] = []; // stores the color wheel input for each project, each color string must start with '#'
-  public colorInputToggleArray: boolean[] = []; // tracks which project's color wheel is toggled on or off
   public uid: number | undefined;
 
   constructor(
@@ -36,9 +31,6 @@ export class UserProjectComponent implements OnInit {
   }
 
   public deleteProject(pid: number): void {
-    if (pid == undefined) {
-      throw new Error("pid is undefined in deleteProject().");
-    }
     this.userProjectService
       .deleteProject(pid)
       .pipe(untilDestroyed(this))
@@ -59,24 +51,8 @@ export class UserProjectComponent implements OnInit {
       this.userProjectService
         .createProject(this.createProjectName)
         .pipe(untilDestroyed(this))
-        .subscribe({
-          next: createdProject => {
-            this.userProjectEntries.push(createdProject); // update local list of projects
-
-            // add color wheel input record for the newly created, colorless project
-            this.userProjectToColorInputIndexMap.set(createdProject.pid, this.userProjectEntries.length - 1);
-            this.userProjectInputColors.push("#ffffff");
-            this.colorInputToggleArray.push(false);
-
-            this.unclickCreateButton();
-          },
-          error: (err: unknown) => {
-            // @ts-ignore
-            this.notificationService.error(err.error.message);
-          },
-        });
+        .subscribe(() => this.getUserProjectArray());
     } else {
-      // show error message and don't call backend
       this.notificationService.error(
         `Cannot create project named: "${this.createProjectName}".  It must be a non-empty, unique name`
       );

--- a/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow-list-item/user-workflow-list-item.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow-list-item/user-workflow-list-item.component.html
@@ -37,7 +37,6 @@
           (click)="editingName = true"
           nz-button
           mat-card-title="Customize Workflow Name"
-          title="Customize Workflow Name"
           nz-tooltip="Customize Workflow Name"
           nzSize="small"
           nzTooltipPlacement="bottom"
@@ -51,7 +50,6 @@
           *ngIf="editable"
           (click)="editingDescription = true"
           nz-button
-          title="Add Description"
           nz-tooltip="Add Description"
           nzSize="small"
           nzTooltipPlacement="bottom"
@@ -65,15 +63,17 @@
         <i
           class="workflow-is-owner-icon"
           *ngIf="entry.workflow.isOwner"
-          ngbTooltip="You are the owner"
+          nz-tooltip="You are the owner"
+          nzTooltipPlacement="bottom"
           nz-icon
           nzTheme="outline"
           nzType="user"></i>
         <i
           *ngIf="!entry.workflow.isOwner"
-          ngbTooltip="{{
+          nz-tooltip="{{
                           entry.workflow.accessLevel
                       }} access shared by {{ entry.workflow.ownerName }}"
+          nzTooltipPlacement="bottom"
           nz-icon
           nzTheme="outline"
           nzType="team"></i>
@@ -142,11 +142,8 @@
     <nz-list-item-action>
       <button
         (click)="onClickOpenShareAccess()"
-        [disabled]="!entry.workflow.isOwner"
+        [disabled]="entry.workflow.accessLevel==='READ'"
         nz-button
-        title="Share the workflow {{
-                      workflow.name
-                  }} to others"
         nz-tooltip="Share the workflow {{
                       workflow.name
                   }} to others"
@@ -163,9 +160,6 @@
         (click)="duplicated.emit()"
         class="duplicate-workflow-btn"
         nz-button
-        title="Duplicate the workflow {{
-                      workflow.name
-                  }}"
         nz-tooltip="Duplicate the workflow {{
                       workflow.name
                   }}"
@@ -181,9 +175,6 @@
       <button
         (click)="onClickDownloadWorkfllow()"
         nz-button
-        title="Download the workflow {{
-                      workflow.name
-                  }}"
         nz-tooltip="Download the workflow {{
                       workflow.name
                   }}"
@@ -203,9 +194,6 @@
         [disabled]="!entry.workflow.isOwner"
         class="delete-workflow-btn"
         nz-button
-        title="Delete the workflow {{
-                      workflow.name
-                  }}"
         nz-tooltip="Delete the workflow {{
                       workflow.name
                   }}"
@@ -220,9 +208,6 @@
       <button
         (click)="onClickGetWorkflowExecutions()"
         nz-button
-        title="Executions of the workflow {{
-                      workflow.name
-                  }}"
         nz-tooltip="Executions of the workflow {{
                       workflow.name
                   }}"

--- a/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow-list-item/user-workflow-list-item.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow-list-item/user-workflow-list-item.component.html
@@ -142,7 +142,6 @@
     <nz-list-item-action>
       <button
         (click)="onClickOpenShareAccess()"
-        [disabled]="entry.workflow.accessLevel==='READ'"
         nz-button
         nz-tooltip="Share the workflow {{
                       workflow.name

--- a/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow-list-item/user-workflow-list-item.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow-list-item/user-workflow-list-item.component.ts
@@ -114,6 +114,7 @@ export class UserWorkflowListItemComponent {
   public async onClickOpenShareAccess(): Promise<void> {
     const owners = await firstValueFrom(this.workflowPersistService.retrieveOwners());
     const modalRef = this.modalService.open(ShareAccessComponent);
+    modalRef.componentInstance.writeAccess = this.entry.workflow.accessLevel === "WRITE";
     modalRef.componentInstance.type = "workflow";
     modalRef.componentInstance.id = this.workflow.wid;
     modalRef.componentInstance.allOwners = owners;

--- a/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
@@ -1,16 +1,12 @@
 import {
   AfterViewInit,
   Component,
-  EventEmitter,
   Input,
-  OnChanges,
-  Output,
-  SimpleChanges,
   ViewChild,
 } from "@angular/core";
 import { Router } from "@angular/router";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
-import { firstValueFrom, map } from "rxjs";
+import { firstValueFrom } from "rxjs";
 import {
   DEFAULT_WORKFLOW_NAME,
   WorkflowPersistService,
@@ -34,9 +30,6 @@ import { SortMethod } from "../../type/sort-method";
 import { isDefined } from "../../../../common/util/predicate";
 
 export const ROUTER_WORKFLOW_CREATE_NEW_URL = "/";
-
-export const WORKFLOW_BASE_URL = "workflow";
-
 /**
  * Saved-workflow-section component contains information and functionality
  * of the saved workflows section and is re-used in the user projects section when a project is clicked
@@ -96,18 +89,6 @@ export class UserWorkflowComponent implements AfterViewInit {
   @Input() public pid?: number = undefined;
   public sortMethod = SortMethod.EditTimeDesc;
   lastSortMethod: SortMethod | null = null;
-  public dashboardWorkflowEntriesIsEditingName: number[] = [];
-  public owners = this.workflowPersistService.retrieveOwners().pipe(
-    map((owners: string[]) => {
-      return owners.map((user: string) => {
-        return {
-          userName: user,
-          checked: false,
-        };
-      });
-    })
-  );
-  public projectFilterList: number[] = []; // for filter by project mode, track which projects are selected
 
   constructor(
     private userService: UserService,

--- a/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
@@ -1,9 +1,4 @@
-import {
-  AfterViewInit,
-  Component,
-  Input,
-  ViewChild,
-} from "@angular/core";
+import { AfterViewInit, Component, Input, ViewChild } from "@angular/core";
 import { Router } from "@angular/router";
 import { NgbModal } from "@ng-bootstrap/ng-bootstrap";
 import { firstValueFrom } from "rxjs";

--- a/core/new-gui/src/app/dashboard/user/type/dashboard-file.interface.ts
+++ b/core/new-gui/src/app/dashboard/user/type/dashboard-file.interface.ts
@@ -1,7 +1,7 @@
 export interface DashboardFile
   extends Readonly<{
     ownerEmail: string;
-    writeAccess: boolean;
+    accessLevel: string;
     file: UserFile;
   }> {}
 

--- a/core/new-gui/src/app/dashboard/user/type/dashboard-project.interface.ts
+++ b/core/new-gui/src/app/dashboard/user/type/dashboard-project.interface.ts
@@ -5,4 +5,5 @@ export interface DashboardProject {
   ownerID: number;
   creationTime: number;
   color: string | null;
+  writeAccess: boolean;
 }

--- a/core/new-gui/src/app/dashboard/user/type/dashboard-project.interface.ts
+++ b/core/new-gui/src/app/dashboard/user/type/dashboard-project.interface.ts
@@ -5,5 +5,5 @@ export interface DashboardProject {
   ownerID: number;
   creationTime: number;
   color: string | null;
-  writeAccess: boolean;
+  accessLevel: string;
 }

--- a/core/new-gui/src/app/dashboard/user/type/dashboard-workflow.interface.ts
+++ b/core/new-gui/src/app/dashboard/user/type/dashboard-workflow.interface.ts
@@ -2,8 +2,8 @@ import { Workflow } from "../../../common/type/workflow";
 
 export interface DashboardWorkflow {
   isOwner: boolean;
-  accessLevel: string;
   ownerName: string | undefined;
   workflow: Workflow;
   projectIDs: number[];
+  accessLevel: string;
 }


### PR DESCRIPTION
In this PR

1. Allows users to cascade the sharing.
For example, User **A** shared a workflow with user **B**, and user **B** can share the same workflow with User **C**.
The same logic is applied to workflow, files, and projects. Resolve issue #2035

2. Some mirror refactoring.

3. Fix the UI bug because the top bar blocks the first workflow's owner information.
<img width="502" alt="image" src="https://github.com/Texera/texera/assets/11544314/2f325902-a81c-4d82-9cc5-431ef31c1856">

4. People can revoke the resources shared with them.

