### PR TITLE
Use currentWorkerNum instead of numWorkerPerNode

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/OpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/OpExecConfig.scala
@@ -99,7 +99,7 @@ case class OpExecConfig(
     // parameters: 1: worker index, 2: this worker layer object
     initIOperatorExecutor: OpExecFunc,
     // preference of parallelism (number of workers)
-    numWorkers: Int = Constants.numWorkerPerNode,
+    numWorkers: Int = Constants.currentWorkerNum,
     // preference of worker placement
     locationPreference: Option[LocationPreference] = None,
     // requirement of partition policy (hash/range/single/none) on inputs

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/OpExecConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/OpExecConfig.scala
@@ -98,7 +98,7 @@ case class OpExecConfig(
     // function to create an operator executor instance
     // parameters: 1: worker index, 2: this worker layer object
     initIOperatorExecutor: OpExecFunc,
-    // preference of parallelism (number of workers)
+    // preference of parallelism (total number of workers)
     numWorkers: Int = Constants.currentWorkerNum,
     // preference of worker placement
     locationPreference: Option[LocationPreference] = None,


### PR DESCRIPTION
This PR addresses a bug in which we were allocating workers for an operator based on the number of workers per node when it should have been using the total number of workers in the cluster.

This change indirectly fixes #2137.