### PR TITLE
Fix rerender issue for error frame

### DIFF
--- a/core/new-gui/src/app/workspace/component/result-panel/error-frame/error-frame.component.html
+++ b/core/new-gui/src/app/workspace/component/result-panel/error-frame/error-frame.component.html
@@ -9,11 +9,11 @@
   </div>
 </div>
 
-<div *ngFor="let category of categoryToErrorMapping.keys()">
-  <div class="error-category">{{category}}:</div>
-  <nz-collapse *ngIf="categoryToErrorMapping.get(category)!.length > 0">
+<div *ngFor="let category of categoryToErrorMapping | keyvalue">
+  <div class="error-category">{{category.key}}:</div>
+  <nz-collapse *ngIf="category.value.length > 0">
     <nz-collapse-panel
-      *ngFor="let error of categoryToErrorMapping.get(category)"
+      *ngFor="let error of category.value"
       [nzHeader]="error.message"
       [nzActive]="false"
       [nzDisabled]="false"

--- a/core/new-gui/src/app/workspace/component/result-panel/error-frame/error-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/error-frame/error-frame.component.ts
@@ -13,7 +13,7 @@ import { WorkflowActionService } from "../../../service/workflow-graph/model/wor
   templateUrl: "./error-frame.component.html",
   styleUrls: ["./error-frame.component.scss"],
 })
-export class ErrorFrameComponent implements OnInit, OnChanges {
+export class ErrorFrameComponent implements OnInit {
   @Input() operatorId?: string;
   // display error message:
   categoryToErrorMapping: ReadonlyMap<string, ReadonlyArray<WorkflowFatalError>> = new Map();
@@ -22,11 +22,6 @@ export class ErrorFrameComponent implements OnInit, OnChanges {
     private executeWorkflowService: ExecuteWorkflowService,
     private workflowActionService: WorkflowActionService
   ) {}
-
-  ngOnChanges(changes: SimpleChanges): void {
-    this.operatorId = changes.operatorId?.currentValue;
-    this.renderError();
-  }
 
   ngOnInit(): void {
     this.renderError();

--- a/core/new-gui/src/app/workspace/component/result-panel/error-frame/error-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/error-frame/error-frame.component.ts
@@ -24,11 +24,8 @@ export class ErrorFrameComponent implements OnInit, OnChanges {
   ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
-    let newOperatorId = changes.operatorId?.currentValue;
-    if (this.operatorId !== newOperatorId) {
-      this.operatorId = newOperatorId;
-      this.renderError();
-    }
+    this.operatorId = changes.operatorId?.currentValue;
+    this.renderError();
   }
 
   ngOnInit(): void {

--- a/core/new-gui/src/app/workspace/component/result-panel/error-frame/error-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/error-frame/error-frame.component.ts
@@ -24,8 +24,11 @@ export class ErrorFrameComponent implements OnInit, OnChanges {
   ) {}
 
   ngOnChanges(changes: SimpleChanges): void {
-    this.operatorId = changes.operatorId?.currentValue;
-    this.renderError();
+    let newOperatorId = changes.operatorId?.currentValue;
+    if(this.operatorId !== newOperatorId){
+      this.operatorId = newOperatorId
+      this.renderError();
+    }
   }
 
   ngOnInit(): void {

--- a/core/new-gui/src/app/workspace/component/result-panel/error-frame/error-frame.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/error-frame/error-frame.component.ts
@@ -25,8 +25,8 @@ export class ErrorFrameComponent implements OnInit, OnChanges {
 
   ngOnChanges(changes: SimpleChanges): void {
     let newOperatorId = changes.operatorId?.currentValue;
-    if(this.operatorId !== newOperatorId){
-      this.operatorId = newOperatorId
+    if (this.operatorId !== newOperatorId) {
+      this.operatorId = newOperatorId;
       this.renderError();
     }
   }

--- a/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/new-gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -168,6 +168,8 @@ export class ResultPanelComponent implements OnInit {
         const errorMessages = this.executeWorkflowService.getErrorMessages();
         if (errorMessages.filter(msg => msg.operatorId === this.currentOperatorId).length > 0) {
           this.displayError(this.currentOperatorId);
+        } else {
+          this.frameComponentConfigs.delete("Static Error");
         }
       }
     } else {


### PR DESCRIPTION
This PR:
1. Fixes a [frontend error](https://stackoverflow.com/questions/48187362/how-to-iterate-using-ngfor-loop-map-containing-key-as-string-and-values-as-map-i) caused by the usage of ngFor with Map in the error frame. As suggested in the Stackoverflow post, the most convenient way of solving this issue is to use `keyvalue` pipe.
2. Removes the `ngOnChanges` callback to prevent it from being refreshed too many times.