### PR TITLE
Fix local user missing email

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/AuthResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/AuthResource.scala
@@ -76,6 +76,7 @@ class AuthResource {
       case 0 =>
         val user = new User
         user.setName(username)
+        user.setEmail(username)
         user.setRole(UserRole.ADMIN)
         // hash the plain text password
         user.setPassword(new StrongPasswordEncryptor().encryptPassword(request.password))


### PR DESCRIPTION
Fix the issue that local users don't have an email. After this PR, local user will have their username as their email.