### PR TITLE
Temporarily disable skew handling and monitoring by default

### DIFF
--- a/core/amber/src/main/resources/application.conf
+++ b/core/amber/src/main/resources/application.conf
@@ -12,7 +12,7 @@ monitoring {
 }
 
 reshape {
-    skew-handling-enabled = true
+    skew-handling-enabled = false
     skew-detection-initial-delay-ms = 5000
     skew-detection-interval-ms = 3000
     eta-threshold = 100

--- a/core/amber/src/main/resources/application.conf
+++ b/core/amber/src/main/resources/application.conf
@@ -7,7 +7,7 @@ constants {
 }
 
 monitoring {
-    monitoring-enabled = true
+    monitoring-enabled = false
     monitoring-interval-ms = 3000
 }
 


### PR DESCRIPTION
This PR changes the default setting for skew-handling and monitoring to false. Users can turn it on manually as needed.