### PR TITLE
Fix missing action button on the first entry of workflow search result

### DIFF
--- a/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow-list-item/user-workflow-list-item.component.html
+++ b/core/new-gui/src/app/dashboard/user/component/user-workflow/user-workflow-list-item/user-workflow-list-item.component.html
@@ -6,6 +6,7 @@
         *ngIf="editable"
         class="workflow-item-checkbox"
         id="{{workflow.wid}}"
+        ngDefaultControl
         [(ngModel)]="entry.checked"></label>
       <nz-avatar
         [ngStyle]="{ 'background-color': 'grey', 'vertical-align': 'middle' }"


### PR DESCRIPTION
This bug is due to [NG01203](https://angular.io/errors/NG01203) because we did not assign a form control to user-workflow list-item component. This PR assigns a default form control to it.