### PR TITLE
Fix All Operators Highlighted upon Loading a Workflow in the Frontend

### DIFF
--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/joint-graph-wrapper.ts
@@ -95,6 +95,8 @@ export class JointGraphWrapper {
   // flag that indicates whether multiselect mode is on
   private multiSelect: boolean = false;
 
+  private reloadingWorkflow: boolean = false;
+
   private currentHighlights: JointHighlights = {
     operators: [],
     groups: [],
@@ -242,6 +244,14 @@ export class JointGraphWrapper {
    */
   public getMultiSelectMode(): boolean {
     return this.multiSelect;
+  }
+
+  public setReloadingWorkflow(reloadingWorkflow: boolean): void {
+    this.reloadingWorkflow = reloadingWorkflow;
+  }
+
+  public getReloadingWorkflow(): boolean {
+    return this.reloadingWorkflow;
   }
 
   /**

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/shared-model-change-handler.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/shared-model-change-handler.ts
@@ -111,7 +111,7 @@ export class SharedModelChangeHandler {
         this.texeraGraph.operatorAddSubject.next(newOperator.toJSON());
       }
 
-      if (event.transaction.local) {
+      if (event.transaction.local && !this.jointGraphWrapper.getReloadingWorkflow()) {
         // Only highlight when this is added by current user.
         this.jointGraphWrapper.setMultiSelectMode(newOpIDs.length > 1);
         this.jointGraphWrapper.highlightOperators(...newOpIDs);

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
@@ -613,6 +613,7 @@ export class WorkflowActionService {
    * (<code>{@link destroySharedModel}</code>) before using this method.</b>
    */
   public reloadWorkflow(workflow: Workflow | undefined, asyncRendering = environment.asyncRenderingEnabled): void {
+    this.jointGraphWrapper.setReloadingWorkflow(true);
     this.jointGraphWrapper.jointGraphContext.withContext({ async: asyncRendering }, () => {
       this.setWorkflowMetadata(workflow);
       // remove the existing operators on the paper currently
@@ -663,14 +664,10 @@ export class WorkflowActionService {
 
       this.addOperatorsAndLinks(operatorsAndPositions, links, groups, breakpoints, commentBoxes);
 
-      // operators and links shouldn't be highlighted during page reload
-      const jointGraphWrapper = this.getJointGraphWrapper();
-      jointGraphWrapper.unhighlightOperators(...jointGraphWrapper.getCurrentHighlightedOperatorIDs());
-      jointGraphWrapper.unhighlightLinks(...jointGraphWrapper.getCurrentHighlightedLinkIDs());
-
       // restore the view point
       this.getJointGraphWrapper().restoreDefaultZoomAndOffset();
     });
+    this.jointGraphWrapper.setReloadingWorkflow(false);
 
     // After reloading a workflow, need to clear undo/redo stacks because some of the actions involved in reloading
     // may remain in the undo manager.


### PR DESCRIPTION
This PR fixes a bug in the Workflow Editor where every operator is highlighted when a user click the operator for the first time. The cause of the bug was that the reload workflow logic is using the same API for adding operators as the one we use for adding a new operator from drag-and-drop (`addOperatorsAndLinks`), and adding a new operator would tigger highlighting on the new operator.

The current codebase actually has a logic to de-highlight the highlight operators during reload, but the async rendering mode is causing the highlight/de-highlight process to not function correctly, causing `JointGraphWrapper` to be out of sync with what is rendered on the canvas. And this was NOT a good design in the first place.

The fix is to directly check whether the editor is reloading a workflow in the event handling of adding an operator, and avoid highlighting during the reload process. The flag is placed inside `JointGraphWrapper`. Since this is a "correct" design, it fixes the problem without having to touch async rendering code.