### PR TITLE
Allow ignore reply on Python side

### DIFF
--- a/core/amber/src/main/python/core/architecture/rpc/async_rpc_server.py
+++ b/core/amber/src/main/python/core/architecture/rpc/async_rpc_server.py
@@ -113,5 +113,5 @@ class AsyncRPCServer:
         return self._handlers[type(cmd)]
 
     @staticmethod
-    def _no_reply_needed( command_id: int) -> bool:
+    def _no_reply_needed(command_id: int) -> bool:
         return command_id < 0

--- a/core/amber/src/main/python/core/architecture/rpc/async_rpc_server.py
+++ b/core/amber/src/main/python/core/architecture/rpc/async_rpc_server.py
@@ -94,6 +94,9 @@ class AsyncRPCServer:
             ),
         )
 
+        if self._no_reply_needed(control_invocation.command_id):
+            return
+
         # reply to the sender
         to = from_
         logger.debug(
@@ -108,3 +111,7 @@ class AsyncRPCServer:
     def look_up(self, cmd: ControlCommandV2) -> Handler:
         logger.debug(cmd)
         return self._handlers[type(cmd)]
+
+    @staticmethod
+    def _no_reply_needed( command_id: int) -> bool:
+        return command_id < 0

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonWorkflowWorker.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonWorkflowWorker.scala
@@ -13,7 +13,7 @@ import edu.uci.ics.amber.engine.architecture.pythonworker.WorkerBatchInternalQue
 import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.TriggerSend
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.BackpressureHandler.Backpressure
 import edu.uci.ics.amber.engine.common.ambermessage._
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.{ControlInvocation, IgnoreReply}
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 import edu.uci.ics.amber.engine.common.virtualidentity.util.SELF
 import edu.uci.ics.texera.Utils
@@ -92,7 +92,7 @@ class PythonWorkflowWorker(
   }
 
   override def handleBackpressure(isBackpressured: Boolean): Unit = {
-    val backpressureMessage = ControlInvocation(0, Backpressure(isBackpressured))
+    val backpressureMessage = ControlInvocation(IgnoreReply, Backpressure(isBackpressured))
     pythonProxyClient.enqueueCommand(backpressureMessage, ChannelID(SELF, SELF, isControl = true))
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCClient.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCClient.scala
@@ -37,8 +37,6 @@ object AsyncRPCClient {
   final val IgnoreReply = -1
   final val IgnoreReplyAndDoNotLog = -2
 
-  def noReplyNeeded(id: Long): Boolean = id < 0
-
   /** The invocation of a control command
     * @param commandID
     * @param command

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCServer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCServer.scala
@@ -4,11 +4,7 @@ import com.twitter.util.Future
 import edu.uci.ics.amber.engine.architecture.messaginglayer.NetworkOutputGateway
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.QueryStatisticsHandler.QueryStatistics
 import edu.uci.ics.amber.engine.common.AmberLogging
-import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.{
-  ControlInvocation,
-  ReturnInvocation,
-  noReplyNeeded
-}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.{ControlInvocation, ReturnInvocation}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCServer.ControlCommand
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCServer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/rpc/AsyncRPCServer.scala
@@ -84,6 +84,9 @@ class AsyncRPCServer(
   }
 
   @inline
+  private def noReplyNeeded(id: Long): Boolean = id < 0
+
+  @inline
   private def returnResult(sender: ActorVirtualIdentity, id: Long, ret: Any): Unit = {
     if (noReplyNeeded(id)) {
       return


### PR DESCRIPTION
When AsyncRPC sends a command, it can optionally tell the server to not send back a reply by using `IgnoreReply` as its command id. Python side now handles the `IgnoreReply` by skipping sending any reply correctly.