### PR TITLE
Enable resizing the visualization operator window

### DIFF
--- a/core/new-gui/src/app/workspace/component/result-panel/visualization-frame/visualization-frame.component.html
+++ b/core/new-gui/src/app/workspace/component/result-panel/visualization-frame/visualization-frame.component.html
@@ -7,7 +7,8 @@
 <ng-template #modalTitle>
   <div
     cdkDrag
-    cdkDragRootElement=".ant-modal-content">
+    cdkDragRootElement=".ant-modal-content"
+    cdkDragHandle>
     <div style="display: flex; align-items: center; justify-content: space-between">
       <span>Visualization</span>
       <span

--- a/core/new-gui/src/app/workspace/component/result-panel/visualization-frame/visualization-frame.component.scss
+++ b/core/new-gui/src/app/workspace/component/result-panel/visualization-frame/visualization-frame.component.scss
@@ -1,8 +1,8 @@
-::ng-deep .ant-modal-content {
-  /* Set a minimum width and height for the modal */
-  min-width: 300px;
-  min-height: 200px;
-  /* Enable resizing behavior */
-  resize: both;
-  overflow: auto;
+::ng-deep .cdk-overlay-pane {
+  /* Target the modal content */
+  .ant-modal-content {
+    /* Enable resizing behavior */
+    resize: both;
+    overflow: auto;
+  }
 }

--- a/core/new-gui/src/app/workspace/component/result-panel/visualization-frame/visualization-frame.component.scss
+++ b/core/new-gui/src/app/workspace/component/result-panel/visualization-frame/visualization-frame.component.scss
@@ -1,0 +1,8 @@
+::ng-deep .ant-modal-content {
+  /* Set a minimum width and height for the modal */
+  min-width: 300px;
+  min-height: 200px;
+  /* Enable resizing behavior */
+  resize: both;
+  overflow: auto;
+}


### PR DESCRIPTION
This PR adds the ability to resize the visualization operator window by dragging the bottom left corner.

![capture](https://github.com/Texera/texera/assets/143021053/01ecaf8f-1d29-4e06-839d-abb7b2835749)