### PR TITLE
Fix runtime statistics being reset randomly during the execution

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/OperatorExecution.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/OperatorExecution.scala
@@ -50,7 +50,7 @@ class OperatorExecution(
     )
   }
   def getWorkerInfo(id: ActorVirtualIdentity): WorkerInfo = {
-    if (!workers.contains(id)) {
+    if (!workers.containsKey(id)) {
       initializeWorkerInfo(id)
     }
     workers.get(id)


### PR DESCRIPTION
This PR fixes an issue introduced by #2275, which randomly resets the stats of the worker to an uninitialized state.

![2023-12-21 20 52 05](https://github.com/Texera/texera/assets/13672781/8740fc5e-8f44-4486-aaad-6286efa40d8d)


The root cause of it was the call of `ConcurrentHashMap.contains`, it is equivalent to `ConcurrentHashMap.containsValue`. But we are checking if a key exists in the map. Thus, we should have used `ConcurrentHashMap.containsKey` to check if the actor ID is in the map.