### PR TITLE
Fix Mysql environment variables being reset after restarting DB

### DIFF
--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/MockTexeraDB.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/MockTexeraDB.scala
@@ -45,7 +45,11 @@ trait MockTexeraDB {
           val i = line.indexOf(' ')
           line = line.substring(i + 1, line.length - " */".length)
         }
-        if (line.trim.nonEmpty) st.execute(line)
+        if (line.trim.nonEmpty) {
+          // mock DB cannot use SET PERSIST keyword
+          line = line.replaceAll("(?i)SET PERSIST", "SET GLOBAL")
+          st.execute(line)
+        }
       }
     } finally if (st != null) st.close()
   }

--- a/core/scripts/sql/texera_ddl.sql
+++ b/core/scripts/sql/texera_ddl.sql
@@ -15,8 +15,8 @@ DROP TABLE IF EXISTS `file_of_workflow`;
 DROP TABLE IF EXISTS `file_of_project`;
 DROP TABLE IF EXISTS `workflow_executions`;
 
-SET GLOBAL time_zone = '+00:00'; -- this line is mandatory
-SET GLOBAL sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));
+SET PERSIST time_zone = '+00:00'; -- this line is mandatory
+SET PERSIST sql_mode=(SELECT REPLACE(@@sql_mode,'ONLY_FULL_GROUP_BY',''));
 
 CREATE TABLE IF NOT EXISTS user
 (


### PR DESCRIPTION
In texera_sql.ddl, we are setting `sql_mode` and `time_zone` using `SET GLOBAL`, this change will not persist after restarting Mysql DB. Many developers reported this issue. This PR changes `SET GLOBAL` to `SET PERSIST` to persist the change of those environment variables.