### PR TITLE
Fix error during editingTimeCompilationRequest and error display with cause

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -16,6 +16,7 @@ import edu.uci.ics.texera.web.workflowruntimestate.WorkflowFatalError
 import edu.uci.ics.texera.web.{ServletAwareConfigurator, SessionState}
 import edu.uci.ics.texera.workflow.common.WorkflowContext
 import edu.uci.ics.texera.workflow.common.workflow.LogicalPlan
+import org.jooq.types.UInteger
 
 import java.time.Instant
 import java.util.concurrent.atomic.AtomicInteger
@@ -90,10 +91,12 @@ class WorkflowWebsocketResource extends LazyLogging {
               }
               stateStore = workflowStateOpt.get.jobService.getValue.stateStore
             }
+
+            val workflowContext = new WorkflowContext(null, uidOpt,  UInteger.valueOf(sessionState.getCurrentWorkflowState.get.wId))
             val newPlan = {
               LogicalPlan.apply(
                 editingTimeCompilationRequest.toLogicalPlanPojo(),
-                new WorkflowContext()
+                workflowContext
               )
             }
             newPlan.initializeLogicalPlan(stateStore)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -92,7 +92,11 @@ class WorkflowWebsocketResource extends LazyLogging {
               stateStore = workflowStateOpt.get.jobService.getValue.stateStore
             }
 
-            val workflowContext = new WorkflowContext(null, uidOpt,  UInteger.valueOf(sessionState.getCurrentWorkflowState.get.wId))
+            val workflowContext = new WorkflowContext(
+              null,
+              uidOpt,
+              UInteger.valueOf(sessionState.getCurrentWorkflowState.get.wId)
+            )
             val newPlan = {
               LogicalPlan.apply(
                 editingTimeCompilationRequest.toLogicalPlanPojo(),

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobStatsService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobStatsService.scala
@@ -179,7 +179,10 @@ class JobStatsService(
                 EXECUTION_FAILURE,
                 Timestamp(Instant.now),
                 evt.e.toString,
-                evt.e.getStackTrace.mkString("\n") + "\ncaused by:\n" + evt.e.getCause.toString + "\n"+evt.e.getCause.getStackTrace.mkString("\n"),
+                evt.e.getStackTrace.mkString(
+                  "\n"
+                ) + "\ncaused by:\n" + evt.e.getCause.toString + "\n" + evt.e.getCause.getStackTrace
+                  .mkString("\n"),
                 operatorId,
                 workerId
               )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobStatsService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobStatsService.scala
@@ -181,7 +181,7 @@ class JobStatsService(
                 evt.e.toString,
                 evt.e.getStackTrace.mkString(
                   "\n"
-                ) + "\ncaused by:\n" + evt.e.getCause.toString + "\n" + evt.e.getCause.getStackTrace
+                ) + "\n\nCaused by:\n" + evt.e.getCause.toString + "\n" + evt.e.getCause.getStackTrace
                   .mkString("\n"),
                 operatorId,
                 workerId

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobStatsService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobStatsService.scala
@@ -163,10 +163,10 @@ class JobStatsService(
       client
         .registerCallback[FatalError]((evt: FatalError) => {
           client.shutdown()
-          var opeartorId = "unknown operator"
+          var operatorId = "unknown operator"
           var workerId = ""
           if (evt.fromActor.isDefined) {
-            opeartorId = VirtualIdentityUtils.getOperator(evt.fromActor.get).operator
+            operatorId = VirtualIdentityUtils.getOperator(evt.fromActor.get).operator
             workerId = evt.fromActor.get.name
           }
           stateStore.statsStore.updateState(stats =>
@@ -179,8 +179,8 @@ class JobStatsService(
                 EXECUTION_FAILURE,
                 Timestamp(Instant.now),
                 evt.e.toString,
-                evt.e.getStackTrace.mkString("\n"),
-                opeartorId,
+                evt.e.getStackTrace.mkString("\n") + "\ncaused by:\n" + evt.e.getCause.toString + "\n"+evt.e.getCause.getStackTrace.mkString("\n"),
+                operatorId,
                 workerId
               )
             )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -48,7 +48,7 @@ object WorkflowService {
 }
 
 class WorkflowService(
-    wId: Int,
+    val wId: Int,
     cleanUpTimeout: Int
 ) extends SubscriptionManager
     with LazyLogging {


### PR DESCRIPTION
This PR fixes issues caused by #2195.
- during editingTimeCompilationRequest, the workflow was analyzed without the context (which could contain user information). Now, we give proper workflow context for it to analyze. 
- when a `WorkflowFatalError` is caused by another underlying error, we now display the underlying error with "caused by:" in the frontend as well to help users better understand the root cause.