### PR TITLE
Using distinct on GroupConcat to remove duplicated project labels

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DashboardResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DashboardResource.scala
@@ -14,7 +14,7 @@ import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowResource.
 import io.dropwizard.auth.Auth
 import org.jooq.Condition
 import org.jooq.impl.DSL
-import org.jooq.impl.DSL.{falseCondition, groupConcat, noCondition}
+import org.jooq.impl.DSL.{falseCondition, groupConcat, groupConcatDistinct, noCondition}
 import org.jooq.types.UInteger
 
 import java.sql.Timestamp
@@ -210,7 +210,7 @@ class DashboardResource {
           WORKFLOW_USER_ACCESS.PRIVILEGE,
           WORKFLOW_OF_USER.UID,
           USER.NAME,
-          groupConcat(WORKFLOW_OF_PROJECT.PID).as("projects"),
+          groupConcatDistinct(WORKFLOW_OF_PROJECT.PID).as("projects"),
           // project attributes: 3 columns
           DSL.inline(null, classOf[UInteger]).as("pid"),
           DSL.inline(null, classOf[UInteger]).as("owner_id"),

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DashboardResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DashboardResource.scala
@@ -14,7 +14,7 @@ import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowResource.
 import io.dropwizard.auth.Auth
 import org.jooq.Condition
 import org.jooq.impl.DSL
-import org.jooq.impl.DSL.{falseCondition, groupConcat, groupConcatDistinct, noCondition}
+import org.jooq.impl.DSL.{falseCondition, groupConcatDistinct, noCondition}
 import org.jooq.types.UInteger
 
 import java.sql.Timestamp

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
@@ -13,7 +13,7 @@ import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos._
 import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowResource._
 import io.dropwizard.auth.Auth
 import org.jooq.{Condition, TableField}
-import org.jooq.impl.DSL.{groupConcat, groupConcatDistinct, noCondition}
+import org.jooq.impl.DSL.{groupConcatDistinct, noCondition}
 import org.jooq.types.UInteger
 
 import java.sql.Timestamp

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
@@ -13,7 +13,7 @@ import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos._
 import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowResource._
 import io.dropwizard.auth.Auth
 import org.jooq.{Condition, TableField}
-import org.jooq.impl.DSL.{groupConcat, noCondition}
+import org.jooq.impl.DSL.{groupConcat, groupConcatDistinct, noCondition}
 import org.jooq.types.UInteger
 
 import java.sql.Timestamp
@@ -352,7 +352,7 @@ class WorkflowResource {
         WORKFLOW_USER_ACCESS.PRIVILEGE,
         WORKFLOW_OF_USER.UID,
         USER.NAME,
-        groupConcat(WORKFLOW_OF_PROJECT.PID).as("projects")
+        groupConcatDistinct(WORKFLOW_OF_PROJECT.PID).as("projects")
       )
       .from(WORKFLOW)
       .leftJoin(WORKFLOW_USER_ACCESS)
@@ -636,7 +636,7 @@ class WorkflowResource {
           WORKFLOW_USER_ACCESS.PRIVILEGE,
           WORKFLOW_OF_USER.UID,
           USER.NAME,
-          groupConcat(PROJECT.PID).as("projects")
+          groupConcatDistinct(PROJECT.PID).as("projects")
         )
         .from(WORKFLOW)
         .leftJoin(WORKFLOW_USER_ACCESS)

--- a/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow-list-item/user-workflow-list-item.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow-list-item/user-workflow-list-item.component.html
@@ -113,7 +113,7 @@
     *ngIf="userProjectsMap.size > 0"
     class="project-label-container">
     <div
-      *ngFor="let projectID of entry.workflow.projectIDs"
+      *ngFor="let projectID of entry.workflow.projectIDs | unique"
       class="project-label">
       <a
         *ngIf="userProjectsMap && userProjectsMap.has(projectID) && userProjectsMap.get(projectID)!.color !== null && projectID !== pid"

--- a/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow-list-item/user-workflow-list-item.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow-list-item/user-workflow-list-item.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
-
+import { UniquePipe } from "ngx-pipes";
 import { UserWorkflowListItemComponent } from "./user-workflow-list-item.component";
 import { FileSaverService } from "../../../service/user-file/file-saver.service";
 import { testWorkflowEntries } from "../../user-dashboard-test-fixtures";
@@ -17,7 +17,7 @@ describe("UserWorkflowListItemComponent", () => {
   const fileSaverServiceSpy = jasmine.createSpyObj<FileSaverService>(["saveAs"]);
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [UserWorkflowListItemComponent],
+      declarations: [UserWorkflowListItemComponent, UniquePipe],
       providers: [
         { provide: WorkflowPersistService, useValue: new StubWorkflowPersistService(testWorkflowEntries) },
         { provide: UserProjectService, useValue: new StubUserProjectService() },


### PR DESCRIPTION
This PR fixes the following bug:

<img width="1191" alt="截屏2023-08-23 下午4 03 37" src="https://github.com/Texera/texera/assets/13672781/0f1f5496-2215-453c-9de6-8be5c68bde7c">

Due to the join, if the workflow is shared by multiple people, the same pid may occur multiple times. By using distinct in the query, we remove those duplicated pids.
