### PR TITLE
Remove amber engine and pause resume config

### DIFF
--- a/core/new-gui/src/app/workspace/component/left-panel/time-travel/time-travel.component.ts
+++ b/core/new-gui/src/app/workspace/component/left-panel/time-travel/time-travel.component.ts
@@ -123,7 +123,7 @@ export class TimeTravelComponent implements OnInit, OnDestroy {
         let replayExecutionInfo = { eid: eid, interaction: interaction };
         this.revertedToInteraction = replayExecutionInfo;
         this.notificationService.info(`start replay to interaction ${interaction} at execution ${eid}`);
-        this.executeWorkflowService.executeWorkflowAmberTexeraWithReplay(replayExecutionInfo);
+        this.executeWorkflowService.executeWorkflowWithReplay(replayExecutionInfo);
       });
   }
 

--- a/core/new-gui/src/app/workspace/component/menu/menu.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/menu/menu.component.spec.ts
@@ -69,7 +69,6 @@
 //     undoRedoService = TestBed.get(UndoRedoService);
 //     validationWorkflowService = TestBed.get(ValidationWorkflowService);
 //     fixture.detectChanges();
-//     environment.pauseResumeEnabled = true;
 //   });
 
 //   it('should create', () => {

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
@@ -48,7 +48,6 @@ describe("ExecuteWorkflowService", () => {
 
     service = TestBed.inject(ExecuteWorkflowService);
     mockWorkflowSnapshotService = TestBed.inject(WorkflowSnapshotService);
-    environment.pauseResumeEnabled = true;
   });
 
   it("should be created", inject([ExecuteWorkflowService], (injectedService: ExecuteWorkflowService) => {

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
@@ -12,7 +12,6 @@ import { Observable, of } from "rxjs";
 
 import { mockLogicalPlan_scan_result, mockWorkflowPlan_scan_result } from "./mock-workflow-plan";
 import { HttpClient } from "@angular/common/http";
-import { WorkflowGraph } from "../workflow-graph/model/workflow-graph";
 import { environment } from "../../../../environments/environment";
 import { WorkflowUtilService } from "../workflow-graph/util/workflow-util.service";
 import { WorkflowSnapshotService } from "../../../dashboard/user/service/workflow-snapshot/workflow-snapshot.service";
@@ -62,16 +61,12 @@ describe("ExecuteWorkflowService", () => {
   });
 
   it("should msg backend when executing workflow", fakeAsync(() => {
-    if (environment.amberEngineEnabled) {
-      const logicalPlan: LogicalPlan = ExecuteWorkflowService.getLogicalPlanRequest(mockWorkflowPlan_scan_result);
-      const wsSendSpy = spyOn((service as any).workflowWebsocketService, "send");
-      service.sendExecutionRequest("", logicalPlan);
-      tick(FORM_DEBOUNCE_TIME_MS + 1);
-      flush();
-      expect(wsSendSpy).toHaveBeenCalledTimes(1);
-    } else {
-      throw new Error("old texera engine not supported");
-    }
+    const logicalPlan: LogicalPlan = ExecuteWorkflowService.getLogicalPlanRequest(mockWorkflowPlan_scan_result);
+    const wsSendSpy = spyOn((service as any).workflowWebsocketService, "send");
+    service.sendExecutionRequest("", logicalPlan);
+    tick(FORM_DEBOUNCE_TIME_MS + 1);
+    flush();
+    expect(wsSendSpy).toHaveBeenCalledTimes(1);
   }));
 
   it("it should raise an error when pauseWorkflow() is called without an execution state", () => {

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -73,7 +73,6 @@ export class ExecuteWorkflowService {
     private workflowWebsocketService: WorkflowWebsocketService,
     private notificationService: NotificationService
   ) {
-    if (environment.amberEngineEnabled) {
       workflowWebsocketService.websocketEvent().subscribe(event => {
         switch (event.type) {
           case "WorkerAssignmentUpdateEvent":
@@ -88,7 +87,6 @@ export class ExecuteWorkflowService {
             }
         }
       });
-    }
   }
 
   public handleReconfigurationEvent(event: TexeraWebsocketEvent) {
@@ -181,22 +179,13 @@ export class ExecuteWorkflowService {
   }
 
   public executeWorkflow(executionName: string): void {
-    if (environment.amberEngineEnabled) {
-      this.executeWorkflowAmberTexera(executionName);
-    } else {
-      throw new Error("old texera engine not supported");
-    }
-  }
-
-  public executeWorkflowAmberTexera(executionName: string): void {
-    // get the current workflow graph
     const logicalPlan = ExecuteWorkflowService.getLogicalPlanRequest(this.workflowActionService.getTexeraGraph());
-    console.log(logicalPlan);
     this.sendExecutionRequest(executionName, logicalPlan);
   }
 
-  public executeWorkflowAmberTexeraWithReplay(replayExecutionInfo: ReplayExecutionInfo): void {
-    // get the current workflow graph
+
+
+  public executeWorkflowWithReplay(replayExecutionInfo: ReplayExecutionInfo): void {
     const logicalPlan = ExecuteWorkflowService.getLogicalPlanRequest(this.workflowActionService.getTexeraGraph());
     this.sendExecutionRequest(
       `Replay run of ${replayExecutionInfo.eid} to ${replayExecutionInfo.interaction}`,
@@ -234,9 +223,6 @@ export class ExecuteWorkflowService {
   }
 
   public pauseWorkflow(): void {
-    if (!environment.pauseResumeEnabled || !environment.amberEngineEnabled) {
-      return;
-    }
     if (this.currentState === undefined || this.currentState.state !== ExecutionState.Running) {
       throw new Error("cannot pause workflow, the current execution state is " + this.currentState?.state);
     }
@@ -244,9 +230,6 @@ export class ExecuteWorkflowService {
   }
 
   public killWorkflow(): void {
-    if (!environment.pauseResumeEnabled || !environment.amberEngineEnabled) {
-      return;
-    }
     if (
       this.currentState.state === ExecutionState.Uninitialized ||
       this.currentState.state === ExecutionState.Completed
@@ -257,9 +240,6 @@ export class ExecuteWorkflowService {
   }
 
   public addExecutionInteraction(): void {
-    if (!environment.pauseResumeEnabled || !environment.amberEngineEnabled) {
-      return;
-    }
     if (
       this.currentState.state === ExecutionState.Uninitialized ||
       this.currentState.state === ExecutionState.Completed
@@ -270,9 +250,6 @@ export class ExecuteWorkflowService {
   }
 
   public resumeWorkflow(): void {
-    if (!environment.pauseResumeEnabled || !environment.amberEngineEnabled) {
-      return;
-    }
     if (
       !(
         this.currentState.state === ExecutionState.Paused ||
@@ -285,9 +262,6 @@ export class ExecuteWorkflowService {
   }
 
   public addBreakpointRuntime(linkID: string, breakpointData: Breakpoint): void {
-    if (!environment.amberEngineEnabled) {
-      return;
-    }
     if (
       this.currentState.state !== ExecutionState.BreakpointTriggered &&
       this.currentState.state !== ExecutionState.Paused
@@ -302,9 +276,6 @@ export class ExecuteWorkflowService {
   }
 
   public skipTuples(workers: ReadonlyArray<string>): void {
-    if (!environment.amberEngineEnabled) {
-      return;
-    }
     if (this.currentState.state !== ExecutionState.Paused) {
       throw new Error("cannot skip tuples, the current execution state is " + this.currentState.state);
     }
@@ -312,9 +283,6 @@ export class ExecuteWorkflowService {
   }
 
   public retryExecution(workers: ReadonlyArray<string>): void {
-    if (!environment.amberEngineEnabled) {
-      return;
-    }
     if (this.currentState.state !== ExecutionState.Paused) {
       throw new Error("cannot retry the current tuple, the current execution state is " + this.currentState.state);
     }
@@ -322,10 +290,6 @@ export class ExecuteWorkflowService {
   }
 
   public modifyOperatorLogic(operatorID: string): void {
-    if (!environment.amberEngineEnabled) {
-      return;
-    }
-    console.log("modifying operator logic " + operatorID);
     if (
       this.currentState.state !== ExecutionState.BreakpointTriggered &&
       this.currentState.state !== ExecutionState.Paused

--- a/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/new-gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -73,20 +73,20 @@ export class ExecuteWorkflowService {
     private workflowWebsocketService: WorkflowWebsocketService,
     private notificationService: NotificationService
   ) {
-      workflowWebsocketService.websocketEvent().subscribe(event => {
-        switch (event.type) {
-          case "WorkerAssignmentUpdateEvent":
-            this.assignedWorkerIds.set(event.operatorId, event.workerIds);
-            break;
-          default:
-            // workflow status related event
-            this.handleReconfigurationEvent(event);
-            const newState = this.handleExecutionEvent(event);
-            if (newState !== undefined) {
-              this.updateExecutionState(newState);
-            }
-        }
-      });
+    workflowWebsocketService.websocketEvent().subscribe(event => {
+      switch (event.type) {
+        case "WorkerAssignmentUpdateEvent":
+          this.assignedWorkerIds.set(event.operatorId, event.workerIds);
+          break;
+        default:
+          // workflow status related event
+          this.handleReconfigurationEvent(event);
+          const newState = this.handleExecutionEvent(event);
+          if (newState !== undefined) {
+            this.updateExecutionState(newState);
+          }
+      }
+    });
   }
 
   public handleReconfigurationEvent(event: TexeraWebsocketEvent) {
@@ -182,8 +182,6 @@ export class ExecuteWorkflowService {
     const logicalPlan = ExecuteWorkflowService.getLogicalPlanRequest(this.workflowActionService.getTexeraGraph());
     this.sendExecutionRequest(executionName, logicalPlan);
   }
-
-
 
   public executeWorkflowWithReplay(replayExecutionInfo: ReplayExecutionInfo): void {
     const logicalPlan = ExecuteWorkflowService.getLogicalPlanRequest(this.workflowActionService.getTexeraGraph());

--- a/core/new-gui/src/environments/environment.default.ts
+++ b/core/new-gui/src/environments/environment.default.ts
@@ -69,8 +69,6 @@ export const defaultEnvironment = {
    */
   workflowExecutionsTrackingEnabled: false,
 
-  amberEngineEnabled: true,
-
   /**
    * whether linkBreakpoint is supported
    */

--- a/core/new-gui/src/environments/environment.default.ts
+++ b/core/new-gui/src/environments/environment.default.ts
@@ -6,28 +6,29 @@ export const defaultEnvironment = {
    * whether we are in production mode, default is false
    */
   production: false,
+
   /**
    * root API URL of the backend
    */
   apiUrl: "api",
+
   /**
    * whether fetching available source tables is enabled
    * see SourceTablesService for details
    */
   sourceTableEnabled: false,
+
   /**
    * whether operator schema propagation and autocomplete feature is enabled,
    * see SchemaPropagationService for details
    */
   schemaPropagationEnabled: true,
-  /**
-   * whether the backend support pause/resume functionality
-   */
-  pauseResumeEnabled: true,
+
   /**
    * whether the backend supports checking execution status
    */
   executionStatusEnabled: true,
+
   /**
    * whether export execution result is supported
    */


### PR DESCRIPTION
Since we have only one engine Amber now, we remove the configurations: 1) `amberEngineEnabled` and 2) `pauseResumeEnabled`.