### PR TITLE
Fix empty groupby key in Aggregate Op

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/aggregate/AggregateOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/aggregate/AggregateOpDesc.scala
@@ -111,6 +111,7 @@ class AggregateOpDesc extends LogicalOp {
     ) {
       return null
     }
+    if (groupByKeys == null) groupByKeys = List()
     Schema
       .builder()
       .add(


### PR DESCRIPTION
This PR fixes an issue where an empty groupby key would break the propagation of Aggregate Op.