### PR TITLE
Fix dropped messages during actor initialization

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/AkkaActorRefMappingService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/AkkaActorRefMappingService.scala
@@ -53,7 +53,7 @@ class AkkaActorRefMappingService(actorService: AkkaActorService) extends AmberLo
   def removeActorRef(id: ActorVirtualIdentity): Unit = {
     if (actorRefMapping.contains(id)) {
       val ref = actorRefMapping.remove(id).get
-      logger.error(s"actor $id is not reachable anymore, it might have crashed. old ref = $ref")
+      logger.warn(s"actor $id is not reachable anymore, it might have crashed. old ref = $ref")
     }
   }
 
@@ -89,14 +89,14 @@ class AkkaActorRefMappingService(actorService: AkkaActorService) extends AmberLo
           queriedActorVirtualIdentities.add(id)
         } catch {
           case e: Throwable =>
-            logger.error(
+            logger.warn(
               "Failed to fetch actorRef for " + id + " parentRef = " + actorService.parent
             )
         }
       }
     } else {
       // on controller, wait for actor ref registration.
-      logger.error(s"unknown identifier: $id")
+      logger.warn(s"unknown identifier: $id")
       val toNotifySet = toNotifyOnRegistration.getOrElseUpdate(id, mutable.HashSet[ActorRef]())
       replyTo.foreach(toNotifySet.add)
     }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/AkkaActorRefMappingService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/AkkaActorRefMappingService.scala
@@ -2,15 +2,15 @@ package edu.uci.ics.amber.engine.architecture.common
 
 import akka.actor.ActorRef
 import edu.uci.ics.amber.engine.architecture.common.WorkflowActor.{
+  CreditRequest,
   GetActorRef,
   NetworkMessage,
-  RegisterActorRef,
-  CreditRequest
+  RegisterActorRef
 }
 import edu.uci.ics.amber.engine.common.AmberLogging
 import edu.uci.ics.amber.engine.common.ambermessage.ChannelID
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
-import edu.uci.ics.amber.engine.common.virtualidentity.util.SELF
+import edu.uci.ics.amber.engine.common.virtualidentity.util.{CONTROLLER, SELF}
 
 import scala.collection.mutable
 
@@ -22,6 +22,8 @@ class AkkaActorRefMappingService(actorService: AkkaActorService) extends AmberLo
 
   private val actorRefMapping: mutable.HashMap[ActorVirtualIdentity, ActorRef] = mutable.HashMap()
   private val queriedActorVirtualIdentities = new mutable.HashSet[ActorVirtualIdentity]()
+  private val toNotifyOnRegistration =
+    new mutable.HashMap[ActorVirtualIdentity, mutable.Set[ActorRef]]()
   private val messageStash =
     new mutable.HashMap[ActorVirtualIdentity, mutable.Queue[NetworkMessage]]
   actorRefMapping(SELF) = actorService.self
@@ -44,7 +46,7 @@ class AkkaActorRefMappingService(actorService: AkkaActorService) extends AmberLo
     } else {
       val stash = messageStash.getOrElseUpdate(id, new mutable.Queue[NetworkMessage]())
       stash.enqueue(msg)
-      fetchActorRefMappingFromParent(id)
+      retrieveActorRef(id, Set())
     }
   }
 
@@ -66,6 +68,12 @@ class AkkaActorRefMappingService(actorService: AkkaActorService) extends AmberLo
         }
       }
     }
+    if (toNotifyOnRegistration.contains(id)) {
+      toNotifyOnRegistration(id).foreach { toNotify =>
+        toNotify ! RegisterActorRef(id, ref)
+      }
+      toNotifyOnRegistration.remove(id)
+    }
   }
 
   def retrieveActorRef(id: ActorVirtualIdentity, replyTo: Set[ActorRef]): Unit = {
@@ -73,10 +81,24 @@ class AkkaActorRefMappingService(actorService: AkkaActorService) extends AmberLo
       replyTo.foreach { actor =>
         actor ! RegisterActorRef(id, actorRefMapping(id))
       }
-    } else if (actorService.parent != null) {
-      actorService.parent ! GetActorRef(id, replyTo + actorService.self)
+    } else if (actorId != CONTROLLER) {
+      // propagation stops at controller
+      if (!queriedActorVirtualIdentities.contains(id)) {
+        try {
+          actorService.parent ! GetActorRef(id, replyTo + actorService.self)
+          queriedActorVirtualIdentities.add(id)
+        } catch {
+          case e: Throwable =>
+            logger.error(
+              "Failed to fetch actorRef for " + id + " parentRef = " + actorService.parent
+            )
+        }
+      }
     } else {
+      // on controller, wait for actor ref registration.
       logger.error(s"unknown identifier: $id")
+      val toNotifySet = toNotifyOnRegistration.getOrElseUpdate(id, mutable.HashSet[ActorRef]())
+      replyTo.foreach(toNotifySet.add)
     }
   }
 
@@ -91,18 +113,5 @@ class AkkaActorRefMappingService(actorService: AkkaActorService) extends AmberLo
           actorRef == ref
       }
       .map(_._1)
-  }
-
-  @inline
-  private[this] def fetchActorRefMappingFromParent(id: ActorVirtualIdentity): Unit = {
-    if (!queriedActorVirtualIdentities.contains(id)) {
-      try {
-        actorService.parent ! GetActorRef(id, Set(actorService.self))
-        queriedActorVirtualIdentities.add(id)
-      } catch {
-        case e: Throwable =>
-          logger.error("Failed to fetch actorRef for " + id + " parentRef = " + actorService.parent)
-      }
-    }
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
@@ -161,6 +161,7 @@ abstract class WorkflowActor(logStorageType: String, val actorId: ActorVirtualId
     try {
       transferService.initialize()
       initState()
+      context.parent ! RegisterActorRef(actorId, context.self)
     } catch {
       case t: Throwable =>
         logger.warn("actor initialization failed due to exception", t)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ExecutionState.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ExecutionState.scala
@@ -1,8 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.controller
 
-import akka.actor.Address
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp
-import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.WorkerInfo
 import edu.uci.ics.amber.engine.architecture.scheduling.PipelinedRegion
 import edu.uci.ics.amber.engine.common.virtualidentity.{
   ActorVirtualIdentity,
@@ -61,14 +59,6 @@ class ExecutionState(workflow: Workflow) {
       region.getOperators ++ region.blockingDownstreamPhysicalOpIdsInOtherRegions.map(_._1)
 
     allOperatorsInRegion.flatMap(opId => getOperatorExecution(opId).getBuiltWorkerIds.toList)
-  }
-
-  def getAllWorkerInfoOfAddress(address: Address): Iterable[WorkerInfo] = {
-    operatorExecutions.values
-      .flatMap(x => {
-        x.getBuiltWorkerIds.map(x.getWorkerInfo)
-      })
-      .filter(info => info.ref.path.address == address)
   }
 
   def getWorkflowStatus: Map[String, OperatorRuntimeStats] = {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/OperatorExecution.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/OperatorExecution.scala
@@ -31,19 +31,18 @@ class OperatorExecution(val executionId: Long, physicalOpId: PhysicalOpIdentity,
 
   def statistics: Array[WorkerStatistics] = workers.values.asScala.map(_.stats).toArray
 
-  def getWorkerInfo(id: ActorVirtualIdentity): WorkerInfo = {
-    if (!workers.containsKey(id)) {
-      workers.put(
+  def initializeWorkerInfo(id: ActorVirtualIdentity): Unit = {
+    workers.put(
+      id,
+      WorkerInfo(
         id,
-        WorkerInfo(
-          id,
-          UNINITIALIZED,
-          WorkerStatistics(UNINITIALIZED, 0, 0),
-          mutable.HashSet(ChannelID(CONTROLLER, id, isControl = true)),
-          null
-        )
+        UNINITIALIZED,
+        WorkerStatistics(UNINITIALIZED, 0, 0),
+        mutable.HashSet(ChannelID(CONTROLLER, id, isControl = true))
       )
-    }
+    )
+  }
+  def getWorkerInfo(id: ActorVirtualIdentity): WorkerInfo = {
     workers.get(id)
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/OperatorExecution.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/OperatorExecution.scala
@@ -43,6 +43,9 @@ class OperatorExecution(val executionId: Long, physicalOpId: PhysicalOpIdentity,
     )
   }
   def getWorkerInfo(id: ActorVirtualIdentity): WorkerInfo = {
+    if (!workers.contains(id)) {
+      initializeWorkerInfo(id)
+    }
     workers.get(id)
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
@@ -456,6 +456,8 @@ case class PhysicalOp(
             )
           )
         }
+        // Note: At this point, we don't know if the actor is fully initialized.
+        // Thus, the ActorRef returned from `controllerActorService.actorOf` is ignored.
         controllerActorService.actorOf(
           workflowWorker.withDeploy(Deploy(scope = RemoteScope(preferredAddress)))
         )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
@@ -2,7 +2,7 @@ package edu.uci.ics.amber.engine.architecture.deploysemantics
 
 import akka.actor.Deploy
 import akka.remote.RemoteScope
-import edu.uci.ics.amber.engine.architecture.common.{AkkaActorRefMappingService, AkkaActorService}
+import edu.uci.ics.amber.engine.architecture.common.AkkaActorService
 import edu.uci.ics.amber.engine.architecture.controller.{ControllerConfig, OperatorExecution}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{
   OpExecInitInfo,
@@ -429,7 +429,6 @@ case class PhysicalOp(
 
   def build(
       controllerActorService: AkkaActorService,
-      actorRefService: AkkaActorRefMappingService,
       opExecution: OperatorExecution,
       controllerConf: ControllerConfig
   ): Unit = {
@@ -457,12 +456,10 @@ case class PhysicalOp(
             )
           )
         }
-        val ref =
-          controllerActorService.actorOf(
-            workflowWorker.withDeploy(Deploy(scope = RemoteScope(preferredAddress)))
-          )
-        actorRefService.registerActorRef(workerId, ref)
-        opExecution.getWorkerInfo(workerId).ref = ref
+        controllerActorService.actorOf(
+          workflowWorker.withDeploy(Deploy(scope = RemoteScope(preferredAddress)))
+        )
+        opExecution.initializeWorkerInfo(workerId)
       })
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerInfo.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/WorkerInfo.scala
@@ -1,6 +1,5 @@
 package edu.uci.ics.amber.engine.architecture.deploysemantics.layer
 
-import akka.actor.ActorRef
 import edu.uci.ics.amber.engine.architecture.worker.statistics.{WorkerState, WorkerStatistics}
 import edu.uci.ics.amber.engine.common.ambermessage.ChannelID
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
@@ -12,6 +11,5 @@ case class WorkerInfo(
     id: ActorVirtualIdentity,
     var state: WorkerState,
     var stats: WorkerStatistics,
-    upstreamChannels: mutable.HashSet[ChannelID],
-    @transient var ref: ActorRef
+    upstreamChannels: mutable.HashSet[ChannelID]
 ) extends Serializable

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowScheduler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowScheduler.scala
@@ -64,7 +64,7 @@ class WorkflowScheduler(
       akkaActorService: AkkaActorService
   ): Future[Seq[Unit]] = {
     val nextRegionsToSchedule = schedulingPolicy.startWorkflow(workflow)
-    doSchedulingWork(workflow, nextRegionsToSchedule, akkaActorRefMappingService, akkaActorService)
+    doSchedulingWork(workflow, nextRegionsToSchedule, akkaActorService)
   }
 
   def onWorkerCompletion(
@@ -75,7 +75,7 @@ class WorkflowScheduler(
   ): Future[Seq[Unit]] = {
     val nextRegionsToSchedule =
       schedulingPolicy.onWorkerCompletion(workflow, executionState, workerId)
-    doSchedulingWork(workflow, nextRegionsToSchedule, akkaActorRefMappingService, akkaActorService)
+    doSchedulingWork(workflow, nextRegionsToSchedule, akkaActorService)
   }
 
   def onLinkCompletion(
@@ -85,7 +85,7 @@ class WorkflowScheduler(
       linkId: PhysicalLinkIdentity
   ): Future[Seq[Unit]] = {
     val nextRegionsToSchedule = schedulingPolicy.onLinkCompletion(workflow, executionState, linkId)
-    doSchedulingWork(workflow, nextRegionsToSchedule, akkaActorRefMappingService, akkaActorService)
+    doSchedulingWork(workflow, nextRegionsToSchedule, akkaActorService)
   }
 
   def onTimeSlotExpired(
@@ -100,7 +100,7 @@ class WorkflowScheduler(
       regionsToPause = timeExpiredRegions
     }
 
-    doSchedulingWork(workflow, nextRegions, akkaActorRefMappingService, akkaActorService)
+    doSchedulingWork(workflow, nextRegions, akkaActorService)
       .flatMap(_ => {
         val pauseFutures = new ArrayBuffer[Future[Unit]]()
         regionsToPause.foreach(stoppingRegion => {
@@ -124,14 +124,11 @@ class WorkflowScheduler(
   private def doSchedulingWork(
       workflow: Workflow,
       regions: Set[PipelinedRegion],
-      akkaActorRefMappingService: AkkaActorRefMappingService,
       actorService: AkkaActorService
   ): Future[Seq[Unit]] = {
     if (regions.nonEmpty) {
       Future.collect(
-        regions.toArray.map(r =>
-          scheduleRegion(workflow, r, akkaActorRefMappingService, actorService)
-        )
+        regions.toArray.map(r => scheduleRegion(workflow, r, actorService))
       )
     } else {
       Future(Seq())
@@ -141,7 +138,6 @@ class WorkflowScheduler(
   private def constructRegion(
       workflow: Workflow,
       region: PipelinedRegion,
-      akkaActorRefMappingService: AkkaActorRefMappingService,
       akkaActorService: AkkaActorService
   ): Unit = {
     val builtOpsInRegion = new mutable.HashSet[PhysicalOpIdentity]()
@@ -153,7 +149,6 @@ class WorkflowScheduler(
             workflow,
             op,
             executionState.getOperatorExecution(op),
-            akkaActorRefMappingService,
             akkaActorService
           )
           builtOperators.add(op)
@@ -176,13 +171,11 @@ class WorkflowScheduler(
       workflow: Workflow,
       physicalOpId: PhysicalOpIdentity,
       opExecution: OperatorExecution,
-      actorRefService: AkkaActorRefMappingService,
       controllerActorService: AkkaActorService
   ): Unit = {
     val physicalOp = workflow.physicalPlan.getOperator(physicalOpId)
     physicalOp.build(
       controllerActorService,
-      actorRefService,
       opExecution,
       controllerConfig
     )
@@ -352,7 +345,6 @@ class WorkflowScheduler(
   private def scheduleRegion(
       workflow: Workflow,
       region: PipelinedRegion,
-      akkaActorRefMappingService: AkkaActorRefMappingService,
       actorService: AkkaActorService
   ): Future[Unit] = {
     if (constructingRegions.contains(region.getId)) {
@@ -360,7 +352,7 @@ class WorkflowScheduler(
     }
     if (!startedRegions.contains(region.getId)) {
       constructingRegions.add(region.getId)
-      constructRegion(workflow, region, akkaActorRefMappingService, actorService)
+      constructRegion(workflow, region, actorService)
       prepareAndStartRegion(workflow, region, actorService).rescue {
         case err: Throwable =>
           // this call may come from client or worker(by execution completed)

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/TrivialControlTester.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/control/utils/TrivialControlTester.scala
@@ -35,7 +35,11 @@ class TrivialControlTester(
   /** flow-control */
   override def getQueuedCredit(channelID: ChannelID): Long = 0L
 
-  override def initState(): Unit = {}
+  override def preStart(): Unit = {
+    transferService.initialize()
+  }
 
   override def handleBackpressure(isBackpressured: Boolean): Unit = {}
+
+  override def initState(): Unit = {}
 }


### PR DESCRIPTION
This PR reworks the ActorRef registration logic of the controller.

### Previous logic:
1. Upon building a physicalOp, the controller calls `actorService.actorOf` which immediately returns an ActorRef as the address of an actor which can be remote.
2. The controller directly uses this ActorRef to send messages.
3. However, if the remote Actor takes a long time to initialize due to whatever reasons, its ActorRef is not usable until it is fully initialized.
4. The messages sent to the ActorRef become dead letters, which makes the controller think the remote actor is dead.

### Reworked logic:
1. The immediate return value from `actorService.actorOf` is ignored.
2. After initialization, the remote actor sends a `RegisterActorRef` message to the controller.
3. After receiving the message, the controller starts to send messages to the actor.

### Additional note:
Since the controller now depends on the remote actors to get their ActorRefs, the ActorRef discovery mechanism(See explanation below) also needs to change a little as we were assuming the controller always knows every ActorRef:

**ActorRef discovery mechanism**:
When a worker actor wants to know the ActorRef of another ActorVirtualIdentity to send a message.
1. if the ActorVirtualIdentity -> ActorRef mapping is known, it directly uses the ActorRef. Otherwise, it will ask its parent actor, which is the controller.
2. when it receives a mapping, it adds that mapping to its state.

**Changes in the discovery mechanism**:
1. The controller keeps a `toNotifyOnRegistration` set to keep track of the actors which asks it for the ActorRef of an actor.
2. Once the ActorRef becomes available for the controller, it immediately notifies those actors. 