### PR TITLE
Rename RegionConfig to ResourceConfig

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ExecutionState.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ExecutionState.scala
@@ -15,9 +15,8 @@ class ExecutionState(workflow: Workflow) {
   private val linkExecutions: Map[PhysicalLink, LinkExecution] =
     workflow.physicalPlan.links.map { link =>
       link -> new LinkExecution(
-        workflow.regionPlan.regions
-          .find(region => region.getEffectiveLinks.contains(link))
-          .get
+        workflow.regionPlan
+          .getRegionOfPhysicalLink(link)
           .resourceConfig
           .get
           .linkConfigs(link)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ExecutionState.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ExecutionState.scala
@@ -18,7 +18,7 @@ class ExecutionState(workflow: Workflow) {
         workflow.regionPlan.regions
           .find(region => region.getEffectiveLinks.contains(link))
           .get
-          .config
+          .resourceConfig
           .get
           .linkConfigs(link)
           .channelConfigs

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LinkWorkersHandler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/promisehandlers/LinkWorkersHandler.scala
@@ -22,12 +22,11 @@ trait LinkWorkersHandler {
 
   registerHandler { (msg: LinkWorkers, sender) =>
     {
-      val linkConfig = cp.workflow.regionPlan
+      val resourceConfig = cp.workflow.regionPlan
         .getRegionOfPhysicalLink(msg.link)
+        .resourceConfig
         .get
-        .config
-        .get
-        .linkConfigs(msg.link)
+      val linkConfig = resourceConfig.linkConfigs(msg.link)
 
       val futures = linkConfig.channelConfigs
         .flatMap(channelConfig =>

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/Region.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/Region.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.scheduling
 
-import edu.uci.ics.amber.engine.architecture.scheduling.config.RegionConfig
+import edu.uci.ics.amber.engine.architecture.scheduling.config.ResourceConfig
 import edu.uci.ics.amber.engine.common.virtualidentity.PhysicalOpIdentity
 import edu.uci.ics.amber.engine.common.workflow.PhysicalLink
 
@@ -14,7 +14,7 @@ case class Region(
     id: RegionIdentity,
     physicalOpIds: Set[PhysicalOpIdentity],
     physicalLinks: Set[PhysicalLink],
-    config: Option[RegionConfig] = None,
+    resourceConfig: Option[ResourceConfig] = None,
     // operators whose all inputs are from upstream region.
     sourcePhysicalOpIds: Set[PhysicalOpIdentity] = Set.empty,
     // links to downstream regions, where this region generates blocking output.

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/RegionPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/RegionPlan.scala
@@ -12,8 +12,8 @@ case class RegionPlan(
     regionLinks.filter(link => link.toRegion == region).map(_.fromRegion)
   }
 
-  def getRegionOfPhysicalLink(link: PhysicalLink): Option[Region] = {
-    regions.find(region => region.getEffectiveLinks.contains(link))
+  def getRegionOfPhysicalLink(link: PhysicalLink): Region = {
+    regions.find(region => region.getEffectiveLinks.contains(link)).get
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowScheduler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/WorkflowScheduler.scala
@@ -134,6 +134,7 @@ class WorkflowScheduler(
       akkaActorService: AkkaActorService
   ): Unit = {
     val builtOpsInRegion = new mutable.HashSet[PhysicalOpIdentity]()
+    val resourceConfig = region.resourceConfig.get
     var frontier = region.sourcePhysicalOpIds
     while (frontier.nonEmpty) {
       frontier.foreach { (physicalOpId: PhysicalOpIdentity) =>
@@ -141,7 +142,7 @@ class WorkflowScheduler(
           buildOperator(
             workflow,
             physicalOpId,
-            region.config.get.operatorConfigs(physicalOpId),
+            resourceConfig.operatorConfigs(physicalOpId),
             akkaActorService
           )
           builtPhysicalOpIds.add(physicalOpId)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/config/ResourceConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/config/ResourceConfig.scala
@@ -3,7 +3,7 @@ package edu.uci.ics.amber.engine.architecture.scheduling.config
 import edu.uci.ics.amber.engine.common.virtualidentity.PhysicalOpIdentity
 import edu.uci.ics.amber.engine.common.workflow.PhysicalLink
 
-case class RegionConfig(
+case class ResourceConfig(
     operatorConfigs: Map[PhysicalOpIdentity, OperatorConfig],
     linkConfigs: Map[PhysicalLink, LinkConfig]
 )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/resourcePolicies/ResourceAllocator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/resourcePolicies/ResourceAllocator.scala
@@ -7,7 +7,7 @@ import edu.uci.ics.amber.engine.architecture.scheduling.config.WorkerConfig.gene
 import edu.uci.ics.amber.engine.architecture.scheduling.config.{
   LinkConfig,
   OperatorConfig,
-  RegionConfig
+  ResourceConfig
 }
 import edu.uci.ics.amber.engine.common.virtualidentity.PhysicalOpIdentity
 import edu.uci.ics.amber.engine.common.workflow.{PhysicalLink, PortIdentity}
@@ -39,8 +39,8 @@ class DefaultResourceAllocator(
     *
     * @param region The region for which to allocate resources.
     * @return A tuple containing:
-    *         1) A new Region instance with new configuration.
-    *         2) An estimated cost of the workflow with the new configuration,
+    *         1) A new Region instance with new resource configuration.
+    *         2) An estimated cost of the workflow with the new resource configuration,
     *         represented as a Double value (currently set to 0, but will be
     *         updated in the future).
     */
@@ -73,9 +73,9 @@ class DefaultResourceAllocator(
 
     linkConfigs ++= linkToLinkConfigMapping
 
-    val config = RegionConfig(opToOperatorConfigMapping, linkToLinkConfigMapping)
+    val resourceConfig = ResourceConfig(opToOperatorConfigMapping, linkToLinkConfigMapping)
 
-    (region.copy(config = Some(config)), 0)
+    (region.copy(resourceConfig = Some(resourceConfig)), 0)
   }
 
   /**


### PR DESCRIPTION
This PR renames `RegionConfig` to `ResourceConfig` to better describe its content.