### PR TITLE
Add an update sql that creates workflow_runtime_statistics table

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobStatsService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobStatsService.scala
@@ -158,7 +158,7 @@ class JobStatsService(
       }
       workflowRuntimeStatisticsDao.insert(list)
     } catch {
-      case _: Throwable => // Do nothing
+      case err: Throwable => logger.error("error occurred when storing runtime statistics", err)
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobStatsService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/JobStatsService.scala
@@ -142,19 +142,24 @@ class JobStatsService(
   private def storeRuntimeStatistics(
       operatorStatistics: scala.collection.immutable.Map[String, OperatorRuntimeStats]
   ): Unit = {
-    val list: util.ArrayList[WorkflowRuntimeStatistics] =
-      new util.ArrayList[WorkflowRuntimeStatistics]()
-    for ((operatorId, stat) <- operatorStatistics) {
-      val execution = new WorkflowRuntimeStatistics()
-      execution.setWorkflowId(workflowContext.wId)
-      execution.setExecutionId(UInteger.valueOf(workflowContext.executionID))
-      execution.setOperatorId(operatorId)
-      execution.setInputTupleCnt(UInteger.valueOf(stat.inputCount))
-      execution.setOutputTupleCnt(UInteger.valueOf(stat.outputCount))
-      execution.setStatus(maptoStatusCode(stat.state))
-      list.add(execution)
+    // Add a try-catch to not produce an error when "workflow_runtime_statistics" table does not exist in MySQL
+    try {
+      val list: util.ArrayList[WorkflowRuntimeStatistics] =
+        new util.ArrayList[WorkflowRuntimeStatistics]()
+      for ((operatorId, stat) <- operatorStatistics) {
+        val execution = new WorkflowRuntimeStatistics()
+        execution.setWorkflowId(workflowContext.wId)
+        execution.setExecutionId(UInteger.valueOf(workflowContext.executionID))
+        execution.setOperatorId(operatorId)
+        execution.setInputTupleCnt(UInteger.valueOf(stat.inputCount))
+        execution.setOutputTupleCnt(UInteger.valueOf(stat.outputCount))
+        execution.setStatus(maptoStatusCode(stat.state))
+        list.add(execution)
+      }
+      workflowRuntimeStatisticsDao.insert(list)
+    } catch {
+      case _: Throwable => // Do nothing
     }
-    workflowRuntimeStatisticsDao.insert(list)
   }
 
   private[this] def registerCallbackOnWorkerAssignedUpdate(): Unit = {

--- a/core/scripts/sql/update/04.sql
+++ b/core/scripts/sql/update/04.sql
@@ -1,0 +1,14 @@
+USE `texera_db`;
+CREATE TABLE IF NOT EXISTS workflow_runtime_statistics
+(
+    `workflow_id`      INT UNSIGNED             NOT NULL,
+    `execution_id`     INT UNSIGNED             NOT NULL,
+    `operator_id`      VARCHAR(100)             NOT NULL,
+    `time`             TIMESTAMP(6)             NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+    `input_tuple_cnt`  INT UNSIGNED             NOT NULL DEFAULT 0,
+    `output_tuple_cnt` INT UNSIGNED             NOT NULL DEFAULT 0,
+    `status`           TINYINT                  NOT NULL DEFAULT 1,
+    PRIMARY KEY (`workflow_id`, `execution_id`, `operator_id`, `time`),
+    FOREIGN KEY (`workflow_id`) REFERENCES `workflow` (`wid`) ON DELETE CASCADE,
+    FOREIGN KEY (`execution_id`) REFERENCES `workflow_executions` (`eid`) ON DELETE CASCADE
+) ENGINE = INNODB;


### PR DESCRIPTION
This PR adds an update SQL file that creates "workflow_runtime_statistics" table to deploy the PR #2249.
Also, it adds a try-catch to not produce an error when "workflow_runtime_statistics" table does not exist in MySQL.