### PR TITLE
Fix exporting results without ViewResult operator

### DIFF
--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -205,7 +205,7 @@ export class ResultPanelComponent implements OnInit {
     const resultService = this.workflowResultService.getResultService(operatorId);
     const paginatedResultService = this.workflowResultService.getPaginatedResultService(operatorId);
     if (paginatedResultService) {
-      // display table result if has paginated results
+      // display table result if it has paginated results
       this.frameComponentConfigs.set("Result", {
         component: ResultTableFrameComponent,
         componentInputs: { operatorId },

--- a/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
@@ -53,6 +53,7 @@ export class WorkflowResultExportService {
         this.workflowActionService
           .getJointGraphWrapper()
           .getCurrentHighlightedOperatorIDs()
+          // only supports exporting paginated results
           .filter(operatorId => this.workflowResultService.hasPaginatedResult(operatorId)).length > 0;
     });
   }

--- a/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
@@ -53,12 +53,7 @@ export class WorkflowResultExportService {
         this.workflowActionService
           .getJointGraphWrapper()
           .getCurrentHighlightedOperatorIDs()
-          .filter(operatorId => {
-
-            return this.workflowResultService.hasPaginatedResult(operatorId)
-            // return isSink(this.workflowActionService.getTexeraGraph().getOperator(operatorId))
-            }
-          ).length > 0;
+          .filter(operatorId => this.workflowResultService.hasPaginatedResult(operatorId)).length > 0;
     });
   }
 

--- a/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
@@ -53,8 +53,7 @@ export class WorkflowResultExportService {
         this.workflowActionService
           .getJointGraphWrapper()
           .getCurrentHighlightedOperatorIDs()
-          // only supports exporting paginated results
-          .filter(operatorId => this.workflowResultService.hasPaginatedResult(operatorId)).length > 0;
+          .filter(operatorId => this.workflowResultService.hasAnyResult(operatorId)).length > 0;
     });
   }
 

--- a/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
@@ -75,6 +75,9 @@ export class WorkflowResultExportService {
       .getJointGraphWrapper()
       .getCurrentHighlightedOperatorIDs()
       .forEach(operatorId => {
+        if (!this.workflowResultService.hasAnyResult(operatorId)) {
+          return;
+        }
         const operator = this.workflowActionService.getTexeraGraph().getOperator(operatorId);
         const operatorName = operator.customDisplayName ?? operator.operatorType;
         this.workflowWebsocketService.send("ResultExportRequest", {

--- a/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
@@ -22,7 +22,7 @@ export class WorkflowResultExportService {
     private workflowActionService: WorkflowActionService,
     private notificationService: NotificationService,
     private executeWorkflowService: ExecuteWorkflowService,
-    private workflowResultService: WorkflowResultService,
+    private workflowResultService: WorkflowResultService
   ) {
     this.registerResultExportResponseHandler();
     this.registerResultToExportUpdateHandler();

--- a/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
@@ -8,7 +8,7 @@ import { NotificationService } from "../../../common/service/notification/notifi
 import { ExecuteWorkflowService } from "../execute-workflow/execute-workflow.service";
 import { ExecutionState } from "../../types/execute-workflow.interface";
 import { filter } from "rxjs/operators";
-import { isSink } from "../workflow-graph/model/workflow-graph";
+import { WorkflowResultService } from "../workflow-result/workflow-result.service";
 
 @Injectable({
   providedIn: "root",
@@ -21,7 +21,8 @@ export class WorkflowResultExportService {
     private workflowWebsocketService: WorkflowWebsocketService,
     private workflowActionService: WorkflowActionService,
     private notificationService: NotificationService,
-    private executeWorkflowService: ExecuteWorkflowService
+    private executeWorkflowService: ExecuteWorkflowService,
+    private workflowResultService: WorkflowResultService,
   ) {
     this.registerResultExportResponseHandler();
     this.registerResultToExportUpdateHandler();
@@ -52,7 +53,12 @@ export class WorkflowResultExportService {
         this.workflowActionService
           .getJointGraphWrapper()
           .getCurrentHighlightedOperatorIDs()
-          .filter(operatorId => isSink(this.workflowActionService.getTexeraGraph().getOperator(operatorId))).length > 0;
+          .filter(operatorId => {
+
+            return this.workflowResultService.hasPaginatedResult(operatorId)
+            // return isSink(this.workflowActionService.getTexeraGraph().getOperator(operatorId))
+            }
+          ).length > 0;
     });
   }
 
@@ -75,9 +81,6 @@ export class WorkflowResultExportService {
       .getCurrentHighlightedOperatorIDs()
       .forEach(operatorId => {
         const operator = this.workflowActionService.getTexeraGraph().getOperator(operatorId);
-        if (!isSink(operator)) {
-          return;
-        }
         const operatorName = operator.customDisplayName ?? operator.operatorType;
         this.workflowWebsocketService.send("ResultExportRequest", {
           exportType,

--- a/core/new-gui/src/app/workspace/service/workflow-result/workflow-result.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-result/workflow-result.service.ts
@@ -42,11 +42,11 @@ export class WorkflowResultService {
     return this.hasResult(operatorID) || this.hasPaginatedResult(operatorID);
   }
 
-  public hasResult(operatorID: string):boolean {
+  public hasResult(operatorID: string): boolean {
     return isDefined(this.getResultService(operatorID));
   }
 
-  public hasPaginatedResult(operatorID: string):boolean {
+  public hasPaginatedResult(operatorID: string): boolean {
     return isDefined(this.getPaginatedResultService(operatorID));
   }
 
@@ -153,8 +153,7 @@ export class OperatorResultService {
   private chartType: ChartType | undefined;
   private resultSnapshot: ReadonlyArray<object> | undefined;
 
-  constructor(public operatorID: string) {
-  }
+  constructor(public operatorID: string) {}
 
   public getCurrentResultSnapshot(): ReadonlyArray<object> | undefined {
     return this.resultSnapshot;
@@ -225,7 +224,7 @@ class OperatorPaginationResultService {
         requestID: "",
         operatorID: this.operatorID,
         pageIndex: pageIndex,
-        table: pageCache
+        table: pageCache,
       });
     } else {
       // fetch result data from server
@@ -235,7 +234,7 @@ class OperatorPaginationResultService {
         requestID,
         operatorID,
         pageIndex,
-        pageSize
+        pageSize,
       });
       const pendingRequestSubject = new Subject<PaginatedResultEvent>();
       this.pendingRequests.set(requestID, pendingRequestSubject);

--- a/core/new-gui/src/app/workspace/service/workflow-result/workflow-result.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-result/workflow-result.service.ts
@@ -13,6 +13,7 @@ import { map, Observable, of, Subject } from "rxjs";
 import { v4 as uuid } from "uuid";
 import { ChartType } from "../../types/visualization.interface";
 import { IndexableObject } from "../../types/result-table.interface";
+import { isDefined } from "../../../common/util/predicate";
 
 export const DEFAULT_PAGE_SIZE = 5;
 
@@ -35,6 +36,18 @@ export class WorkflowResultService {
     this.wsService
       .subscribeToEvent("WorkflowAvailableResultEvent")
       .subscribe(event => this.handleCleanResultCache(event));
+  }
+
+  public hasAnyResult(operatorID: string): boolean {
+    return this.hasResult(operatorID) || this.hasPaginatedResult(operatorID);
+  }
+
+  public hasResult(operatorID: string):boolean {
+    return isDefined(this.getResultService(operatorID));
+  }
+
+  public hasPaginatedResult(operatorID: string):boolean {
+    return isDefined(this.getPaginatedResultService(operatorID));
   }
 
   public getResultUpdateStream(): Observable<Record<string, WebResultUpdate | undefined>> {
@@ -140,7 +153,8 @@ export class OperatorResultService {
   private chartType: ChartType | undefined;
   private resultSnapshot: ReadonlyArray<object> | undefined;
 
-  constructor(public operatorID: string) {}
+  constructor(public operatorID: string) {
+  }
 
   public getCurrentResultSnapshot(): ReadonlyArray<object> | undefined {
     return this.resultSnapshot;
@@ -211,7 +225,7 @@ class OperatorPaginationResultService {
         requestID: "",
         operatorID: this.operatorID,
         pageIndex: pageIndex,
-        table: pageCache,
+        table: pageCache
       });
     } else {
       // fetch result data from server
@@ -221,7 +235,7 @@ class OperatorPaginationResultService {
         requestID,
         operatorID,
         pageIndex,
-        pageSize,
+        pageSize
       });
       const pendingRequestSubject = new Subject<PaginatedResultEvent>();
       this.pendingRequests.set(requestID, pendingRequestSubject);


### PR DESCRIPTION
This PR fixes #2183. Now frontend will check if an operator actually has a result or not, instead of checking if it is a sink operator, to enable/disable the result export button.