### PR TITLE
Fix the issue that a killed workflow is not modifiable

### DIFF
--- a/core/new-gui/src/app/common/util/switch.ts
+++ b/core/new-gui/src/app/common/util/switch.ts
@@ -1,0 +1,3 @@
+export function exhaustiveGuard(_value: never): never {
+  throw new Error(`ERROR! Reached forbidden guard function with unexpected value: ${JSON.stringify(_value)}`);
+}

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -8,7 +8,7 @@ import {
   ExecutionStateInfo,
   LogicalLink,
   LogicalOperator,
-  LogicalPlan,
+  LogicalPlan
 } from "../../types/execute-workflow.interface";
 import { environment } from "../../../../environments/environment";
 import { WorkflowWebsocketService } from "../workflow-websocket/workflow-websocket.service";
@@ -357,6 +357,7 @@ export class ExecuteWorkflowService {
       case ExecutionState.Failed:
       case ExecutionState.Uninitialized:
       case ExecutionState.BreakpointTriggered:
+      case ExecutionState.Killed:
         this.workflowActionService.enableWorkflowModification();
         return;
       case ExecutionState.Paused:

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -19,6 +19,7 @@ import { PAGINATION_INFO_STORAGE_KEY, ResultPaginationInfo } from "../../types/r
 import { sessionGetObject, sessionSetObject } from "../../../common/util/storage";
 import { Version as version } from "src/environments/version";
 import { NotificationService } from "src/app/common/service/notification/notification.service";
+import { exhaustiveGuard } from "../../../common/util/switch";
 
 // TODO: change this declaration
 export const FORM_DEBOUNCE_TIME_MS = 150;
@@ -369,7 +370,7 @@ export class ExecuteWorkflowService {
         this.workflowActionService.disableWorkflowModification();
         return;
       default:
-        return;
+        return exhaustiveGuard(stateInfo)
     }
   }
 

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -8,7 +8,7 @@ import {
   ExecutionStateInfo,
   LogicalLink,
   LogicalOperator,
-  LogicalPlan
+  LogicalPlan,
 } from "../../types/execute-workflow.interface";
 import { environment } from "../../../../environments/environment";
 import { WorkflowWebsocketService } from "../workflow-websocket/workflow-websocket.service";

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -370,7 +370,7 @@ export class ExecuteWorkflowService {
         this.workflowActionService.disableWorkflowModification();
         return;
       default:
-        return exhaustiveGuard(stateInfo)
+        return exhaustiveGuard(stateInfo);
     }
   }
 


### PR DESCRIPTION
This PR fixes #2185. The breaking change was introduced in #2131, where it adds a new workflow state `Killed`. The `Killed` state did not enable the workflow to be modified.