### PR TITLE
Minor refactoring and bug fix for error reporting

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowCacheChecker.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowCacheChecker.scala
@@ -1,7 +1,5 @@
 package edu.uci.ics.texera.web.service
 
-import edu.uci.ics.texera.web.SessionState
-import edu.uci.ics.texera.web.model.websocket.event.{CacheStatusUpdateEvent, WorkflowStateEvent}
 import edu.uci.ics.texera.web.model.websocket.request.EditingTimeCompilationRequest
 import edu.uci.ics.texera.workflow.common.workflow.LogicalPlan
 
@@ -12,15 +10,13 @@ object WorkflowCacheChecker {
   def handleCacheStatusUpdate(
       oldPlan: Option[LogicalPlan],
       newPlan: LogicalPlan,
-      sessionState: SessionState,
       request: EditingTimeCompilationRequest
-  ): Unit = {
+  ): Map[String, String] = {
     val validCacheOps = new WorkflowCacheChecker(oldPlan, newPlan).getValidCacheReuse()
     val cacheUpdateResult = request.opsToReuseResult
       .map(o => (o, if (validCacheOps.contains(o)) "cache valid" else "cache invalid"))
       .toMap
-    sessionState.send(WorkflowStateEvent("Uninitialized"))
-    sessionState.send(CacheStatusUpdateEvent(cacheUpdateResult))
+    cacheUpdateResult
   }
 
 }

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -174,7 +174,7 @@ export class ResultPanelComponent implements OnInit {
         }
       }
     } else {
-      this.frameComponentConfigs.delete("Error");
+      this.frameComponentConfigs.delete("Static Error");
     }
 
     // current result panel is closed or there is no operator highlighted, do nothing


### PR DESCRIPTION
This PR:
1. resolves an issue where the frontend was not correctly removing the error frame.
2. explicitly handles the following 2 cases upon receiving a websocket event:
- the workflow has not started yet, and no job state created. In this case, we will use a temporal job state and send the events through websocket session.
- the workflow is executed once, the job state is created. In this case, we will use the existing job state and let it propagate events.