### PR TITLE
Fix cleanup logic for mongo collection

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWebApplication.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWebApplication.scala
@@ -13,38 +13,22 @@ import edu.uci.ics.texera.Utils
 import edu.uci.ics.texera.Utils.{maptoStatusCode, objectMapper}
 import edu.uci.ics.texera.web.TexeraWebApplication.scheduleRecurringCallThroughActorSystem
 import edu.uci.ics.texera.web.auth.JwtAuth.jwtConsumer
-import edu.uci.ics.texera.web.auth.{
-  GuestAuthFilter,
-  SessionUser,
-  UserAuthenticator,
-  UserRoleAuthorizer
-}
+import edu.uci.ics.texera.web.auth.{GuestAuthFilter, SessionUser, UserAuthenticator, UserRoleAuthorizer}
 import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.WorkflowExecutions
 import edu.uci.ics.texera.web.resource.auth.{AuthResource, GoogleAuthResource}
 import edu.uci.ics.texera.web.resource._
 import edu.uci.ics.texera.web.resource.dashboard.DashboardResource
 import edu.uci.ics.texera.web.resource.dashboard.admin.execution.AdminExecutionResource
 import edu.uci.ics.texera.web.resource.dashboard.admin.user.AdminUserResource
-import edu.uci.ics.texera.web.resource.dashboard.user.file.{
-  UserFileAccessResource,
-  UserFileResource
-}
-import edu.uci.ics.texera.web.resource.dashboard.user.project.{
-  ProjectAccessResource,
-  ProjectResource,
-  PublicProjectResource
-}
+import edu.uci.ics.texera.web.resource.dashboard.user.file.{UserFileAccessResource, UserFileResource}
+import edu.uci.ics.texera.web.resource.dashboard.user.project.{ProjectAccessResource, ProjectResource, PublicProjectResource}
 import edu.uci.ics.texera.web.resource.dashboard.user.quota.UserQuotaResource
 import edu.uci.ics.texera.web.resource.dashboard.user.discussion.UserDiscussionResource
-import edu.uci.ics.texera.web.resource.dashboard.user.workflow.{
-  WorkflowAccessResource,
-  WorkflowExecutionsResource,
-  WorkflowResource,
-  WorkflowVersionResource
-}
+import edu.uci.ics.texera.web.resource.dashboard.user.workflow.{WorkflowAccessResource, WorkflowExecutionsResource, WorkflowResource, WorkflowVersionResource}
 import edu.uci.ics.texera.web.service.ExecutionsMetadataPersistService
 import edu.uci.ics.texera.web.storage.MongoDatabaseManager
 import edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState.{COMPLETED, FAILED}
+import edu.uci.ics.texera.workflow.common.storage.OpResultStorage
 import io.dropwizard.auth.{AuthDynamicFeature, AuthValueFactoryProvider}
 import io.dropwizard.setup.{Bootstrap, Environment}
 import io.dropwizard.websockets.WebsocketBundle
@@ -255,14 +239,23 @@ class TexeraWebApplication extends io.dropwizard.Application[TexeraWebConfigurat
   }
 
   def dropCollections(result: String): Unit = {
-    if (result.isEmpty) {
+    if (result == null || result.isEmpty) {
       return
     }
     // parse the JSON
     val node = objectMapper.readTree(result)
-    val collections = node.get("results")
+    val collectionEntries = node.get("results")
     // loop every collection and drop it
-    collections.forEach(collection => MongoDatabaseManager.dropCollection(collection.asText()))
+    collectionEntries.forEach(collection => {
+      val collectionInfo = collection.asText().split(":")
+      val (storageType, collectionName) = (collectionInfo(0), collectionInfo(1))
+      storageType match{
+        case OpResultStorage.MEMORY =>
+          // skip cleanup for now.
+        case OpResultStorage.MONGODB =>
+          MongoDatabaseManager.dropCollection(collectionName)
+      }
+    })
   }
 
   def deleteReplayLog(logLocation: String): Unit = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWebApplication.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWebApplication.scala
@@ -13,18 +13,35 @@ import edu.uci.ics.texera.Utils
 import edu.uci.ics.texera.Utils.{maptoStatusCode, objectMapper}
 import edu.uci.ics.texera.web.TexeraWebApplication.scheduleRecurringCallThroughActorSystem
 import edu.uci.ics.texera.web.auth.JwtAuth.jwtConsumer
-import edu.uci.ics.texera.web.auth.{GuestAuthFilter, SessionUser, UserAuthenticator, UserRoleAuthorizer}
+import edu.uci.ics.texera.web.auth.{
+  GuestAuthFilter,
+  SessionUser,
+  UserAuthenticator,
+  UserRoleAuthorizer
+}
 import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.WorkflowExecutions
 import edu.uci.ics.texera.web.resource.auth.{AuthResource, GoogleAuthResource}
 import edu.uci.ics.texera.web.resource._
 import edu.uci.ics.texera.web.resource.dashboard.DashboardResource
 import edu.uci.ics.texera.web.resource.dashboard.admin.execution.AdminExecutionResource
 import edu.uci.ics.texera.web.resource.dashboard.admin.user.AdminUserResource
-import edu.uci.ics.texera.web.resource.dashboard.user.file.{UserFileAccessResource, UserFileResource}
-import edu.uci.ics.texera.web.resource.dashboard.user.project.{ProjectAccessResource, ProjectResource, PublicProjectResource}
+import edu.uci.ics.texera.web.resource.dashboard.user.file.{
+  UserFileAccessResource,
+  UserFileResource
+}
+import edu.uci.ics.texera.web.resource.dashboard.user.project.{
+  ProjectAccessResource,
+  ProjectResource,
+  PublicProjectResource
+}
 import edu.uci.ics.texera.web.resource.dashboard.user.quota.UserQuotaResource
 import edu.uci.ics.texera.web.resource.dashboard.user.discussion.UserDiscussionResource
-import edu.uci.ics.texera.web.resource.dashboard.user.workflow.{WorkflowAccessResource, WorkflowExecutionsResource, WorkflowResource, WorkflowVersionResource}
+import edu.uci.ics.texera.web.resource.dashboard.user.workflow.{
+  WorkflowAccessResource,
+  WorkflowExecutionsResource,
+  WorkflowResource,
+  WorkflowVersionResource
+}
 import edu.uci.ics.texera.web.service.ExecutionsMetadataPersistService
 import edu.uci.ics.texera.web.storage.MongoDatabaseManager
 import edu.uci.ics.texera.web.workflowruntimestate.WorkflowAggregatedState.{COMPLETED, FAILED}
@@ -249,9 +266,9 @@ class TexeraWebApplication extends io.dropwizard.Application[TexeraWebConfigurat
     collectionEntries.forEach(collection => {
       val collectionInfo = collection.asText().split(":")
       val (storageType, collectionName) = (collectionInfo(0), collectionInfo(1))
-      storageType match{
+      storageType match {
         case OpResultStorage.MEMORY =>
-          // skip cleanup for now.
+        // skip cleanup for now.
         case OpResultStorage.MONGODB =>
           MongoDatabaseManager.dropCollection(collectionName)
       }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWebApplication.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWebApplication.scala
@@ -268,7 +268,7 @@ class TexeraWebApplication extends io.dropwizard.Application[TexeraWebConfigurat
       val (storageType, collectionName) = (collectionInfo(0), collectionInfo(1))
       storageType match {
         case OpResultStorage.MEMORY =>
-        // skip cleanup for now.
+          // rely on the server-side result cleanup logic.
         case OpResultStorage.MONGODB =>
           MongoDatabaseManager.dropCollection(collectionName)
       }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
@@ -116,7 +116,7 @@ object WorkflowCacheRewriter {
           )
           sink.getStorage.setSchema(logicalPlan.getOpOutputSchemas(o.operatorIdentifier).head)
           // add the sink collection name to the JSON array of sinks
-          sinksPointers.add(o.getContext.executionId + "_" + storageKey)
+          sinksPointers.add(storageType+":"+o.getContext.executionId + "_" + storageKey)
         }
         storage.get(storageKey)
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
@@ -116,7 +116,10 @@ object WorkflowCacheRewriter {
           )
           sink.getStorage.setSchema(logicalPlan.getOpOutputSchemas(o.operatorIdentifier).head)
           // add the sink collection name to the JSON array of sinks
-          sinksPointers.add(storageType + ":" + o.getContext.executionId + "_" + storageKey)
+          val storageNode = objectMapper.createObjectNode()
+          storageNode.put("storageType", storageType)
+          storageNode.put("storageKey", o.getContext.executionId + "_" + storageKey)
+          sinksPointers.add(storageNode)
         }
         storage.get(storageKey)
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCacheRewriter.scala
@@ -116,7 +116,7 @@ object WorkflowCacheRewriter {
           )
           sink.getStorage.setSchema(logicalPlan.getOpOutputSchemas(o.operatorIdentifier).head)
           // add the sink collection name to the JSON array of sinks
-          sinksPointers.add(storageType+":"+o.getContext.executionId + "_" + storageKey)
+          sinksPointers.add(storageType + ":" + o.getContext.executionId + "_" + storageKey)
         }
         storage.get(storageKey)
 


### PR DESCRIPTION
This PR:
1. Add both storage type and key to the result field of an execution.
2. based on the storage type, we do cleanup accordingly. This will avoid access to MongoDB if it is never enabled.