### PR TITLE
Fix incorrect "shared by" icon display for file entries in search results

### DIFF
--- a/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.html
@@ -55,7 +55,7 @@
             <texera-user-file-list-item
               [editable]="editable"
               [entry]="entry.file"
-              [uid]="uid">
+              [uid]="getUid()">
             </texera-user-file-list-item> </nz-content
         ></nz-layout>
       </ng-container>

--- a/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.html
@@ -54,7 +54,8 @@
           <nz-content>
             <texera-user-file-list-item
               [editable]="editable"
-              [entry]="entry.file">
+              [entry]="entry.file"
+              [uid]="uid">
             </texera-user-file-list-item> </nz-content
         ></nz-layout>
       </ng-container>

--- a/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.ts
@@ -15,15 +15,16 @@ export class SearchResultsComponent {
   more = false;
   entries: ReadonlyArray<DashboardEntry> = [];
   private resetCounter = 0;
-  public uid: number | undefined = undefined;
   @Input() showResourceTypes = false;
   @Input() public pid: number = 0;
   @Input() editable = false;
   @Output() deleted = new EventEmitter<DashboardEntry>();
   @Output() duplicated = new EventEmitter<DashboardEntry>();
 
-  constructor(private userService: UserService) {
-    this.uid = this.userService.getCurrentUser()?.uid;
+  constructor(private userService: UserService) {}
+
+  getUid(): number | undefined {
+    return this.userService.getCurrentUser()?.uid;
   }
 
   reset(loadMoreFunction: LoadMoreFunction): void {

--- a/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.ts
+++ b/core/new-gui/src/app/dashboard/user/component/search-results/search-results.component.ts
@@ -1,5 +1,6 @@
 import { Component, EventEmitter, Input, OnInit, Output } from "@angular/core";
 import { DashboardEntry } from "../../type/dashboard-entry";
+import { UserService } from "../../../../common/service/user/user.service";
 
 export type LoadMoreFunction = (start: number, count: number) => Promise<{ entries: DashboardEntry[]; more: boolean }>;
 
@@ -14,11 +15,16 @@ export class SearchResultsComponent {
   more = false;
   entries: ReadonlyArray<DashboardEntry> = [];
   private resetCounter = 0;
+  public uid: number | undefined = undefined;
   @Input() showResourceTypes = false;
   @Input() public pid: number = 0;
   @Input() editable = false;
   @Output() deleted = new EventEmitter<DashboardEntry>();
   @Output() duplicated = new EventEmitter<DashboardEntry>();
+
+  constructor(private userService: UserService) {
+    this.uid = this.userService.getCurrentUser()?.uid;
+  }
 
   reset(loadMoreFunction: LoadMoreFunction): void {
     this.entries = [];

--- a/core/new-gui/src/app/dashboard/user/component/search/search.component.spec.ts
+++ b/core/new-gui/src/app/dashboard/user/component/search/search.component.spec.ts
@@ -19,6 +19,8 @@ import { ScrollingModule } from "@angular/cdk/scrolling";
 import { NoopAnimationsModule } from "@angular/platform-browser/animations";
 import { DashboardEntry } from "../../type/dashboard-entry";
 import { SearchResultsComponent } from "../search-results/search-results.component";
+import { UserService } from "../../../../common/service/user/user.service";
+import { StubUserService } from "../../../../common/service/user/stub-user.service";
 
 describe("SearchComponent", () => {
   let component: SearchComponent;
@@ -35,6 +37,7 @@ describe("SearchComponent", () => {
             ...testUserProjects.map(i => new DashboardEntry(i)),
           ]),
         },
+        { provide: UserService, useClass: StubUserService },
         { provide: OperatorMetadataService, useClass: StubOperatorMetadataService },
         { provide: UserProjectService, useClass: StubUserProjectService },
         { provide: WorkflowPersistService, useValue: new StubWorkflowPersistService(testWorkflowEntries) },


### PR DESCRIPTION
This PR fixes the incorrect "shared by" icon by passing the uid correctly to search result component.

Before:
<img width="885" alt="截屏2024-02-15 下午10 34 54" src="https://github.com/Texera/texera/assets/13672781/8984f663-153f-4cf2-8aac-7d0effe659db">
After:
<img width="886" alt="截屏2024-02-15 下午10 33 32" src="https://github.com/Texera/texera/assets/13672781/3ef93b8a-72ac-43d6-bfcc-d72a4f4839ca">
