### PR TITLE
Showing error message with HTML linebreakers

### DIFF
--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -150,7 +150,12 @@ export class ExecuteWorkflowService {
       case "BreakpointTriggeredEvent":
         return { state: ExecutionState.BreakpointTriggered, breakpoint: event };
       case "WorkflowErrorEvent":
-        return { state: ExecutionState.Failed, errorMessages: event.fatalErrors };
+        return {
+          state: ExecutionState.Failed,
+          errorMessages: event.fatalErrors.map(err => {
+            return { ...err, message: err.message.replace("\\n", "<br>") };
+          }),
+        };
       default:
         return undefined;
     }


### PR DESCRIPTION
This PR adds the convertion on the frontend for the `\n` in error messages to `<br>` so the frontend can break the line correctly.