### PR TITLE
Support multiple sources in a Region

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
@@ -3,7 +3,10 @@ package edu.uci.ics.amber.engine.architecture.scheduling
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp
 import edu.uci.ics.amber.engine.architecture.scheduling.ExpansionGreedyRegionPlanGenerator.replaceVertex
-import edu.uci.ics.amber.engine.architecture.scheduling.resourcePolicies.{DefaultResourceAllocator, ExecutionClusterInfo}
+import edu.uci.ics.amber.engine.architecture.scheduling.resourcePolicies.{
+  DefaultResourceAllocator,
+  ExecutionClusterInfo
+}
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.virtualidentity.PhysicalOpIdentity
 import edu.uci.ics.amber.engine.common.workflow.{OutputPort, PhysicalLink, PortIdentity}
@@ -101,7 +104,6 @@ class ExpansionGreedyRegionPlanGenerator(
         Region(RegionIdentity(idx.toString), operatorIds, links)
     }
   }
-
 
   /**
     * Try connect the regions in the DAG while respecting the dependencies of PhysicalLinks (e.g., HashJoin).

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/Region.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/Region.scala
@@ -8,8 +8,6 @@ case class RegionLink(fromRegion: Region, toRegion: Region)
 
 case class RegionIdentity(id: String)
 
-// A (pipelined) region can have a single source. A source is an operator with
-// only blocking inputs or no inputs at all.
 case class Region(
     id: RegionIdentity,
     physicalOpIds: Set[PhysicalOpIdentity],

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/FriesReconfigurationAlgorithm.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/FriesReconfigurationAlgorithm.scala
@@ -50,7 +50,7 @@ object FriesReconfigurationAlgorithm {
     val oneToManyOperators = getOneToManyOperators(physicalPlan)
     oneToManyOperators.foreach(oneToManyOp => {
       val intersection =
-        physicalPlan.getDownstreamPhysicalOpIds(oneToManyOp).toSet.intersect(reconfigOps)
+        physicalPlan.getDescendantPhysicalOpIds(oneToManyOp).intersect(reconfigOps)
       if (intersection.nonEmpty) {
         M += oneToManyOp
       }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/FriesReconfigurationAlgorithm.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/FriesReconfigurationAlgorithm.scala
@@ -50,7 +50,7 @@ object FriesReconfigurationAlgorithm {
     val oneToManyOperators = getOneToManyOperators(physicalPlan)
     oneToManyOperators.foreach(oneToManyOp => {
       val intersection =
-        physicalPlan.getDescendantPhysicalOpIds(oneToManyOp).toSet.intersect(reconfigOps)
+        physicalPlan.getDownstreamPhysicalOpIds(oneToManyOp).toSet.intersect(reconfigOps)
       if (intersection.nonEmpty) {
         M += oneToManyOp
       }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
@@ -3,7 +3,11 @@ package edu.uci.ics.texera.workflow.common.workflow
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp
 import edu.uci.ics.amber.engine.common.VirtualIdentityUtils
-import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, OperatorIdentity, PhysicalOpIdentity}
+import edu.uci.ics.amber.engine.common.virtualidentity.{
+  ActorVirtualIdentity,
+  OperatorIdentity,
+  PhysicalOpIdentity
+}
 import edu.uci.ics.amber.engine.common.workflow.{PhysicalLink, PortIdentity}
 import edu.uci.ics.texera.workflow.common.WorkflowContext
 import org.jgrapht.graph.{DefaultEdge, DirectedAcyclicGraph}
@@ -266,14 +270,16 @@ case class PhysicalPlan(
   }
 
   def getConnectedComponents: Set[Set[PhysicalOpIdentity]] = {
-    val components : Set[Set[PhysicalOpIdentity]] = getSourceOperatorIds.map(
-      sourcePhysicalOpId =>  getDescendantPhysicalOpIds(sourcePhysicalOpId) ++ Set(sourcePhysicalOpId)
+    val components: Set[Set[PhysicalOpIdentity]] = getSourceOperatorIds.map(sourcePhysicalOpId =>
+      getDescendantPhysicalOpIds(sourcePhysicalOpId) ++ Set(sourcePhysicalOpId)
     )
 
-    def unionSetsWithCommonElements(sets: Set[Set[PhysicalOpIdentity]]): Set[Set[PhysicalOpIdentity]] = {
+    def unionSetsWithCommonElements(
+        sets: Set[Set[PhysicalOpIdentity]]
+    ): Set[Set[PhysicalOpIdentity]] = {
       sets.foldLeft(Set.empty[Set[PhysicalOpIdentity]]) { (result, currentSet) =>
         val (intersected, others) = result.partition(_.intersect(currentSet).nonEmpty)
-        Set(currentSet ++ intersected.flatten) ++  others
+        Set(currentSet ++ intersected.flatten) ++ others
       }
     }
     unionSetsWithCommonElements(components)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
@@ -269,28 +269,4 @@ case class PhysicalPlan(
     }
   }
 
-  /**
-    * A Physical Plan (which is DAG) could have multiple components.
-    * A component is connected subDAG that is not part of any larger connected subDAG.
-    *
-    * This method returns the set of components for this Physical Plan, each represented as a set
-    * of PhysicalOpIdentities.
-    */
-  def getConnectedComponents: Set[Set[PhysicalOpIdentity]] = {
-    val componentCandidates: Set[Set[PhysicalOpIdentity]] =
-      getSourceOperatorIds.map(sourcePhysicalOpId =>
-        getDescendantPhysicalOpIds(sourcePhysicalOpId) ++ Set(sourcePhysicalOpId)
-      )
-
-    def unionComponents(
-        sets: Set[Set[PhysicalOpIdentity]]
-    ): Set[Set[PhysicalOpIdentity]] = {
-      sets.foldLeft(Set.empty[Set[PhysicalOpIdentity]]) { (result, currentSet) =>
-        val (intersected, others) = result.partition(_.intersect(currentSet).nonEmpty)
-        Set(currentSet ++ intersected.flatten) ++ others
-      }
-    }
-    unionComponents(componentCandidates)
-  }
-
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
@@ -136,6 +136,9 @@ case class PhysicalPlan(
     links.filter(l => l.fromOpId == physicalOpId)
   }
 
+  def getDescendantPhysicalOpIds(physicalOpId: PhysicalOpIdentity): Set[PhysicalOpIdentity] = {
+    dag.getDescendants(physicalOpId).asScala.toSet
+  }
   def topologicalIterator(): Iterator[PhysicalOpIdentity] = {
     new TopologicalOrderIterator(dag).asScala
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
@@ -269,6 +269,13 @@ case class PhysicalPlan(
     }
   }
 
+  /**
+    * A Physical Plan (which is DAG) could have multiple components.
+    * A component is connected subDAG that is not part of any larger connected subDAG.
+    *
+    * This method returns the set of components for this Physical Plan, each represented as a set
+    * of PhysicalOpIdentities.
+    */
   def getConnectedComponents: Set[Set[PhysicalOpIdentity]] = {
     val components: Set[Set[PhysicalOpIdentity]] = getSourceOperatorIds.map(sourcePhysicalOpId =>
       getDescendantPhysicalOpIds(sourcePhysicalOpId) ++ Set(sourcePhysicalOpId)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
@@ -14,7 +14,6 @@ import org.jgrapht.graph.{DefaultEdge, DirectedAcyclicGraph}
 import org.jgrapht.traverse.TopologicalOrderIterator
 
 import scala.collection.JavaConverters._
-import scala.collection.{immutable, mutable}
 
 object PhysicalPlan {
 
@@ -135,10 +134,6 @@ case class PhysicalPlan(
 
   def getDownstreamPhysicalLinks(physicalOpId: PhysicalOpIdentity): Set[PhysicalLink] = {
     links.filter(l => l.fromOpId == physicalOpId)
-  }
-
-  def getDescendantPhysicalOpIds(physicalOpId: PhysicalOpIdentity): Set[PhysicalOpIdentity] = {
-    dag.getDescendants(physicalOpId).asScala.toSet
   }
 
   def topologicalIterator(): Iterator[PhysicalOpIdentity] = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/workflow/PhysicalPlan.scala
@@ -277,11 +277,12 @@ case class PhysicalPlan(
     * of PhysicalOpIdentities.
     */
   def getConnectedComponents: Set[Set[PhysicalOpIdentity]] = {
-    val components: Set[Set[PhysicalOpIdentity]] = getSourceOperatorIds.map(sourcePhysicalOpId =>
-      getDescendantPhysicalOpIds(sourcePhysicalOpId) ++ Set(sourcePhysicalOpId)
-    )
+    val componentCandidates: Set[Set[PhysicalOpIdentity]] =
+      getSourceOperatorIds.map(sourcePhysicalOpId =>
+        getDescendantPhysicalOpIds(sourcePhysicalOpId) ++ Set(sourcePhysicalOpId)
+      )
 
-    def unionSetsWithCommonElements(
+    def unionComponents(
         sets: Set[Set[PhysicalOpIdentity]]
     ): Set[Set[PhysicalOpIdentity]] = {
       sets.foldLeft(Set.empty[Set[PhysicalOpIdentity]]) { (result, currentSet) =>
@@ -289,7 +290,7 @@ case class PhysicalPlan(
         Set(currentSet ++ intersected.flatten) ++ others
       }
     }
-    unionSetsWithCommonElements(components)
+    unionComponents(componentCandidates)
   }
 
 }


### PR DESCRIPTION
As we are doing region-by-region propagation to generate resources, a region needs all its links to be ready for partition requirement propagation. For an operator that has multiple sources connected to multiple ports, if there is no dependency between the input ports, then all sources can be within the same region. This PR changes the region to have multiple sources and removes the old single-source limitation. 

We don't currently see issues stated in #1768. We will fix them if encountered.