### PR TITLE
Remove Execution ID from ActorVirtualIdentity

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/OperatorExecution.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/OperatorExecution.scala
@@ -80,7 +80,7 @@ class OperatorExecution(
   def setAllWorkerState(state: WorkerState): Unit = {
     (0 until numWorkers).foreach { i =>
       getWorkerInfo(
-        VirtualIdentityUtils.createWorkerIdentity(workflowId, executionId, physicalOpId, i)
+        VirtualIdentityUtils.createWorkerIdentity(workflowId, physicalOpId, i)
       ).state = state
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
@@ -513,7 +513,7 @@ case class PhysicalOp(
   def assignWorkers(workerCount: Int): Unit = {
     (0 until workerCount).foreach(workerIdx => {
       workerIds.add(
-        VirtualIdentityUtils.createWorkerIdentity(workflowId, executionId, id, workerIdx)
+        VirtualIdentityUtils.createWorkerIdentity(workflowId, id, workerIdx)
       )
     })
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
@@ -394,7 +394,7 @@ class ExpansionGreedyRegionPlanGenerator(
       opResultStorage: OpResultStorage
     )
     materializationReader.setContext(context)
-    materializationReader.setOperatorId("cacheSource-" + matWriterLogicalOp.operatorIdentifier.id)
+    materializationReader.setOperatorId("cacheSource_" + matWriterLogicalOp.operatorIdentifier.id)
     materializationReader.schema = matWriterLogicalOp.getStorage.getSchema
     val matReaderOutputSchema = materializationReader.getOutputSchemas(Array())
     val matReaderOp = materializationReader.getPhysicalOp(
@@ -412,7 +412,7 @@ class ExpansionGreedyRegionPlanGenerator(
   ): (ProgressiveSinkOpDesc, PhysicalOp) = {
     val matWriterLogicalOp = new ProgressiveSinkOpDesc()
     matWriterLogicalOp.setContext(context)
-    matWriterLogicalOp.setOperatorId("materialized-" + fromOp.id.logicalOpId.id)
+    matWriterLogicalOp.setOperatorId("materialized_" + fromOp.id.logicalOpId.id)
     val fromLogicalOp = logicalPlan.getOperator(fromOp.id.logicalOpId)
     val fromOpInputSchema: Array[Schema] =
       if (!fromLogicalOp.isInstanceOf[SourceOperatorDescriptor]) {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/VirtualIdentityUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/VirtualIdentityUtils.scala
@@ -2,7 +2,6 @@ package edu.uci.ics.amber.engine.common
 
 import edu.uci.ics.amber.engine.common.virtualidentity.{
   ActorVirtualIdentity,
-  ExecutionIdentity,
   OperatorIdentity,
   PhysicalOpIdentity,
   WorkflowIdentity
@@ -12,30 +11,27 @@ import scala.util.matching.Regex
 
 object VirtualIdentityUtils {
 
-  private val workerNamePattern: Regex = raw"Worker:WF(\d+)-E(\d+)-(.+)-(\w+)-(\d+)".r
+  private val workerNamePattern: Regex = raw"Worker:WF(\d+)-(.+)-(\w+)-(\d+)".r
   private val operatorUUIDPattern: Regex = raw"(\w+)-(.+)-(\w+)".r
   def createWorkerIdentity(
       workflowId: WorkflowIdentity,
-      executionId: ExecutionIdentity,
       operator: String,
       layerName: String,
       workerId: Int
   ): ActorVirtualIdentity = {
 
     ActorVirtualIdentity(
-      s"Worker:WF${workflowId.id}-E${executionId.id}-$operator-$layerName-$workerId"
+      s"Worker:WF${workflowId.id}-$operator-$layerName-$workerId"
     )
   }
 
   def createWorkerIdentity(
       workflowId: WorkflowIdentity,
-      executionId: ExecutionIdentity,
       physicalOpId: PhysicalOpIdentity,
       workerId: Int
   ): ActorVirtualIdentity = {
     createWorkerIdentity(
       workflowId,
-      executionId,
       physicalOpId.logicalOpId.id,
       physicalOpId.layerName,
       workerId
@@ -44,21 +40,21 @@ object VirtualIdentityUtils {
 
   def getPhysicalOpId(workerId: ActorVirtualIdentity): PhysicalOpIdentity = {
     workerId.name match {
-      case workerNamePattern(_, _, operator, layerName, _) =>
+      case workerNamePattern(_, operator, layerName, _) =>
         PhysicalOpIdentity(OperatorIdentity(operator), layerName)
     }
   }
 
   def getWorkerIndex(workerId: ActorVirtualIdentity): Int = {
     workerId.name match {
-      case workerNamePattern(_, _, _, _, idx) =>
+      case workerNamePattern(_, _, _, idx) =>
         idx.toInt
     }
   }
 
   def toShorterString(workerId: ActorVirtualIdentity): String = {
     workerId.name match {
-      case workerNamePattern(workflowId, executionId, operatorName, layerName, workerIndex) =>
+      case workerNamePattern(workflowId, operatorName, layerName, workerIndex) =>
         val shorterName = if (operatorName.length > 6) {
           operatorName match {
             case operatorUUIDPattern(op, _, postfix) => op + "-" + postfix.takeRight(6)
@@ -68,8 +64,8 @@ object VirtualIdentityUtils {
           operatorName
         }
 
-        s"WF$workflowId-E$executionId-$shorterName-$layerName-$workerIndex"
-      case _ => workerId.toString
+        s"WF$workflowId-$shorterName-$layerName-$workerIndex"
+      case _ => workerId.name
     }
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/SinkInjectionTransformer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/SinkInjectionTransformer.scala
@@ -24,7 +24,7 @@ object SinkInjectionTransformer {
       val op = logicalPlan.getOperator(opId)
       op.operatorInfo.outputPorts.indices.foreach(outPort => {
         val sink = new ProgressiveSinkOpDesc()
-        sink.setOperatorId("sink - " + opId)
+        sink.setOperatorId("sink_" + opId.id)
         logicalPlan = logicalPlan
           .addOperator(sink)
           .addLink(op.operatorIdentifier, outPort, sink.operatorIdentifier, toPort = 0)

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowSchedulerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowSchedulerSpec.scala
@@ -65,7 +65,6 @@ class WorkflowSchedulerSpec extends AnyFlatSpec with MockFactory {
         executionState,
         VirtualIdentityUtils.createWorkerIdentity(
           workflow.context.workflowId,
-          workflow.context.executionId,
           physicalOpId,
           0
         )
@@ -135,7 +134,6 @@ class WorkflowSchedulerSpec extends AnyFlatSpec with MockFactory {
         executionState,
         VirtualIdentityUtils.createWorkerIdentity(
           workflow.context.workflowId,
-          workflow.context.executionId,
           physicalOpId,
           0
         )
@@ -200,7 +198,6 @@ class WorkflowSchedulerSpec extends AnyFlatSpec with MockFactory {
       executionState,
       VirtualIdentityUtils.createWorkerIdentity(
         workflow.context.workflowId,
-        workflow.context.executionId,
         probePhysicalOpId,
         0
       )

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -37,13 +37,11 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
   private val upstreamOpId = PhysicalOpIdentity(OperatorIdentity("sender"), "main")
   private val testWorkerId: ActorVirtualIdentity = VirtualIdentityUtils.createWorkerIdentity(
     DEFAULT_WORKFLOW_ID,
-    DEFAULT_EXECUTION_ID,
     testOpId,
     0
   )
   private val senderWorkerId: ActorVirtualIdentity = VirtualIdentityUtils.createWorkerIdentity(
     DEFAULT_WORKFLOW_ID,
-    DEFAULT_EXECUTION_ID,
     upstreamOpId,
     0
   )


### PR DESCRIPTION
This PR:
1. Fixes short name display for non-worker operators, including Controller.
2. Corrects short name display for cache sources and sinks.
3. Removes execution ID from actor ID to ensure consistency in replay logs.
