### PR TITLE
Bump lbmq version to 0.6.0

### DIFF
--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -215,7 +215,7 @@ libraryDependencies += "com.univocity" % "univocity-parsers" % "2.9.1"
 libraryDependencies += "com.konghq" % "unirest-java" % "3.11.11"
 
 // https://mvnrepository.com/artifact/com.github.marianobarrios/lbmq
-libraryDependencies += "com.github.marianobarrios" % "lbmq" % "0.5.0"
+libraryDependencies += "com.github.marianobarrios" % "lbmq" % "0.6.0"
 
 // https://mvnrepository.com/artifact/io.github.redouane59.twitter/twittered
 libraryDependencies += "io.github.redouane59.twitter" % "twittered" % "2.16"


### PR DESCRIPTION
This PR fixes bumps lbmq version to the latest (0.6.0) to fix [an issue introduced by lbmq](https://github.com/marianobarrios/linked-blocking-multi-queue/issues/29).