### PR TITLE
Fix list length checks in the workflow version history

### DIFF
--- a/core/new-gui/src/app/dashboard/user/service/workflow-version/workflow-version.service.ts
+++ b/core/new-gui/src/app/dashboard/user/service/workflow-version/workflow-version.service.ts
@@ -88,7 +88,7 @@ export class WorkflowVersionService {
     differentOpIDsList.modified.map(id => this.highlightOpBoundary(id, "255,118,20,0.5"));
     differentOpIDsList.added.map(id => this.highlightOpBoundary(id, "0,255,0,0.5"));
 
-    if (differentOpIDsList.deleted != []) {
+    if (differentOpIDsList.deleted.length > 0) {
       const tempWorkflow = this.workflowActionService.getTempWorkflow();
       if (tempWorkflow != undefined) {
         for (const link of tempWorkflow.content.links) {


### PR DESCRIPTION
Fix list length checks in the workflow version history. 

The condition check of a reference will return false in Angular 14.