### PR TITLE
Disable renaming execution when the workflow is not modifiable

### DIFF
--- a/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
+++ b/core/new-gui/src/app/workspace/component/navigation/navigation.component.html
@@ -373,7 +373,8 @@
         <ng-template #execution_name>
           <input
             [(ngModel)]="currentExecutionName"
-            placeholder="Untitled Execution" />
+            placeholder="Untitled Execution"
+            [disabled]="!isWorkflowModifiable" />
         </ng-template>
         <div [ngStyle]="{ 'margin-left': '5px' }">
           <nz-badge


### PR DESCRIPTION
This PR fixes the issue [#2081](https://github.com/Texera/texera/issues/2081). During workflow execution, the user can look at the current execution name but cannot rename it unless the workflow is modifiable.

![media2](https://github.com/Texera/texera/assets/143021053/e4216591-aa50-49cd-9f74-a8bc5ce24fb2)
