### PR TITLE
Remove unreachable worker nodes and enable auto-restart of worker

### DIFF
--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -35,7 +35,7 @@ PB.generate / excludeFilter := "scalapb.proto"
 
 /////////////////////////////////////////////////////////////////////////////
 // Akka related
-val akkaVersion = "2.6.12"
+val akkaVersion = "2.8.3"
 val akkaDependencies = Seq(
   "com.typesafe.akka" %% "akka-actor" % akkaVersion,
   "com.typesafe.akka" %% "akka-remote" % akkaVersion,

--- a/core/amber/src/main/resources/cluster.conf
+++ b/core/amber/src/main/resources/cluster.conf
@@ -45,7 +45,8 @@ akka {
         # auto downing is NOT safe for production deployments.
         # you may want to use it during development, read more about it in the docs.
         auto-down-unreachable-after = off
-        unreachable-nodes-reaper-interval = 100s
+        downing-provider-class = "akka.cluster.sbr.SplitBrainResolverProvider"
+        unreachable-nodes-reaper-interval = 5s
         gossip-interval = 10s
         leader-actions-interval = 10s
         gossip-time-to-live = 20s

--- a/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
@@ -47,7 +47,7 @@ class ClusterListener extends Actor with AmberLogging {
       .map(_.address)
   }
 
-  private def forcefullyStop(jobService:WorkflowJobService, cause:Throwable): Unit ={
+  private def forcefullyStop(jobService: WorkflowJobService, cause: Throwable): Unit = {
     jobService.client.shutdown()
     jobService.stateStore.statsStore.updateState(stats =>
       stats.withEndTimeStamp(System.currentTimeMillis())
@@ -65,8 +65,10 @@ class ClusterListener extends Actor with AmberLogging {
         WorkflowService.getAllWorkflowService.foreach { workflow =>
           val jobService = workflow.jobService.getValue
           if (jobService != null && !jobService.workflow.isCompleted) {
-            if(AmberUtils.amberConfig.getBoolean("fault-tolerance.enable-determinant-logging")){
-              logger.info(s"Trigger recovery process for execution id = ${jobService.stateStore.jobMetadataStore.getState.eid}")
+            if (AmberUtils.amberConfig.getBoolean("fault-tolerance.enable-determinant-logging")) {
+              logger.info(
+                s"Trigger recovery process for execution id = ${jobService.stateStore.jobMetadataStore.getState.eid}"
+              )
               try {
                 futures.append(jobService.client.notifyNodeFailure(member.address))
               } catch {
@@ -76,8 +78,10 @@ class ClusterListener extends Actor with AmberLogging {
                   )
                   forcefullyStop(jobService, t)
               }
-            }else{
-              logger.info(s"Kill execution id = ${jobService.stateStore.jobMetadataStore.getState.eid}")
+            } else {
+              logger.info(
+                s"Kill execution id = ${jobService.stateStore.jobMetadataStore.getState.eid}"
+              )
               forcefullyStop(jobService, new RuntimeException("fault tolerance is not enabled"))
             }
           }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
@@ -59,7 +59,7 @@ class ClusterListener extends Actor with AmberLogging {
 
   private def updateClusterStatus(evt: MemberEvent): Unit = {
     evt match {
-      case MemberExited(member) =>
+      case MemberRemoved(member, status) =>
         logger.info("Cluster node " + member + " is down!")
         val futures = new ArrayBuffer[Future[Any]]
         WorkflowService.getAllWorkflowService.foreach { workflow =>

--- a/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/clustering/ClusterListener.scala
@@ -5,8 +5,8 @@ import akka.cluster.ClusterEvent._
 import akka.cluster.Cluster
 import com.twitter.util.{Await, Future}
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
-import edu.uci.ics.amber.engine.common.{AmberLogging, Constants}
-import edu.uci.ics.texera.web.service.WorkflowService
+import edu.uci.ics.amber.engine.common.{AmberLogging, AmberUtils, Constants}
+import edu.uci.ics.texera.web.service.{WorkflowJobService, WorkflowService}
 import edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState.ABORTED
 
 import scala.collection.mutable.ArrayBuffer
@@ -47,28 +47,38 @@ class ClusterListener extends Actor with AmberLogging {
       .map(_.address)
   }
 
+  private def forcefullyStop(jobService:WorkflowJobService, cause:Throwable): Unit ={
+    jobService.client.shutdown()
+    jobService.stateStore.statsStore.updateState(stats =>
+      stats.withEndTimeStamp(System.currentTimeMillis())
+    )
+    jobService.stateStore.jobMetadataStore.updateState { jobInfo =>
+      jobInfo.withState(ABORTED).withError(cause.getLocalizedMessage)
+    }
+  }
+
   private def updateClusterStatus(evt: MemberEvent): Unit = {
     evt match {
       case MemberExited(member) =>
-        logger.info("Cluster node " + member + " is down! Trigger recovery process.")
+        logger.info("Cluster node " + member + " is down!")
         val futures = new ArrayBuffer[Future[Any]]
         WorkflowService.getAllWorkflowService.foreach { workflow =>
           val jobService = workflow.jobService.getValue
           if (jobService != null && !jobService.workflow.isCompleted) {
-            try {
-              futures.append(jobService.client.notifyNodeFailure(member.address))
-            } catch {
-              case t: Throwable =>
-                logger.warn(
-                  s"execution ${jobService.workflow.getWorkflowId()} cannot recover! forcing it to stop"
-                )
-                jobService.client.shutdown()
-                jobService.stateStore.statsStore.updateState(stats =>
-                  stats.withEndTimeStamp(System.currentTimeMillis())
-                )
-                jobService.stateStore.jobMetadataStore.updateState { jobInfo =>
-                  jobInfo.withState(ABORTED).withError(t.getLocalizedMessage)
-                }
+            if(AmberUtils.amberConfig.getBoolean("fault-tolerance.enable-determinant-logging")){
+              logger.info(s"Trigger recovery process for execution id = ${jobService.stateStore.jobMetadataStore.getState.eid}")
+              try {
+                futures.append(jobService.client.notifyNodeFailure(member.address))
+              } catch {
+                case t: Throwable =>
+                  logger.warn(
+                    s"execution ${jobService.workflow.getWorkflowId()} cannot recover! forcing it to stop"
+                  )
+                  forcefullyStop(jobService, t)
+              }
+            }else{
+              logger.info(s"Kill execution id = ${jobService.stateStore.jobMetadataStore.getState.eid}")
+              forcefullyStop(jobService, new RuntimeException("fault tolerance is not enabled"))
             }
           }
         }

--- a/core/scripts/cron-restart-crashed-worker.sh
+++ b/core/scripts/cron-restart-crashed-worker.sh
@@ -10,7 +10,6 @@ if jps -m | grep -q "TexeraWebApplication"; then
     # Restart TexeraRunWorker
     cd "$(dirname "$0")"
     cd ../
-    pwd
     ./scripts/worker.sh >/dev/null
 
     echo "TexeraRunWorker restarted."

--- a/core/scripts/cron-restart-crashed-worker.sh
+++ b/core/scripts/cron-restart-crashed-worker.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if jps -m | grep -q "TexeraWebApplication"; then
+  echo "TexeraWebApplication is running."
+
+  # Check if TexeraRunWorker is missing
+  if ! jps -m | grep -q "TexeraRunWorker"; then
+    echo "TexeraRunWorker is missing. Restarting..."
+
+    # Restart TexeraRunWorker
+    cd "$(dirname "$0")"
+    cd ../
+    pwd
+    ./scripts/worker.sh >/dev/null
+
+    echo "TexeraRunWorker restarted."
+  else
+    echo "TexeraRunWorker is already running."
+  fi
+else
+  echo "TexeraWebApplication is not running."
+fi
+


### PR DESCRIPTION
This PR:
1. Upgraded to Akka version 2.8.3, enabling the use of `akka.cluster.sbr.SplitBrainResolverProvider` for automatic removal of unreachable nodes after 20 seconds of inactivity.
2. Improved handling of unreachable worker nodes, with server-side execution record cleanup if fault-tolerance is disabled, or recovery attempts if enabled.
3. Added a cron script to automatically start a worker node and connect to the server when only a server process is running.
