### PR TITLE
Show All Errors in Schema Propagation

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
@@ -190,7 +190,9 @@ case class LogicalPlan(
   ): PhysicalPlan = {
 
     if (errorList.nonEmpty) {
-      throw new RuntimeException(s"${errorList.size} error(s) occurred in schema propagation.")
+      val err = new Exception(s"${errorList.size} error(s) occurred in schema propagation.")
+      errorList.foreach(err.addSuppressed)
+      throw err
     }
 
     // assign storage to texera-managed sinks before generating exec config


### PR DESCRIPTION
This PR addresses the unclear error messages on the frontend. Now, during schema propagation, all errors will be listed as suppressed exceptions.