### PR TITLE
Include Build Table Schema in Hash Join's Build Output Schema

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinBuildOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinBuildOpExec.scala
@@ -22,8 +22,8 @@ class HashJoinBuildOpExec[K](buildAttributeName: String) extends OperatorExecuto
         buildTableHashMap.getOrElseUpdate(key, new ListBuffer[Tuple]()) += tuple
         Iterator()
       case Right(_) =>
-        buildTableHashMap.iterator.map {
-          case (k, v) => TupleLike(k, v)
+        buildTableHashMap.iterator.flatMap {
+          case (k, v) => v.map(t => TupleLike(List(k) ++ t.fields: _*))
         }
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.hashJoin
 
-import edu.uci.ics.texera.workflow.operators.hashJoin.HashJoinOpDesc.HashJoinInternalKeyName
+import edu.uci.ics.texera.workflow.operators.hashJoin.HashJoinOpDesc.HASH_JOIN_INTERNAL_KEY_NAME
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp
@@ -23,7 +23,7 @@ import edu.uci.ics.texera.workflow.common.workflow.{HashPartition, PhysicalPlan}
 import scala.collection.mutable
 
 object HashJoinOpDesc {
-  val HashJoinInternalKeyName = "__internal__hashtable__key__"
+  val HASH_JOIN_INTERNAL_KEY_NAME = "__internal__hashtable__key__"
 }
 
 @JsonSchemaInject(json = """
@@ -68,7 +68,7 @@ class HashJoinOpDesc[K] extends LogicalOp {
     val probeSchema = inputSchemas(1)
 
     val internalHashTableSchema =
-      Schema.builder().add(HashJoinInternalKeyName, AttributeType.ANY).add(buildSchema).build()
+      Schema.builder().add(HASH_JOIN_INTERNAL_KEY_NAME, AttributeType.ANY).add(buildSchema).build()
 
     val buildInputPort = operatorInfo.inputPorts.head
     val buildOutputPort = OutputPort(PortIdentity(0, internal = true))
@@ -87,7 +87,7 @@ class HashJoinOpDesc[K] extends LogicalOp {
           mutable.Map(buildOutputPort.id -> internalHashTableSchema)
         )
         .withPartitionRequirement(List(Option(HashPartition(List(buildAttributeName)))))
-        .withDerivePartition(_ => HashPartition(List(HashJoinInternalKeyName)))
+        .withDerivePartition(_ => HashPartition(List(HASH_JOIN_INTERNAL_KEY_NAME)))
         .withParallelizable(true)
 
     val probeBuildInputPort = InputPort(PortIdentity(0, internal = true))
@@ -121,7 +121,7 @@ class HashJoinOpDesc[K] extends LogicalOp {
         .withOutputPorts(List(probeOutputPort), mutable.Map(probeOutputPort.id -> outputSchema))
         .withPartitionRequirement(
           List(
-            Option(HashPartition(List(HashJoinInternalKeyName))),
+            Option(HashPartition(List(HASH_JOIN_INTERNAL_KEY_NAME))),
             Option(HashPartition(List(probeAttributeName)))
           )
         )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpDesc.scala
@@ -1,5 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.hashJoin
 
+import edu.uci.ics.texera.workflow.operators.hashJoin.HashJoinOpDesc.HashJoinInternalKeyName
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp
@@ -20,6 +21,10 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType
 import edu.uci.ics.texera.workflow.common.workflow.{HashPartition, PhysicalPlan}
 
 import scala.collection.mutable
+
+object HashJoinOpDesc {
+  val HashJoinInternalKeyName = "__internal__hashtable__key__"
+}
 
 @JsonSchemaInject(json = """
 {
@@ -63,7 +68,7 @@ class HashJoinOpDesc[K] extends LogicalOp {
     val probeSchema = inputSchemas(1)
 
     val internalHashTableSchema =
-      Schema.builder().add("key", AttributeType.ANY).add("value", AttributeType.ANY).build()
+      Schema.builder().add(HashJoinInternalKeyName, AttributeType.ANY).add(buildSchema).build()
 
     val buildInputPort = operatorInfo.inputPorts.head
     val buildOutputPort = OutputPort(PortIdentity(0, internal = true))
@@ -82,7 +87,7 @@ class HashJoinOpDesc[K] extends LogicalOp {
           mutable.Map(buildOutputPort.id -> internalHashTableSchema)
         )
         .withPartitionRequirement(List(Option(HashPartition(List(buildAttributeName)))))
-        .withDerivePartition(_ => HashPartition(List("key")))
+        .withDerivePartition(_ => HashPartition(List(HashJoinInternalKeyName)))
         .withParallelizable(true)
 
     val probeBuildInputPort = InputPort(PortIdentity(0, internal = true))
@@ -116,7 +121,7 @@ class HashJoinOpDesc[K] extends LogicalOp {
         .withOutputPorts(List(probeOutputPort), mutable.Map(probeOutputPort.id -> outputSchema))
         .withPartitionRequirement(
           List(
-            Option(HashPartition(List("key"))),
+            Option(HashPartition(List(HashJoinInternalKeyName))),
             Option(HashPartition(List(probeAttributeName)))
           )
         )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinProbeOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinProbeOpExec.scala
@@ -1,5 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.hashJoin
 
+import edu.uci.ics.texera.workflow.operators.hashJoin.HashJoinOpDesc.HashJoinInternalKeyName
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.tuple.amber.TupleLike
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
@@ -55,7 +56,9 @@ class HashJoinProbeOpExec[K](
     tuple match {
       case Left(tuple) if port == 0 =>
         // Load build hash map
-        buildTableHashMap(tuple.getField("key")) = (tuple.getField("value"), false)
+        val key = tuple.getField[K](HashJoinInternalKeyName)
+        buildTableHashMap.getOrElseUpdate(key, (new ListBuffer[Tuple](), false))._1 += tuple
+          .getPartialTuple(tuple.getSchema.getAttributeNames.filterNot(n => n == "key"))
         Iterator.empty
 
       case Left(tuple) =>

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinProbeOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinProbeOpExec.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.hashJoin
 
-import edu.uci.ics.texera.workflow.operators.hashJoin.HashJoinOpDesc.HashJoinInternalKeyName
+import edu.uci.ics.texera.workflow.operators.hashJoin.HashJoinOpDesc.HASH_JOIN_INTERNAL_KEY_NAME
 import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.tuple.amber.TupleLike
 import edu.uci.ics.texera.workflow.common.operators.OperatorExecutor
@@ -56,9 +56,11 @@ class HashJoinProbeOpExec[K](
     tuple match {
       case Left(tuple) if port == 0 =>
         // Load build hash map
-        val key = tuple.getField[K](HashJoinInternalKeyName)
+        val key = tuple.getField[K](HASH_JOIN_INTERNAL_KEY_NAME)
         buildTableHashMap.getOrElseUpdate(key, (new ListBuffer[Tuple](), false))._1 += tuple
-          .getPartialTuple(tuple.getSchema.getAttributeNames.filterNot(n => n == "key"))
+          .getPartialTuple(
+            tuple.getSchema.getAttributeNames.filterNot(n => n == HASH_JOIN_INTERNAL_KEY_NAME)
+          )
         Iterator.empty
 
       case Left(tuple) =>
@@ -96,8 +98,7 @@ class HashJoinProbeOpExec[K](
         tuples.map { tuple =>
           TupleLike(
             tuple.getSchema.getAttributeNames
-              .map(attributeName => attributeName -> tuple.getField(attributeName))
-              .toSeq: _*
+              .map(attributeName => attributeName -> tuple.getField(attributeName)): _*
           )
         }
       }
@@ -116,8 +117,7 @@ class HashJoinProbeOpExec[K](
     Iterator(
       TupleLike(
         tuple.getSchema.getAttributeNames
-          .map(attributeName => attributeName -> tuple.getField(attributeName))
-          .toSeq: _*
+          .map(attributeName => attributeName -> tuple.getField(attributeName)): _*
       )
     )
 

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpSpec.scala
@@ -4,7 +4,7 @@ import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.tuple.amber.TupleLike
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
-import edu.uci.ics.texera.workflow.operators.hashJoin.HashJoinOpDesc.HashJoinInternalKeyName
+import edu.uci.ics.texera.workflow.operators.hashJoin.HashJoinOpDesc.HASH_JOIN_INTERNAL_KEY_NAME
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -17,7 +17,11 @@ class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
   var opDesc: HashJoinOpDesc[String] = _
 
   def getInternalHashTableSchema(buildInputSchema: Schema): Schema = {
-    Schema.builder().add(HashJoinInternalKeyName, AttributeType.ANY).add(buildInputSchema).build()
+    Schema
+      .builder()
+      .add(HASH_JOIN_INTERNAL_KEY_NAME, AttributeType.ANY)
+      .add(buildInputSchema)
+      .build()
   }
   def tuple(name: String, n: Int = 1, i: Option[Int]): Tuple = {
 

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/hashJoin/HashJoinOpSpec.scala
@@ -4,6 +4,7 @@ import edu.uci.ics.amber.engine.common.InputExhausted
 import edu.uci.ics.amber.engine.common.tuple.amber.TupleLike
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
+import edu.uci.ics.texera.workflow.operators.hashJoin.HashJoinOpDesc.HashJoinInternalKeyName
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -14,8 +15,10 @@ class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
   var buildOpExec: HashJoinBuildOpExec[String] = _
   var probeOpExec: HashJoinProbeOpExec[String] = _
   var opDesc: HashJoinOpDesc[String] = _
-  val internalHashTableSchema: Schema =
-    Schema.builder().add("key", AttributeType.ANY).add("value", AttributeType.ANY).build()
+
+  def getInternalHashTableSchema(buildInputSchema: Schema): Schema = {
+    Schema.builder().add(HashJoinInternalKeyName, AttributeType.ANY).add(buildInputSchema).build()
+  }
   def tuple(name: String, n: Int = 1, i: Option[Int]): Tuple = {
 
     Tuple
@@ -65,7 +68,12 @@ class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
       assert(
         probeOpExec
           .processTuple(
-            Left(TupleLike.enforceSchema(buildOpOutputIterator.next(), internalHashTableSchema)),
+            Left(
+              TupleLike.enforceSchema(
+                buildOpOutputIterator.next(),
+                getInternalHashTableSchema(inputSchemas.head)
+              )
+            ),
             build
           )
           .isEmpty
@@ -120,7 +128,12 @@ class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
       assert(
         probeOpExec
           .processTuple(
-            Left(TupleLike.enforceSchema(buildOpOutputIterator.next(), internalHashTableSchema)),
+            Left(
+              TupleLike.enforceSchema(
+                buildOpOutputIterator.next(),
+                getInternalHashTableSchema(inputSchemas.head)
+              )
+            ),
             build
           )
           .isEmpty
@@ -174,7 +187,12 @@ class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
       assert(
         probeOpExec
           .processTuple(
-            Left(TupleLike.enforceSchema(buildOpOutputIterator.next(), internalHashTableSchema)),
+            Left(
+              TupleLike.enforceSchema(
+                buildOpOutputIterator.next(),
+                getInternalHashTableSchema(inputSchemas.head)
+              )
+            ),
             build
           )
           .isEmpty


### PR DESCRIPTION
To enable schema propagation to be done only once on the physical plan level, this PR refactors Hash Join by changing the hard-coded schema between build op and probe op to include the build table's input schema. Previously this internal schema was hardcoded to be `(key, value)`. Now it is key appended by build input schema.