### PR TITLE
Bump Apache Arrow to 14.0.1

### DIFF
--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -132,7 +132,7 @@ val googleServiceDependencies = Seq(
 
 /////////////////////////////////////////////////////////////////////////////
 // Arrow related
-val arrowVersion = "13.0.0"
+val arrowVersion = "14.0.1"
 val arrowDependencies = Seq(
   // https://mvnrepository.com/artifact/org.apache.arrow/flight-grpc
   "org.apache.arrow" % "flight-grpc" % arrowVersion,

--- a/core/amber/requirements.txt
+++ b/core/amber/requirements.txt
@@ -5,7 +5,7 @@ flake8
 black
 iniconfig==1.1.1
 loguru==0.7.0
-pyarrow==13.0.0
+pyarrow==14.0.1
 pytest==7.4.0
 python-dateutil==2.8.1
 pytest-timeout


### PR DESCRIPTION
This PR bumps the Apache Arrow version from 13.0.0 to 14.0.1.

For main changes, please take a look at the official change logs
- [14.0.0 (Nov 2023)](https://arrow.apache.org/release/14.0.0.html);
- [14.0.1 (Nov 2023)](https://arrow.apache.org/release/14.0.1.html). This will also resolve a [security concern](https://github.com/Texera/texera/security/dependabot/194). 