### PR TITLE
Fix result export on the frontend

### DIFF
--- a/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
@@ -6,7 +6,7 @@ import { merge } from "rxjs";
 import { ResultExportResponse } from "../../types/workflow-websocket.interface";
 import { NotificationService } from "../../../common/service/notification/notification.service";
 import { ExecuteWorkflowService } from "../execute-workflow/execute-workflow.service";
-import { ExecutionState } from "../../types/execute-workflow.interface";
+import { ExecutionState, isNotInExecution } from "../../types/execute-workflow.interface";
 import { filter } from "rxjs/operators";
 import { WorkflowResultService } from "../workflow-result/workflow-result.service";
 
@@ -49,7 +49,7 @@ export class WorkflowResultExportService {
       this.workflowActionService.getJointGraphWrapper().getJointOperatorUnhighlightStream()
     ).subscribe(() => {
       this.hasResultToExport =
-        this.executeWorkflowService.getExecutionState().state === ExecutionState.Completed &&
+        isNotInExecution(this.executeWorkflowService.getExecutionState().state) &&
         this.workflowActionService
           .getJointGraphWrapper()
           .getCurrentHighlightedOperatorIDs()

--- a/core/new-gui/src/app/workspace/types/execute-workflow.interface.ts
+++ b/core/new-gui/src/app/workspace/types/execute-workflow.interface.ts
@@ -115,6 +115,15 @@ export function isWebDataUpdate(update: WebResultUpdate): update is WebDataUpdat
   return (update !== undefined && update.mode.type === "SetSnapshotMode") || update.mode.type === "SetDeltaMode";
 }
 
+export function isNotInExecution(state: ExecutionState) {
+  return [
+    ExecutionState.Uninitialized,
+    ExecutionState.Failed,
+    ExecutionState.Killed,
+    ExecutionState.Completed,
+  ].includes(state);
+}
+
 export enum ExecutionState {
   Uninitialized = "Uninitialized",
   Initializing = "Initializing",


### PR DESCRIPTION
Since we introduced editing time compilation from #2195, the workflow state maintained on the frontend will change based on the complication result. However, the result export only works if the workflow is in a completed state. This PR allows the result export to work on any non-running state.