### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -86,7 +86,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
 
     steps:
       - name: Checkout Texera


### PR DESCRIPTION
As PyArrow supports Python 3.11, we are now adding support for Python 3.11 as well.