### PR TITLE
Remove bootstrap from navigation bars

### DIFF
--- a/core/new-gui/src/app/dashboard/user/component/dashboard.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/dashboard.component.html
@@ -1,19 +1,11 @@
-<nav class="navbar navbar-expand navbar-light bg-light">
-  <a
-    class="navbar-brand"
-    href="#"
-    ><img
-      alt="texera-logo"
-      class="logo"
-      src="../../../../assets/logos/logo.png"
-  /></a>
-  <div
-    class="collapse navbar-collapse"
-    id="navbarText">
-    <div class="mr-auto"></div>
-    <texera-user-icon></texera-user-icon>
-  </div>
-</nav>
+<div id="nav">
+  <img
+    alt="logo"
+    class="logo"
+    height="50"
+    src="../../../../assets/logos/logo.png" />
+  <texera-user-icon></texera-user-icon>
+</div>
 <nz-layout class="layout">
   <nz-sider
     nzCollapsible

--- a/core/new-gui/src/app/dashboard/user/component/dashboard.component.scss
+++ b/core/new-gui/src/app/dashboard/user/component/dashboard.component.scss
@@ -1,13 +1,16 @@
-.navbar {
+#nav {
   height: 70px;
+  background-color: #f8f9fa;
+  padding: 8px 16px;
 }
 
 button {
   border: none;
 }
 
-.logo {
-  width: 70px;
+texera-user-icon {
+  float: right;
+  padding: 8px;
 }
 
 .layout {

--- a/core/new-gui/src/app/home/component/home.component.html
+++ b/core/new-gui/src/app/home/component/home.component.html
@@ -1,48 +1,21 @@
-<nav class="navbar navbar-expand navbar-light bg-light">
-  <a
-    class="navbar-brand"
-    href="#"
-    ><img
-      src="assets/logos/logo.png"
-      alt="texera-logo"
-      class="logo"
-  /></a>
-  <div
-    class="collapse navbar-collapse"
-    id="navbarText">
-    <ul class="navbar-nav mr-auto">
-      <li class="nav-item active">
-        <a
-          class="nav-link"
-          href="https://github.com/Texera/texera/wiki/Getting-Started"
-          >Getting Started</a
-        >
-      </li>
-      <li class="nav-item active">
-        <a
-          class="nav-link"
-          href="https://texera.github.io/blog/"
-          >Blogs</a
-        >
-      </li>
-      <li class="nav-item active">
-        <div class="nav-link">
-          <iframe
-            style="margin-top: 2px"
-            src="https://ghbtns.com/github-btn.html?user=Texera&repo=texera&type=star&count=true"
-            frameborder="0"
-            scrolling="0"
-            width="90"
-            height="20"
-            title="GitHub"></iframe>
-        </div>
-      </li>
-    </ul>
-
-    <div id="googleButton"></div>
-  </div>
-</nav>
-
+<ul>
+  <li id="logo"><img
+    src="assets/logos/logo.png"
+    height="50"
+    alt="logo"
+  /></li>
+  <li><a href="https://github.com/Texera/texera/wiki/Getting-Started">Getting Started</a></li>
+  <li><a href="https://texera.github.io/blog/">Blogs</a></li>
+  <li><iframe
+    style="margin-top: 2px"
+    src="https://ghbtns.com/github-btn.html?user=Texera&repo=texera&type=star&count=true"
+    frameborder="0"
+    scrolling="0"
+    width="90"
+    height="20"
+    title="GitHub"></iframe></li>
+  <li id="googleButton"></li>
+</ul>
 <div
   nz-row
   nzJustify="space-around"

--- a/core/new-gui/src/app/home/component/home.component.html
+++ b/core/new-gui/src/app/home/component/home.component.html
@@ -1,19 +1,22 @@
 <ul>
-  <li id="logo"><img
-    src="assets/logos/logo.png"
-    height="50"
-    alt="logo"
-  /></li>
+  <li id="logo">
+    <img
+      src="assets/logos/logo.png"
+      height="50"
+      alt="logo" />
+  </li>
   <li><a href="https://github.com/Texera/texera/wiki/Getting-Started">Getting Started</a></li>
   <li><a href="https://texera.github.io/blog/">Blogs</a></li>
-  <li><iframe
-    style="margin-top: 2px"
-    src="https://ghbtns.com/github-btn.html?user=Texera&repo=texera&type=star&count=true"
-    frameborder="0"
-    scrolling="0"
-    width="90"
-    height="20"
-    title="GitHub"></iframe></li>
+  <li>
+    <iframe
+      style="margin-top: 2px"
+      src="https://ghbtns.com/github-btn.html?user=Texera&repo=texera&type=star&count=true"
+      frameborder="0"
+      scrolling="0"
+      width="90"
+      height="20"
+      title="GitHub"></iframe>
+  </li>
   <li id="googleButton"></li>
 </ul>
 <div

--- a/core/new-gui/src/app/home/component/home.component.scss
+++ b/core/new-gui/src/app/home/component/home.component.scss
@@ -28,6 +28,6 @@ li a {
 }
 
 #googleButton {
-  float:right;
+  float: right;
   padding: 5px 0;
 }

--- a/core/new-gui/src/app/home/component/home.component.scss
+++ b/core/new-gui/src/app/home/component/home.component.scss
@@ -1,17 +1,33 @@
-.logo {
-  width: 70px;
-  margin-right: 2vw;
-}
-
 .content {
   text-align: center;
 }
 
-a:link {
-  color: black !important;
+ul {
+  list-style-type: none;
+  height: 70px;
+  padding: 10px;
+  overflow: hidden;
+  background-color: #f8f9fa;
+  vertical-align: baseline;
+}
+
+li {
+  float: left;
+  padding: 14px;
+}
+
+li a {
+  color: black;
   font-weight: bold;
 }
 
-.navbar {
+#logo {
   height: 70px;
+  padding: 0;
+  margin-right: 14px;
+}
+
+#googleButton {
+  float:right;
+  padding: 5px 0;
 }


### PR DESCRIPTION
Remove Bootstrap from navigation bars since it's not supported in Angular 14, and we plan to drop Bootstrap support.

There is no change to functionality and GUI in this PR.