### PR TITLE
Add a hyperlink to the Texera main logo on the navigation page for system users

### DIFF
--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -1,7 +1,9 @@
 <div class="texera-navigation-body">
   <div class="texera-navigation-padded">
     <div class="texera-navigation-title">
-      <a *ngIf="userSystemEnabled; else noLink" [routerLink]="'/dashboard/workflow'">
+      <a
+        *ngIf="userSystemEnabled; else noLink"
+        [routerLink]="'/dashboard/workflow'">
         <img
           [ngClass]="{ 'user-system-enabled': userSystemEnabled }"
           alt="Texera"

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -1,10 +1,13 @@
 <div class="texera-navigation-body">
   <div class="texera-navigation-padded">
-    <img
-      [ngClass]="{ 'user-system-enabled': userSystemEnabled }"
-      alt="Texera"
-      class="texera-navigation-title"
-      src="assets/logos/full_logo_small.png?v=1" />
+    <a [routerLink]="'/dashboard/workflow'">
+      <img
+        [ngClass]="{ 'user-system-enabled': userSystemEnabled }"
+        alt="Texera"
+        class="texera-navigation-title"
+        src="assets/logos/full_logo_small.png?v=1"
+        title="dashboard" />
+    </a>
 
     <!-- workflow metadata display -->
     <div

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -1,13 +1,20 @@
 <div class="texera-navigation-body">
   <div class="texera-navigation-padded">
     <div class="texera-navigation-title">
-      <a [routerLink]="'/dashboard/workflow'">
+      <a *ngIf="userSystemEnabled; else noLink" [routerLink]="'/dashboard/workflow'">
         <img
           [ngClass]="{ 'user-system-enabled': userSystemEnabled }"
           alt="Texera"
           src="assets/logos/full_logo_small.png?v=1"
           title="dashboard" />
       </a>
+      <ng-template #noLink>
+        <img
+          [ngClass]="{ 'user-system-enabled': userSystemEnabled }"
+          alt="Texera"
+          src="assets/logos/full_logo_small.png?v=1"
+          title="dashboard" />
+      </ng-template>
     </div>
 
     <!-- workflow metadata display -->

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -12,8 +12,7 @@
         <img
           [ngClass]="{ 'user-system-enabled': userSystemEnabled }"
           alt="Texera"
-          src="assets/logos/full_logo_small.png?v=1"
-          title="dashboard" />
+          src="assets/logos/full_logo_small.png?v=1" />
       </ng-template>
     </div>
 

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -1,13 +1,14 @@
 <div class="texera-navigation-body">
   <div class="texera-navigation-padded">
-    <a [routerLink]="'/dashboard/workflow'">
-      <img
-        [ngClass]="{ 'user-system-enabled': userSystemEnabled }"
-        alt="Texera"
-        class="texera-navigation-title"
-        src="assets/logos/full_logo_small.png?v=1"
-        title="dashboard" />
-    </a>
+    <div class="texera-navigation-title">
+      <a [routerLink]="'/dashboard/workflow'">
+        <img
+          [ngClass]="{ 'user-system-enabled': userSystemEnabled }"
+          alt="Texera"
+          src="assets/logos/full_logo_small.png?v=1"
+          title="dashboard" />
+      </a>
+    </div>
 
     <!-- workflow metadata display -->
     <div

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.scss
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.scss
@@ -31,6 +31,9 @@
     margin-left: auto;
     margin-right: auto;
     display: block;
+  }
+
+  .texera-navigation-title img {
     width: 96px;
     height: 54px;
 


### PR DESCRIPTION
This PR adds a hyperlink to the Texera logo on the navigation page for system users. The page will redirect to the dashboard if a system user clicks the logo. The behavior is the same when clicking the dashboard button on the navigation page. If the user is not a system user, the hyperlink will be disabled.

[System User]
![Texera - Chrome 2023-08-31 14-28-02_edited_trimmed](https://github.com/Texera/texera/assets/143021053/77cb255b-331d-4547-abc1-6004b7787c81)

[Non-system User]
![Texera - Chrome 2023-08-31 14-39-02](https://github.com/Texera/texera/assets/143021053/37270aa0-acc0-442d-a1e8-4cffab392012)
