### PR TITLE
Introduce OperatorConfig

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ExecutionState.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ExecutionState.scala
@@ -2,7 +2,7 @@ package edu.uci.ics.amber.engine.architecture.controller
 
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp
 import edu.uci.ics.amber.engine.architecture.scheduling.Region
-import edu.uci.ics.amber.engine.architecture.scheduling.config.{OperatorConfig, WorkerConfig}
+import edu.uci.ics.amber.engine.architecture.scheduling.config.OperatorConfig
 import edu.uci.ics.amber.engine.common.virtualidentity.{
   ActorVirtualIdentity,
   PhysicalLinkIdentity,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ExecutionState.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ExecutionState.scala
@@ -2,7 +2,7 @@ package edu.uci.ics.amber.engine.architecture.controller
 
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp
 import edu.uci.ics.amber.engine.architecture.scheduling.Region
-import edu.uci.ics.amber.engine.architecture.scheduling.config.WorkerConfig
+import edu.uci.ics.amber.engine.architecture.scheduling.config.{OperatorConfig, WorkerConfig}
 import edu.uci.ics.amber.engine.common.virtualidentity.{
   ActorVirtualIdentity,
   PhysicalLinkIdentity,
@@ -35,13 +35,13 @@ class ExecutionState(workflow: Workflow) {
 
   def initOperatorState(
       physicalOpId: PhysicalOpIdentity,
-      workerConfigs: List[WorkerConfig]
+      operatorConfig: OperatorConfig
   ): OperatorExecution = {
     operatorExecutions += physicalOpId -> new OperatorExecution(
       workflow.context.workflowId,
       workflow.context.executionId,
       physicalOpId,
-      workerConfigs.length
+      operatorConfig.workerConfigs.length
     )
     operatorExecutions(physicalOpId)
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
@@ -5,12 +5,25 @@ import akka.remote.RemoteScope
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.architecture.common.AkkaActorService
 import edu.uci.ics.amber.engine.architecture.controller.OperatorExecution
-import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{OpExecInitInfo, OpExecInitInfoWithCode, OpExecInitInfoWithFunc}
-import edu.uci.ics.amber.engine.architecture.deploysemantics.locationpreference.{AddressInfo, LocationPreference, PreferController, RoundRobinPreference}
+import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{
+  OpExecInitInfo,
+  OpExecInitInfoWithCode,
+  OpExecInitInfoWithFunc
+}
+import edu.uci.ics.amber.engine.architecture.deploysemantics.locationpreference.{
+  AddressInfo,
+  LocationPreference,
+  PreferController,
+  RoundRobinPreference
+}
 import edu.uci.ics.amber.engine.architecture.pythonworker.PythonWorkflowWorker
 import edu.uci.ics.amber.engine.architecture.scheduling.config.OperatorConfig
 import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker
-import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.{WorkerReplayInitialization, WorkerReplayLoggingConfig, WorkerStateRestoreConfig}
+import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.{
+  WorkerReplayInitialization,
+  WorkerReplayLoggingConfig,
+  WorkerStateRestoreConfig
+}
 import edu.uci.ics.amber.engine.common.VirtualIdentityUtils
 import edu.uci.ics.amber.engine.common.virtualidentity._
 import edu.uci.ics.texera.workflow.common.metadata.{InputPort, OperatorInfo, OutputPort}
@@ -507,10 +520,9 @@ case class PhysicalOp(
       val preferredAddress = locationPreference.getPreferredLocation(addressInfo, this, workerIndex)
 
       val workflowWorker = if (this.isPythonOperator) {
-        PythonWorkflowWorker.props(workerId, workerConfig)
+        PythonWorkflowWorker.props(workerConfig)
       } else {
         WorkflowWorker.props(
-          workerId,
           workerConfig,
           physicalOp = this,
           operatorConfig,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
@@ -239,7 +239,7 @@ case class PhysicalOp(
   def isHashJoinOperator: Boolean = {
     opExecInitInfo match {
       case OpExecInitInfoWithCode(codeGen) => false
-      case OpExecInitInfoWithFunc(opGen)   => opGen(0, this, null).isInstanceOf[HashJoinOpExec[_]]
+      case OpExecInitInfoWithFunc(opGen)   => opGen(0, this, OperatorConfig(workerConfigs = List())).isInstanceOf[HashJoinOpExec[_]]
     }
   }
 
@@ -247,7 +247,7 @@ case class PhysicalOp(
     if (!isPythonOperator) {
       throw new RuntimeException("operator " + id + " is not a python operator")
     }
-    opExecInitInfo.asInstanceOf[OpExecInitInfoWithCode].codeGen(0, this, null)
+    opExecInitInfo.asInstanceOf[OpExecInitInfoWithCode].codeGen(0, this, OperatorConfig(workerConfigs = List()))
   }
 
   def getOutputSchema: Schema = {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
@@ -17,7 +17,7 @@ import edu.uci.ics.amber.engine.architecture.deploysemantics.locationpreference.
   RoundRobinPreference
 }
 import edu.uci.ics.amber.engine.architecture.pythonworker.PythonWorkflowWorker
-import edu.uci.ics.amber.engine.architecture.scheduling.config.WorkerConfig
+import edu.uci.ics.amber.engine.architecture.scheduling.config.{OperatorConfig, WorkerConfig}
 import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker
 import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.{
   WorkerReplayInitialization,
@@ -523,7 +523,7 @@ case class PhysicalOp(
   def build(
       controllerActorService: AkkaActorService,
       opExecution: OperatorExecution,
-      workerConfigs: List[WorkerConfig],
+      operatorConfig: OperatorConfig,
       stateRestoreConfigGen: ActorVirtualIdentity => Option[WorkerStateRestoreConfig],
       replayLoggingConfigGen: ActorVirtualIdentity => Option[WorkerReplayLoggingConfig]
   ): Unit = {
@@ -534,7 +534,7 @@ case class PhysicalOp(
 
     workerIds.foreach(workerId => {
       val workerIndex = VirtualIdentityUtils.getWorkerIndex(workerId)
-      val workerConfig = workerConfigs(workerIndex)
+      val workerConfig = operatorConfig.workerConfigs(workerIndex)
       val locationPreference = this.locationPreference.getOrElse(new RoundRobinPreference())
       val preferredAddress = locationPreference.getPreferredLocation(addressInfo, this, workerIndex)
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
@@ -239,7 +239,8 @@ case class PhysicalOp(
   def isHashJoinOperator: Boolean = {
     opExecInitInfo match {
       case OpExecInitInfoWithCode(codeGen) => false
-      case OpExecInitInfoWithFunc(opGen)   => opGen(0, this, OperatorConfig(workerConfigs = List())).isInstanceOf[HashJoinOpExec[_]]
+      case OpExecInitInfoWithFunc(opGen) =>
+        opGen(0, this, OperatorConfig.empty).isInstanceOf[HashJoinOpExec[_]]
     }
   }
 
@@ -247,7 +248,7 @@ case class PhysicalOp(
     if (!isPythonOperator) {
       throw new RuntimeException("operator " + id + " is not a python operator")
     }
-    opExecInitInfo.asInstanceOf[OpExecInitInfoWithCode].codeGen(0, this, OperatorConfig(workerConfigs = List()))
+    opExecInitInfo.asInstanceOf[OpExecInitInfoWithCode].codeGen(0, this, OperatorConfig.empty)
   }
 
   def getOutputSchema: Schema = {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/PhysicalOp.scala
@@ -33,7 +33,6 @@ import edu.uci.ics.texera.workflow.operators.hashJoin.HashJoinOpExec
 import org.jgrapht.graph.{DefaultEdge, DirectedAcyclicGraph}
 import org.jgrapht.traverse.TopologicalOrderIterator
 
-import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
 object PhysicalOp {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/OpExecInitInfo.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/OpExecInitInfo.scala
@@ -1,18 +1,19 @@
 package edu.uci.ics.amber.engine.architecture.deploysemantics.layer
 
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp
+import edu.uci.ics.amber.engine.architecture.scheduling.config.OperatorConfig
 import edu.uci.ics.amber.engine.common.IOperatorExecutor
 
 object OpExecInitInfo {
 
-  type OpExecFunc = ((Int, PhysicalOp)) => IOperatorExecutor
-  type JavaOpExecFunc = java.util.function.Function[(Int, PhysicalOp), IOperatorExecutor]
+  type OpExecFunc = (Int, PhysicalOp, OperatorConfig) => IOperatorExecutor
+  type JavaOpExecFunc = java.util.function.Function[(Int, PhysicalOp, OperatorConfig), IOperatorExecutor]
     with java.io.Serializable
 
-  def apply(code: String): OpExecInitInfo = OpExecInitInfoWithCode(_ => code)
+  def apply(code: String): OpExecInitInfo = OpExecInitInfoWithCode((_, _, _) => code)
   def apply(opExecFunc: OpExecFunc): OpExecInitInfo = OpExecInitInfoWithFunc(opExecFunc)
   def apply(opExecFunc: JavaOpExecFunc): OpExecInitInfo =
-    OpExecInitInfoWithFunc(x => opExecFunc.apply(x))
+    OpExecInitInfoWithFunc((idx, physicalOp, operatorConfig) => opExecFunc.apply(idx, physicalOp, operatorConfig))
 }
 
 /**
@@ -28,7 +29,7 @@ sealed trait OpExecInitInfo
 
 // only for Python right now
 // TODO: add language type into this class
-final case class OpExecInitInfoWithCode(codeGen: ((Int, PhysicalOp)) => String)
+final case class OpExecInitInfoWithCode(codeGen: (Int, PhysicalOp,OperatorConfig) => String)
     extends OpExecInitInfo
-final case class OpExecInitInfoWithFunc(opGen: ((Int, PhysicalOp)) => IOperatorExecutor)
+final case class OpExecInitInfoWithFunc(opGen: (Int, PhysicalOp, OperatorConfig) => IOperatorExecutor)
     extends OpExecInitInfo

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/OpExecInitInfo.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/deploysemantics/layer/OpExecInitInfo.scala
@@ -7,13 +7,16 @@ import edu.uci.ics.amber.engine.common.IOperatorExecutor
 object OpExecInitInfo {
 
   type OpExecFunc = (Int, PhysicalOp, OperatorConfig) => IOperatorExecutor
-  type JavaOpExecFunc = java.util.function.Function[(Int, PhysicalOp, OperatorConfig), IOperatorExecutor]
-    with java.io.Serializable
+  type JavaOpExecFunc =
+    java.util.function.Function[(Int, PhysicalOp, OperatorConfig), IOperatorExecutor]
+      with java.io.Serializable
 
   def apply(code: String): OpExecInitInfo = OpExecInitInfoWithCode((_, _, _) => code)
   def apply(opExecFunc: OpExecFunc): OpExecInitInfo = OpExecInitInfoWithFunc(opExecFunc)
   def apply(opExecFunc: JavaOpExecFunc): OpExecInitInfo =
-    OpExecInitInfoWithFunc((idx, physicalOp, operatorConfig) => opExecFunc.apply(idx, physicalOp, operatorConfig))
+    OpExecInitInfoWithFunc((idx, physicalOp, operatorConfig) =>
+      opExecFunc.apply(idx, physicalOp, operatorConfig)
+    )
 }
 
 /**
@@ -29,7 +32,8 @@ sealed trait OpExecInitInfo
 
 // only for Python right now
 // TODO: add language type into this class
-final case class OpExecInitInfoWithCode(codeGen: (Int, PhysicalOp,OperatorConfig) => String)
+final case class OpExecInitInfoWithCode(codeGen: (Int, PhysicalOp, OperatorConfig) => String)
     extends OpExecInitInfo
-final case class OpExecInitInfoWithFunc(opGen: (Int, PhysicalOp, OperatorConfig) => IOperatorExecutor)
-    extends OpExecInitInfo
+final case class OpExecInitInfoWithFunc(
+    opGen: (Int, PhysicalOp, OperatorConfig) => IOperatorExecutor
+) extends OpExecInitInfo

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonWorkflowWorker.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonWorkflowWorker.scala
@@ -14,7 +14,6 @@ import edu.uci.ics.amber.engine.architecture.scheduling.config.WorkerConfig
 import edu.uci.ics.amber.engine.common.actormessage.{Backpressure, CreditUpdate}
 import edu.uci.ics.amber.engine.common.ambermessage.WorkflowMessage.getInMemSize
 import edu.uci.ics.amber.engine.common.ambermessage._
-import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 import edu.uci.ics.texera.Utils
 
 import java.nio.file.Path

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowScheduler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowScheduler.scala
@@ -12,7 +12,7 @@ import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.LinkWork
 import edu.uci.ics.amber.engine.architecture.controller.{ControllerConfig, ExecutionState, Workflow}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalLink
 import edu.uci.ics.amber.engine.architecture.pythonworker.promisehandlers.InitializeOperatorLogicHandler.InitializeOperatorLogic
-import edu.uci.ics.amber.engine.architecture.scheduling.config.WorkerConfig
+import edu.uci.ics.amber.engine.architecture.scheduling.config.{OperatorConfig, WorkerConfig}
 import edu.uci.ics.amber.engine.architecture.scheduling.policies.SchedulingPolicy
 import edu.uci.ics.amber.engine.architecture.worker.controlcommands.LinkOrdinal
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.OpenOperatorHandler.OpenOperator
@@ -145,7 +145,7 @@ class WorkflowScheduler(
           buildOperator(
             workflow,
             physicalOpId,
-            region.config.get.workerConfigs(physicalOpId),
+            region.config.get.operatorConfigs(physicalOpId),
             akkaActorService
           )
           builtPhysicalOpIds.add(physicalOpId)
@@ -167,15 +167,15 @@ class WorkflowScheduler(
   private def buildOperator(
       workflow: Workflow,
       physicalOpId: PhysicalOpIdentity,
-      workerConfigs: List[WorkerConfig],
+      operatorConfig: OperatorConfig,
       controllerActorService: AkkaActorService
   ): Unit = {
     val physicalOp = workflow.physicalPlan.getOperator(physicalOpId)
-    val opExecution = executionState.initOperatorState(physicalOpId, workerConfigs)
+    val opExecution = executionState.initOperatorState(physicalOpId, operatorConfig)
     physicalOp.build(
       controllerActorService,
       opExecution,
-      workerConfigs,
+      operatorConfig,
       controllerConfig.workerRestoreConfMapping,
       controllerConfig.workerLoggingConfMapping
     )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowScheduler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowScheduler.scala
@@ -12,7 +12,7 @@ import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.LinkWork
 import edu.uci.ics.amber.engine.architecture.controller.{ControllerConfig, ExecutionState, Workflow}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalLink
 import edu.uci.ics.amber.engine.architecture.pythonworker.promisehandlers.InitializeOperatorLogicHandler.InitializeOperatorLogic
-import edu.uci.ics.amber.engine.architecture.scheduling.config.{OperatorConfig, WorkerConfig}
+import edu.uci.ics.amber.engine.architecture.scheduling.config.OperatorConfig
 import edu.uci.ics.amber.engine.architecture.scheduling.policies.SchedulingPolicy
 import edu.uci.ics.amber.engine.architecture.worker.controlcommands.LinkOrdinal
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.OpenOperatorHandler.OpenOperator

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/config/OperatorConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/config/OperatorConfig.scala
@@ -1,0 +1,5 @@
+package edu.uci.ics.amber.engine.architecture.scheduling.config
+
+case class OperatorConfig(
+    workerConfigs: List[WorkerConfig]
+)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/config/OperatorConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/config/OperatorConfig.scala
@@ -1,5 +1,10 @@
 package edu.uci.ics.amber.engine.architecture.scheduling.config
 
+case object OperatorConfig {
+  def empty: OperatorConfig = {
+    OperatorConfig(workerConfigs = List())
+  }
+}
 case class OperatorConfig(
     workerConfigs: List[WorkerConfig]
 )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/config/RegionConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/config/RegionConfig.scala
@@ -3,6 +3,6 @@ package edu.uci.ics.amber.engine.architecture.scheduling.config
 import edu.uci.ics.amber.engine.common.virtualidentity.{PhysicalLinkIdentity, PhysicalOpIdentity}
 
 case class RegionConfig(
-    workerConfigs: Map[PhysicalOpIdentity, List[WorkerConfig]],
+    operatorConfigs: Map[PhysicalOpIdentity, OperatorConfig],
     linkConfigs: Map[PhysicalLinkIdentity, LinkConfig]
 )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/resourcePolicies/ResourceAllocator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/resourcePolicies/ResourceAllocator.scala
@@ -55,13 +55,6 @@ class DefaultResourceAllocator(
 
     operatorConfigs ++= opToOperatorConfigMapping
 
-    // assign workers to physical plan
-    // TODO: move workers information into WorkerConfig completely
-    opToOperatorConfigMapping.toList.foreach {
-      case (physicalOpId, operatorConfig) =>
-        physicalPlan.getOperator(physicalOpId).assignWorkers(operatorConfig.workerConfigs.length)
-    }
-
     propagatePartitionRequirement(region)
 
     val linkToLinkConfigMapping = region.getEffectiveLinks.map { physicalLinkId =>

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/resourcePolicies/ResourceAllocator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/resourcePolicies/ResourceAllocator.scala
@@ -7,8 +7,7 @@ import edu.uci.ics.amber.engine.architecture.scheduling.config.WorkerConfig.gene
 import edu.uci.ics.amber.engine.architecture.scheduling.config.{
   LinkConfig,
   OperatorConfig,
-  RegionConfig,
-  WorkerConfig
+  RegionConfig
 }
 import edu.uci.ics.amber.engine.common.virtualidentity.{PhysicalLinkIdentity, PhysicalOpIdentity}
 import edu.uci.ics.texera.workflow.common.workflow.{PartitionInfo, PhysicalPlan, UnknownPartition}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessor.scala
@@ -7,17 +7,33 @@ import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.LinkComp
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.WorkerExecutionCompletedHandler.WorkerExecutionCompleted
 import edu.uci.ics.amber.engine.architecture.controller.promisehandlers.WorkerExecutionStartedHandler.WorkerStateUpdated
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp
-import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{OpExecInitInfoWithCode, OpExecInitInfoWithFunc}
+import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{
+  OpExecInitInfoWithCode,
+  OpExecInitInfoWithFunc
+}
 import edu.uci.ics.amber.engine.architecture.messaginglayer.{OutputManager, WorkerTimerService}
 import edu.uci.ics.amber.engine.architecture.scheduling.config.OperatorConfig
-import edu.uci.ics.amber.engine.architecture.worker.DataProcessor.{DPOutputIterator, FinalizeLink, FinalizeOperator}
+import edu.uci.ics.amber.engine.architecture.worker.DataProcessor.{
+  DPOutputIterator,
+  FinalizeLink,
+  FinalizeOperator
+}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.PauseHandler.PauseWorker
-import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState.{COMPLETED, PAUSED, READY, RUNNING}
+import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState.{
+  COMPLETED,
+  PAUSED,
+  READY,
+  RUNNING
+}
 import edu.uci.ics.amber.engine.common.ambermessage._
 import edu.uci.ics.amber.engine.common.statetransition.WorkerStateManager
 import edu.uci.ics.amber.engine.common.tuple.ITuple
 import edu.uci.ics.amber.engine.common.virtualidentity.util.{CONTROLLER, SELF, SOURCE_STARTER_OP}
-import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, PhysicalLinkIdentity, PhysicalOpIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.{
+  ActorVirtualIdentity,
+  PhysicalLinkIdentity,
+  PhysicalOpIdentity
+}
 import edu.uci.ics.amber.engine.common.{IOperatorExecutor, InputExhausted, VirtualIdentityUtils}
 import edu.uci.ics.amber.error.ErrorUtils.{mkConsoleMessage, safely}
 
@@ -80,7 +96,7 @@ class DataProcessor(
   def initOperator(
       workerIdx: Int,
       physicalOp: PhysicalOp,
-      operatorConfig:OperatorConfig,
+      operatorConfig: OperatorConfig,
       currentOutputIterator: Iterator[(ITuple, Option[Int])]
   ): Unit = {
     this.workerIdx = workerIdx

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkflowWorker.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/WorkflowWorker.scala
@@ -10,7 +10,13 @@ import edu.uci.ics.amber.engine.architecture.messaginglayer.WorkerTimerService
 import edu.uci.ics.amber.engine.architecture.scheduling.config.{OperatorConfig, WorkerConfig}
 import edu.uci.ics.amber.engine.common.actormessage.{ActorCommand, Backpressure}
 import edu.uci.ics.amber.engine.common.ambermessage.WorkflowMessage.getInMemSize
-import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.{ActorCommandElement, DPInputQueueElement, FIFOMessageElement, TimerBasedControlElement, WorkerReplayInitialization}
+import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.{
+  ActorCommandElement,
+  DPInputQueueElement,
+  FIFOMessageElement,
+  TimerBasedControlElement,
+  WorkerReplayInitialization
+}
 import edu.uci.ics.amber.engine.common.VirtualIdentityUtils
 import edu.uci.ics.amber.engine.common.ambermessage.{ChannelID, WorkflowFIFOMessage}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
@@ -22,15 +28,13 @@ import java.util.concurrent.LinkedBlockingQueue
 
 object WorkflowWorker {
   def props(
-      id: ActorVirtualIdentity,
       workerConfig: WorkerConfig,
       physicalOp: PhysicalOp,
-      operatorConfig:OperatorConfig,
+      operatorConfig: OperatorConfig,
       replayInitialization: WorkerReplayInitialization
   ): Props =
     Props(
       new WorkflowWorker(
-        id,
         workerConfig,
         physicalOp,
         operatorConfig,
@@ -58,27 +62,26 @@ object WorkflowWorker {
 }
 
 class WorkflowWorker(
-    workerId: ActorVirtualIdentity,
-    workerConf: WorkerConfig,
+    workerConfig: WorkerConfig,
     physicalOp: PhysicalOp,
     operatorConfig: OperatorConfig,
     replayInitialization: WorkerReplayInitialization
-) extends WorkflowActor(replayInitialization.replayLogConfOpt, workerId) {
+) extends WorkflowActor(replayInitialization.replayLogConfOpt, workerConfig.workerId) {
   val inputQueue: LinkedBlockingQueue[DPInputQueueElement] =
     new LinkedBlockingQueue()
   var dp = new DataProcessor(
-    workerId,
+    workerConfig.workerId,
     logManager.sendCommitted
   )
   val timerService = new WorkerTimerService(actorService)
 
   val dpThread =
-    new DPThread(workerId, dp, logManager, inputQueue)
+    new DPThread(workerConfig.workerId, dp, logManager, inputQueue)
 
   override def initState(): Unit = {
     dp.initTimerService(timerService)
     dp.initOperator(
-      VirtualIdentityUtils.getWorkerIndex(workerId),
+      VirtualIdentityUtils.getWorkerIndex(workerConfig.workerId),
       physicalOp,
       operatorConfig,
       currentOutputIterator = Iterator.empty
@@ -107,7 +110,7 @@ class WorkflowWorker(
     logger.error(s"Encountered fatal error, worker is shutting done.", reason)
     postStop()
     dp.asyncRPCClient.send(
-      FatalError(reason, Some(workerId)),
+      FatalError(reason, Some(workerConfig.workerId)),
       CONTROLLER
     )
   }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ModifyOperatorLogicHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ModifyOperatorLogicHandler.scala
@@ -46,7 +46,7 @@ trait ModifyOperatorLogicHandler {
 
   private def performModifyLogic(modifyLogic: WorkerModifyLogic): Unit = {
     val oldOpExecState = dp.operator
-    dp.initOperator(dp.workerIdx, modifyLogic.physicalOp,dp.operatorConfig, dp.outputIterator)
+    dp.initOperator(dp.workerIdx, modifyLogic.physicalOp, dp.operatorConfig, dp.outputIterator)
 
     if (modifyLogic.stateTransferFunc.nonEmpty) {
       modifyLogic.stateTransferFunc.get.apply(oldOpExecState, dp.operator)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ModifyOperatorLogicHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/promisehandlers/ModifyOperatorLogicHandler.scala
@@ -46,7 +46,7 @@ trait ModifyOperatorLogicHandler {
 
   private def performModifyLogic(modifyLogic: WorkerModifyLogic): Unit = {
     val oldOpExecState = dp.operator
-    dp.initOperator(dp.workerIdx, modifyLogic.physicalOp, dp.outputIterator)
+    dp.initOperator(dp.workerIdx, modifyLogic.physicalOp,dp.operatorConfig, dp.outputIterator)
 
     if (modifyLogic.stateTransferFunc.nonEmpty) {
       modifyLogic.stateTransferFunc.get.apply(oldOpExecState, dp.operator)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/aggregate/AggregateOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/aggregate/AggregateOpDesc.scala
@@ -29,7 +29,7 @@ object AggregateOpDesc {
           PhysicalOpIdentity(id, "localAgg"),
           workflowId,
           executionId,
-          OpExecInitInfo(_ => new PartialAggregateOpExec(aggFuncs, groupByKeys, schemaInfo))
+          OpExecInitInfo((_, _, _) => new PartialAggregateOpExec(aggFuncs, groupByKeys, schemaInfo))
         )
         .withIsOneToManyOp(true)
         // a hacky solution to have unique port names for reference purpose
@@ -41,7 +41,7 @@ object AggregateOpDesc {
           PhysicalOpIdentity(id, "globalAgg"),
           workflowId,
           executionId,
-          OpExecInitInfo(_ => new FinalAggregateOpExec(aggFuncs, groupByKeys, schemaInfo))
+          OpExecInitInfo((_, _, _) => new FinalAggregateOpExec(aggFuncs, groupByKeys, schemaInfo))
         )
         .withParallelizable(false)
         .withIsOneToManyOp(true)
@@ -57,7 +57,7 @@ object AggregateOpDesc {
           PhysicalOpIdentity(id, "globalAgg"),
           workflowId,
           executionId,
-          OpExecInitInfo(_ => new FinalAggregateOpExec(aggFuncs, groupByKeys, schemaInfo)),
+          OpExecInitInfo((_, _, _) => new FinalAggregateOpExec(aggFuncs, groupByKeys, schemaInfo)),
           partitionColumns
         )
         .withParallelizable(false)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
@@ -2,12 +2,8 @@ package edu.uci.ics.texera.workflow.common.workflow
 
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalLink, PhysicalOp}
-import edu.uci.ics.amber.engine.common.virtualidentity.{
-  ActorVirtualIdentity,
-  OperatorIdentity,
-  PhysicalLinkIdentity,
-  PhysicalOpIdentity
-}
+import edu.uci.ics.amber.engine.common.VirtualIdentityUtils
+import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, OperatorIdentity, PhysicalLinkIdentity, PhysicalOpIdentity}
 import edu.uci.ics.texera.workflow.common.WorkflowContext
 import org.jgrapht.graph.{DefaultEdge, DirectedAcyclicGraph}
 import org.jgrapht.traverse.TopologicalOrderIterator
@@ -233,7 +229,7 @@ case class PhysicalPlan(
   }
 
   def getPhysicalOpByWorkerId(workerId: ActorVirtualIdentity): PhysicalOp =
-    operators.find(physicalOp => physicalOp.getWorkerIds.contains(workerId)).get
+    getOperator(VirtualIdentityUtils.getPhysicalOpId(workerId))
 
   def getLinksBetween(
       from: PhysicalOpIdentity,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
@@ -3,7 +3,12 @@ package edu.uci.ics.texera.workflow.common.workflow
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalLink, PhysicalOp}
 import edu.uci.ics.amber.engine.common.VirtualIdentityUtils
-import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, OperatorIdentity, PhysicalLinkIdentity, PhysicalOpIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.{
+  ActorVirtualIdentity,
+  OperatorIdentity,
+  PhysicalLinkIdentity,
+  PhysicalOpIdentity
+}
 import edu.uci.ics.texera.workflow.common.WorkflowContext
 import org.jgrapht.graph.{DefaultEdge, DirectedAcyclicGraph}
 import org.jgrapht.traverse.TopologicalOrderIterator

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/cartesianProduct/CartesianProductOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/cartesianProduct/CartesianProductOpDesc.scala
@@ -24,7 +24,7 @@ class CartesianProductOpDesc extends LogicalOp {
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecInitInfo(_ => new CartesianProductOpExec(operatorSchemaInfo))
+        OpExecInitInfo((_, _, _) => new CartesianProductOpExec(operatorSchemaInfo))
       )
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts((operatorInfo.outputPorts))

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/dictionary/DictionaryMatcherOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/dictionary/DictionaryMatcherOpDesc.scala
@@ -42,7 +42,7 @@ class DictionaryMatcherOpDesc extends MapOpDesc {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new DictionaryMatcherOpExec(this, operatorSchemaInfo))
+      OpExecInitInfo((_, _, _) => new DictionaryMatcherOpExec(this, operatorSchemaInfo))
     )
 
   override def operatorInfo: OperatorInfo =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpDesc.scala
@@ -24,7 +24,7 @@ class DifferenceOpDesc extends LogicalOp {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new DifferenceOpExec())
+      OpExecInitInfo((_, _, _) => new DifferenceOpExec())
     )
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/distinct/DistinctOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/distinct/DistinctOpDesc.scala
@@ -24,7 +24,7 @@ class DistinctOpDesc extends LogicalOp {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new DistinctOpExec()),
+      OpExecInitInfo((_, _, _) => new DistinctOpExec()),
       operatorSchemaInfo.inputSchemas(0).getAttributes.toArray.indices.toList
     )
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/download/BulkDownloaderOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/download/BulkDownloaderOpDesc.scala
@@ -49,7 +49,7 @@ class BulkDownloaderOpDesc extends LogicalOp {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ =>
+      OpExecInitInfo((_, _, _) =>
         new BulkDownloaderOpExec(
           getContext,
           urlAttribute,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/filter/SpecializedFilterOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/filter/SpecializedFilterOpDesc.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp;
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfo;
+import edu.uci.ics.amber.engine.architecture.scheduling.config.OperatorConfig;
 import edu.uci.ics.amber.engine.common.IOperatorExecutor;
 import edu.uci.ics.amber.engine.common.virtualidentity.ExecutionIdentity;
 import edu.uci.ics.amber.engine.common.virtualidentity.WorkflowIdentity;
@@ -13,7 +14,7 @@ import edu.uci.ics.texera.workflow.common.metadata.OperatorInfo;
 import edu.uci.ics.texera.workflow.common.metadata.OutputPort;
 import edu.uci.ics.texera.workflow.common.operators.filter.FilterOpDesc;
 import edu.uci.ics.texera.workflow.common.tuple.schema.OperatorSchemaInfo;
-import scala.Tuple2;
+import scala.Tuple3;
 
 import java.util.List;
 import java.util.function.Function;
@@ -33,7 +34,10 @@ public class SpecializedFilterOpDesc extends FilterOpDesc {
                 workflowId,
                 executionId,
                 operatorIdentifier(),
-                OpExecInitInfo.apply((Function<Tuple2<Object, PhysicalOp>, IOperatorExecutor> & java.io.Serializable) x -> new SpecializedFilterOpExec(this))
+                OpExecInitInfo.apply(
+                        (Function<Tuple3<Object, PhysicalOp, OperatorConfig>, IOperatorExecutor> & java.io.Serializable)
+                                x -> new SpecializedFilterOpExec(this)
+                )
         );
     }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpDesc.scala
@@ -90,7 +90,7 @@ class HashJoinOpDesc[K] extends LogicalOp {
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecInitInfo(_ =>
+        OpExecInitInfo((_, _, _) =>
           new HashJoinOpExec[K](
             buildAttributeName,
             probeAttributeName,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpDesc.scala
@@ -24,7 +24,7 @@ class IntersectOpDesc extends LogicalOp {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new IntersectOpExec()),
+      OpExecInitInfo((_, _, _) => new IntersectOpExec()),
       operatorSchemaInfo.inputSchemas(0).getAttributes.toArray.indices.toList
     )
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intervalJoin/IntervalJoinOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intervalJoin/IntervalJoinOpDesc.scala
@@ -89,7 +89,7 @@ class IntervalJoinOpDesc extends LogicalOp {
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecInitInfo(_ => new IntervalJoinOpExec(operatorSchemaInfo, this))
+        OpExecInitInfo((_, _, _) => new IntervalJoinOpExec(operatorSchemaInfo, this))
       )
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/keywordSearch/KeywordSearchOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/keywordSearch/KeywordSearchOpDesc.scala
@@ -37,7 +37,7 @@ class KeywordSearchOpDesc extends FilterOpDesc {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new KeywordSearchOpExec(this))
+      OpExecInitInfo((_, _, _) => new KeywordSearchOpExec(this))
     )
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/limit/LimitOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/limit/LimitOpDesc.scala
@@ -35,7 +35,7 @@ class LimitOpDesc extends LogicalOp {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(p => new LimitOpExec(limitPerWorker(p._1)))
+      OpExecInitInfo((idx, _, _) => new LimitOpExec(limitPerWorker(idx)))
     )
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/linearregression/LinearRegressionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/linearregression/LinearRegressionOpDesc.scala
@@ -39,7 +39,7 @@ class LinearRegressionOpDesc extends MLModelOpDesc {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new LinearRegressionOpExec(xAttr, yAttr, learningRate))
+      OpExecInitInfo((_, _, _) => new LinearRegressionOpExec(xAttr, yAttr, learningRate))
     )
 
   override def operatorInfo: OperatorInfo =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/projection/ProjectionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/projection/ProjectionOpDesc.scala
@@ -32,7 +32,7 @@ class ProjectionOpDesc extends MapOpDesc {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new ProjectionOpExec(attributes, operatorSchemaInfo))
+      OpExecInitInfo((_, _, _) => new ProjectionOpExec(attributes, operatorSchemaInfo))
     ).withDerivePartition(this.derivePartition(operatorSchemaInfo))
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/randomksampling/RandomKSamplingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/randomksampling/RandomKSamplingOpDesc.scala
@@ -41,7 +41,7 @@ class RandomKSamplingOpDesc extends FilterOpDesc {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(p => new RandomKSamplingOpExec(p._1, this))
+      OpExecInitInfo((idx, _, _) => new RandomKSamplingOpExec(idx, this))
     )
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/regex/RegexOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/regex/RegexOpDesc.scala
@@ -40,7 +40,7 @@ class RegexOpDesc extends FilterOpDesc {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new RegexOpExec(this))
+      OpExecInitInfo((_, _, _) => new RegexOpExec(this))
     )
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/reservoirsampling/ReservoirSamplingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/reservoirsampling/ReservoirSamplingOpDesc.scala
@@ -55,7 +55,7 @@ class ReservoirSamplingOpDesc extends LogicalOp {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(p => new ReservoirSamplingOpExec(p._1, this))
+      OpExecInitInfo((idx, _, _) => new ReservoirSamplingOpExec(idx, this))
     )
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sentiment/SentimentAnalysisOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sentiment/SentimentAnalysisOpDesc.scala
@@ -50,7 +50,7 @@ class SentimentAnalysisOpDesc extends MapOpDesc {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new SentimentAnalysisOpExec(this, operatorSchemaInfo))
+      OpExecInitInfo((_, _, _) => new SentimentAnalysisOpExec(this, operatorSchemaInfo))
     )
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/managed/ProgressiveSinkOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/managed/ProgressiveSinkOpDesc.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp;
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfo;
+import edu.uci.ics.amber.engine.architecture.scheduling.config.OperatorConfig;
 import edu.uci.ics.amber.engine.common.IOperatorExecutor;
 import edu.uci.ics.amber.engine.common.virtualidentity.ExecutionIdentity;
 import edu.uci.ics.amber.engine.common.virtualidentity.OperatorIdentity;
@@ -18,7 +19,7 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.OperatorSchemaInfo;
 import edu.uci.ics.texera.workflow.operators.sink.SinkOpDesc;
 import edu.uci.ics.texera.workflow.operators.sink.storage.SinkStorageReader;
 import scala.Option;
-import scala.Tuple2;
+import scala.Tuple3;
 import scala.collection.immutable.List;
 
 import java.util.function.Function;
@@ -54,7 +55,10 @@ public class ProgressiveSinkOpDesc extends SinkOpDesc {
                 workflowId,
                 executionId,
                 operatorIdentifier(),
-                OpExecInitInfo.apply((Function<Tuple2<Object, PhysicalOp>, IOperatorExecutor> & java.io.Serializable) worker -> new ProgressiveSinkOpExec(operatorSchemaInfo, outputMode, storage.getStorageWriter()))
+                OpExecInitInfo.apply(
+                        (Function<Tuple3<Object, PhysicalOp, OperatorConfig>, IOperatorExecutor> & java.io.Serializable)
+                                worker -> new ProgressiveSinkOpExec(operatorSchemaInfo, outputMode, storage.getStorageWriter())
+                )
         ).withPorts(this.operatorInfo());
     }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sortPartitions/SortPartitionsOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sortPartitions/SortPartitionsOpDesc.scala
@@ -64,15 +64,14 @@ class SortPartitionsOpDesc extends LogicalOp {
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecInitInfo(p => {
-          val (idx, physicalOp) = p
+        OpExecInitInfo((idx, _, operatorConfig) => {
           new SortPartitionOpExec(
             sortAttributeName,
             operatorSchemaInfo,
             idx,
             domainMin,
             domainMax,
-            physicalOp.getWorkerIds.length
+            operatorConfig.workerConfigs.length
           )
         })
       )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpDesc.scala
@@ -54,7 +54,7 @@ class TwitterFullArchiveSearchSourceOpDesc extends TwitterSourceOpDesc {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new TwitterFullArchiveSearchSourceOpExec(this, operatorSchemaInfo))
+      OpExecInitInfo((_, _, _) => new TwitterFullArchiveSearchSourceOpExec(this, operatorSchemaInfo))
     )
 
   override def sourceSchema(): Schema = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterFullArchiveSearchSourceOpDesc.scala
@@ -54,7 +54,9 @@ class TwitterFullArchiveSearchSourceOpDesc extends TwitterSourceOpDesc {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo((_, _, _) => new TwitterFullArchiveSearchSourceOpExec(this, operatorSchemaInfo))
+      OpExecInitInfo((_, _, _) =>
+        new TwitterFullArchiveSearchSourceOpExec(this, operatorSchemaInfo)
+      )
     )
 
   override def sourceSchema(): Schema = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterSearchSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/apis/twitter/v2/TwitterSearchSourceOpDesc.scala
@@ -44,7 +44,7 @@ class TwitterSearchSourceOpDesc extends TwitterSourceOpDesc {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new TwitterSearchSourceOpExec(this, operatorSchemaInfo))
+      OpExecInitInfo((_, _, _) => new TwitterSearchSourceOpExec(this, operatorSchemaInfo))
     )
 
   override def sourceSchema(): Schema = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/cache/CacheSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/cache/CacheSourceOpDesc.scala
@@ -37,7 +37,7 @@ class CacheSourceOpDesc(val targetSinkStorageId: OperatorIdentity, opResultStora
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new CacheSourceOpExec(opResultStorage.get(targetSinkStorageId)))
+      OpExecInitInfo((_, _, _) => new CacheSourceOpExec(opResultStorage.get(targetSinkStorageId)))
     )
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/fetcher/URLFetcherOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/fetcher/URLFetcherOpDesc.scala
@@ -54,7 +54,7 @@ class URLFetcherOpDesc extends SourceOperatorDescriptor {
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecInitInfo(_ =>
+        OpExecInitInfo((_, _, _) =>
           new URLFetcherOpExec(
             url,
             decodingMethod,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/FileScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/FileScanSourceOpDesc.scala
@@ -57,7 +57,7 @@ class FileScanSourceOpDesc extends ScanSourceOpDesc with TextSourceOpDesc {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new FileScanSourceOpExec(this))
+      OpExecInitInfo((_, _, _) => new FileScanSourceOpExec(this))
     )
 
   override def inferSchema(): Schema = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/CSVScanSourceOpDesc.scala
@@ -50,7 +50,7 @@ class CSVScanSourceOpDesc extends ScanSourceOpDesc {
           workflowId,
           executionId,
           operatorIdentifier,
-          OpExecInitInfo(_ => new CSVScanSourceOpExec(this))
+          OpExecInitInfo((_, _, _) => new CSVScanSourceOpExec(this))
         )
       case None =>
         throw new RuntimeException("File path is not provided.")

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/ParallelCSVScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/ParallelCSVScanSourceOpDesc.scala
@@ -53,14 +53,13 @@ class ParallelCSVScanSourceOpDesc extends ScanSourceOpDesc {
             workflowId,
             executionId,
             operatorIdentifier,
-            OpExecInitInfo(p => {
-              val (i, physicalOp) = p
-              val workerCount = physicalOp.getWorkerIds.length
+            OpExecInitInfo((idx, _, operatorConfig) => {
+              val workerCount = operatorConfig.workerConfigs.length
               // TODO: add support for limit
               // TODO: add support for offset
-              val startOffset: Long = totalBytes / workerCount * i
+              val startOffset: Long = totalBytes / workerCount * idx
               val endOffset: Long =
-                if (i != workerCount - 1) totalBytes / workerCount * (i + 1) else totalBytes
+                if (idx != workerCount - 1) totalBytes / workerCount * (idx + 1) else totalBytes
               new ParallelCSVScanSourceOpExec(
                 this,
                 startOffset,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csvOld/CSVOldScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csvOld/CSVOldScanSourceOpDesc.scala
@@ -50,7 +50,7 @@ class CSVOldScanSourceOpDesc extends ScanSourceOpDesc {
           workflowId,
           executionId,
           operatorIdentifier,
-          OpExecInitInfo(_ => new CSVOldScanSourceOpExec(this))
+          OpExecInitInfo((_, _, _) => new CSVOldScanSourceOpExec(this))
         )
       case None =>
         throw new RuntimeException("File path is not provided.")

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/json/JSONLScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/json/JSONLScanSourceOpDesc.scala
@@ -51,7 +51,8 @@ class JSONLScanSourceOpDesc extends ScanSourceOpDesc {
               val workerCount = operatorConfig.workerConfigs.length
               val startOffset: Int = offsetValue + count / workerCount * idx
               val endOffset: Int =
-                offsetValue + (if (idx != workerCount - 1) count / workerCount * (idx + 1) else count)
+                offsetValue + (if (idx != workerCount - 1) count / workerCount * (idx + 1)
+                               else count)
               new JSONLScanSourceOpExec(this, startOffset, endOffset)
             })
           )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/json/JSONLScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/json/JSONLScanSourceOpDesc.scala
@@ -47,12 +47,11 @@ class JSONLScanSourceOpDesc extends ScanSourceOpDesc {
             workflowId,
             executionId,
             operatorIdentifier,
-            OpExecInitInfo(p => {
-              val i = p._1
-              val workerCount = p._2.getWorkerIds.length
-              val startOffset: Int = offsetValue + count / workerCount * i
+            OpExecInitInfo((idx, physicalOp, operatorConfig) => {
+              val workerCount = operatorConfig.workerConfigs.length
+              val startOffset: Int = offsetValue + count / workerCount * idx
               val endOffset: Int =
-                offsetValue + (if (i != workerCount - 1) count / workerCount * (i + 1) else count)
+                offsetValue + (if (idx != workerCount - 1) count / workerCount * (idx + 1) else count)
               new JSONLScanSourceOpExec(this, startOffset, endOffset)
             })
           )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextInputSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextInputSourceOpDesc.scala
@@ -29,7 +29,7 @@ class TextInputSourceOpDesc extends SourceOperatorDescriptor with TextSourceOpDe
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new TextInputSourceOpExec(this))
+      OpExecInitInfo((_, _, _) => new TextInputSourceOpExec(this))
     )
 
   override def sourceSchema(): Schema =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/asterixdb/AsterixDBSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/asterixdb/AsterixDBSourceOpDesc.scala
@@ -108,7 +108,7 @@ class AsterixDBSourceOpDesc extends SQLSourceOpDesc {
       workflowId,
       executionId,
       this.operatorIdentifier,
-      OpExecInitInfo(_ =>
+      OpExecInitInfo((_, _, _) =>
         new AsterixDBSourceOpExec(
           sourceSchema(),
           host,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/mysql/MySQLSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/mysql/MySQLSourceOpDesc.scala
@@ -27,7 +27,7 @@ class MySQLSourceOpDesc extends SQLSourceOpDesc {
       workflowId,
       executionId,
       this.operatorIdentifier,
-      OpExecInitInfo(_ =>
+      OpExecInitInfo((_, _, _) =>
         new MySQLSourceOpExec(
           this.querySchema,
           host,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/postgresql/PostgreSQLSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/sql/postgresql/PostgreSQLSourceOpDesc.scala
@@ -40,7 +40,7 @@ class PostgreSQLSourceOpDesc extends SQLSourceOpDesc {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ =>
+      OpExecInitInfo((_, _, _) =>
         new PostgreSQLSourceOpExec(
           querySchema,
           host,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/split/SplitOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/split/SplitOpDesc.scala
@@ -37,7 +37,7 @@ class SplitOpDesc extends LogicalOp {
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecInitInfo(p => new SplitOpExec(p._1, this))
+        OpExecInitInfo((idx, _, _) => new SplitOpExec(idx, this))
       )
       .withPorts(operatorInfo)
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/symmetricDifference/SymmetricDifferenceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/symmetricDifference/SymmetricDifferenceOpDesc.scala
@@ -24,7 +24,7 @@ class SymmetricDifferenceOpDesc extends LogicalOp {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new SymmetricDifferenceOpExec()),
+      OpExecInitInfo((_, _, _) => new SymmetricDifferenceOpExec()),
       operatorSchemaInfo.inputSchemas(0).getAttributes.toArray.indices.toList
     )
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/typecasting/TypeCastingOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/typecasting/TypeCastingOpDesc.java
@@ -6,6 +6,7 @@ import com.google.common.base.Preconditions;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp;
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfo;
+import edu.uci.ics.amber.engine.architecture.scheduling.config.OperatorConfig;
 import edu.uci.ics.amber.engine.common.IOperatorExecutor;
 import edu.uci.ics.amber.engine.common.virtualidentity.ExecutionIdentity;
 import edu.uci.ics.amber.engine.common.virtualidentity.WorkflowIdentity;
@@ -17,7 +18,7 @@ import edu.uci.ics.texera.workflow.common.operators.map.MapOpDesc;
 import edu.uci.ics.texera.workflow.common.tuple.schema.AttributeTypeUtils;
 import edu.uci.ics.texera.workflow.common.tuple.schema.OperatorSchemaInfo;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema;
-import scala.Tuple2;
+import scala.Tuple3;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,7 +41,10 @@ public class TypeCastingOpDesc extends MapOpDesc {
                 workflowId,
                 executionId,
                 operatorIdentifier(),
-                OpExecInitInfo.apply((Function<Tuple2<Object, PhysicalOp>, IOperatorExecutor> & java.io.Serializable) worker -> new TypeCastingOpExec(operatorSchemaInfo.outputSchemas()[0]))
+                OpExecInitInfo.apply(
+                        (Function<Tuple3<Object, PhysicalOp, OperatorConfig>, IOperatorExecutor> & java.io.Serializable)
+                                worker -> new TypeCastingOpExec(operatorSchemaInfo.outputSchemas()[0])
+                )
         );
     }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/union/UnionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/union/UnionOpDesc.scala
@@ -24,7 +24,7 @@ class UnionOpDesc extends LogicalOp {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new UnionOpExec())
+      OpExecInitInfo((_, _, _) => new UnionOpExec())
     )
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/unneststring/UnnestStringOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/unneststring/UnnestStringOpDesc.scala
@@ -48,7 +48,7 @@ class UnnestStringOpDesc extends FlatMapOpDesc {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new UnnestStringOpExec(this, operatorSchemaInfo))
+      OpExecInitInfo((_, _, _) => new UnnestStringOpExec(this, operatorSchemaInfo))
     )
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/htmlviz/HtmlVizOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/htmlviz/HtmlVizOpDesc.scala
@@ -46,7 +46,7 @@ class HtmlVizOpDesc extends VisualizationOperator {
       workflowId,
       executionId,
       operatorIdentifier,
-      OpExecInitInfo(_ => new HtmlVizOpExec(htmlContentAttrName, operatorSchemaInfo))
+      OpExecInitInfo((_, _, _) => new HtmlVizOpExec(htmlContentAttrName, operatorSchemaInfo))
     )
 
   override def operatorInfo: OperatorInfo =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/scatterplot/ScatterplotOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/scatterplot/ScatterplotOpDesc.java
@@ -6,6 +6,7 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp;
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfo;
+import edu.uci.ics.amber.engine.architecture.scheduling.config.OperatorConfig;
 import edu.uci.ics.amber.engine.common.IOperatorExecutor;
 import edu.uci.ics.amber.engine.common.virtualidentity.ExecutionIdentity;
 import edu.uci.ics.amber.engine.common.virtualidentity.WorkflowIdentity;
@@ -20,7 +21,7 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.OperatorSchemaInfo;
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema;
 import edu.uci.ics.texera.workflow.operators.visualization.VisualizationConstants;
 import edu.uci.ics.texera.workflow.operators.visualization.VisualizationOperator;
-import scala.Tuple2;
+import scala.Tuple3;
 
 import java.util.EnumSet;
 import java.util.Set;
@@ -87,7 +88,10 @@ public class ScatterplotOpDesc extends VisualizationOperator {
                     workflowId,
                     executionId,
                     this.operatorIdentifier(),
-                    OpExecInitInfo.apply((Function<Tuple2<Object, PhysicalOp>, IOperatorExecutor> & java.io.Serializable) worker -> new ScatterplotOpExec(this, operatorSchemaInfo))
+                    OpExecInitInfo.apply(
+                            (Function<Tuple3<Object, PhysicalOp, OperatorConfig>, IOperatorExecutor> & java.io.Serializable)
+                                    worker -> new ScatterplotOpExec(this, operatorSchemaInfo)
+                    )
                 )
                 .withIsOneToManyOp(true).withParallelizable(!isGeometric);
     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpDesc.scala
@@ -58,7 +58,7 @@ class UrlVizOpDesc extends VisualizationOperator {
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecInitInfo(_ => new UrlVizOpExec(urlContentAttrName, operatorSchemaInfo))
+        OpExecInitInfo((_, _, _) => new UrlVizOpExec(urlContentAttrName, operatorSchemaInfo))
       )
 
   override def operatorInfo: OperatorInfo =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpDesc.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/wordCloud/WordCloudOpDesc.java
@@ -7,6 +7,7 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle;
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalLink;
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp;
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfo;
+import edu.uci.ics.amber.engine.architecture.scheduling.config.OperatorConfig;
 import edu.uci.ics.amber.engine.common.IOperatorExecutor;
 import edu.uci.ics.amber.engine.common.virtualidentity.ExecutionIdentity;
 import edu.uci.ics.amber.engine.common.virtualidentity.PhysicalOpIdentity;
@@ -25,6 +26,7 @@ import edu.uci.ics.texera.workflow.common.workflow.PhysicalPlan;
 import edu.uci.ics.texera.workflow.operators.visualization.VisualizationConstants;
 import edu.uci.ics.texera.workflow.operators.visualization.VisualizationOperator;
 import scala.Tuple2;
+import scala.Tuple3;
 
 import java.util.function.Function;
 
@@ -78,9 +80,15 @@ public class WordCloudOpDesc extends VisualizationOperator {
                 workflowId,
                 executionId,
                 this.operatorIdentifier(),
-                OpExecInitInfo.apply((Function<Tuple2<Object, PhysicalOp>, IOperatorExecutor> & java.io.Serializable) worker -> new WordCloudOpPartialExec(textColumn))
-        ).withId(partialId).withIsOneToManyOp(true).withParallelizable(false).withOutputPorts(
-                asScalaBuffer(singletonList(new OutputPort("internal-output"))).toList());
+                OpExecInitInfo.apply(
+                        (Function<Tuple3<Object, PhysicalOp, OperatorConfig>, IOperatorExecutor> & java.io.Serializable)
+                                worker -> new WordCloudOpPartialExec(textColumn)
+                )
+        )
+                .withId(partialId)
+                .withIsOneToManyOp(true)
+                .withParallelizable(false)
+                .withOutputPorts(asScalaBuffer(singletonList(new OutputPort("internal-output"))).toList());
 
 
         PhysicalOpIdentity finalId = new PhysicalOpIdentity(operatorIdentifier(), "global");
@@ -88,7 +96,10 @@ public class WordCloudOpDesc extends VisualizationOperator {
                 workflowId,
                 executionId,
                 this.operatorIdentifier(),
-                OpExecInitInfo.apply((Function<Tuple2<Object, PhysicalOp>, IOperatorExecutor> & java.io.Serializable) worker -> new WordCloudOpFinalExec(topN))
+                OpExecInitInfo.apply(
+                        (Function<Tuple3<Object, PhysicalOp, OperatorConfig>, IOperatorExecutor> & java.io.Serializable)
+                                worker -> new WordCloudOpFinalExec(topN)
+                )
         )
         .withId(finalId).withIsOneToManyOp(true)
         .withInputPorts(asScalaBuffer(singletonList(new InputPort("internal-input", false))).toList());

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowSchedulerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowSchedulerSpec.scala
@@ -20,7 +20,10 @@ class WorkflowSchedulerSpec extends AnyFlatSpec with MockFactory {
   ): Unit = {
     val physicalOps = workflow.physicalPlan.getPhysicalOpsOfLogicalOp(logicalOpId)
     physicalOps.foreach { physicalOp =>
-      executionState.initOperatorState(physicalOp.id, OperatorConfig(List(WorkerConfig(workerId = null))))
+      executionState.initOperatorState(
+        physicalOp.id,
+        OperatorConfig(List(WorkerConfig(workerId = null)))
+      )
       executionState.getOperatorExecution(physicalOp.id).setAllWorkerState(COMPLETED)
     }
   }

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowSchedulerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowSchedulerSpec.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.amber.engine.architecture.scheduling
 
 import edu.uci.ics.amber.engine.architecture.controller.{ControllerConfig, ExecutionState, Workflow}
-import edu.uci.ics.amber.engine.architecture.scheduling.config.WorkerConfig
+import edu.uci.ics.amber.engine.architecture.scheduling.config.{OperatorConfig, WorkerConfig}
 import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState.COMPLETED
 import edu.uci.ics.amber.engine.common.VirtualIdentityUtils
 import edu.uci.ics.amber.engine.common.virtualidentity.{OperatorIdentity, PhysicalLinkIdentity}
@@ -20,7 +20,7 @@ class WorkflowSchedulerSpec extends AnyFlatSpec with MockFactory {
   ): Unit = {
     val physicalOps = workflow.physicalPlan.getPhysicalOpsOfLogicalOp(logicalOpId)
     physicalOps.foreach { physicalOp =>
-      executionState.initOperatorState(physicalOp.id, List(WorkerConfig(workerId = null)))
+      executionState.initOperatorState(physicalOp.id, OperatorConfig(List(WorkerConfig(workerId = null))))
       executionState.getOperatorExecution(physicalOp.id).setAllWorkerState(COMPLETED)
     }
   }

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DPThreadSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DPThreadSpec.scala
@@ -5,6 +5,7 @@ import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalLink, Phys
 import edu.uci.ics.amber.engine.architecture.logreplay.ReplayLogManager
 import edu.uci.ics.amber.engine.architecture.logreplay.storage.ReplayLogStorage
 import edu.uci.ics.amber.engine.architecture.messaginglayer.WorkerTimerService
+import edu.uci.ics.amber.engine.architecture.scheduling.config.{OperatorConfig, WorkerConfig}
 import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.{
   DPInputQueueElement,
   FIFOMessageElement,
@@ -58,7 +59,7 @@ class DPThreadSpec extends AnyFlatSpec with MockFactory {
       workflowId = DEFAULT_WORKFLOW_ID,
       executionId = DEFAULT_EXECUTION_ID,
       logicalOpId = operatorIdentity,
-      OpExecInitInfo(_ => operator)
+      OpExecInitInfo((_, _, _) => operator)
     )
     .copy(
       inputPortToLinkIdMapping = Map(0 -> List(mockLink.id)),
@@ -71,7 +72,7 @@ class DPThreadSpec extends AnyFlatSpec with MockFactory {
 
   "DP Thread" should "handle pause/resume during processing" in {
     val dp = new DataProcessor(identifier, x => {})
-    dp.initOperator(0, physicalOp, Iterator.empty)
+    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(null))), Iterator.empty)
     val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
     dp.registerInput(senderID, mockLink.id)
     dp.adaptiveBatchingMonitor = mock[WorkerTimerService]
@@ -97,7 +98,7 @@ class DPThreadSpec extends AnyFlatSpec with MockFactory {
 
   "DP Thread" should "handle pause/resume using fifo messages" in {
     val dp = new DataProcessor(identifier, x => {})
-    dp.initOperator(0, physicalOp, Iterator.empty)
+    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(null))), Iterator.empty)
     val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
     dp.registerInput(senderID, mockLink.id)
     dp.adaptiveBatchingMonitor = mock[WorkerTimerService]
@@ -126,7 +127,7 @@ class DPThreadSpec extends AnyFlatSpec with MockFactory {
 
   "DP Thread" should "handle multiple batches from multiple sources" in {
     val dp = new DataProcessor(identifier, x => {})
-    dp.initOperator(0, physicalOp, Iterator.empty)
+    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(null))), Iterator.empty)
     val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
     val anotherSender = ActorVirtualIdentity("another")
     dp.registerInput(senderID, mockLink.id)
@@ -138,7 +139,7 @@ class DPThreadSpec extends AnyFlatSpec with MockFactory {
     tuples.foreach { x =>
       (operator.processTuple _).expects(Left(x), 0, dp.pauseManager, dp.asyncRPCClient)
     }
-    val dataChannelID2 = ChannelID(anotherSender, identifier, false)
+    val dataChannelID2 = ChannelID(anotherSender, identifier, isControl = false)
     val message1 = WorkflowFIFOMessage(dataChannelID, 0, DataFrame(tuples.slice(0, 100)))
     val message2 = WorkflowFIFOMessage(dataChannelID, 1, DataFrame(tuples.slice(100, 200)))
     val message3 = WorkflowFIFOMessage(dataChannelID2, 0, DataFrame(tuples.slice(300, 1000)))
@@ -157,7 +158,7 @@ class DPThreadSpec extends AnyFlatSpec with MockFactory {
 
   "DP Thread" should "write determinant logs to local storage while processing" in {
     val dp = new DataProcessor(identifier, x => {})
-    dp.initOperator(0, physicalOp, Iterator.empty)
+    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(null))), Iterator.empty)
     val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
     val anotherSender = ActorVirtualIdentity("another")
     dp.registerInput(senderID, mockLink.id)

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DPThreadSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DPThreadSpec.scala
@@ -72,7 +72,7 @@ class DPThreadSpec extends AnyFlatSpec with MockFactory {
 
   "DP Thread" should "handle pause/resume during processing" in {
     val dp = new DataProcessor(identifier, x => {})
-    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(null))), Iterator.empty)
+    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(identifier))), Iterator.empty)
     val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
     dp.registerInput(senderID, mockLink.id)
     dp.adaptiveBatchingMonitor = mock[WorkerTimerService]
@@ -98,7 +98,7 @@ class DPThreadSpec extends AnyFlatSpec with MockFactory {
 
   "DP Thread" should "handle pause/resume using fifo messages" in {
     val dp = new DataProcessor(identifier, x => {})
-    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(null))), Iterator.empty)
+    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(identifier))), Iterator.empty)
     val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
     dp.registerInput(senderID, mockLink.id)
     dp.adaptiveBatchingMonitor = mock[WorkerTimerService]
@@ -127,7 +127,7 @@ class DPThreadSpec extends AnyFlatSpec with MockFactory {
 
   "DP Thread" should "handle multiple batches from multiple sources" in {
     val dp = new DataProcessor(identifier, x => {})
-    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(null))), Iterator.empty)
+    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(identifier))), Iterator.empty)
     val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
     val anotherSender = ActorVirtualIdentity("another")
     dp.registerInput(senderID, mockLink.id)
@@ -158,7 +158,7 @@ class DPThreadSpec extends AnyFlatSpec with MockFactory {
 
   "DP Thread" should "write determinant logs to local storage while processing" in {
     val dp = new DataProcessor(identifier, x => {})
-    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(null))), Iterator.empty)
+    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(identifier))), Iterator.empty)
     val inputQueue = new LinkedBlockingQueue[DPInputQueueElement]()
     val anotherSender = ActorVirtualIdentity("another")
     dp.registerInput(senderID, mockLink.id)

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -72,7 +72,7 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
         override val outputManager: OutputManager = mock[OutputManager]
         override val asyncRPCClient: AsyncRPCClient = mock[AsyncRPCClient]
       }
-    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(null))), Iterator.empty)
+    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(testWorkerId))), Iterator.empty)
     dp.initTimerService(adaptiveBatchingMonitor)
     dp
   }

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/DataProcessorSpec.scala
@@ -4,6 +4,7 @@ import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInf
 import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalLink, PhysicalOp}
 import edu.uci.ics.amber.engine.architecture.messaginglayer.OutputManager.FlushNetworkBuffer
 import edu.uci.ics.amber.engine.architecture.messaginglayer.{OutputManager, WorkerTimerService}
+import edu.uci.ics.amber.engine.architecture.scheduling.config.{OperatorConfig, WorkerConfig}
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.OpenOperatorHandler.OpenOperator
 import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState.READY
 import edu.uci.ics.amber.engine.common.{InputExhausted, VirtualIdentityUtils}
@@ -58,7 +59,7 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
         DEFAULT_WORKFLOW_ID,
         DEFAULT_EXECUTION_ID,
         testOpId.logicalOpId,
-        OpExecInitInfo(_ => operator)
+        OpExecInitInfo((_, _, _) => operator)
       )
       .addInput(link.fromOp, 0, 0)
   private val outputHandler = mock[WorkflowFIFOMessage => Unit]
@@ -71,7 +72,7 @@ class DataProcessorSpec extends AnyFlatSpec with MockFactory with BeforeAndAfter
         override val outputManager: OutputManager = mock[OutputManager]
         override val asyncRPCClient: AsyncRPCClient = mock[AsyncRPCClient]
       }
-    dp.initOperator(0, physicalOp, Iterator.empty)
+    dp.initOperator(0, physicalOp, OperatorConfig(List(WorkerConfig(null))), Iterator.empty)
     dp.initTimerService(adaptiveBatchingMonitor)
     dp
   }

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
@@ -7,7 +7,7 @@ import edu.uci.ics.amber.engine.architecture.common.WorkflowActor.NetworkMessage
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfo
 import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalLink, PhysicalOp}
 import edu.uci.ics.amber.engine.architecture.messaginglayer.OutputManager
-import edu.uci.ics.amber.engine.architecture.scheduling.config.WorkerConfig
+import edu.uci.ics.amber.engine.architecture.scheduling.config.{OperatorConfig, WorkerConfig}
 import edu.uci.ics.amber.engine.architecture.sendsemantics.partitionings.OneToOnePartitioning
 import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.WorkerReplayInitialization
 import edu.uci.ics.amber.engine.architecture.worker.promisehandlers.AddPartitioningHandler.AddPartitioning
@@ -86,7 +86,7 @@ class WorkerSpec
       DEFAULT_WORKFLOW_ID,
       DEFAULT_EXECUTION_ID,
       operatorIdentity,
-      OpExecInitInfo(_ => mockOpExecutor)
+      OpExecInitInfo((_, _, _) => mockOpExecutor)
     )
     .copy(
       inputPortToLinkIdMapping = Map(0 -> List(mockLink.id)),
@@ -114,15 +114,20 @@ class WorkerSpec
   def mkWorker: ActorRef = {
     TestActorRef(
       new WorkflowWorker(
-        identifier1,
-        physicalOp,
         WorkerConfig(identifier1),
+        physicalOp,
+        OperatorConfig(List(WorkerConfig(identifier1))),
         WorkerReplayInitialization(restoreConfOpt = None, replayLogConfOpt = None)
       ) {
         this.dp = new DataProcessor(identifier1, mockHandler) {
           override val outputManager: OutputManager = mockOutputManager
         }
-        this.dp.initOperator(0, physicalOp, Iterator.empty)
+        this.dp.initOperator(
+          0,
+          physicalOp,
+          OperatorConfig(List(WorkerConfig(identifier1))),
+          Iterator.empty
+        )
         this.dp.initTimerService(timerService)
         override val dpThread: DPThread =
           new DPThread(


### PR DESCRIPTION
This PR introduces `OperatorConfig`, as part of the `RegionConfig`. The previous `List[WorkerConfig]` is now moved inside the corresponding `OperatorConfig`.

## OperatorConfig and RegionConfig
An OperatorConfig describes the resources for an operator. Currently we only have the list of WorkerConfigs, more to be added.
```
case class OperatorConfig(
    workerConfigs: List[WorkerConfig]
)
```

The updated RegionConfig:
```
case class RegionConfig(
    operatorConfigs: Map[PhysicalOpIdentity, OperatorConfig],
    linkConfigs: Map[PhysicalLinkIdentity, LinkConfig]
)
```


## New operator initialization life cycle
OperatorConfig is generated by the ResourceAllocator, and to be used at a few places:
1. `OpExecInitInfo` now takes in an `OperatorConfig` besides the index and the physicalOp.
2. `WorkflowWorker.prop` now takes in an `OperatorConfig`.

## Other affected changes
With this change, we now removed workerIds from physicalOp. All the actorIds are to be found in the configs.