### PR TITLE
Fix optional field displaying "no longer a valid option" error message

### DIFF
--- a/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
@@ -481,8 +481,7 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
 
       if (isDefined(mapSource.enum)) {
         mappedField.validators.inEnum = {
-          expression: (c: AbstractControl) =>
-            ("nullable" in mapSource && c.value === "") || mapSource.enum?.includes(c.value),
+          expression: (c: AbstractControl) => mapSource.enum?.includes(c.value),
           message: (error: any, field: FormlyFieldConfig) =>
             `"${field.formControl?.value}" is no longer a valid option`,
         };

--- a/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
@@ -481,7 +481,8 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
 
       if (isDefined(mapSource.enum)) {
         mappedField.validators.inEnum = {
-          expression: (c: AbstractControl) => mapSource.enum?.includes(c.value),
+          expression: (c: AbstractControl) =>
+            ("nullable" in mapSource && c.value === "") || mapSource.enum?.includes(c.value),
           message: (error: any, field: FormlyFieldConfig) =>
             `"${field.formControl?.value}" is no longer a valid option`,
         };

--- a/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.spec.ts
@@ -359,6 +359,9 @@ describe("SchemaPropagationService", () => {
       attr => attr.attributeName
     );
 
+    // since field "attribute" is not required, we need to allow empty value.
+    expectedEnum!.push("");
+
     expect(schema.jsonSchema!.properties).toEqual({
       listOfAggregations: {
         title: "list of aggregations",

--- a/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.ts
@@ -218,6 +218,9 @@ export class SchemaPropagationService {
       if (v.additionalEnumValue) {
         attrNames.push(v.additionalEnumValue);
       }
+      if (v.title && !operatorSchema.jsonSchema.required?.includes(v.title)) {
+        attrNames.push("");
+      }
       return attrNames;
     };
 

--- a/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.ts
@@ -219,7 +219,14 @@ export class SchemaPropagationService {
         attrNames.push(v.additionalEnumValue);
       }
       if (v.title && !operatorSchema.jsonSchema.required?.includes(v.title)) {
-        attrNames.push("");
+        if (v.default) {
+          if (typeof v.default !== "string") {
+            throw new Error("default value must be a string");
+          }
+          attrNames.push(v.default);
+        } else {
+          attrNames.push("");
+        }
       }
       return attrNames;
     };

--- a/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.ts
+++ b/core/new-gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.ts
@@ -218,11 +218,18 @@ export class SchemaPropagationService {
       if (v.additionalEnumValue) {
         attrNames.push(v.additionalEnumValue);
       }
+
+      // ajv does not support null values, so it converts all the nulls to empty strings.
+      // https://github.com/ajv-validator/ajv/issues/1471
+      // the null -> "" change is done by Ajv.validate() with useDefault set to true.
+      // It is converted during the property editor form initialization and workflow validation, instead of during schema propagation.
       if (v.title && !operatorSchema.jsonSchema.required?.includes(v.title)) {
         if (v.default) {
           if (typeof v.default !== "string") {
             throw new Error("default value must be a string");
           }
+          // We are adding the default value or "" into
+          // the enum list to pass the frontend check for optional properties.
           attrNames.push(v.default);
         } else {
           attrNames.push("");


### PR DESCRIPTION
This PR addresses an issue in the current master where certain operators contain an optional field annotated with `@AutofillAttributeName`. In the backend code, this optional field is assigned a null value. However, during schema propagation, the frontend performs a check to ensure that the 
value corresponds to a valid attribute name. The null value will be converted to an empty string by the frontend, then an error message is generated for the optional field, as an empty string is not present in the enum of all attribute names.
<img width="344" alt="screen" src="https://github.com/Texera/texera/assets/13672781/ad545c43-a150-4606-816a-aa9556ceb8ef">

This PR adds an empty string to the enum list if the field is not marked as required.