### PR TITLE
Fix NullpointerException on SentimentAnalysisOpExec

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sentiment/SentimentAnalysisOpExec.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sentiment/SentimentAnalysisOpExec.java
@@ -44,7 +44,7 @@ public class SentimentAnalysisOpExec extends MapOpExec {
                 .orElse(0);
 
         int normalizedSentimentScore = Integer.compare(sentimentScore, 2);
-        java.util.List<Object> tupleFields = Arrays.asList(t.getFields());
+        ArrayList<Object> tupleFields = new ArrayList<>(Arrays.asList(t.getFields()));
         tupleFields.add(normalizedSentimentScore);
 
         return TupleLike.apply(tupleFields);


### PR DESCRIPTION
This PR addresses an issue where tuple.getFields in Scala returns an Array[Any], which Java fails to properly recognize when converted to an `ArrayList`. Instead of leveraging `ArrayList<T>.add`, Java uses the abstract `List<T>.add`. By explicitly using `ArrayList`, this PR ensures the correct `add` method is called.