### PR TITLE
Refactor URLVizOp

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpDesc.scala
@@ -1,9 +1,8 @@
 package edu.uci.ics.texera.workflow.operators.visualization.urlviz
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecConfig
-import edu.uci.ics.amber.engine.common.virtualidentity.{LinkIdentity, util}
 import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.texera.workflow.common.metadata.{
   InputPort,
@@ -17,8 +16,6 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.{
   OperatorSchemaInfo,
   Schema
 }
-import edu.uci.ics.texera.workflow.common.workflow.PhysicalPlan
-import edu.uci.ics.texera.workflow.operators.visualization.htmlviz.HtmlVizOpExec
 import edu.uci.ics.texera.workflow.operators.visualization.{
   VisualizationConstants,
   VisualizationOperator
@@ -31,16 +28,33 @@ import scala.collection.JavaConverters.asScalaBuffer
   * URL Visualization operator to render any content in given URL link
   * This is the description of the operator
   */
+@JsonSchemaInject(json =
+  """
+ {
+   "attributeTypeRules": {
+     "urlContentAttrName": {
+       "enum": ["string"]
+     }
+   }
+ }
+ """)
 class UrlVizOpDesc extends VisualizationOperator {
+
+
   @JsonProperty(required = true)
   @JsonSchemaTitle("URL")
   @AutofillAttributeName
-  var urlContentAttrName: String = _
+  private val urlContentAttrName: String = ""
 
   override def chartType: String = VisualizationConstants.HTML_VIZ
 
-  override def operatorExecutor(operatorSchemaInfo: OperatorSchemaInfo) =
-    throw new UnsupportedOperationException("opExec implemented in operatorExecutorMultiLayer")
+  override def operatorExecutor(operatorSchemaInfo: OperatorSchemaInfo): OpExecConfig =
+    OpExecConfig
+      .manyToOneLayer(
+        operatorIdentifier,
+        _ => new UrlVizOpExec(urlContentAttrName, operatorSchemaInfo)
+      )
+
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
       "URL visualizer",
@@ -50,23 +64,7 @@ class UrlVizOpDesc extends VisualizationOperator {
       asScalaBuffer(singletonList(OutputPort(""))).toList
     )
 
-  override def operatorExecutorMultiLayer(operatorSchemaInfo: OperatorSchemaInfo): PhysicalPlan = {
-    val partialId = util.makeLayer(operatorIdentifier, "url")
-    val partialLayer = OpExecConfig
-      .oneToOneLayer(
-        operatorIdentifier,
-        _ => new UrlVizOpPartialExec(urlContentAttrName, operatorSchemaInfo)
-      )
-      .withId(partialId)
-      .withNumWorkers(1)
-    val finalId = util.makeLayer(operatorIdentifier, "html")
-    val finalLayer = OpExecConfig
-      .oneToOneLayer(operatorIdentifier, _ => new HtmlVizOpExec("html-content", operatorSchemaInfo))
-      .withId(finalId)
-    val layers = Array(partialLayer, finalLayer)
-    val links = Array(new LinkIdentity(partialLayer.id, finalLayer.id))
-    PhysicalPlan.apply(layers, links)
-  }
   override def getOutputSchema(schemas: Array[Schema]): Schema =
     Schema.newBuilder.add(new Attribute("html-content", AttributeType.STRING)).build
+
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpDesc.scala
@@ -28,8 +28,7 @@ import scala.collection.JavaConverters.asScalaBuffer
   * URL Visualization operator to render any content in given URL link
   * This is the description of the operator
   */
-@JsonSchemaInject(json =
-  """
+@JsonSchemaInject(json = """
  {
    "attributeTypeRules": {
      "urlContentAttrName": {
@@ -39,7 +38,6 @@ import scala.collection.JavaConverters.asScalaBuffer
  }
  """)
 class UrlVizOpDesc extends VisualizationOperator {
-
 
   @JsonProperty(required = true)
   @JsonSchemaTitle("URL")

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpDesc.scala
@@ -40,7 +40,7 @@ import scala.collection.JavaConverters.asScalaBuffer
 class UrlVizOpDesc extends VisualizationOperator {
 
   @JsonProperty(required = true)
-  @JsonSchemaTitle("URL")
+  @JsonSchemaTitle("URL content")
   @AutofillAttributeName
   private val urlContentAttrName: String = ""
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpExec.scala
@@ -11,7 +11,7 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.{AttributeType, OperatorS
   * URL Visualization operator to render any given URL link
   */
 class UrlVizOpExec(
-    htmlContentAttrName: String,
+                    URLAttributeName: String,
     operatorSchemaInfo: OperatorSchemaInfo
 ) extends OperatorExecutor {
 
@@ -26,12 +26,18 @@ class UrlVizOpExec(
       asyncRPCClient: AsyncRPCClient
   ): Iterator[Tuple] =
     tuple match {
-      case Left(t) =>
+      case Left(tuple) =>
         val iframe =
-          "<!DOCTYPE html>\n" + "<html lang=\"en\">\n" + "<body><div class=\"modal-body\">\n" + "<iframe src=\"" + t
-            .getField(
-              htmlContentAttrName
-            ) + "\" frameborder=\"0\" style=\"height:100vh; width:100%; border:none;\"></iframe>\n" + "</div></body>\n" + "</html>"
+           s"""<!DOCTYPE html>
+              |<html lang="en">
+              |<body>
+              |  <div class="modal-body">
+              |    <iframe src="${tuple.getField(URLAttributeName)}" frameborder="0"
+              |       style="height:100vh; width:100%; border:none;">
+              |    </iframe>
+              |  </div>
+              |</body>
+              |</html>""".stripMargin
         Iterator(
           Tuple
             .newBuilder(operatorSchemaInfo.outputSchemas(0))

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpExec.scala
@@ -11,7 +11,7 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.{AttributeType, OperatorS
   * URL Visualization operator to render any given URL link
   */
 class UrlVizOpExec(
-    URLAttributeName: String,
+    urlContentAttrName: String,
     operatorSchemaInfo: OperatorSchemaInfo
 ) extends OperatorExecutor {
 
@@ -32,7 +32,7 @@ class UrlVizOpExec(
               |<html lang="en">
               |<body>
               |  <div class="modal-body">
-              |    <iframe src="${tuple.getField(URLAttributeName)}" frameborder="0"
+              |    <iframe src="${tuple.getField(urlContentAttrName)}" frameborder="0"
               |       style="height:100vh; width:100%; border:none;">
               |    </iframe>
               |  </div>

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpExec.scala
@@ -11,7 +11,7 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.{AttributeType, OperatorS
   * URL Visualization operator to render any given URL link
   */
 class UrlVizOpExec(
-                    URLAttributeName: String,
+    URLAttributeName: String,
     operatorSchemaInfo: OperatorSchemaInfo
 ) extends OperatorExecutor {
 
@@ -28,7 +28,7 @@ class UrlVizOpExec(
     tuple match {
       case Left(tuple) =>
         val iframe =
-           s"""<!DOCTYPE html>
+          s"""<!DOCTYPE html>
               |<html lang="en">
               |<body>
               |  <div class="modal-body">

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpExec.scala
@@ -10,7 +10,7 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.{AttributeType, OperatorS
 /**
   * URL Visualization operator to render any given URL link
   */
-class UrlVizOpPartialExec(
+class UrlVizOpExec(
     htmlContentAttrName: String,
     operatorSchemaInfo: OperatorSchemaInfo
 ) extends OperatorExecutor {


### PR DESCRIPTION
This PR:
1. simplifies `URLVizOp` by using single operator layer and mark it as HTML visualize type.
2. renames `URLVizOpPartialExec` to `URLVizOpExec` to reflect the layer change.
3. adds attribute type validation warning.