### PR TITLE
Fix flow control first message issue

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
@@ -136,7 +136,7 @@ class Controller(
       case NetworkMessage(id, WorkflowControlMessage(from, seqNum, payload)) =>
         controlInputPort.handleMessage(
           this.sender(),
-          Constants.unprocessedBatchesSizeLimitPerSender, // Controller is assumed to have enough credits
+          Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair, // Controller is assumed to have enough credits
           id,
           from,
           seqNum,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/WorkerBatchInternalQueue.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/WorkerBatchInternalQueue.scala
@@ -110,7 +110,7 @@ trait WorkerBatchInternalQueue {
   def getSenderCredits(sender: ActorVirtualIdentity): Int = {
     val inBytes = inQueueSizeMapping.getOrElseUpdate(sender, 0L)
     val outBytes = outQueueSizeMapping.getOrElseUpdate(sender, 0L)
-    (Constants.unprocessedBatchesSizeLimitPerSender - (inBytes - outBytes)).toInt
+    (Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair - (inBytes - outBytes)).toInt
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerInternalQueue.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerInternalQueue.scala
@@ -69,7 +69,7 @@ class WorkerInternalQueue(
   def getSenderCredits(sender: ActorVirtualIdentity): Int = {
     val inBytes = inQueueSizeMapping.getOrElseUpdate(sender, 0L)
     val outBytes = outQueueSizeMapping.getOrElseUpdate(sender, 0L)
-    (Constants.unprocessedBatchesSizeLimitPerSender - (inBytes - outBytes)).toInt
+    (Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair - (inBytes - outBytes)).toInt
   }
 
   def appendElement(elem: InternalQueueElement): Unit = {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/Constants.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/Constants.scala
@@ -49,7 +49,7 @@ object Constants {
   // flow control related
   var flowControlEnabled: Boolean =
     AmberUtils.amberConfig.getBoolean("flow-control.credit-based-flow-control-enabled")
-  var unprocessedBatchesSizeLimitPerSender: Int =
+  var unprocessedBatchesSizeLimitInBytesPerWorkerPair: Int =
     AmberUtils.amberConfig.getInt(
       "flow-control.unprocessed-batches-size-limit-in-bytes-per-worker-pair"
     )

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/TrivialControlSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/TrivialControlSpec.scala
@@ -52,7 +52,10 @@ class TrivialControlSpec
             msgID,
             WorkflowControlMessage(_, _, ReturnInvocation(id, returnValue))
           ) =>
-        probe.sender() ! NetworkAck(msgID, Some(Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair))
+        probe.sender() ! NetworkAck(
+          msgID,
+          Some(Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair)
+        )
         returnValue match {
           case e: Throwable => throw e
           case _            => assert(returnValue.asInstanceOf[T] == expectedValues(id.toInt))

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/TrivialControlSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/TrivialControlSpec.scala
@@ -52,7 +52,7 @@ class TrivialControlSpec
             msgID,
             WorkflowControlMessage(_, _, ReturnInvocation(id, returnValue))
           ) =>
-        probe.sender() ! NetworkAck(msgID, Some(Constants.unprocessedBatchesSizeLimitPerSender))
+        probe.sender() ! NetworkAck(msgID, Some(Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair))
         returnValue match {
           case e: Throwable => throw e
           case _            => assert(returnValue.asInstanceOf[T] == expectedValues(id.toInt))

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/TrivialControlTester.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/TrivialControlTester.scala
@@ -33,7 +33,7 @@ class TrivialControlTester(
         logger.info(s"received $internalMessage")
         this.controlInputPort.handleMessage(
           this.sender(),
-          Constants.unprocessedBatchesSizeLimitPerSender,
+          Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair,
           id,
           from,
           sequenceNumber,

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkInputPortSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/NetworkInputPortSpec.scala
@@ -34,7 +34,7 @@ class NetworkInputPortSpec extends AnyFlatSpec with MockFactory {
     List(2, 1, 0, 3).foreach(id => {
       inputPort.handleMessage(
         testActor.ref,
-        Constants.unprocessedBatchesSizeLimitPerSender,
+        Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair,
         id,
         messages(id).from,
         messages(id).sequenceNumber,
@@ -58,7 +58,7 @@ class NetworkInputPortSpec extends AnyFlatSpec with MockFactory {
     (0 until 10).foreach(i => {
       inputPort.handleMessage(
         testActor.ref,
-        Constants.unprocessedBatchesSizeLimitPerSender,
+        Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair,
         i,
         message.from,
         message.sequenceNumber,
@@ -77,14 +77,14 @@ class NetworkInputPortSpec extends AnyFlatSpec with MockFactory {
 
     inputPort.handleMessage(
       testActor.ref,
-      Constants.unprocessedBatchesSizeLimitPerSender,
+      Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair,
       messageID,
       message.from,
       message.sequenceNumber,
       message.payload
     )
     testActor.expectMsg(
-      NetworkAck(messageID, Some(Constants.unprocessedBatchesSizeLimitPerSender))
+      NetworkAck(messageID, Some(Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair))
     )
   }
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -368,7 +368,7 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
       assert(
         dp.internalQueue.getSenderCredits(
           senderID
-        ) < Constants.unprocessedBatchesSizeLimitPerSender
+        ) < Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair
       )
       dp.internalQueue.appendElement(EndMarker(senderID))
     }(ExecutionContext.global)
@@ -418,7 +418,7 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
     assert(
       dp.internalQueue.getSenderCredits(
         senderID
-      ) == Constants.unprocessedBatchesSizeLimitPerSender
+      ) == Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair
     )
     Await.result(monitorCredits(senderID, dp, tuplesToSend), 3.seconds)
     dp.shutdown()

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
@@ -162,7 +162,10 @@ class WorkerSpec
             msgID,
             WorkflowControlMessage(_, _, ReturnInvocation(id, returnValue))
           ) =>
-        probe.sender() ! NetworkAck(msgID, Some(Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair))
+        probe.sender() ! NetworkAck(
+          msgID,
+          Some(Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair)
+        )
         returnValue match {
           case e: Throwable => throw e
           case _ =>

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
@@ -162,7 +162,7 @@ class WorkerSpec
             msgID,
             WorkflowControlMessage(_, _, ReturnInvocation(id, returnValue))
           ) =>
-        probe.sender() ! NetworkAck(msgID, Some(Constants.unprocessedBatchesSizeLimitPerSender))
+        probe.sender() ! NetworkAck(msgID, Some(Constants.unprocessedBatchesSizeLimitInBytesPerWorkerPair))
         returnValue match {
           case e: Throwable => throw e
           case _ =>


### PR DESCRIPTION
This PR fixes an issue with the current flow control mechanism. When a worker recovers from a backpressure pause, it mistakenly sends out a stashed message regardless of its size. Now it will check the available credit and only send out a stashed message that is within the available credit.