### PR TITLE
Increase workflow content size in DDL to support large workflow

### DIFF
--- a/core/scripts/sql/texera_ddl.sql
+++ b/core/scripts/sql/texera_ddl.sql
@@ -71,7 +71,7 @@ CREATE TABLE IF NOT EXISTS workflow
     `name`               VARCHAR(128)                NOT NULL,
 	`description`        VARCHAR(500),
     `wid`                INT UNSIGNED AUTO_INCREMENT NOT NULL,
-    `content`            MEDIUMTEXT                  NOT NULL,
+    `content`            LONGTEXT                    NOT NULL,
     `creation_time`      TIMESTAMP                   NOT NULL DEFAULT CURRENT_TIMESTAMP,
     `last_modified_time` TIMESTAMP                   NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
     PRIMARY KEY (`wid`)

--- a/core/scripts/sql/update/03.sql
+++ b/core/scripts/sql/update/03.sql
@@ -1,0 +1,3 @@
+USE `texera_db`;
+ALTER table workflow
+    MODIFY content longtext not null;


### PR DESCRIPTION
This PR changes the workflow content field in DDL from MEDIUMTEXT to LONGTEXT to support larger workflow with more operators. 

MEDIUMTEXT can store up to 16,777,215 characters i.e 16,777,215 bytes or 64MB of data. LONGTEXT can store the maximum characters among all text types, up to 4,294,967,295 characters i,e 4,294,967,295 bytes or 4GB.

Existing DB can be updated with `core/scripts/sql/update/03.sql`