### PR TITLE
Expose worker id to python

### DIFF
--- a/core/amber/src/main/python/core/architecture/managers/context.py
+++ b/core/amber/src/main/python/core/architecture/managers/context.py
@@ -20,7 +20,8 @@ class Context:
     Context class can be viewed as a friend of DataProcessor.
     """
 
-    def __init__(self, main_loop):
+    def __init__(self, worker_id, main_loop):
+        self.worker_id = worker_id
         self.main_loop = main_loop
         self.input_queue = main_loop._input_queue
         self.operator_manager = OperatorManager()

--- a/core/amber/src/main/python/core/python_worker.py
+++ b/core/amber/src/main/python/core/python_worker.py
@@ -8,7 +8,7 @@ from core.util.stoppable.stoppable import Stoppable
 
 
 class PythonWorker(Runnable, Stoppable):
-    def __init__(self, host: str, output_port: int):
+    def __init__(self, worker_id: str, host: str, output_port: int):
         self._input_queue = InternalQueue()
         self._output_queue = InternalQueue()
         # start the server
@@ -21,7 +21,7 @@ class PythonWorker(Runnable, Stoppable):
             handshake_port=self._network_receiver.proxy_server.get_port_number(),
         )
 
-        self._main_loop = MainLoop(self._input_queue, self._output_queue)
+        self._main_loop = MainLoop(worker_id, self._input_queue, self._output_queue)
         self._network_receiver.register_shutdown(self.stop)
 
     @overrides

--- a/core/amber/src/main/python/core/runnables/main_loop.py
+++ b/core/amber/src/main/python/core/runnables/main_loop.py
@@ -41,13 +41,13 @@ from proto.edu.uci.ics.amber.engine.common import (
 
 
 class MainLoop(StoppableQueueBlockingRunnable):
-    def __init__(self, input_queue: InternalQueue, output_queue: InternalQueue):
+    def __init__(self, worker_id: str, input_queue: InternalQueue, output_queue:
+    InternalQueue):
         super().__init__(self.__class__.__name__, queue=input_queue)
-
         self._input_queue: InternalQueue = input_queue
         self._output_queue: InternalQueue = output_queue
 
-        self.context = Context(self)
+        self.context = Context(worker_id, self)
         self._async_rpc_server = AsyncRPCServer(output_queue, context=self.context)
         self._async_rpc_client = AsyncRPCClient(output_queue, context=self.context)
 

--- a/core/amber/src/main/python/core/runnables/main_loop.py
+++ b/core/amber/src/main/python/core/runnables/main_loop.py
@@ -41,8 +41,9 @@ from proto.edu.uci.ics.amber.engine.common import (
 
 
 class MainLoop(StoppableQueueBlockingRunnable):
-    def __init__(self, worker_id: str, input_queue: InternalQueue, output_queue:
-    InternalQueue):
+    def __init__(
+        self, worker_id: str, input_queue: InternalQueue, output_queue: InternalQueue
+    ):
         super().__init__(self.__class__.__name__, queue=input_queue)
         self._input_queue: InternalQueue = input_queue
         self._output_queue: InternalQueue = output_queue

--- a/core/amber/src/main/python/core/runnables/test_main_loop.py
+++ b/core/amber/src/main/python/core/runnables/test_main_loop.py
@@ -242,7 +242,7 @@ class TestMainLoop:
 
     @pytest.fixture
     def main_loop(self, input_queue, output_queue, mock_link):
-        main_loop = MainLoop(input_queue, output_queue)
+        main_loop = MainLoop("dummy_worker_id", input_queue, output_queue)
         yield main_loop
         main_loop.stop()
 

--- a/core/amber/src/main/python/texera_run_python_worker.py
+++ b/core/amber/src/main/python/texera_run_python_worker.py
@@ -22,6 +22,8 @@ def init_loguru_logger(stream_log_level) -> None:
 
 
 if __name__ == "__main__":
-    init_loguru_logger(sys.argv[2])
+    _, worker_id, output_port, logger_level = sys.argv
+    init_loguru_logger(logger_level)
 
-    PythonWorker(host="localhost", output_port=int(sys.argv[1])).run()
+    PythonWorker(worker_id=worker_id, host="localhost", output_port=int(
+        output_port)).run()

--- a/core/amber/src/main/python/texera_run_python_worker.py
+++ b/core/amber/src/main/python/texera_run_python_worker.py
@@ -25,5 +25,6 @@ if __name__ == "__main__":
     _, worker_id, output_port, logger_level = sys.argv
     init_loguru_logger(logger_level)
 
-    PythonWorker(worker_id=worker_id, host="localhost", output_port=int(
-        output_port)).run()
+    PythonWorker(
+        worker_id=worker_id, host="localhost", output_port=int(output_port)
+    ).run()

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonWorkflowWorker.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonWorkflowWorker.scala
@@ -151,6 +151,7 @@ class PythonWorkflowWorker(
         else pythonENVPath, // add fall back in case of empty
         "-u",
         udfEntryScriptPath,
+        actorId.name,
         Integer.toString(pythonProxyServer.getPortNumber.get()),
         config.getString("python.log.streamHandler.level")
       )


### PR DESCRIPTION
This PR exposes the worker id through command line arguments to the Python engine. This information is bonded once and never changed. The Python engine can use this worker id to identify itself.