### PR TITLE
Null value handing and timer cleanup in execution dashboard

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/execution/AdminExecutionResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/execution/AdminExecutionResource.scala
@@ -91,7 +91,7 @@ class AdminExecutionResource {
       .map(workflowRecord => {
         val startingTime = workflowRecord.get(WORKFLOW_EXECUTIONS.STARTING_TIME).getTime
 
-        var lastUpdateTime = workflowRecord.get(WORKFLOW_EXECUTIONS.LAST_UPDATE_TIME).getTime
+        var lastUpdateTime: Long = 0
         if (workflowRecord.get(WORKFLOW_EXECUTIONS.LAST_UPDATE_TIME) == null) {
           lastUpdateTime = 0
         } else {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/execution/AdminExecutionResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/execution/AdminExecutionResource.scala
@@ -90,7 +90,14 @@ class AdminExecutionResource {
     workflowEntries
       .map(workflowRecord => {
         val startingTime = workflowRecord.get(WORKFLOW_EXECUTIONS.STARTING_TIME).getTime
-        val lastUpdateTime = workflowRecord.get(WORKFLOW_EXECUTIONS.LAST_UPDATE_TIME).getTime
+
+        var lastUpdateTime = workflowRecord.get(WORKFLOW_EXECUTIONS.LAST_UPDATE_TIME).getTime
+        if (workflowRecord.get(WORKFLOW_EXECUTIONS.LAST_UPDATE_TIME) == null) {
+          lastUpdateTime = 0
+        } else {
+          lastUpdateTime = workflowRecord.get(WORKFLOW_EXECUTIONS.LAST_UPDATE_TIME).getTime
+        }
+
         val timeDifferenceSeconds = (lastUpdateTime - startingTime) / 1000.0
         val hasAccess = availableWorkflowIds.contains(workflowRecord.get(WORKFLOW_VERSION.WID))
         dashboardExecution(

--- a/core/new-gui/src/app/dashboard/admin/component/admin-dashboard.component.html
+++ b/core/new-gui/src/app/dashboard/admin/component/admin-dashboard.component.html
@@ -67,8 +67,23 @@
       <td>{{ maxStringLength(execution.executionName, 20) }} ({{ execution.executionId }})</td>
       <td>{{ execution.userName }}</td>
       <td [ngStyle]="{ 'color': getStatusColor(execution.executionStatus) }"><b>{{ execution.executionStatus }}</b></td>
-      <td>{{ convertSecondsToTime(execution.executionTime) }}</td>
-      <td>{{ convertTimeToTimestamp(execution.executionStatus, execution.endTime) }}</td>
+      <td>
+        <div *ngIf="execution.executionTime >= 0; else endTimeNotAvailable">
+          {{ convertSecondsToTime(execution.executionTime) }}
+        </div>
+        <ng-template #endTimeNotAvailable>
+          <div>Not Available</div>
+        </ng-template>
+      </td>
+
+      <td>
+        <div *ngIf="execution.endTime != 0; else endTimeNotAvailable">
+          {{ convertTimeToTimestamp(execution.executionStatus, execution.endTime) }}
+        </div>
+        <ng-template #endTimeNotAvailable>
+          <div>Not Available</div>
+        </ng-template>
+      </td>
       <td>
         <button
           type="button"

--- a/core/new-gui/src/app/dashboard/admin/component/admin-dashboard.component.html
+++ b/core/new-gui/src/app/dashboard/admin/component/admin-dashboard.component.html
@@ -77,7 +77,7 @@
       </td>
 
       <td>
-        <div *ngIf="execution.endTime != 0; else endTimeNotAvailable">
+        <div *ngIf="execution.endTime !== 0; else endTimeNotAvailable">
           {{ convertTimeToTimestamp(execution.executionStatus, execution.endTime) }}
         </div>
         <ng-template #endTimeNotAvailable>

--- a/core/new-gui/src/app/dashboard/admin/component/admin-dashboard.component.ts
+++ b/core/new-gui/src/app/dashboard/admin/component/admin-dashboard.component.ts
@@ -78,7 +78,7 @@ export class AdminDashboardComponent implements OnInit, OnDestroy {
   }
 
   ngOnDestroy(): void {
-      clearInterval(this.timer);
+    clearInterval(this.timer);
   }
 
   maxStringLength(input: string, length: number): string {

--- a/core/new-gui/src/app/dashboard/admin/component/admin-dashboard.component.ts
+++ b/core/new-gui/src/app/dashboard/admin/component/admin-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from "@angular/core";
+import { Component, OnInit, OnDestroy } from "@angular/core";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { AdminExecutionService } from "../service/admin-execution.service";
 import { Execution } from "../../../common/type/execution";
@@ -14,7 +14,7 @@ import { WorkflowWebsocketService } from "src/app/workspace/service/workflow-web
   templateUrl: "./admin-dashboard.component.html",
   styleUrls: ["./admin-dashboard.component.scss"],
 })
-export class AdminDashboardComponent implements OnInit {
+export class AdminDashboardComponent implements OnInit, OnDestroy {
   Executions: ReadonlyArray<Execution> = [];
   workflowsCount: number = 0;
   usersCount: number = 0;
@@ -26,7 +26,7 @@ export class AdminDashboardComponent implements OnInit {
   // This interval function fetches the latest execution list and checks for updates.
   // If some execution's data has changed, it triggers a component refresh.
   // The interval runs every 1 second (1000 milliseconds).
-  intervals = setInterval(() => {
+  timer = setInterval(() => {
     this.adminExecutionService
       .getExecutionList()
       .pipe(untilDestroyed(this))
@@ -75,6 +75,10 @@ export class AdminDashboardComponent implements OnInit {
         this.reset();
         this.workflowsCount = this.listOfExecutions.length;
       });
+  }
+
+  ngOnDestroy(): void {
+      clearInterval(this.timer);
   }
 
   maxStringLength(input: string, length: number): string {


### PR DESCRIPTION
Fix the issue that keeps send http requests even after closing the page.

Checking the null values of last_update_time value in backend.