### PR TITLE
Shutdown AmberClient upon cleanup

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -69,7 +69,8 @@ class WorkflowService(
       opResultStorage.close()
       WorkflowService.wIdToWorkflowState.remove(mkWorkflowStateId(wId))
       if (jobService.getValue != null) {
-        jobService.getValue.wsInput.onNext(WorkflowKillRequest(), None)
+        // shutdown client
+        jobService.getValue.client.shutdown()
       }
       unsubscribeAll()
     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -7,7 +7,7 @@ import edu.uci.ics.amber.engine.common.AmberUtils
 import scala.collection.JavaConverters._
 import edu.uci.ics.texera.web.model.websocket.event.TexeraWebSocketEvent
 import edu.uci.ics.texera.web.{SubscriptionManager, WorkflowLifecycleManager}
-import edu.uci.ics.texera.web.model.websocket.request.{WorkflowExecuteRequest, WorkflowKillRequest}
+import edu.uci.ics.texera.web.model.websocket.request.WorkflowExecuteRequest
 import edu.uci.ics.texera.web.resource.WorkflowWebsocketResource
 import edu.uci.ics.texera.web.service.WorkflowService.mkWorkflowStateId
 import edu.uci.ics.texera.web.storage.WorkflowStateStore


### PR DESCRIPTION
This PR shuts down the Amber client instead of sending a kill message. Previously, we sent a kill message, which would make the workflow state be marked as `KILLED`.