### PR TITLE
Fix cache source operator not flushing output to downstream operator

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/EpochManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/EpochManager.scala
@@ -26,7 +26,7 @@ class EpochManager(
 
     // check if the epoch marker is completed
     val sendersWithinScope = dp.upstreamLinkStatus.allUncompletedSenders.filter(sender =>
-      marker.scope.links.contains(dp.upstreamLinkStatus.upstreamMapReverse(sender))
+      marker.scope.links.contains(dp.upstreamLinkStatus.getInputLink(sender))
     )
     val epochMarkerCompleted = epochMarkerReceived(markerId) == sendersWithinScope
     if (epochMarkerCompleted) {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/UpstreamLinkStatus.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/UpstreamLinkStatus.scala
@@ -1,13 +1,19 @@
 package edu.uci.ics.amber.engine.architecture.worker
 
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecConfig
+import edu.uci.ics.amber.engine.common.virtualidentity.util.SOURCE_STARTER_OP
 import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LinkIdentity}
 
 import scala.collection.mutable
 
 class UpstreamLinkStatus(opExecConfig: OpExecConfig) {
 
-  val allUpstreamLinkIds: Set[LinkIdentity] = opExecConfig.inputToOrdinalMapping.keySet
+  private val allUpstreamLinkIds: Set[LinkIdentity] = {
+    if (opExecConfig.isSourceOperator)
+      Set(LinkIdentity(SOURCE_STARTER_OP, opExecConfig.id)) // special case for source operator
+    else
+      opExecConfig.inputToOrdinalMapping.keySet
+  }
 
   /**
     * The scheduler may not schedule the entire workflow at once. Consider a 2-phase hash join where the first
@@ -17,14 +23,18 @@ class UpstreamLinkStatus(opExecConfig: OpExecConfig) {
     * the build part completes. Therefore, we have a `allUpstreamLinkIds` to track the number of actual upstream
     * links that a worker receives data from.
     */
-  val upstreamMap =
+  private val upstreamMap =
     new mutable.HashMap[LinkIdentity, Set[ActorVirtualIdentity]].withDefaultValue(Set())
-  val upstreamMapReverse =
+  private val upstreamMapReverse =
     new mutable.HashMap[ActorVirtualIdentity, LinkIdentity]
   private val endReceivedFromWorkers = new mutable.HashSet[ActorVirtualIdentity]
   private val completedLinkIds = new mutable.HashSet[LinkIdentity]()
 
   def registerInput(identifier: ActorVirtualIdentity, input: LinkIdentity): Unit = {
+    assert(
+      allUpstreamLinkIds.contains(input),
+      "unexpected input link " + input + " for operator " + opExecConfig.id
+    )
     upstreamMap.update(input, upstreamMap(input) + identifier)
     upstreamMapReverse.update(identifier, input)
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
@@ -234,17 +234,6 @@ case class LogicalPlan(
           o.operatorInfo.outputPorts
       )
 
-      // special case for source operators, add an input port from a virtual operator
-      val sourceOps = ops.operators
-        .filter(op => op.isSourceOperator)
-        .map(op =>
-          op.copy(
-            inputPorts = List(InputPort()),
-            inputToOrdinalMapping = Map(LinkIdentity(SOURCE_STARTER_OP, op.id) -> 0)
-          )
-        )
-      sourceOps.foreach(op => ops = ops.setOperator(op))
-
       // add all physical operators to physical DAG
       ops.operators.foreach(op => physicalPlan = physicalPlan.addOperator(op))
       // connect intra-operator links

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
@@ -1,11 +1,9 @@
 package edu.uci.ics.texera.workflow.common.workflow
 
 import com.google.common.base.Verify
-import edu.uci.ics.amber.engine.common.virtualidentity.util.SOURCE_STARTER_OP
-import edu.uci.ics.amber.engine.common.virtualidentity.{LinkIdentity, OperatorIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.OperatorIdentity
 import edu.uci.ics.texera.web.model.websocket.request.LogicalPlanPojo
 import edu.uci.ics.texera.workflow.common.WorkflowContext
-import edu.uci.ics.texera.workflow.common.metadata.InputPort
 import edu.uci.ics.texera.workflow.common.operators.OperatorDescriptor
 import edu.uci.ics.texera.workflow.common.operators.source.SourceOperatorDescriptor
 import edu.uci.ics.texera.workflow.common.storage.OpResultStorage


### PR DESCRIPTION
This PR fixes a bug where the cache source operator does not flush the output tuples to the downstream operator. This bug  causes a self join cannot be run, as a self join relies on a cache source to read materialization results. 

The cause of the bug is because the source operators has a special input link from a dummy operator to kick start the execution of the source. This special input link must be properly set to make sure `isAllEOF` returns true, which means the engine thinks that the input is exhausted and flush the result. The bug is that the compiler forgot to set the special link for cache source operator.

This PR fixes the bug by uniformly handling this special link at the engine level, instead of at the compiler level. All source operators will be automatically added this special link inside the engine.