### PR TITLE
Fix Formly CSS

### DIFF
--- a/core/new-gui/src/material-custom-theme.scss
+++ b/core/new-gui/src/material-custom-theme.scss
@@ -1,68 +1,66 @@
 @use "@angular/material" as mat;
 
 $fontConfig: (
-        display-4: mat.define-typography-level(112px, 112px, 300, "Roboto", -0.0134em),
-        display-3: mat.define-typography-level(56px, 56px, 400, "Roboto", -0.0089em),
-        display-2: mat.define-typography-level(45px, 48px, 400, "Roboto", 0em),
-        display-1: mat.define-typography-level(34px, 40px, 400, "Roboto", 0.0074em),
-        headline: mat.define-typography-level(24px, 32px, 400, "Roboto", 0em),
-        title: mat.define-typography-level(20px, 32px, 500, "Roboto", 0.0075em),
-        subheading-2: mat.define-typography-level(16px, 28px, 400, "Roboto", 0.0094em),
-        subheading-1: mat.define-typography-level(15px, 24px, 500, "Roboto", 0.0067em),
-        body-2: mat.define-typography-level(14px, 24px, 500, "Roboto", 0.0179em),
-        body-1: mat.define-typography-level(14px, 20px, 400, "Roboto", 0.0179em),
-        button: mat.define-typography-level(14px, 14px, 500, "Roboto", 0.0893em),
-        caption: mat.define-typography-level(12px, 20px, 400, "Roboto", 0.0333em),
-        input: mat.define-typography-level(inherit, 1.125, 400, "Roboto", 1.5px),
+  display-4: mat.define-typography-level(112px, 112px, 300, "Roboto", -0.0134em),
+  display-3: mat.define-typography-level(56px, 56px, 400, "Roboto", -0.0089em),
+  display-2: mat.define-typography-level(45px, 48px, 400, "Roboto", 0em),
+  display-1: mat.define-typography-level(34px, 40px, 400, "Roboto", 0.0074em),
+  headline: mat.define-typography-level(24px, 32px, 400, "Roboto", 0em),
+  title: mat.define-typography-level(20px, 32px, 500, "Roboto", 0.0075em),
+  subheading-2: mat.define-typography-level(16px, 28px, 400, "Roboto", 0.0094em),
+  subheading-1: mat.define-typography-level(15px, 24px, 500, "Roboto", 0.0067em),
+  body-2: mat.define-typography-level(14px, 24px, 500, "Roboto", 0.0179em),
+  body-1: mat.define-typography-level(14px, 20px, 400, "Roboto", 0.0179em),
+  button: mat.define-typography-level(14px, 14px, 500, "Roboto", 0.0893em),
+  caption: mat.define-typography-level(12px, 20px, 400, "Roboto", 0.0333em),
+  input: mat.define-typography-level(inherit, 1.125, 400, "Roboto", 1.5px),
 );
-
 
 // Compute font config
 @include mat.core($fontConfig);
 
 $mat-primary: (
-        main: #343a40,
-        lighter: #c2c4c6,
-        darker: #21252a,
-        200: #343a40,
+  main: #343a40,
+  lighter: #c2c4c6,
+  darker: #21252a,
+  200: #343a40,
   // For slide toggle,
-        contrast:
-        (
-                main: white,
-                lighter: rgba(black, 0.87),
-                darker: white,
-        ),
+  contrast:
+    (
+      main: white,
+      lighter: rgba(black, 0.87),
+      darker: white,
+    ),
 );
 $theme-primary: mat.define-palette($mat-primary, main, lighter, darker);
 
 $mat-accent: (
-        main: #5081f3,
-        lighter: #cbd9fb,
-        darker: #3764ed,
-        200: #5081f3,
+  main: #5081f3,
+  lighter: #cbd9fb,
+  darker: #3764ed,
+  200: #5081f3,
   // For slide toggle,
-        contrast:
-        (
-                main: white,
-                lighter: rgba(black, 0.87),
-                darker: white,
-        ),
+  contrast:
+    (
+      main: white,
+      lighter: rgba(black, 0.87),
+      darker: white,
+    ),
 );
 $theme-accent: mat.define-palette($mat-accent, main, lighter, darker);
 
-
 $mat-warn: (
-        main: #ff0000,
-        lighter: #ffb3b3,
-        darker: #ff0000,
-        200: #ff0000,
+  main: #ff0000,
+  lighter: #ffb3b3,
+  darker: #ff0000,
+  200: #ff0000,
   // For slide toggle,
-        contrast:
-        (
-                main: white,
-                lighter: rgba(black, 0.87),
-                darker: white,
-        ),
+  contrast:
+    (
+      main: white,
+      lighter: rgba(black, 0.87),
+      darker: white,
+    ),
 );
 $theme-warn: mat.define-palette($mat-warn, main, lighter, darker);
 

--- a/core/new-gui/src/material-custom-theme.scss
+++ b/core/new-gui/src/material-custom-theme.scss
@@ -1,0 +1,71 @@
+@use "@angular/material" as mat;
+
+$fontConfig: (
+        display-4: mat.define-typography-level(112px, 112px, 300, "Roboto", -0.0134em),
+        display-3: mat.define-typography-level(56px, 56px, 400, "Roboto", -0.0089em),
+        display-2: mat.define-typography-level(45px, 48px, 400, "Roboto", 0em),
+        display-1: mat.define-typography-level(34px, 40px, 400, "Roboto", 0.0074em),
+        headline: mat.define-typography-level(24px, 32px, 400, "Roboto", 0em),
+        title: mat.define-typography-level(20px, 32px, 500, "Roboto", 0.0075em),
+        subheading-2: mat.define-typography-level(16px, 28px, 400, "Roboto", 0.0094em),
+        subheading-1: mat.define-typography-level(15px, 24px, 500, "Roboto", 0.0067em),
+        body-2: mat.define-typography-level(14px, 24px, 500, "Roboto", 0.0179em),
+        body-1: mat.define-typography-level(14px, 20px, 400, "Roboto", 0.0179em),
+        button: mat.define-typography-level(14px, 14px, 500, "Roboto", 0.0893em),
+        caption: mat.define-typography-level(12px, 20px, 400, "Roboto", 0.0333em),
+        input: mat.define-typography-level(inherit, 1.125, 400, "Roboto", 1.5px),
+);
+
+
+// Compute font config
+@include mat.core($fontConfig);
+
+$mat-primary: (
+        main: #343a40,
+        lighter: #c2c4c6,
+        darker: #21252a,
+        200: #343a40,
+  // For slide toggle,
+        contrast:
+        (
+                main: white,
+                lighter: rgba(black, 0.87),
+                darker: white,
+        ),
+);
+$theme-primary: mat.define-palette($mat-primary, main, lighter, darker);
+
+$mat-accent: (
+        main: #5081f3,
+        lighter: #cbd9fb,
+        darker: #3764ed,
+        200: #5081f3,
+  // For slide toggle,
+        contrast:
+        (
+                main: white,
+                lighter: rgba(black, 0.87),
+                darker: white,
+        ),
+);
+$theme-accent: mat.define-palette($mat-accent, main, lighter, darker);
+
+
+$mat-warn: (
+        main: #ff0000,
+        lighter: #ffb3b3,
+        darker: #ff0000,
+        200: #ff0000,
+  // For slide toggle,
+        contrast:
+        (
+                main: white,
+                lighter: rgba(black, 0.87),
+                darker: white,
+        ),
+);
+$theme-warn: mat.define-palette($mat-warn, main, lighter, darker);
+
+$theme: mat.define-light-theme($theme-primary, $theme-accent, $theme-warn);
+// Theme Init
+@include mat.all-component-themes($theme);

--- a/core/new-gui/src/styles.scss
+++ b/core/new-gui/src/styles.scss
@@ -1,4 +1,5 @@
 @import "~c3/c3.min.css";
+@import "material-custom-theme.scss";
 
 // make the UI takes full screen
 html,


### PR DESCRIPTION
Some parts of the `material-custom-theme.scss` are still required by Formly, so we added them back.