### PR TITLE
Add Python native operator dependencies

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -113,6 +113,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           if [ -f core/amber/requirements.txt ]; then pip install -r core/amber/requirements.txt; fi
+          if [ -f core/amber/operator-requirements.txt ]; then pip install -r core/amber/operator-requirements.txt; fi
       - name: Lint with flake8 and black
         run: |
           cd core/amber/src/main/python && flake8 && black . --check

--- a/core/amber/operator-requirements.txt
+++ b/core/amber/operator-requirements.txt
@@ -1,1 +1,2 @@
 wordcloud
+plotly

--- a/core/amber/operator-requirements.txt
+++ b/core/amber/operator-requirements.txt
@@ -1,2 +1,3 @@
 wordcloud
 plotly
+praw

--- a/core/amber/operator-requirements.txt
+++ b/core/amber/operator-requirements.txt
@@ -1,3 +1,5 @@
 wordcloud
 plotly
 praw
+pillow
+pybase64


### PR DESCRIPTION
Following up on #2157, this PR adds a dependency file `operator-requirements.txt`, which declares the dependencies used in native Python operators. 