### PR TITLE
Fix self-message dropping during Actor initialization in Akka

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
@@ -129,7 +129,13 @@ abstract class WorkflowActor(logStorageType: String, val actorId: ActorVirtualId
 
   def receiveDeadLetterMessage: Receive = {
     case MessageBecomesDeadLetter(msg) =>
-      actorRefMappingService.removeActorRef(msg.internalMessage.channel.from)
+      val dest = msg.internalMessage.channel.to
+      if (dest == actorId) {
+        logger.warn(s"sending message to self failed, retry sending $msg to self directly.")
+        self ! msg
+      } else {
+        actorRefMappingService.removeActorRef(dest)
+      }
   }
 
   def handleInputMessage(id: Long, workflowMsg: WorkflowFIFOMessage): Unit

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
@@ -131,8 +131,13 @@ abstract class WorkflowActor(logStorageType: String, val actorId: ActorVirtualId
     case MessageBecomesDeadLetter(msg) =>
       val dest = msg.internalMessage.channel.to
       if (dest == actorId) {
-        logger.warn(s"sending message to self failed, retry sending $msg to self directly.")
-        self ! msg
+        actorService.scheduleOnce(
+          100.millis,
+          () => {
+            logger.warn(s"sending message to self failed, retry sending $msg to self directly.")
+            self ! msg
+          }
+        )
       } else {
         actorRefMappingService.removeActorRef(dest)
       }


### PR DESCRIPTION
**This fix is considered a potential solution, pending further testing and validation.**

This PR addresses a message-dropping issue in Akka. The problem occurs when an actor, during its initialization, sends immediate messages to itself. These messages may be dropped if Akka is still resolving the actor ref. The proposed fix ensures that if a message is dropped, the actor will automatically resend it. 