### PR TITLE
Remove Optional Mark in Coeditor

### DIFF
--- a/core/new-gui/src/app/workspace/component/menu/coeditor-user-icon/coeditor-user-icon.component.html
+++ b/core/new-gui/src/app/workspace/component/menu/coeditor-user-icon/coeditor-user-icon.component.html
@@ -1,7 +1,7 @@
 <texera-user-avatar
-  [googleId]="coeditor?.googleId || '' "
-  [userName]="coeditor?.name || ''"
-  [userColor]="coeditor?.color || ''"
+  [googleId]="coeditor.googleId || '' "
+  [userName]="coeditor.name || ''"
+  [userColor]="coeditor.color || ''"
   nz-button
   nz-dropdown
   nzTrigger="click"


### PR DESCRIPTION
Remove Optional Mark in Coeditor since it's unnecessary and will cause an error in Angular 14.