### PR TITLE
Disable user to enter the execution name during workflow

### DIFF
--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -372,7 +372,10 @@
         <ng-template #execution_name>
           <input
             [(ngModel)]="currentExecutionName"
-            placeholder="Untitled Execution" />
+            placeholder="Untitled Execution"
+            [disabled]="!(executionState === ExecutionState.Uninitialized ||
+						    executionState === ExecutionState.Completed ||
+						    executionState === ExecutionState.Aborted)" />
         </ng-template>
         <div [ngStyle]="{ 'margin-left': '5px' }">
           <nz-badge

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -366,7 +366,7 @@
           <input
             [(ngModel)]="currentExecutionName"
             placeholder="Untitled Execution"
-            [disabled]="!isExecutionInTerminalState()" />
+            [disabled]="!isWorkflowModifiable" />
         </ng-template>
         <div [ngStyle]="{ 'margin-left': '5px' }">
           <nz-badge

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -298,10 +298,7 @@
     <div
       [ngClass]="{
 				'texera-navigation-execute': true,
-				'reveal-stop-button':
-					executionState !== ExecutionState.Uninitialized &&
-					executionState !== ExecutionState.Completed &&
-					executionState !== ExecutionState.Aborted
+				'reveal-stop-button': !isExecutionInTerminalState()
 			}">
       <nz-button-group nzSize="large">
         <button
@@ -336,11 +333,7 @@
         <button
           #runStopButton
           (click)="handleKill()"
-          [disabled]="
-						executionState === ExecutionState.Uninitialized ||
-						executionState === ExecutionState.Completed ||
-						executionState === ExecutionState.Aborted
-					"
+          [disabled]="isExecutionInTerminalState()"
           class="texera-navigation-stop-button"
           nz-button
           nzDanger
@@ -373,9 +366,7 @@
           <input
             [(ngModel)]="currentExecutionName"
             placeholder="Untitled Execution"
-            [disabled]="!(executionState === ExecutionState.Uninitialized ||
-						    executionState === ExecutionState.Completed ||
-						    executionState === ExecutionState.Aborted)" />
+            [disabled]="!isExecutionInTerminalState()" />
         </ng-template>
         <div [ngStyle]="{ 'margin-left': '5px' }">
           <nz-badge

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -506,7 +506,7 @@ export class NavigationComponent implements OnInit {
     return (
       this.executionState === ExecutionState.Uninitialized ||
       this.executionState === ExecutionState.Completed ||
-      this.executionState == ExecutionState.Aborted
+      this.executionState === ExecutionState.Aborted
     );
   }
 }

--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.ts
@@ -501,4 +501,12 @@ export class NavigationComponent implements OnInit {
       .pipe(untilDestroyed(this))
       .subscribe(metadata => (this.workflowId = metadata.wid));
   }
+
+  isExecutionInTerminalState(): boolean {
+    return (
+      this.executionState === ExecutionState.Uninitialized ||
+      this.executionState === ExecutionState.Completed ||
+      this.executionState == ExecutionState.Aborted
+    );
+  }
 }


### PR DESCRIPTION
This PR fixes the issue [#2081](https://github.com/Texera/texera/issues/2081). During workflow execution, the user can look at the current execution name but cannot rename it unless the workflow is modifiable.

![media2](https://github.com/Texera/texera/assets/143021053/e4216591-aa50-49cd-9f74-a8bc5ce24fb2)
