### PR TITLE
Remove region from region link

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
@@ -182,15 +182,15 @@ class ExpansionGreedyRegionPlanGenerator(
       .foreach {
         case List(prevLink, nextLink) =>
           // Create edges between regions
-          val regionLinks = toRegionOrderPairs(prevLink.fromOpId, nextLink.fromOpId, regionDAG)
+          val regionOrderPairs = toRegionOrderPairs(prevLink.fromOpId, nextLink.fromOpId, regionDAG)
           // Attempt to add edges to regionDAG
           try {
-            regionLinks.foreach {
+            regionOrderPairs.foreach {
               case (fromRegion, toRegion) =>
                 regionDAG.addEdge(fromRegion, toRegion, RegionLink(fromRegion.id, toRegion.id))
             }
           } catch {
-            case e: IllegalArgumentException =>
+            case _: IllegalArgumentException =>
               // adding the edge causes cycle. return the link for materialization replacement
               return Some(Set(nextLink))
           }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
@@ -73,12 +73,13 @@ class ExpansionGreedyRegionPlanGenerator(
 
   /**
     * Takes in a pair of operatorIds, `upstreamOpId` and `downstreamOpId`, finds all regions they each
-    * belong to, and creates the order relationships between the Region of upstreamOpId,
-    * with the Regions of downstreamOpId. The relation ship can be N to M.
+    * belong to, and creates the order relationships between the Regions of upstreamOpId, with the Regions
+    * of downstreamOpId. The relation ship can be N to M.
     *
     * This method does not consider ports.
     *
-    * Returns pairs of (upstreamRegion, downstreamRegion) indicating the order from upstreamRegion to downstreamRegion.
+    * Returns pairs of (upstreamRegion, downstreamRegion) indicating the order from
+    * upstreamRegion to downstreamRegion.
     */
   private def toRegionOrderPairs(
       upstreamOpId: PhysicalOpIdentity,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
@@ -191,7 +191,6 @@ class ExpansionGreedyRegionPlanGenerator(
             }
           } catch {
             case e: IllegalArgumentException =>
-              logger.warn("got error", e)
               // adding the edge causes cycle. return the link for materialization replacement
               return Some(Set(nextLink))
           }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
@@ -180,8 +180,9 @@ class ExpansionGreedyRegionPlanGenerator(
           val regionLinks = createLinks(prevLink.fromOpId, nextLink.fromOpId, regionDAG)
           // Attempt to add edges to regionDAG
           try {
-            regionLinks.foreach{
-              case (fromRegion, toRegion) => regionDAG.addEdge(fromRegion, toRegion, RegionLink(fromRegion.id, toRegion.id))
+            regionLinks.foreach {
+              case (fromRegion, toRegion) =>
+                regionDAG.addEdge(fromRegion, toRegion, RegionLink(fromRegion.id, toRegion.id))
             }
           } catch {
             case e: IllegalArgumentException =>
@@ -231,8 +232,8 @@ class ExpansionGreedyRegionPlanGenerator(
     try {
       matReaderWriterPairs.foreach {
         case (writer, reader) =>
-          createLinks(writer, reader, regionDAG).foreach{
-            case (fromRegion, toRegion)=>
+          createLinks(writer, reader, regionDAG).foreach {
+            case (fromRegion, toRegion) =>
               regionDAG.addEdge(fromRegion, toRegion, RegionLink(fromRegion.id, toRegion.id))
           }
       }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
@@ -3,7 +3,10 @@ package edu.uci.ics.amber.engine.architecture.scheduling
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp
 import edu.uci.ics.amber.engine.architecture.scheduling.ExpansionGreedyRegionPlanGenerator.replaceVertex
-import edu.uci.ics.amber.engine.architecture.scheduling.resourcePolicies.{DefaultResourceAllocator, ExecutionClusterInfo}
+import edu.uci.ics.amber.engine.architecture.scheduling.resourcePolicies.{
+  DefaultResourceAllocator,
+  ExecutionClusterInfo
+}
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.virtualidentity.PhysicalOpIdentity
 import edu.uci.ics.amber.engine.common.workflow.{OutputPort, PhysicalLink, PortIdentity}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
@@ -3,10 +3,7 @@ package edu.uci.ics.amber.engine.architecture.scheduling
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp
 import edu.uci.ics.amber.engine.architecture.scheduling.ExpansionGreedyRegionPlanGenerator.replaceVertex
-import edu.uci.ics.amber.engine.architecture.scheduling.resourcePolicies.{
-  DefaultResourceAllocator,
-  ExecutionClusterInfo
-}
+import edu.uci.ics.amber.engine.architecture.scheduling.resourcePolicies.{DefaultResourceAllocator, ExecutionClusterInfo}
 import edu.uci.ics.amber.engine.common.amberexception.WorkflowRuntimeException
 import edu.uci.ics.amber.engine.common.virtualidentity.PhysicalOpIdentity
 import edu.uci.ics.amber.engine.common.workflow.{OutputPort, PhysicalLink, PortIdentity}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/Region.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/Region.scala
@@ -9,7 +9,7 @@ import org.jgrapht.traverse.TopologicalOrderIterator
 
 import scala.jdk.CollectionConverters.asScalaIteratorConverter
 
-case class RegionLink(fromRegion: Region, toRegion: Region)
+case class RegionLink(fromRegionId: RegionIdentity, toRegionId: RegionIdentity)
 
 case class RegionIdentity(id: Long)
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/RegionPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/RegionPlan.scala
@@ -10,7 +10,10 @@ case class RegionPlan(
     regions.map(region => region.id -> region).toMap
 
   def getUpstreamRegions(region: Region): Set[Region] = {
-    regionLinks.filter(link => link.toRegionId == region.id).map(_.fromRegionId).map(regionId=> regionMapping(regionId))
+    regionLinks
+      .filter(link => link.toRegionId == region.id)
+      .map(_.fromRegionId)
+      .map(regionId => regionMapping(regionId))
   }
 
   def getRegionOfPhysicalLink(link: PhysicalLink): Region = {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/RegionPlan.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/RegionPlan.scala
@@ -1,5 +1,4 @@
 package edu.uci.ics.amber.engine.architecture.scheduling
-
 import edu.uci.ics.amber.engine.common.workflow.PhysicalLink
 
 case class RegionPlan(
@@ -7,9 +6,11 @@ case class RegionPlan(
     regions: List[Region],
     regionLinks: Set[RegionLink]
 ) {
+  private val regionMapping: Map[RegionIdentity, Region] =
+    regions.map(region => region.id -> region).toMap
 
   def getUpstreamRegions(region: Region): Set[Region] = {
-    regionLinks.filter(link => link.toRegion == region).map(_.fromRegion)
+    regionLinks.filter(link => link.toRegionId == region.id).map(_.fromRegionId).map(regionId=> regionMapping(regionId))
   }
 
   def getRegionOfPhysicalLink(link: PhysicalLink): Region = {


### PR DESCRIPTION
This PR makes the `RegionLink` a weak entity by using Ids only. Removed Region from RegionLink:
```
case class RegionLink(fromRegionId: RegionIdentity, toRegionId: RegionIdentity)
```