### PR TITLE
Fix port descriptor

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OperatorDescriptor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/OperatorDescriptor.scala
@@ -162,7 +162,7 @@ trait StateTransferFunc
     new Type(value = classOf[BoxPlotOpDesc], name = "BoxPlot")
   )
 )
-abstract class OperatorDescriptor extends Serializable {
+abstract class OperatorDescriptor extends PortDescriptor with Serializable {
 
   @JsonIgnore
   var context: WorkflowContext = _

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonUDFOpDescV2.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonUDFOpDescV2.scala
@@ -77,7 +77,10 @@ class PythonUDFOpDescV2 extends OperatorDescriptor {
       opInfo.inputPorts.map(_ => None)
     }
     val dependency: Map[Int, Int] = if (inputPorts != null) {
-      inputPorts.zipWithIndex.flatMap {
+      inputPorts.zipWithIndex.filter {
+        case (port, _) => port.dependencies !=null
+      }
+        .flatMap {
         case (port, i) => port.dependencies.map(dependee => i -> dependee)
       }.toMap
     } else {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonUDFOpDescV2.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonUDFOpDescV2.scala
@@ -21,7 +21,7 @@ import edu.uci.ics.texera.workflow.common.workflow.{PartitionInfo, UnknownPartit
 import scala.collection.JavaConverters._
 import scala.util.{Success, Try}
 
-class PythonUDFOpDescV2 extends OperatorDescriptor with PortDescriptor {
+class PythonUDFOpDescV2 extends OperatorDescriptor {
   @JsonProperty(
     required = true,
     defaultValue =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonUDFOpDescV2.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonUDFOpDescV2.scala
@@ -10,10 +10,7 @@ import edu.uci.ics.texera.workflow.common.metadata.{
   OperatorInfo,
   OutputPort
 }
-import edu.uci.ics.texera.workflow.common.operators.{
-  OperatorDescriptor,
-  StateTransferFunc
-}
+import edu.uci.ics.texera.workflow.common.operators.{OperatorDescriptor, StateTransferFunc}
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, OperatorSchemaInfo, Schema}
 import edu.uci.ics.texera.workflow.common.workflow.{PartitionInfo, UnknownPartition}
 
@@ -77,12 +74,14 @@ class PythonUDFOpDescV2 extends OperatorDescriptor {
       opInfo.inputPorts.map(_ => None)
     }
     val dependency: Map[Int, Int] = if (inputPorts != null) {
-      inputPorts.zipWithIndex.filter {
-        case (port, _) => port.dependencies !=null
-      }
+      inputPorts.zipWithIndex
+        .filter {
+          case (port, _) => port.dependencies != null
+        }
         .flatMap {
-        case (port, i) => port.dependencies.map(dependee => i -> dependee)
-      }.toMap
+          case (port, i) => port.dependencies.map(dependee => i -> dependee)
+        }
+        .toMap
     } else {
       Map()
     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonUDFOpDescV2.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonUDFOpDescV2.scala
@@ -11,7 +11,6 @@ import edu.uci.ics.texera.workflow.common.metadata.{
   OutputPort
 }
 import edu.uci.ics.texera.workflow.common.operators.{
-  PortDescriptor,
   OperatorDescriptor,
   StateTransferFunc
 }

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -409,18 +409,14 @@ export class ExecuteWorkflowService {
         operatorID: op.operatorID,
         operatorType: op.operatorType,
       };
-      if (op.inputPorts.some(p => p.isDynamicPort)) {
-        logicalOp = {
-          ...logicalOp,
-          inputPorts: op.inputPorts,
-        };
-      }
-      if (op.outputPorts.some(p => p.isDynamicPort)) {
-        logicalOp = {
-          ...logicalOp,
-          outputPorts: op.outputPorts,
-        };
-      }
+      logicalOp = {
+        ...logicalOp,
+        inputPorts: op.inputPorts,
+      };
+      logicalOp = {
+        ...logicalOp,
+        outputPorts: op.outputPorts,
+      };
       return logicalOp;
     });
 

--- a/core/new-gui/src/app/workspace/service/execute-workflow/mock-workflow-plan.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/mock-workflow-plan.ts
@@ -21,15 +21,14 @@ export const mockLogicalPlan_scan_result: LogicalPlan = {
       operatorID: mockScanPredicate.operatorID,
       operatorType: mockScanPredicate.operatorType,
       inputPorts: mockScanPredicate.inputPorts,
-      outputPorts: mockScanPredicate.outputPorts
-
+      outputPorts: mockScanPredicate.outputPorts,
     },
     {
       ...mockResultPredicate.operatorProperties,
       operatorID: mockResultPredicate.operatorID,
       operatorType: mockResultPredicate.operatorType,
       inputPorts: mockResultPredicate.inputPorts,
-      outputPorts: mockResultPredicate.outputPorts
+      outputPorts: mockResultPredicate.outputPorts,
     },
   ],
   links: [

--- a/core/new-gui/src/app/workspace/service/execute-workflow/mock-workflow-plan.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/mock-workflow-plan.ts
@@ -20,11 +20,16 @@ export const mockLogicalPlan_scan_result: LogicalPlan = {
       ...mockScanPredicate.operatorProperties,
       operatorID: mockScanPredicate.operatorID,
       operatorType: mockScanPredicate.operatorType,
+      inputPorts: mockScanPredicate.inputPorts,
+      outputPorts: mockScanPredicate.outputPorts
+
     },
     {
       ...mockResultPredicate.operatorProperties,
       operatorID: mockResultPredicate.operatorID,
       operatorType: mockResultPredicate.operatorType,
+      inputPorts: mockResultPredicate.inputPorts,
+      outputPorts: mockResultPredicate.outputPorts
     },
   ],
   links: [


### PR DESCRIPTION
This PR fixes an issue where a port described on the frontend does not reflect on the backend. This is because we previously only allowed dynamic ports to be describable. 

In this PR, we generalize the setting and let every port description from the frontend be sent to the backend. And let all backend operators take and parse the port descriptions (by extending `PortDescriptor`). 