### PR TITLE
Fix removal of LogicalLink

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
@@ -96,7 +96,6 @@ case class LogicalPlan(
       .toList
   }
 
-  // returns a new logical plan with the given operator added
   def addOperator(op: LogicalOp): LogicalPlan = {
     // TODO: fix schema for the new operator
     this.copy(context, operators :+ op, links, breakpoints)
@@ -114,32 +113,20 @@ case class LogicalPlan(
     )
   }
 
-  // returns a new logical plan with the given edge added
-  def addEdge(
+  def addLink(
       from: OperatorIdentity,
+      fromPort: Int = 0, // by default, we have only one output port, thus giving a default port index 0
       to: OperatorIdentity,
-      fromPort: Int = 0,
-      toPort: Int = 0
+      toPort: Int
   ): LogicalPlan = {
     val newLink = LogicalLink(LogicalPort(from, fromPort), LogicalPort(to, toPort))
     val newLinks = links :+ newLink
     this.copy(context, operators, newLinks, breakpoints)
   }
 
-  def removeEdge(linkToRemove: LogicalLink): LogicalPlan = {
+  def removeLink(linkToRemove: LogicalLink): LogicalPlan = {
     val newLinks = links.filter(l => l != linkToRemove)
     this.copy(context, operators, newLinks, breakpoints)
-  }
-
-  // returns a new logical plan with the given edge removed
-  def removeEdge(
-      from: OperatorIdentity,
-      to: OperatorIdentity,
-      fromPort: Int = 0,
-      toPort: Int = 0
-  ): LogicalPlan = {
-    val linkToRemove = LogicalLink(LogicalPort(from, fromPort), LogicalPort(to, toPort))
-    removeEdge(linkToRemove)
   }
 
   def getDownstreamOps(opId: OperatorIdentity): List[LogicalOp] = {
@@ -150,7 +137,7 @@ case class LogicalPlan(
     downstream.toList
   }
 
-  def getDownstreamEdges(opId: OperatorIdentity): List[LogicalLink] = {
+  def getDownstreamLinks(opId: OperatorIdentity): List[LogicalLink] = {
     links.filter(l => l.origin.operatorId == opId)
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
@@ -126,6 +126,11 @@ case class LogicalPlan(
     this.copy(context, operators, newLinks, breakpoints)
   }
 
+  def removeEdge(linkToRemove: LogicalLink): LogicalPlan = {
+    val newLinks = links.filter(l => l != linkToRemove)
+    this.copy(context, operators, newLinks, breakpoints)
+  }
+
   // returns a new logical plan with the given edge removed
   def removeEdge(
       from: OperatorIdentity,
@@ -134,8 +139,7 @@ case class LogicalPlan(
       toPort: Int = 0
   ): LogicalPlan = {
     val linkToRemove = LogicalLink(LogicalPort(from, fromPort), LogicalPort(to, toPort))
-    val newLinks = links.filter(l => l != linkToRemove)
-    this.copy(context, operators, newLinks, breakpoints)
+    removeEdge(linkToRemove)
   }
 
   def getDownstreamOps(opId: OperatorIdentity): List[LogicalOp] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
@@ -115,7 +115,8 @@ case class LogicalPlan(
 
   def addLink(
       from: OperatorIdentity,
-      fromPort: Int = 0, // by default, we have only one output port, thus giving a default port index 0
+      fromPort: Int =
+        0, // by default, we have only one output port, thus giving a default port index 0
       to: OperatorIdentity,
       toPort: Int
   ): LogicalPlan = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/LogicalPlan.scala
@@ -126,8 +126,7 @@ case class LogicalPlan(
   }
 
   def removeLink(linkToRemove: LogicalLink): LogicalPlan = {
-    val newLinks = links.filter(l => l != linkToRemove)
-    this.copy(context, operators, newLinks, breakpoints)
+    this.copy(context, operators, links.filter(l => l != linkToRemove), breakpoints)
   }
 
   def getDownstreamOps(opId: OperatorIdentity): List[LogicalOp] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/SinkInjectionTransformer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/SinkInjectionTransformer.scala
@@ -26,7 +26,7 @@ object SinkInjectionTransformer {
         val sink = new ProgressiveSinkOpDesc()
         logicalPlan = logicalPlan
           .addOperator(sink)
-          .addEdge(op.operatorIdentifier, sink.operatorIdentifier, outPort)
+          .addLink(op.operatorIdentifier,outPort,  sink.operatorIdentifier, toPort=0)
       })
     })
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/SinkInjectionTransformer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/SinkInjectionTransformer.scala
@@ -26,7 +26,7 @@ object SinkInjectionTransformer {
         val sink = new ProgressiveSinkOpDesc()
         logicalPlan = logicalPlan
           .addOperator(sink)
-          .addLink(op.operatorIdentifier,outPort,  sink.operatorIdentifier, toPort=0)
+          .addLink(op.operatorIdentifier, outPort, sink.operatorIdentifier, toPort = 0)
       })
     })
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
@@ -40,12 +40,14 @@ object WorkflowCacheRewriter {
       // replace the connection of all outgoing edges of opId with the cache
       val edgesToReplace = resultPlan.getDownstreamLinks(opId)
       edgesToReplace.foreach(edge => {
-        resultPlan = resultPlan.removeLink(edge).addLink(
-          materializationReader.operatorIdentifier,
-          0,
-          edge.destination.operatorId,
-          edge.destination.portOrdinal
-        )
+        resultPlan = resultPlan
+          .removeLink(edge)
+          .addLink(
+            materializationReader.operatorIdentifier,
+            0,
+            edge.destination.operatorId,
+            edge.destination.portOrdinal
+          )
       })
       resultPlan = resultPlan.removeOperator(opId)
     })

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
@@ -40,19 +40,14 @@ object WorkflowCacheRewriter {
       // replace the connection of all outgoing edges of opId with the cache
       val edgesToReplace = resultPlan.getDownstreamEdges(opId)
       edgesToReplace.foreach(e => {
-        resultPlan = resultPlan.removeEdge(
-          e.origin.operatorId,
-          e.destination.operatorId,
-          e.origin.portOrdinal,
-          e.destination.portOrdinal
-        )
-        resultPlan = resultPlan.addEdge(
+        resultPlan = resultPlan.removeEdge(e).addEdge(
           materializationReader.operatorIdentifier,
           e.destination.operatorId,
           0,
           e.destination.portOrdinal
         )
       })
+      resultPlan = resultPlan.removeOperator(opId)
     })
 
     // after an operator is replaced with reading from cached result

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
@@ -38,13 +38,13 @@ object WorkflowCacheRewriter {
       val materializationReader = new CacheSourceOpDesc(opId, storage)
       resultPlan = resultPlan.addOperator(materializationReader)
       // replace the connection of all outgoing edges of opId with the cache
-      val edgesToReplace = resultPlan.getDownstreamEdges(opId)
-      edgesToReplace.foreach(e => {
-        resultPlan = resultPlan.removeEdge(e).addEdge(
+      val edgesToReplace = resultPlan.getDownstreamLinks(opId)
+      edgesToReplace.foreach(edge => {
+        resultPlan = resultPlan.removeLink(edge).addLink(
           materializationReader.operatorIdentifier,
-          e.destination.operatorId,
           0,
-          e.destination.portOrdinal
+          edge.destination.operatorId,
+          edge.destination.portOrdinal
         )
       })
       resultPlan = resultPlan.removeOperator(opId)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
@@ -37,7 +37,7 @@ object WorkflowCacheRewriter {
     opsCanUseCache.foreach(opId => {
       val materializationReader = new CacheSourceOpDesc(opId, storage)
       resultPlan = resultPlan.addOperator(materializationReader)
-      // replace the connection of all outgoing edges of opId with the cache
+      // replace all outgoing links of the original operator with the new links from cache
       val linksToReplace = resultPlan.getDownstreamLinks(opId)
       linksToReplace.foreach(link => {
         resultPlan = resultPlan

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
@@ -38,15 +38,14 @@ object WorkflowCacheRewriter {
       val materializationReader = new CacheSourceOpDesc(opId, storage)
       resultPlan = resultPlan.addOperator(materializationReader)
       // replace the connection of all outgoing edges of opId with the cache
-      val edgesToReplace = resultPlan.getDownstreamLinks(opId)
-      edgesToReplace.foreach(edge => {
+      val linksToReplace = resultPlan.getDownstreamLinks(opId)
+      linksToReplace.foreach(link => {
         resultPlan = resultPlan
-          .removeLink(edge)
+          .removeLink(link)
           .addLink(
-            materializationReader.operatorIdentifier,
-            0,
-            edge.destination.operatorId,
-            edge.destination.portOrdinal
+            from = materializationReader.operatorIdentifier,
+            to = link.destination.operatorId,
+            toPort = link.destination.portOrdinal
           )
       })
       resultPlan = resultPlan.removeOperator(opId)


### PR DESCRIPTION
This PR fixes an issue brought in #2257 where a LogicalLink is not being removed properly during cache rewrite, and during cache rewrite, the rewritten operator is not properly removed due to this. The root cause is that we constructed a new Link to do the removal instead of using the existing one. In this fix, we now require the passing of the original link to be removed. 