### PR TITLE
Bump Apache Arrow to 13.0.0 and drop support for Python 3.7

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -94,7 +94,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10' ]
 
     steps:
       - name: Cancel Previous Runs

--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -132,7 +132,7 @@ val googleServiceDependencies = Seq(
 
 /////////////////////////////////////////////////////////////////////////////
 // Arrow related
-val arrowVersion = "12.0.1"
+val arrowVersion = "13.0.0"
 val arrowDependencies = Seq(
   // https://mvnrepository.com/artifact/org.apache.arrow/flight-grpc
   "org.apache.arrow" % "flight-grpc" % arrowVersion,

--- a/core/amber/requirements.txt
+++ b/core/amber/requirements.txt
@@ -5,7 +5,7 @@ flake8
 black
 iniconfig==1.1.1
 loguru==0.7.0
-pyarrow==12.0.1
+pyarrow==13.0.0
 pytest==7.4.0
 python-dateutil==2.8.1
 pytest-timeout


### PR DESCRIPTION
This PR bumps the Apache Arrow version from 12.0.1 to 13.0.0.

For main changes, please take a look at the official change log [13.0.0 (August 2023](https://arrow.apache.org/release/13.0.0.html).

This PR also drops support for Python 3.7 as it has reached [end-of-life]((https://endoflife.date/python), and PyArrow has dropped its support. Support for Python 3.11 will be added in a later PR.