### PR TITLE
Improve Co-editor Color Generation Method

### DIFF
--- a/core/new-gui/src/app/common/service/user/user.service.ts
+++ b/core/new-gui/src/app/common/service/user/user.service.ts
@@ -67,10 +67,10 @@ export class UserService {
    */
   private changeUser(user: User | undefined): void {
     if (user) {
-      const r = Math.floor(Math.random() * 155);
-      const g = Math.floor(Math.random() * 155);
-      const b = Math.floor(Math.random() * 155);
-      this.currentUser = { ...user, color: "rgba(" + r + "," + g + "," + b + ",0.8)" };
+      const hue = Math.floor(Math.random() * 360); // Hue (0-360)
+      const sat = Math.floor(60 + Math.random() * 20); // Saturation (60%-80%)
+      const light = 50; // Lightness (50%)
+      this.currentUser = { ...user, color: `hsl(${hue}, ${sat}%, ${light}%)` };
     } else {
       this.currentUser = user;
     }


### PR DESCRIPTION
This PR changes the method and parameters for generating a collaborative editor's user-color. Previously we limited the color to only dark colors so that the text on the editor canvas (bright background) can be visually easy. However, Python-UDF editor also relies on this color for a co-editor's cursor, which is on a dark background. To make it both easy-to-see on dark and bright background, we limit the brightness to be always 50%, and saturation to be randomized from 60% - 80%, and hue to be randomized. The resulting colors look like the following screenshots:

<img width="616" alt="Snipaste_2023-10-03_12-36-44" src="https://github.com/Texera/texera/assets/36582710/12812664-5244-4295-9e24-379681124327">
<img width="709" alt="Snipaste_2023-10-03_12-38-07" src="https://github.com/Texera/texera/assets/36582710/e93af250-79cf-43ca-beb7-65c23d76f998">
