### PR TITLE
Fix UDF Editor not Loading Properly

### DIFF
--- a/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
+++ b/core/new-gui/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
@@ -817,7 +817,7 @@ export class WorkflowGraph {
     // ) as YType<OperatorPropertiesType>;
     // set the new copy back to the operator ID map
     // TODO: we temporarily disable this due to Yjs update causing issues in Formly.
-    this.getSharedOperatorType(operatorID).set("operatorProperties", newProperty);
+    this.getSharedOperatorType(operatorID).set("operatorProperties", createYTypeFromObject(newProperty));
     // updateYTypeFromObject(previousProperty, newProperty);
   }
 


### PR DESCRIPTION
#2014 disabled fine-grained operator property shared editing but did not use the correct API to replace the property. As a result, Python UDF editor cannot load the correct shared text sometimes. This PR fixes that issue.