### PR TITLE
Fix error in NotAnIterable trait

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/tuple/amber/TupleLike.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/tuple/amber/TupleLike.scala
@@ -87,7 +87,7 @@ object TupleLike {
     // Ensure Iterable types do not have an implicit NotAnIterable available
     // This is a way to "exclude" Iterable types by not providing an implicit instance for them
     implicit def iterableIsNotAnIterable[C[_] <: Iterable[A], A]: NotAnIterable[C[A]] =
-      sys.error("Iterable types are not allowed")
+      throw new RuntimeException("Iterable types are not allowed")
   }
 
   def apply(mappings: Map[String, Any]): MapTupleLike = {


### PR DESCRIPTION
Currently, when compiles, it throws an error:
```
object error is not a member of package sys
      sys.error("Iterable types are not allowed")
```

This PR fixes it by changing `sys.error` to an explicit RuntimeException.