### PR TITLE
Remove the Dependency of Environment when Workflow executes without user system enabled

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionsMetadataPersistService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionsMetadataPersistService.scala
@@ -6,6 +6,7 @@ import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, Workf
 import edu.uci.ics.texera.web.SqlServer
 import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.WorkflowExecutionsDao
 import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.WorkflowExecutions
+import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowResource
 import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowVersionResource._
 import edu.uci.ics.texera.workflow.common.WorkflowContext.DEFAULT_EXECUTION_ID
 import org.jooq.types.UInteger
@@ -34,12 +35,14 @@ object ExecutionsMetadataPersistService extends LazyLogging {
       workflowId: WorkflowIdentity,
       uid: Option[UInteger],
       executionName: String,
-      environmentVersion: String,
-      environmentEid: UInteger
+      environmentVersion: String
   ): ExecutionIdentity = {
     if (!AmberConfig.isUserSystemEnabled) return DEFAULT_EXECUTION_ID
     // first retrieve the latest version of this workflow
     val vid = getLatestVersion(UInteger.valueOf(workflowId.id))
+    // fetch the workflow's environment eid
+    val environmentEid =
+      WorkflowResource.getEnvironmentEidOfWorkflow(UInteger.valueOf(workflowId.id))
     val newExecution = new WorkflowExecutions()
     if (executionName != "") {
       newExecution.setName(executionName)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -15,7 +15,6 @@ import edu.uci.ics.amber.engine.common.virtualidentity.{
 }
 import edu.uci.ics.texera.web.model.websocket.event.TexeraWebSocketEvent
 import edu.uci.ics.texera.web.model.websocket.request.WorkflowExecuteRequest
-import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowResource
 import edu.uci.ics.texera.web.service.WorkflowService.mkWorkflowStateId
 import edu.uci.ics.texera.web.storage.ExecutionStateStore.updateWorkflowState
 import edu.uci.ics.texera.web.storage.{ExecutionStateStore, WorkflowStateStore}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -153,15 +153,11 @@ class WorkflowService(
     val workflowContext: WorkflowContext = createWorkflowContext(uidOpt)
     var controllerConf = ControllerConfig.default
 
-    // fetch the workflow's environment eid
-    val environmentEid =
-      WorkflowResource.getEnvironmentEidOfWorkflow(UInteger.valueOf(workflowContext.workflowId.id))
     workflowContext.executionId = ExecutionsMetadataPersistService.insertNewExecution(
       workflowContext.workflowId,
       workflowContext.userId,
       req.executionName,
-      convertToJson(req.engineVersion),
-      environmentEid
+      convertToJson(req.engineVersion)
     )
 
     if (AmberConfig.isUserSystemEnabled) {


### PR DESCRIPTION
This PR fixes the issue that when user system is enabled, the workflow execution still depends on the environment and MySQL.

## How the fix is done

Since when user system is enabled, the workflow execution will be stored in the MySQL, along with the `environment_eid` which indicates which environment the workflow execution happens. I moved the fetch of `environment_eid` to the `ExecutionsMetadataPersistService.insertNewExecution`, only when user system is enabled will the environment_eid be fetched.

## Some consideration

Regarding #2451 , since the whole dataset+environment things rely on MySQL, and `user-system-enabled` flag indicates whether to use MySQL, in this fix I didn't include another flag to enable/disable environment, as this flag has dependency with `user-system-enabled`, meaning that this `environment-on` flag will only work if `user-system-enabled` is on. I think we can discuss and introduce this flag in the future development.
