### PR TITLE
Fix initialization issue for Mongo sink storage 

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/managed/ProgressiveSinkOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/managed/ProgressiveSinkOpExec.scala
@@ -8,6 +8,11 @@ import edu.uci.ics.texera.workflow.operators.sink.storage.SinkStorageWriter
 
 class ProgressiveSinkOpExec(outputMode: IncrementalOutputMode, storage: SinkStorageWriter)
     extends SinkOperatorExecutor {
+
+  override def open(): Unit = {
+    storage.open()
+  }
+
   override def consumeTuple(
       tuple: Tuple,
       input: Int
@@ -26,6 +31,10 @@ class ProgressiveSinkOpExec(outputMode: IncrementalOutputMode, storage: SinkStor
     } else {
       storage.removeOne(tupleValue)
     }
+  }
+
+  override def close(): Unit = {
+    storage.close()
   }
 
 }


### PR DESCRIPTION
This PR fixed a bug introduced by #2463 where the open/close calls of the sink operator are accidentally being removed.