### PR TITLE
Align hash function for Java and Python

### DIFF
--- a/core/amber/src/main/python/core/architecture/sendsemantics/hash_based_shuffle_partitioner.py
+++ b/core/amber/src/main/python/core/architecture/sendsemantics/hash_based_shuffle_partitioner.py
@@ -18,7 +18,7 @@ from proto.edu.uci.ics.amber.engine.common import ActorVirtualIdentity
 class HashBasedShufflePartitioner(Partitioner):
     def __init__(self, partitioning: HashBasedShufflePartitioning):
         super().__init__(set_one_of(Partitioning, partitioning))
-        logger.info(f"got {partitioning}")
+        logger.debug(f"got {partitioning}")
         self.batch_size = partitioning.batch_size
         self.receivers: List[typing.Tuple[ActorVirtualIdentity, List[Tuple]]] = [
             (receiver, list()) for receiver in partitioning.receivers
@@ -29,7 +29,7 @@ class HashBasedShufflePartitioner(Partitioner):
     def add_tuple_to_batch(
         self, tuple_: Tuple
     ) -> Iterator[typing.Tuple[ActorVirtualIdentity, OutputDataFrame]]:
-        partial_tuple = tuple_.get_fields(self.hash_column_indices)
+        partial_tuple = tuple_.get_partial_tuple(self.hash_column_indices)
         hash_code = hash(partial_tuple) % len(self.receivers)
         receiver, batch = self.receivers[hash_code]
         batch.append(tuple_)

--- a/core/amber/src/main/python/core/models/schema/schema.py
+++ b/core/amber/src/main/python/core/models/schema/schema.py
@@ -108,7 +108,13 @@ class Schema:
         """
         return [(k, v) for k, v in self._name_type_mapping.items()]
 
-    def get_partial_schema(self, indices) -> "Schema":
+    def get_partial_schema(self, indices: List[int]) -> "Schema":
+        """
+        Create a partial Schema with fields specified by the indices.
+        :param indices: A list of index values.
+        :return: A new Schema with the selected fields, with the same order specified
+        by the indices.
+        """
         raw_schema = OrderedDict()
         for index, (key, value) in enumerate(self.as_key_value_pairs(), 0):
             if index in indices:

--- a/core/amber/src/main/python/core/models/schema/schema.py
+++ b/core/amber/src/main/python/core/models/schema/schema.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 from typing import MutableMapping, Optional, Mapping, List, Tuple
 
 import pyarrow as pa
@@ -32,7 +33,7 @@ class Schema:
         arrow_schema: Optional[pa.Schema] = None,
         raw_schema: Optional[Mapping[str, str]] = None,
     ):
-        self._name_type_mapping: MutableMapping[str, AttributeType] = dict()
+        self._name_type_mapping: MutableMapping[str, AttributeType] = OrderedDict()
 
         if arrow_schema is not None:
             self._from_arrow_schema(arrow_schema)
@@ -56,7 +57,7 @@ class Schema:
         :param raw_schema: a map of attr_name -> type_str.
         :return:
         """
-        self._name_type_mapping = dict()
+        self._name_type_mapping = OrderedDict()
         for attr_name, raw_type in raw_schema.items():
             attr_type = RAW_TYPE_MAPPING[raw_type]
             self.add(attr_name, attr_type)
@@ -67,7 +68,7 @@ class Schema:
         :param arrow_schema: a pyarrow.Schema.
         :return:
         """
-        self._name_type_mapping = dict()
+        self._name_type_mapping = OrderedDict()
         for attr_name in arrow_schema.names:
             arrow_type = arrow_schema.field(attr_name).type  # type: ignore
             attr_type = FROM_ARROW_MAPPING[arrow_type.id]
@@ -107,6 +108,13 @@ class Schema:
         """
         return [(k, v) for k, v in self._name_type_mapping.items()]
 
+    def get_partial_schema(self, indices) -> "Schema":
+        raw_schema = OrderedDict()
+        for index, (key, value) in enumerate(self.as_key_value_pairs(), 0):
+            if index in indices:
+                raw_schema[key] = RAW_TYPE_MAPPING.inverse[value]
+        return Schema(raw_schema=raw_schema)
+
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, Schema):
             return False
@@ -115,8 +123,8 @@ class Schema:
         return left_pairs == right_pairs
 
     def __str__(self) -> str:
-        content = ", ".join(
-            f"{attr_name}: {attr_type}"
-            for attr_name, attr_type in self.as_key_value_pairs()
+        content = ",\n".join(
+            f"({index}){repr(attr_name)} -> {attr_type}"
+            for index, (attr_name, attr_type) in enumerate(self.as_key_value_pairs(), 0)
         )
-        return f"Schema[{content}]"
+        return f"Schema[\n{content}\n]"

--- a/core/amber/src/main/python/core/models/test_tuple.py
+++ b/core/amber/src/main/python/core/models/test_tuple.py
@@ -108,3 +108,16 @@ class TestTuple:
         tuple_.finalize(schema)
         assert isinstance(tuple_["scores"], bytes)
         assert tuple_["height"] is None
+
+    def test_hash(self):
+        tuple_ = Tuple(
+            {"col-int": 1, "col-string": "string-attr", "col-bool": True},
+            schema=Schema(
+                raw_schema={
+                    "col-int": "integer",
+                    "col-string": "string",
+                    "col-bool": "boolean",
+                }
+            ),
+        )
+        print(hash(tuple_))

--- a/core/amber/src/main/python/core/models/test_tuple.py
+++ b/core/amber/src/main/python/core/models/test_tuple.py
@@ -136,7 +136,7 @@ class TestTuple:
             },
             schema,
         )
-        assert hash(tuple_) == -1335416166  # calculated with Java 11
+        assert hash(tuple_) == -1335416166  # calculated with Java
 
         tuple2 = Tuple(
             {
@@ -151,7 +151,7 @@ class TestTuple:
             schema,
         )
 
-        assert hash(tuple2) == -1409761483  # calculated with Java 11
+        assert hash(tuple2) == -1409761483  # calculated with Java
 
         tuple3 = Tuple(
             {
@@ -166,7 +166,7 @@ class TestTuple:
             schema,
         )
 
-        assert hash(tuple3) == 1742810335  # calculated with Java 11
+        assert hash(tuple3) == 1742810335  # calculated with Java
 
         tuple4 = Tuple(
             {
@@ -180,7 +180,7 @@ class TestTuple:
             },
             schema,
         )
-        assert hash(tuple4) == -592643630  # calculated with Java 8
+        assert hash(tuple4) == -592643630  # calculated with Java
 
         tuple5 = Tuple(
             {
@@ -194,4 +194,4 @@ class TestTuple:
             },
             schema,
         )
-        assert hash(tuple5) == 431028091  # calculated with Java 8
+        assert hash(tuple5) == 431028091  # calculated with Java

--- a/core/amber/src/main/python/core/models/test_tuple.py
+++ b/core/amber/src/main/python/core/models/test_tuple.py
@@ -194,4 +194,4 @@ class TestTuple:
             },
             schema,
         )
-        assert hash(tuple5) == 431028091  # calculated with Java
+        assert hash(tuple5) == -2099556631  # calculated with Java

--- a/core/amber/src/main/python/core/models/test_tuple.py
+++ b/core/amber/src/main/python/core/models/test_tuple.py
@@ -120,7 +120,7 @@ class TestTuple:
                 "col-long": "long",
                 "col-double": "double",
                 "col-timestamp": "timestamp",
-                "col-binary": "binary"
+                "col-binary": "binary",
             }
         )
 
@@ -132,7 +132,7 @@ class TestTuple:
                 "col-long": 1123213213213,
                 "col-double": 214214.9969346,
                 "col-timestamp": datetime.datetime.fromtimestamp(100000000),
-                "col-binary": b'hello'
+                "col-binary": b"hello",
             },
             schema,
         )
@@ -146,7 +146,7 @@ class TestTuple:
                 "col-long": 0,
                 "col-double": 0.0,
                 "col-timestamp": datetime.datetime.fromtimestamp(0),
-                "col-binary": b''
+                "col-binary": b"",
             },
             schema,
         )
@@ -161,7 +161,7 @@ class TestTuple:
                 "col-long": None,
                 "col-double": None,
                 "col-timestamp": None,
-                "col-binary": None
+                "col-binary": None,
             },
             schema,
         )

--- a/core/amber/src/main/python/core/models/test_tuple.py
+++ b/core/amber/src/main/python/core/models/test_tuple.py
@@ -1,3 +1,5 @@
+import datetime
+
 import pandas
 import pytest
 from copy import deepcopy
@@ -110,14 +112,58 @@ class TestTuple:
         assert tuple_["height"] is None
 
     def test_hash(self):
-        tuple_ = Tuple(
-            {"col-int": 1, "col-string": "string-attr", "col-bool": True},
-            schema=Schema(
-                raw_schema={
-                    "col-int": "integer",
-                    "col-string": "string",
-                    "col-bool": "boolean",
-                }
-            ),
+        schema = Schema(
+            raw_schema={
+                "col-int": "integer",
+                "col-string": "string",
+                "col-bool": "boolean",
+                "col-long": "long",
+                "col-double": "double",
+                "col-timestamp": "timestamp",
+                "col-binary": "binary"
+            }
         )
-        print(hash(tuple_))
+
+        tuple_ = Tuple(
+            {
+                "col-int": 922323,
+                "col-string": "string-attr",
+                "col-bool": True,
+                "col-long": 1123213213213,
+                "col-double": 214214.9969346,
+                "col-timestamp": datetime.datetime.fromtimestamp(100000000),
+                "col-binary": b'hello'
+            },
+            schema,
+        )
+        assert hash(tuple_) == -1335416166  # calculated with Java 11
+
+        tuple2 = Tuple(
+            {
+                "col-int": 0,
+                "col-string": "",
+                "col-bool": False,
+                "col-long": 0,
+                "col-double": 0.0,
+                "col-timestamp": datetime.datetime.fromtimestamp(0),
+                "col-binary": b''
+            },
+            schema,
+        )
+
+        assert hash(tuple2) == -1409761483  # calculated with Java 11
+
+        tuple3 = Tuple(
+            {
+                "col-int": None,
+                "col-string": None,
+                "col-bool": None,
+                "col-long": None,
+                "col-double": None,
+                "col-timestamp": None,
+                "col-binary": None
+            },
+            schema,
+        )
+
+        assert hash(tuple3) == 1742810335  # calculated with Java 11

--- a/core/amber/src/main/python/core/models/test_tuple.py
+++ b/core/amber/src/main/python/core/models/test_tuple.py
@@ -184,13 +184,13 @@ class TestTuple:
 
         tuple5 = Tuple(
             {
-                "col-int":  0x7fffffff,
+                "col-int": 0x7FFFFFFF,
                 "col-string": "",
                 "col-bool": True,
-                "col-long": 0x7fffffffffffffff,
+                "col-long": 0x7FFFFFFFFFFFFFFF,
                 "col-double": 7 / 17,
                 "col-timestamp": datetime.datetime.fromtimestamp(1234567890),
-                "col-binary": b'o'*4097,
+                "col-binary": b"o" * 4097,
             },
             schema,
         )

--- a/core/amber/src/main/python/core/models/test_tuple.py
+++ b/core/amber/src/main/python/core/models/test_tuple.py
@@ -167,3 +167,31 @@ class TestTuple:
         )
 
         assert hash(tuple3) == 1742810335  # calculated with Java 11
+
+        tuple4 = Tuple(
+            {
+                "col-int": -3245763,
+                "col-string": "\n\r\napple",
+                "col-bool": True,
+                "col-long": -8965536434247,
+                "col-double": 1 / 3,
+                "col-timestamp": datetime.datetime.fromtimestamp(-1990),
+                "col-binary": None,
+            },
+            schema,
+        )
+        assert hash(tuple4) == -592643630  # calculated with Java 8
+
+        tuple5 = Tuple(
+            {
+                "col-int":  0x7fffffff,
+                "col-string": "",
+                "col-bool": True,
+                "col-long": 0x7fffffffffffffff,
+                "col-double": 7 / 17,
+                "col-timestamp": datetime.datetime.fromtimestamp(1234567890),
+                "col-binary": b'o'*4097,
+            },
+            schema,
+        )
+        assert hash(tuple5) == 431028091  # calculated with Java 8

--- a/core/amber/src/main/python/core/models/tuple.py
+++ b/core/amber/src/main/python/core/models/tuple.py
@@ -77,9 +77,9 @@ class ArrowTableTupleProvider:
 
             # for binary types, convert pickled objects back.
             if (
-                    field_type == pyarrow.binary()
-                    and value is not None
-                    and value[:6] == b"pickle"
+                field_type == pyarrow.binary()
+                and value is not None
+                and value[:6] == b"pickle"
             ):
                 value = pickle.loads(value[10:])
             return value
@@ -106,9 +106,9 @@ class Tuple:
     """
 
     def __init__(
-            self,
-            tuple_like: typing.Optional["TupleLike"] = None,
-            schema: typing.Optional[Schema] = None,
+        self,
+        tuple_like: typing.Optional["TupleLike"] = None,
+        schema: typing.Optional[Schema] = None,
     ):
         """
         Construct a lazy-tuple with given TupleLike object. If the field value is a
@@ -144,9 +144,9 @@ class Tuple:
             item: str = self.get_field_names()[item]
 
         if (
-                callable(self._field_data[item])
-                and getattr(self._field_data[item], "__name__", "Unknown")
-                == "field_accessor"
+            callable(self._field_data[item])
+            and getattr(self._field_data[item], "__name__", "Unknown")
+            == "field_accessor"
         ):
             # evaluate the field now
             field_accessor = self._field_data[item]
@@ -231,7 +231,8 @@ class Tuple:
                 if field_value is not None:
                     field_type = schema.get_attr_type(field_name)
                     if field_type == AttributeType.BINARY and not isinstance(
-                            field_value, bytes):
+                        field_value, bytes
+                    ):
                         self[field_name] = b"pickle    " + pickle.dumps(field_value)
             except Exception as err:
                 # Surpass exceptions during cast.
@@ -269,7 +270,7 @@ class Tuple:
         for field_name, field_value in self.as_key_value_pairs():
             expected = schema.get_attr_type(field_name)
             if not isinstance(
-                    field_value, (TO_PYOBJECT_MAPPING.get(expected), type(None))
+                field_value, (TO_PYOBJECT_MAPPING.get(expected), type(None))
             ):
                 raise TypeError(
                     f"Unmatched type for field '{field_name}', expected {expected}, "
@@ -289,9 +290,9 @@ class Tuple:
 
     def __eq__(self, other: Any) -> bool:
         return (
-                isinstance(other, Tuple)
-                and self.get_field_names() == other.get_field_names()
-                and all(self[i] == other[i] for i in self.get_field_names())
+            isinstance(other, Tuple)
+            and self.get_field_names() == other.get_field_names()
+            and all(self[i] == other[i] for i in self.get_field_names())
         )
 
     def __ne__(self, other) -> bool:
@@ -313,7 +314,6 @@ class Tuple:
         return Tuple(new_raw_tuple, schema=schema)
 
     def __hash__(self):
-
         result = 1
         salt = 31
         for name, field in self.as_key_value_pairs():
@@ -329,7 +329,6 @@ class Tuple:
             elif attr_type == AttributeType.LONG:
                 result = result * salt + java_int(field ^ (field >> 32))
             elif attr_type == AttributeType.DOUBLE:
-
                 long_value = double_to_long_bits(field)
                 result = result * salt + java_int(long_value ^ (long_value >> 32))
             elif attr_type == AttributeType.STRING:

--- a/core/amber/src/main/python/core/models/tuple.py
+++ b/core/amber/src/main/python/core/models/tuple.py
@@ -77,9 +77,9 @@ class ArrowTableTupleProvider:
 
             # for binary types, convert pickled objects back.
             if (
-                    field_type == pyarrow.binary()
-                    and value is not None
-                    and value[:6] == b"pickle"
+                field_type == pyarrow.binary()
+                and value is not None
+                and value[:6] == b"pickle"
             ):
                 value = pickle.loads(value[10:])
             return value
@@ -94,9 +94,9 @@ class Tuple:
     """
 
     def __init__(
-            self,
-            tuple_like: typing.Optional["TupleLike"] = None,
-            schema: typing.Optional[Schema] = None,
+        self,
+        tuple_like: typing.Optional["TupleLike"] = None,
+        schema: typing.Optional[Schema] = None,
     ):
         """
         Construct a lazy-tuple with given TupleLike object. If the field value is a
@@ -132,9 +132,9 @@ class Tuple:
             item: str = self.get_field_names()[item]
 
         if (
-                callable(self._field_data[item])
-                and getattr(self._field_data[item], "__name__", "Unknown")
-                == "field_accessor"
+            callable(self._field_data[item])
+            and getattr(self._field_data[item], "__name__", "Unknown")
+            == "field_accessor"
         ):
             # evaluate the field now
             field_accessor = self._field_data[item]
@@ -256,7 +256,7 @@ class Tuple:
         for field_name, field_value in self.as_key_value_pairs():
             expected = schema.get_attr_type(field_name)
             if not isinstance(
-                    field_value, (TO_PYOBJECT_MAPPING.get(expected), type(None))
+                field_value, (TO_PYOBJECT_MAPPING.get(expected), type(None))
             ):
                 raise TypeError(
                     f"Unmatched type for field '{field_name}', expected {expected}, "
@@ -273,9 +273,9 @@ class Tuple:
 
     def __eq__(self, other: Any) -> bool:
         return (
-                isinstance(other, Tuple)
-                and self.get_field_names() == other.get_field_names()
-                and all(self[i] == other[i] for i in self.get_field_names())
+            isinstance(other, Tuple)
+            and self.get_field_names() == other.get_field_names()
+            and all(self[i] == other[i] for i in self.get_field_names())
         )
 
     def __ne__(self, other) -> bool:

--- a/core/amber/src/main/python/core/models/tuple.py
+++ b/core/amber/src/main/python/core/models/tuple.py
@@ -160,6 +160,7 @@ class Tuple:
             memory, or a callable accessor.
         """
         assert len(tuple_like) != 0
+        self._field_data: "OrderedDict[str, Field]"
         if isinstance(tuple_like, Tuple):
             self._field_data = tuple_like._field_data
         elif isinstance(tuple_like, pandas.Series):
@@ -209,7 +210,7 @@ class Tuple:
         """Convert the tuple to Pandas series format"""
         return pandas.Series(self.as_dict())
 
-    def as_dict(self) -> OrderedDict[str, Field]:
+    def as_dict(self) -> "OrderedDict[str, Field]":
         """
         Return a dictionary copy of this tuple.
         Fields will be fetched from accessor if absent.
@@ -226,7 +227,7 @@ class Tuple:
     def get_field_names(self) -> typing.Tuple[str]:
         return tuple(map(str, self._field_data.keys()))
 
-    def get_fields(self, output_field_names=None) -> typing.Tuple[Field]:
+    def get_fields(self, output_field_names=None) -> typing.Tuple[Field, ...]:
         """
         Get values from tuple for selected fields.
         """

--- a/core/amber/src/main/python/core/models/tuple.py
+++ b/core/amber/src/main/python/core/models/tuple.py
@@ -311,17 +311,11 @@ class Tuple:
             elif attr_type == AttributeType.LONG:
                 result = result * salt + field ^ (field >> 32)
             elif attr_type == AttributeType.DOUBLE:
-
                 def double_to_long_bits(double_value):
                     # Pack the double value into a binary string of 8 bytes
                     packed_value = struct.pack("d", double_value)
-
-                    # Unpack the binary string to a 64-bit integer (long in Python 2, int in Python 3)
+                    # Unpack the binary string to a 64-bit integer (int in Python 3)
                     long_bits = struct.unpack("Q", packed_value)[0]
-
-                    # If you need a signed long (for Python 2 or Python 3)
-                    # signed_long_bits = ctypes.c_longlong(long_bits).value
-
                     return long_bits
 
                 long_value = double_to_long_bits(field)

--- a/core/amber/src/main/python/core/models/tuple.py
+++ b/core/amber/src/main/python/core/models/tuple.py
@@ -4,7 +4,7 @@ import typing
 from collections import OrderedDict
 from copy import deepcopy
 from dataclasses import dataclass
-from typing import Any, List, Iterator, Dict, Callable
+from typing import Any, List, Iterator, Callable
 
 from typing_extensions import Protocol, runtime_checkable
 import pandas
@@ -301,8 +301,6 @@ class Tuple:
         salt = 31
         for name, field in self.as_key_value_pairs():
             attr_type = self._schema.get_attr_type(name)
-            for c in name:
-                result = result * salt + ord(c)
 
             if attr_type == AttributeType.BOOL:
                 result = result * salt + int(field)

--- a/core/amber/src/main/python/core/models/tuple.py
+++ b/core/amber/src/main/python/core/models/tuple.py
@@ -267,8 +267,8 @@ class Tuple:
         return iter(self.get_fields())
 
     def __str__(self) -> str:
-        content =', '.join(
-            [repr(key) + ': '+ repr(value) for key, value in self.as_key_value_pairs()]
+        content = ", ".join(
+            [repr(key) + ": " + repr(value) for key, value in self.as_key_value_pairs()]
         )
         return f"Tuple[{content}]"
 

--- a/core/amber/src/main/python/core/models/tuple.py
+++ b/core/amber/src/main/python/core/models/tuple.py
@@ -319,6 +319,21 @@ class Tuple:
                     f"got {field_value} ({type(field_value)}) instead."
                 )
 
+    def get_partial_tuple(self, indices: List[int]) -> "Tuple":
+        """
+        Create a partial Tuple with fields specified by the indices.
+        :param indices: A list of index values.
+        :return: A new Tuple with the selected fields, with the same order specified
+        by the indices.
+        """
+        assert self._schema is not None
+        schema = self._schema.get_partial_schema(indices)
+        new_raw_tuple = OrderedDict()
+        for index, (key, value) in enumerate(self.as_key_value_pairs(), 0):
+            if index in indices:
+                new_raw_tuple[key] = value
+        return Tuple(new_raw_tuple, schema=schema)
+
     def __iter__(self) -> Iterator[Field]:
         return iter(self.get_fields())
 
@@ -345,15 +360,6 @@ class Tuple:
 
     def __contains__(self, __x: object) -> bool:
         return __x in self._field_data
-
-    def get_partial_tuple(self, indices) -> "Tuple":
-        assert self._schema is not None
-        schema = self._schema.get_partial_schema(indices)
-        new_raw_tuple = OrderedDict()
-        for index, (key, value) in enumerate(self.as_key_value_pairs(), 0):
-            if index in indices:
-                new_raw_tuple[key] = value
-        return Tuple(new_raw_tuple, schema=schema)
 
     def __hash__(self) -> int:
         """

--- a/core/amber/src/main/python/core/models/tuple.py
+++ b/core/amber/src/main/python/core/models/tuple.py
@@ -267,7 +267,10 @@ class Tuple:
         return iter(self.get_fields())
 
     def __str__(self) -> str:
-        return f"Tuple[{str(self.as_dict()).strip('{').strip('}')}]"
+        content =', '.join(
+            [repr(key) + ': '+ repr(value) for key, value in self.as_key_value_pairs()]
+        )
+        return f"Tuple[{content}]"
 
     __repr__ = __str__
 
@@ -309,6 +312,7 @@ class Tuple:
             elif attr_type == AttributeType.LONG:
                 result = result * salt + field ^ (field >> 32)
             elif attr_type == AttributeType.DOUBLE:
+
                 def double_to_long_bits(double_value):
                     # Pack the double value into a binary string of 8 bytes
                     packed_value = struct.pack("d", double_value)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/partitioners/HashBasedShufflePartitioner.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/partitioners/HashBasedShufflePartitioner.scala
@@ -10,10 +10,13 @@ case class HashBasedShufflePartitioner(partitioning: HashBasedShufflePartitionin
 
   override def getBucketIndex(tuple: ITuple): Iterator[Int] = {
     val numBuckets = partitioning.receivers.length
-    val index = tuple
-      .asInstanceOf[Tuple]
-      .getPartialTuple(partitioning.hashColumnIndices.toArray)
-      .hashCode() % numBuckets
+    val index = Math.floorMod(
+      tuple
+        .asInstanceOf[Tuple]
+        .getPartialTuple(partitioning.hashColumnIndices.toArray)
+        .hashCode(),
+      numBuckets
+    )
     Iterator(index)
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/partitioners/HashBasedShufflePartitioner.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/sendsemantics/partitioners/HashBasedShufflePartitioner.scala
@@ -3,18 +3,17 @@ package edu.uci.ics.amber.engine.architecture.sendsemantics.partitioners
 import edu.uci.ics.amber.engine.architecture.sendsemantics.partitionings.HashBasedShufflePartitioning
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
+import edu.uci.ics.texera.workflow.common.tuple.Tuple
 
 case class HashBasedShufflePartitioner(partitioning: HashBasedShufflePartitioning)
     extends Partitioner {
 
   override def getBucketIndex(tuple: ITuple): Iterator[Int] = {
     val numBuckets = partitioning.receivers.length
-
-    val index = (partitioning.hashColumnIndices
-      .map(i => tuple.get(i))
-      .toList
-      .hashCode() % numBuckets + numBuckets) % numBuckets
-
+    val index = tuple
+      .asInstanceOf[Tuple]
+      .getPartialTuple(partitioning.hashColumnIndices.toArray)
+      .hashCode() % numBuckets
     Iterator(index)
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/controlcommands/ControlCommandConvertUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/controlcommands/ControlCommandConvertUtils.scala
@@ -29,6 +29,7 @@ import edu.uci.ics.amber.engine.architecture.worker.statistics.{WorkerState, Wor
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, LinkIdentity}
 
+import scala.collection.immutable.ListMap
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.asScalaBufferConverter
 
@@ -61,7 +62,9 @@ object ControlCommandConvertUtils {
           isSource,
           inputMapping,
           outputMapping,
-          schema.getAttributes.asScala.map(attr => attr.getName -> attr.getType.toString).toMap
+          schema.getAttributes.asScala.foldLeft(ListMap[String, String]())((list, attr) =>
+            list + (attr.getName -> attr.getType.toString)
+          )
         )
       case ReplayCurrentTuple() =>
         ReplayCurrentTupleV2()

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCClient.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCClient.scala
@@ -63,9 +63,9 @@ class AsyncRPCClient(
 
   def send[T](cmd: ControlCommand[T], to: ActorVirtualIdentity): Future[T] = {
     val (p, id) = createPromise[T]()
-//    logger.info(
-//      s"send request: ${cmd} to $to (controlID: ${id})"
-//    )
+    logger.info(
+      s"send request: ${cmd} to $to (controlID: ${id})"
+    )
     controlOutputEndpoint.sendTo(to, ControlInvocation(id, cmd))
     p
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCClient.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCClient.scala
@@ -63,9 +63,9 @@ class AsyncRPCClient(
 
   def send[T](cmd: ControlCommand[T], to: ActorVirtualIdentity): Future[T] = {
     val (p, id) = createPromise[T]()
-    logger.info(
-      s"send request: ${cmd} to $to (controlID: ${id})"
-    )
+//    logger.info(
+//      s"send request: ${cmd} to $to (controlID: ${id})"
+//    )
     controlOutputEndpoint.sendTo(to, ControlInvocation(id, cmd))
     p
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/Tuple.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/Tuple.java
@@ -102,9 +102,6 @@ public class Tuple implements ITuple, Serializable {
             AttributeType attributeType = attribute.getType();
             String attributeName = attribute.getName();
 
-            for (char ch : attributeName.toCharArray()){
-                result.set(result.get() * salt + (int)ch);                                // 16 bits » 32-bit
-            }
             switch (attributeType) {
                 case BOOLEAN:
                     Boolean booleanField = getField(attributeName);
@@ -129,7 +126,6 @@ public class Tuple implements ITuple, Serializable {
 
                     while (it.current() != CharacterIterator.DONE) {
                         char c = it.current();
-//                        System.out.println("adding " + (int) c + " to " + result.get());
                         result.set(result.get() * salt + (int)c);                                // 16 bits » 32-bit
                         it.next();
                     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/Schema.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/tuple/schema/Schema.java
@@ -169,6 +169,14 @@ public class Schema implements Serializable {
                 attributeName, attributeNameList);
     }
 
+    public Schema getPartialSchema(int[] indices){
+        Schema.Builder builder = Schema.newBuilder();
+        for (int index : indices) {
+            builder.add(attributes.get(index));
+        }
+        return builder.build();
+    }
+
     public static Schema.Builder newBuilder() {
         return new Schema.Builder();
     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/distinct/DistinctOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/distinct/DistinctOpExec.scala
@@ -5,11 +5,10 @@ import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
-
 import scala.collection.mutable
 
 class DistinctOpExec extends OperatorExecutor {
-  private val hashset: mutable.HashSet[Tuple] = mutable.HashSet()
+  private val hashset: mutable.LinkedHashSet[Tuple] = mutable.LinkedHashSet()
   override def processTexeraTuple(
       tuple: Either[Tuple, InputExhausted],
       input: Int,

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/common/tuple/TupleSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/common/tuple/TupleSpec.scala
@@ -159,7 +159,7 @@ class TupleSpec extends AnyFlatSpec {
       .add(stringAttribute, "\n\r\napple")
       .add(boolAttribute, true)
       .add(longAttribute, -8965536434247L)
-      .add(doubleAttribute, 1/3.0d)
+      .add(doubleAttribute, 1 / 3.0d)
       .add(timestampAttribute, new Timestamp(-1990))
       .add(binaryAttribute, null)
       .build()

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/common/tuple/TupleSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/common/tuple/TupleSpec.scala
@@ -5,10 +5,16 @@ import edu.uci.ics.texera.workflow.common.tuple.exception.TupleBuildingException
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
 import org.scalatest.flatspec.AnyFlatSpec
 
+import java.sql.Timestamp
+
 class TupleSpec extends AnyFlatSpec {
   val stringAttribute = new Attribute("col-string", AttributeType.STRING)
   val integerAttribute = new Attribute("col-int", AttributeType.INTEGER)
   val boolAttribute = new Attribute("col-bool", AttributeType.BOOLEAN)
+  val longAttribute = new Attribute("col-long", AttributeType.LONG)
+  val doubleAttribute = new Attribute("col-double", AttributeType.DOUBLE)
+  val timestampAttribute = new Attribute("col-timestamp", AttributeType.TIMESTAMP)
+  val binaryAttribute = new Attribute("col-binary", AttributeType.BINARY)
 
   val capitalizedStringAttribute = new Attribute("COL-string", AttributeType.STRING)
 
@@ -100,13 +106,51 @@ class TupleSpec extends AnyFlatSpec {
 
   it should "calculate hash" in {
     val inputSchema =
-      Schema.newBuilder().add(integerAttribute).add(stringAttribute).add(boolAttribute).build()
+      Schema
+        .newBuilder()
+        .add(integerAttribute)
+        .add(stringAttribute)
+        .add(boolAttribute)
+        .add(longAttribute)
+        .add(doubleAttribute)
+        .add(timestampAttribute)
+        .add(binaryAttribute)
+        .build()
+
     val inputTuple = Tuple
       .newBuilder(inputSchema)
-      .add(integerAttribute, 1)
+      .add(integerAttribute, 922323)
       .add(stringAttribute, "string-attr")
       .add(boolAttribute, true)
+      .add(longAttribute, 1123213213213L)
+      .add(doubleAttribute, 214214.9969346)
+      .add(timestampAttribute, new Timestamp(100000000L))
+      .add(binaryAttribute, Array[Byte](104, 101, 108, 108, 111))
       .build()
-    println(s"hash ${inputTuple.hashCode()}")
+    assert(inputTuple.hashCode() == -1335416166)
+
+    val inputTuple2 = Tuple
+      .newBuilder(inputSchema)
+      .add(integerAttribute, 0)
+      .add(stringAttribute, "")
+      .add(boolAttribute, false)
+      .add(longAttribute, 0L)
+      .add(doubleAttribute, 0.0)
+      .add(timestampAttribute, new Timestamp(0L))
+      .add(binaryAttribute, Array[Byte]())
+      .build()
+    assert(inputTuple2.hashCode() == -1409761483)
+
+    val inputTuple3 = Tuple
+      .newBuilder(inputSchema)
+      .add(integerAttribute, null)
+      .add(stringAttribute, null)
+      .add(boolAttribute, null)
+      .add(longAttribute, null)
+      .add(doubleAttribute, null)
+      .add(timestampAttribute, null)
+      .add(binaryAttribute, null)
+      .build()
+    assert(inputTuple3.hashCode() == 1742810335)
   }
 }

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/common/tuple/TupleSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/common/tuple/TupleSpec.scala
@@ -97,4 +97,16 @@ class TupleSpec extends AnyFlatSpec {
     assert(line == tuple2json(newTuple))
 
   }
+
+  it should "calculate hash" in {
+    val inputSchema =
+      Schema.newBuilder().add(integerAttribute).add(stringAttribute).add(boolAttribute).build()
+    val inputTuple = Tuple
+      .newBuilder(inputSchema)
+      .add(integerAttribute, 1)
+      .add(stringAttribute, "string-attr")
+      .add(boolAttribute, true)
+      .build()
+    println(s"hash ${inputTuple.hashCode()}")
+  }
 }

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/common/tuple/TupleSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/common/tuple/TupleSpec.scala
@@ -152,5 +152,29 @@ class TupleSpec extends AnyFlatSpec {
       .add(binaryAttribute, null)
       .build()
     assert(inputTuple3.hashCode() == 1742810335)
+
+    val inputTuple4 = Tuple
+      .newBuilder(inputSchema)
+      .add(integerAttribute, -3245763)
+      .add(stringAttribute, "\n\r\napple")
+      .add(boolAttribute, true)
+      .add(longAttribute, -8965536434247L)
+      .add(doubleAttribute, 1/3.0d)
+      .add(timestampAttribute, new Timestamp(-1990))
+      .add(binaryAttribute, null)
+      .build()
+    assert(inputTuple4.hashCode() == -592643630)
+
+    val inputTuple5 = Tuple
+      .newBuilder(inputSchema)
+      .add(integerAttribute, Int.MaxValue)
+      .add(stringAttribute, new String())
+      .add(boolAttribute, true)
+      .add(longAttribute, Long.MaxValue)
+      .add(doubleAttribute, 7 / 17.0d)
+      .add(timestampAttribute, new Timestamp(1234567890L))
+      .add(binaryAttribute, Array.fill[Byte](4097)('o'))
+      .build()
+    assert(inputTuple5.hashCode() == -2099556631)
   }
 }


### PR DESCRIPTION
This PR fixes #1601 by implementing the same hash function on both the Java and the Python side. 

### Implementation
We implemented the hash algorithm proposed in _Josh Bloch's Effective Java_ in Python Tuple, following the [suggestions](https://stackoverflow.com/questions/113511/best-implementation-for-hashcode-method-for-a-collection). This way, Java-side Tuple uses `Arrays.deepHashCode(fields.toArray())`, which is the built-in implementation of hashing an array of Objects.

### Performance
Python-side Tuple hash is tested to have `2.95e-05`s runtime on a local env, which is a rough 34K tuple/s throughput. The performance is reasonable.