### PR TITLE
Separate Replay Initialization from Worker Config

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/common/WorkflowActor.scala
@@ -19,14 +19,13 @@ import edu.uci.ics.amber.engine.architecture.logreplay.{
   ReplayLogManager,
   ReplayOrderEnforcer
 }
-import edu.uci.ics.amber.engine.architecture.scheduling.{
+import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.{
+  TriggerSend,
   WorkerReplayLoggingConfig,
   WorkerStateRestoreConfig
 }
-import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.TriggerSend
 import edu.uci.ics.amber.engine.common.AmberLogging
 import edu.uci.ics.amber.engine.common.ambermessage.ChannelID
-import edu.uci.ics.amber.engine.common.AmberLogging
 import edu.uci.ics.amber.engine.common.ambermessage.{ChannelID, WorkflowFIFOMessage}
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
@@ -9,15 +9,13 @@ import edu.uci.ics.amber.engine.architecture.controller.Controller.{
   WorkflowRecoveryStatus
 }
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.FatalErrorHandler.FatalError
-import edu.uci.ics.amber.engine.architecture.scheduling.{
+import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.{
   WorkerReplayLoggingConfig,
   WorkerStateRestoreConfig
 }
 import edu.uci.ics.amber.engine.common.ambermessage.WorkflowMessage.getInMemSize
 import edu.uci.ics.amber.engine.common.ambermessage.{ChannelID, ControlPayload, WorkflowFIFOMessage}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
-import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
-import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 import edu.uci.ics.amber.engine.common.AmberConfig
 import edu.uci.ics.amber.engine.common.virtualidentity.util.{CLIENT, CONTROLLER, SELF}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
@@ -19,6 +19,11 @@ import edu.uci.ics.amber.engine.architecture.deploysemantics.locationpreference.
 import edu.uci.ics.amber.engine.architecture.pythonworker.PythonWorkflowWorker
 import edu.uci.ics.amber.engine.architecture.scheduling.WorkerConfig
 import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker
+import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.{
+  WorkerReplayInitialization,
+  WorkerReplayLoggingConfig,
+  WorkerStateRestoreConfig
+}
 import edu.uci.ics.amber.engine.common.virtualidentity.{
   ActorVirtualIdentity,
   ExecutionIdentity,
@@ -516,7 +521,9 @@ case class PhysicalOp(
   def build(
       controllerActorService: AkkaActorService,
       opExecution: OperatorExecution,
-      workerConfigs: List[WorkerConfig]
+      workerConfigs: List[WorkerConfig],
+      stateRestoreConfigGen: ActorVirtualIdentity => Option[WorkerStateRestoreConfig],
+      replayLoggingConfigGen: ActorVirtualIdentity => Option[WorkerReplayLoggingConfig]
   ): Unit = {
     val addressInfo = AddressInfo(
       controllerActorService.getClusterNodeAddresses,
@@ -535,7 +542,11 @@ case class PhysicalOp(
         WorkflowWorker.props(
           workerId,
           physicalOp = this,
-          workerConfig
+          workerConfig,
+          WorkerReplayInitialization(
+            stateRestoreConfigGen(workerId),
+            replayLoggingConfigGen(workerId)
+          )
         )
       }
       // Note: At this point, we don't know if the actor is fully initialized.

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
@@ -1,10 +1,9 @@
 package edu.uci.ics.amber.engine.architecture.scheduling
 
 import com.typesafe.scalalogging.LazyLogging
-import edu.uci.ics.amber.engine.architecture.controller.ControllerConfig
 import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalLink, PhysicalOp}
 import edu.uci.ics.amber.engine.architecture.scheduling.ExpansionGreedyRegionPlanGenerator.replaceVertex
-import edu.uci.ics.amber.engine.common.{AmberConfig, VirtualIdentityUtils}
+import edu.uci.ics.amber.engine.common.AmberConfig
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.virtualidentity.PhysicalOpIdentity
 import edu.uci.ics.texera.workflow.common.WorkflowContext
@@ -59,8 +58,7 @@ object ExpansionGreedyRegionPlanGenerator {
 class ExpansionGreedyRegionPlanGenerator(
     logicalPlan: LogicalPlan,
     var physicalPlan: PhysicalPlan,
-    opResultStorage: OpResultStorage,
-    controllerConfig: ControllerConfig
+    opResultStorage: OpResultStorage
 ) extends RegionPlanGenerator(
       logicalPlan,
       physicalPlan,
@@ -318,19 +316,7 @@ class ExpansionGreedyRegionPlanGenerator(
                   }
 
                 physicalOp.id -> (0 until workerCount)
-                  .map(idx => {
-                    val workerId = VirtualIdentityUtils
-                      .createWorkerIdentity(
-                        physicalOp.workflowId,
-                        physicalOp.executionId,
-                        physicalOp.id,
-                        idx
-                      )
-                    WorkerConfig(
-                      controllerConfig.workerRestoreConfMapping(workerId),
-                      controllerConfig.workerLoggingConfMapping(workerId)
-                    )
-                  })
+                  .map(idx => WorkerConfig())
                   .toList
               }
             }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
@@ -316,7 +316,7 @@ class ExpansionGreedyRegionPlanGenerator(
                   }
 
                 physicalOp.id -> (0 until workerCount)
-                  .map(idx => WorkerConfig())
+                  .map(_ => WorkerConfig())
                   .toList
               }
             }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/Region.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/Region.scala
@@ -2,20 +2,11 @@ package edu.uci.ics.amber.engine.architecture.scheduling
 
 import edu.uci.ics.amber.engine.common.virtualidentity.{PhysicalLinkIdentity, PhysicalOpIdentity}
 
-import java.net.URI
-
 case class RegionLink(fromRegion: Region, toRegion: Region)
 
 case class RegionIdentity(id: String)
 
-case class WorkerConfig(
-    restoreConfOpt: Option[WorkerStateRestoreConfig] = None,
-    replayLogConfOpt: Option[WorkerReplayLoggingConfig] = None
-)
-
-final case class WorkerStateRestoreConfig(readFrom: URI, replayTo: Long)
-
-final case class WorkerReplayLoggingConfig(writeTo: URI)
+case class WorkerConfig()
 
 case class RegionConfig(
     workerConfigs: Map[PhysicalOpIdentity, List[WorkerConfig]]

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowScheduler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowScheduler.scala
@@ -183,7 +183,9 @@ class WorkflowScheduler(
       workflow.regionPlan.regions
         .find(region => region.id == regionId)
         .map(region => region.config.get.workerConfigs(physicalOp.id))
-        .get
+        .get,
+      controllerConfig.workerRestoreConfMapping,
+      controllerConfig.workerLoggingConfMapping
     )
   }
   private def initializePythonOperators(region: Region): Future[Seq[Unit]] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -2,7 +2,7 @@ package edu.uci.ics.texera.web.service
 
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.architecture.controller.ControllerConfig
-import edu.uci.ics.amber.engine.architecture.scheduling.{
+import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.{
   WorkerReplayLoggingConfig,
   WorkerStateRestoreConfig
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/WorkflowCompiler.scala
@@ -92,8 +92,7 @@ class WorkflowCompiler(
     val (regionPlan, updatedPhysicalPlan) = new ExpansionGreedyRegionPlanGenerator(
       rewrittenLogicalPlan,
       physicalPlan,
-      opResultStorage,
-      controllerConfig
+      opResultStorage
     ).generate(context)
 
     // validate the plan

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
@@ -117,7 +117,7 @@ class WorkerSpec
         identifier1,
         physicalOp,
         WorkerConfig(),
-        WorkerReplayInitialization(None, None)
+        WorkerReplayInitialization(restoreConfOpt = None, replayLogConfOpt = None)
       ) {
         this.dp = new DataProcessor(identifier1, mockHandler) {
           override val outputManager: OutputManager = mockOutputManager

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
@@ -9,6 +9,7 @@ import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalLink, Phys
 import edu.uci.ics.amber.engine.architecture.messaginglayer.OutputManager
 import edu.uci.ics.amber.engine.architecture.scheduling.WorkerConfig
 import edu.uci.ics.amber.engine.architecture.sendsemantics.partitionings.OneToOnePartitioning
+import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.WorkerReplayInitialization
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.AddPartitioningHandler.AddPartitioning
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.UpdateInputLinkingHandler.UpdateInputLinking
 import edu.uci.ics.amber.engine.common.ambermessage.{ChannelID, DataFrame, WorkflowFIFOMessage}
@@ -115,7 +116,8 @@ class WorkerSpec
       new WorkflowWorker(
         identifier1,
         physicalOp,
-        WorkerConfig(restoreConfOpt = None, replayLogConfOpt = None)
+        WorkerConfig(),
+        WorkerReplayInitialization(None, None)
       ) {
         this.dp = new DataProcessor(identifier1, mockHandler) {
           override val outputManager: OutputManager = mockOutputManager


### PR DESCRIPTION
This PR:
1. Separated replay-related configs from worker config. Now they are inside `ReplayInitialization`.
2. For now, we cannot make replay initialization as a separate message since the worker does not support resetting its state. So the replay is highly coupled with the constructor. Will make it a separate message later when we can load the state from a checkpoint.