### PR TITLE
Fix race condition on updating server execution state

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/storage/StateStore.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/storage/StateStore.scala
@@ -29,8 +29,10 @@ class StateStore[T](defaultState: T) {
   def getState: T = stateSubject.getValue
 
   def updateState(func: T => T): Unit = {
-    val newState = func(stateSubject.getValue)
-    serializedSubject.onNext(newState)
+    withLock {
+      val newState = func(stateSubject.getValue)
+      serializedSubject.onNext(newState)
+    }
   }
 
   def registerDiffHandler(handler: (T, T) => Iterable[TexeraWebSocketEvent]): Disposable = {


### PR DESCRIPTION
When receiving simultaneous updates from a websocket and from Amber, both targeting the same state, a race condition occurs where the 2nd update may overwrite the 1st update. This PR makes the 2 updates synchronized.