### PR TITLE
Fix missing ports on Scala operator and allowMultiLinks

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/ParallelCSVScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/csv/ParallelCSVScanSourceOpDesc.scala
@@ -61,6 +61,8 @@ class ParallelCSVScanSourceOpDesc extends ScanSourceOpDesc {
               )
             })
           )
+          .withInputPorts(operatorInfo.inputPorts, inputPortToSchemaMapping)
+          .withOutputPorts(operatorInfo.outputPorts, outputPortToSchemaMapping)
           .withParallelizable(true)
 
       case None =>

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/union/UnionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/union/UnionOpDesc.scala
@@ -15,12 +15,15 @@ class UnionOpDesc extends LogicalOp {
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity
   ): PhysicalOp = {
-    PhysicalOp.oneToOnePhysicalOp(
-      workflowId,
-      executionId,
-      operatorIdentifier,
-      OpExecInitInfo((_, _, _) => new UnionOpExec())
-    )
+    PhysicalOp
+      .oneToOnePhysicalOp(
+        workflowId,
+        executionId,
+        operatorIdentifier,
+        OpExecInitInfo((_, _, _) => new UnionOpExec())
+      )
+      .withInputPorts(operatorInfo.inputPorts, inputPortToSchemaMapping)
+      .withOutputPorts(operatorInfo.outputPorts, outputPortToSchemaMapping)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/unneststring/UnnestStringOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/unneststring/UnnestStringOpDesc.scala
@@ -39,12 +39,15 @@ class UnnestStringOpDesc extends FlatMapOpDesc {
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity
   ): PhysicalOp = {
-    PhysicalOp.oneToOnePhysicalOp(
-      workflowId,
-      executionId,
-      operatorIdentifier,
-      OpExecInitInfo((_, _, _) => new UnnestStringOpExec(this))
-    )
+    PhysicalOp
+      .oneToOnePhysicalOp(
+        workflowId,
+        executionId,
+        operatorIdentifier,
+        OpExecInitInfo((_, _, _) => new UnnestStringOpExec(this))
+      )
+      .withInputPorts(operatorInfo.inputPorts, inputPortToSchemaMapping)
+      .withOutputPorts(operatorInfo.outputPorts, outputPortToSchemaMapping)
   }
 
   override def getOutputSchema(schemas: Array[Schema]): Schema = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/htmlviz/HtmlVizOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/htmlviz/HtmlVizOpDesc.scala
@@ -31,12 +31,15 @@ class HtmlVizOpDesc extends VisualizationOperator {
   ): PhysicalOp = {
     val outputSchema =
       operatorInfo.outputPorts.map(outputPort => outputPortToSchemaMapping(outputPort.id)).head
-    PhysicalOp.oneToOnePhysicalOp(
-      workflowId,
-      executionId,
-      operatorIdentifier,
-      OpExecInitInfo((_, _, _) => new HtmlVizOpExec(htmlContentAttrName, outputSchema))
-    )
+    PhysicalOp
+      .oneToOnePhysicalOp(
+        workflowId,
+        executionId,
+        operatorIdentifier,
+        OpExecInitInfo((_, _, _) => new HtmlVizOpExec(htmlContentAttrName, outputSchema))
+      )
+      .withInputPorts(operatorInfo.inputPorts, inputPortToSchemaMapping)
+      .withOutputPorts(operatorInfo.outputPorts, outputPortToSchemaMapping)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/urlviz/UrlVizOpDesc.scala
@@ -49,6 +49,8 @@ class UrlVizOpDesc extends VisualizationOperator {
         operatorIdentifier,
         OpExecInitInfo((_, _, _) => new UrlVizOpExec(urlContentAttrName, outputSchema))
       )
+      .withInputPorts(operatorInfo.inputPorts, inputPortToSchemaMapping)
+      .withOutputPorts(operatorInfo.outputPorts, outputPortToSchemaMapping)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/new-gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -1222,7 +1222,7 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
       if (portIndex >= 0) {
         const portInfo =
           this.dynamicSchemaService.getDynamicSchema(targetCellID).additionalMetadata.inputPorts[portIndex];
-        allowMultiInput = portInfo?.allowMultiInputs ?? false;
+        allowMultiInput = portInfo?.allowMultiLinks ?? false;
       }
     }
     return !(connectedLinksToTargetPort.length > 0 && !allowMultiInput);

--- a/core/new-gui/src/app/workspace/service/operator-metadata/mock-operator-metadata.data.ts
+++ b/core/new-gui/src/app/workspace/service/operator-metadata/mock-operator-metadata.data.ts
@@ -245,7 +245,7 @@ export const mockUnionSchema: OperatorSchema = {
     userFriendlyName: "Union",
     operatorDescription: "Union multiple inputs",
     operatorGroupName: "Analysis",
-    inputPorts: [{ allowMultiInputs: true }],
+    inputPorts: [{ allowMultiLinks: true }],
     outputPorts: [{}],
   },
   operatorVersion: "union1",

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
@@ -672,7 +672,6 @@ export class WorkflowActionService {
       const commentBoxes = workflowContent.commentBoxes;
 
       operatorsAndPositions = this.updateOperatorVersions(operatorsAndPositions);
-      console.log(operatorsAndPositions);
 
       this.addOperatorsAndLinks(operatorsAndPositions, links, groups, breakpoints, commentBoxes);
 

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
@@ -672,6 +672,7 @@ export class WorkflowActionService {
       const commentBoxes = workflowContent.commentBoxes;
 
       operatorsAndPositions = this.updateOperatorVersions(operatorsAndPositions);
+      console.log(operatorsAndPositions);
 
       this.addOperatorsAndLinks(operatorsAndPositions, links, groups, breakpoints, commentBoxes);
 

--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
@@ -2,18 +2,18 @@ import { Observable, Subject } from "rxjs";
 import {
   Breakpoint,
   Comment,
-  PortDescription,
   CommentBox,
-  OperatorLink,
   LogicalPort,
+  OperatorLink,
   OperatorPredicate,
   PartitionInfo,
+  PortDescription,
   PortProperty,
 } from "../../../types/workflow-common.interface";
 import { isEqual } from "lodash-es";
 import { SharedModel } from "./shared-model";
-import { User, CoeditorState } from "../../../../common/type/user";
-import { createYTypeFromObject, YType, updateYTypeFromObject } from "../../../types/shared-editing.interface";
+import { CoeditorState, User } from "../../../../common/type/user";
+import { createYTypeFromObject, updateYTypeFromObject, YType } from "../../../types/shared-editing.interface";
 import { Awareness } from "y-protocols/awareness";
 import * as Y from "yjs";
 
@@ -571,9 +571,7 @@ export class WorkflowGraph {
       throw new Error(`operator ${operatorID} does not exist`);
     }
     const yoperator = this.sharedModel.operatorIDMap.get(operatorID) as YType<OperatorPredicate>;
-    const operator = yoperator.toJSON();
-    console.log("found this op predicate", operator);
-    return operator;
+    return yoperator.toJSON();
   }
 
   /**

--- a/core/new-gui/src/app/workspace/service/workflow-graph/util/workflow-util.service.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/util/workflow-util.service.ts
@@ -124,7 +124,7 @@ export class WorkflowUtilService {
       inputPorts.push({
         portID,
         displayName: portInfo.displayName ?? "",
-        allowMultiInputs: portInfo.allowMultiInputs ?? false,
+        allowMultiInputs: portInfo.allowMultiLinks ?? false,
         isDynamicPort: false,
         dependencies: portInfo.dependencies ?? [],
       });
@@ -184,7 +184,7 @@ export class WorkflowUtilService {
       inputPorts.push({
         portID,
         displayName: portInfo.displayName ?? "",
-        allowMultiInputs: portInfo.allowMultiInputs ?? false,
+        allowMultiInputs: portInfo.allowMultiLinks ?? false,
         isDynamicPort: false,
         dependencies: portInfo.dependencies ?? [],
       });

--- a/core/new-gui/src/app/workspace/types/operator-schema.interface.ts
+++ b/core/new-gui/src/app/workspace/types/operator-schema.interface.ts
@@ -13,7 +13,7 @@ import { CustomJSONSchema7 } from "./custom-json-schema.interface";
 export interface InputPortInfo
   extends Readonly<{
     displayName?: string;
-    allowMultiInputs?: boolean;
+    allowMultiLinks?: boolean;
     dependencies?: { id: number; internal: boolean }[];
   }> {}
 


### PR DESCRIPTION
This PR fixes 
1. the missed ports of scala operators, caused by #2299 
2. the `allowMultiLinks` parameter is mismatched on the frontend. 