### PR TITLE
Enhance the DumbbellPlot Visualization Operator

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/dumbbellPlot/DumbbellDotConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/dumbbellPlot/DumbbellDotConfig.scala
@@ -1,0 +1,24 @@
+package edu.uci.ics.texera.workflow.operators.visualization.dumbbellPlot
+
+import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
+import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName
+
+@JsonSchemaInject(json = """
+{
+  "attributeTypeRules": {
+    "dot": {
+      "enum": ["integer", "long", "double"]
+    }
+  }
+}
+""")
+class DumbbellDotConfig {
+
+  @JsonProperty(value = "dot", required = true)
+  @JsonSchemaTitle("Dot Column Value")
+  @JsonPropertyDescription("value for dot axis")
+  @AutofillAttributeName
+  var dotValue: String = ""
+
+}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/dumbbellPlot/DumbbellPlotOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/dumbbellPlot/DumbbellPlotOpDesc.scala
@@ -7,10 +7,10 @@ import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttribute
 import edu.uci.ics.texera.workflow.common.operators.PythonOperatorDescriptor
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.engine.common.workflow.{InputPort, OutputPort}
-import edu.uci.ics.texera.workflow.operators.visualization.{
-  VisualizationConstants,
-  VisualizationOperator
-}
+import edu.uci.ics.texera.workflow.operators.visualization.{VisualizationConstants, VisualizationOperator}
+
+import java.util
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 //type constraint: measurementColumnName can only be a numeric column
 @JsonSchemaInject(json = """
@@ -35,15 +35,15 @@ class DumbbellPlotOpDesc extends VisualizationOperator with PythonOperatorDescri
   @AutofillAttributeName
   var categoryColumnName: String = ""
 
-  @JsonProperty(value = "startValue", required = true)
-  @JsonSchemaTitle("Start Value")
+  @JsonProperty(value = "dumbbellStartValue", required = true)
+  @JsonSchemaTitle("Dumbbell Start Value")
   @JsonPropertyDescription("the start point value of each dumbbell")
-  var startValue: String = ""
+  var dumbbellStartValue: String = ""
 
-  @JsonProperty(value = "endValue", required = true)
-  @JsonSchemaTitle("End Value")
+  @JsonProperty(value = "dumbbellEndValue", required = true)
+  @JsonSchemaTitle("Dumbbell End Value")
   @JsonPropertyDescription("the end value of each dumbbell")
-  var endValue: String = ""
+  var dumbbellEndValue: String = ""
 
   @JsonProperty(value = "measurementColumnName", required = true)
   @JsonSchemaTitle("Measurement Column Name")
@@ -56,6 +56,15 @@ class DumbbellPlotOpDesc extends VisualizationOperator with PythonOperatorDescri
   @JsonPropertyDescription("the column name that is being compared")
   @AutofillAttributeName
   var comparedColumnName: String = ""
+
+  @JsonProperty(value="dots", required = false)
+  var dots: util.List[DumbbellDotConfig] = _
+
+  @JsonProperty(value = "showLegends", required = false)
+  @JsonSchemaTitle("Show Legends?")
+  @JsonPropertyDescription("whether show legends in the graph")
+  var showLegends: Boolean = false;
+
 
   override def getOutputSchema(schemas: Array[Schema]): Schema = {
     Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
@@ -70,34 +79,69 @@ class DumbbellPlotOpDesc extends VisualizationOperator with PythonOperatorDescri
       outputPorts = List(OutputPort())
     )
 
-  def createPlotlyFigure(): String = {
-    val dumbbellValues = startValue + ", " + endValue
-
+  def createPlotlyDumbbellLineFigure(): String = {
+    val dumbbellValues = dumbbellStartValue + ", " + dumbbellEndValue
+    var showLegendsOption = "showlegend=False"
+    if (showLegends) {
+      showLegendsOption = "showlegend=True"
+    }
     s"""
      |
      |        entityNames = list(table['${comparedColumnName}'].unique())
+     |        entityNames = sorted(entityNames, reverse=True)
      |        categoryValues = [${dumbbellValues}]
      |        filtered_table = table[(table['${comparedColumnName}'].isin(entityNames)) &
      |                    (table['${categoryColumnName}'].isin(categoryValues))]
      |
-     |        # Create the dumbbell plot using Plotly
+     |        # Create the dumbbell line using Plotly
      |        fig = go.Figure()
-     |
+     |        color = 'black'
      |        for entity in entityNames:
      |          entity_data = filtered_table[filtered_table['${comparedColumnName}'] == entity]
      |          fig.add_trace(go.Scatter(x=entity_data['${measurementColumnName}'],
-     |                             y=[entity]*2,
-     |                             mode='lines+markers+text',
+     |                             y=[entity]*len(entity_data),
+     |                             mode='lines',
      |                             name=entity,
-     |                             text=entity_data['${categoryColumnName}'],
-     |                             textposition='top center',
-     |                             marker=dict(size=10)))
+     |                             line=dict(color=color)))
      |
      |          fig.update_layout(title="${title}",
      |                  xaxis_title="${measurementColumnName}",
      |                  yaxis_title="${comparedColumnName}",
-     |                  yaxis=dict(categoryorder='array', categoryarray=entityNames))
+     |                  yaxis=dict(categoryorder='array', categoryarray=entityNames),
+     |                  ${showLegendsOption},
+     |                  height=20 * len(entityNames)
+     |                  )
      |""".stripMargin
+  }
+
+  def addPlotlyDots(): String = {
+
+    var dotColumnNames = ""
+    if (dots != null && dots.size() != 0) {
+      dotColumnNames = dots.asScala
+        .map { dot =>
+          s"'${dot.dotValue}'"
+        }.mkString(",")
+    }
+
+    s"""
+       |        dotColumnNames = [${dotColumnNames}]
+       |        print("dot column: ", filtered_table)
+       |        print("column names: ", dotColumnNames)
+       |        if len(dotColumnNames) > 0:
+       |          for dotColumn in dotColumnNames:
+       |              # Extract dot data for each entity
+       |              for entity in entityNames:
+       |                  entity_dot_data = filtered_table[filtered_table['${comparedColumnName}'] == entity]
+       |                  # Extract X and Y values for the dot
+       |                  x_values = entity_dot_data[dotColumn].values
+       |                  y_values = [entity] * len(x_values)
+       |                  # Add scatter plot for dots
+       |                  fig.add_trace(go.Scatter(x=x_values, y=y_values,
+       |                                         mode='markers',
+       |                                         name=entity + ' ' + dotColumn,
+       |                                         marker=dict(color='black', size=5)))  # Customize color and size as needed
+       |""".stripMargin
   }
 
   override def generatePythonCode(): String = {
@@ -120,7 +164,8 @@ class DumbbellPlotOpDesc extends VisualizationOperator with PythonOperatorDescri
      |        if table.empty:
      |           yield {'html-content': self.render_error("input table is empty.")}
      |           return
-     |        ${createPlotlyFigure()}
+     |        ${createPlotlyDumbbellLineFigure()}
+     |        ${addPlotlyDots()}
      |        # convert fig to html content
      |        html = plotly.io.to_html(fig, include_plotlyjs='cdn', auto_play=False)
      |        yield {'html-content': html}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/dumbbellPlot/DumbbellPlotOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/dumbbellPlot/DumbbellPlotOpDesc.scala
@@ -7,7 +7,10 @@ import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttribute
 import edu.uci.ics.texera.workflow.common.operators.PythonOperatorDescriptor
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.engine.common.workflow.{InputPort, OutputPort}
-import edu.uci.ics.texera.workflow.operators.visualization.{VisualizationConstants, VisualizationOperator}
+import edu.uci.ics.texera.workflow.operators.visualization.{
+  VisualizationConstants,
+  VisualizationOperator
+}
 
 import java.util
 import scala.jdk.CollectionConverters.CollectionHasAsScala
@@ -57,14 +60,13 @@ class DumbbellPlotOpDesc extends VisualizationOperator with PythonOperatorDescri
   @AutofillAttributeName
   var comparedColumnName: String = ""
 
-  @JsonProperty(value="dots", required = false)
+  @JsonProperty(value = "dots", required = false)
   var dots: util.List[DumbbellDotConfig] = _
 
   @JsonProperty(value = "showLegends", required = false)
   @JsonSchemaTitle("Show Legends?")
   @JsonPropertyDescription("whether show legends in the graph")
   var showLegends: Boolean = false;
-
 
   override def getOutputSchema(schemas: Array[Schema]): Schema = {
     Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
@@ -121,7 +123,8 @@ class DumbbellPlotOpDesc extends VisualizationOperator with PythonOperatorDescri
       dotColumnNames = dots.asScala
         .map { dot =>
           s"'${dot.dotValue}'"
-        }.mkString(",")
+        }
+        .mkString(",")
     }
 
     s"""


### PR DESCRIPTION
This PR fixes some issues in DumbbellPlot Visualization Operator, and adds more options to make it look nicer.

## Features
The new graph looks like this:
<img width="1542" alt="Screenshot 2024-03-05 at 7 32 10 PM" src="https://github.com/Texera/texera/assets/43344272/501698e7-90d2-4cb1-b0bd-5f9496a66e0e">



## Before the fix

The y-axis of the graph has the hardcoded height, which results in incomplete information display, and the labels on two ends of the dumbbell line cannot be hide. The overall graph looks messy.
<img width="1024" alt="Screenshot 2024-03-05 at 7 35 39 PM" src="https://github.com/Texera/texera/assets/43344272/1386cf10-49f6-4916-8ec8-87c9d4eb9980">

