### PR TITLE
Fix forum display frame

### DIFF
--- a/core/new-gui/src/app/dashboard/user/component/flarum/flarum.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/flarum/flarum.component.html
@@ -3,7 +3,7 @@
     <h2>Discussion</h2>
   </nz-card>
   <iframe
-    style="border: none; width: 100%; height: calc(100vh - 85px - 75px)"
+    style="border: none; width: 100%; height: calc(100vh - 95px - 70px)"
     [src]="flarumUrl">
   </iframe>
 </div>


### PR DESCRIPTION
Fix the size of the forum frame: Removing the outter scroll bar.
The forum frame was few pixel larger than the proper size such that it cause overflow to the outter div.
![image](https://github.com/Texera/texera/assets/11544314/fb13d392-ff12-468b-a7c8-ecce09bc2157)
