### PR TITLE
Fix Google Render Button Not Showing

### DIFF
--- a/core/new-gui/src/app/common/service/user/google-auth.service.ts
+++ b/core/new-gui/src/app/common/service/user/google-auth.service.ts
@@ -24,7 +24,7 @@ export class GoogleAuthService {
               this._googleCredentialResponse.next(auth);
             },
           });
-          window.google.accounts.id.renderButton(parent, { width: "270" });
+          window.google.accounts.id.renderButton(parent, { width: 270 });
           window.google.accounts.id.prompt();
         };
       },


### PR DESCRIPTION
This PR fixes a recent bug that Google Login Button does not show up on the landing page. According to [this documentation](https://developers.google.com/identity/gsi/web/reference/js-reference),  the parameter `width` should be a number. Previously it was a string but still worked, but now it is not working. Changing it to a number should fix the problem.