### PR TITLE
Fix the bug left-panel disappear after resizing

### DIFF
--- a/core/new-gui/src/app/workspace/component/left-panel/left-panel.component.html
+++ b/core/new-gui/src/app/workspace/component/left-panel/left-panel.component.html
@@ -1,19 +1,21 @@
-<mat-expansion-panel
-  [expanded]="true"
-  hideToggle
-  cdkDrag
-  cdkDragBoundary="texera-workspace"
-  id="left-panel-container"
-  nz-resizable
-  [nzMinWidth]="175"
-  [nzMaxWidth]="screenWidth*0.5"
-  [style.width.px]="width"
-  (nzResize)="onResize($event)">
-  <mat-expansion-panel-header cdkDragHandle>
-    <mat-panel-title>Operators</mat-panel-title>
-  </mat-expansion-panel-header>
-  <div id="left-panel-content">
-    <ng-container *ngComponentOutlet="currentComponent;"></ng-container>
-  </div>
-  <nz-resize-handles [nzDirections]="['right']"></nz-resize-handles>
-</mat-expansion-panel>
+<div>
+  <mat-expansion-panel
+    [expanded]="true"
+    hideToggle
+    cdkDrag
+    cdkDragBoundary="texera-workspace"
+    id="left-panel-container"
+    nz-resizable
+    [nzMinWidth]="175"
+    [nzMaxWidth]="screenWidth*0.5"
+    [style.width.px]="width"
+    (nzResize)="onResize($event)">
+    <mat-expansion-panel-header cdkDragHandle>
+      <mat-panel-title>Operators</mat-panel-title>
+    </mat-expansion-panel-header>
+    <div id="left-panel-content">
+      <ng-container *ngComponentOutlet="currentComponent;"></ng-container>
+    </div>
+    <nz-resize-handles [nzDirections]="['right']"></nz-resize-handles>
+  </mat-expansion-panel>
+</div>


### PR DESCRIPTION
A simple fix for the bug left-panel disappears after resizing.
It's caused by the NzResizeEvent handler failing to get a parent DOM element other than DIV, i.e., the texera-left-panel tag is not a valid DOM element for NzResizeEvent. The solution is simple: add a div layer after the texera-left-panel tag and use the div as the parent element for the NzResize box.

Before the fix:
`<texera-left-panel><nz-resizable></nz-resizable></texera-left-panel>`

After the fix:
`<texera-left-panel><div><nz-resizable></nz-resizable></div></texera-left-panel>`