### PR TITLE
Fix angular warnings

### DIFF
--- a/core/new-gui/nx.json
+++ b/core/new-gui/nx.json
@@ -1,5 +1,4 @@
 {
-  "defaultProject": "texera-gui",
   "tasksRunnerOptions": {
     "default": {
       "runner": "@nrwl/nx-cloud",

--- a/core/new-gui/tsconfig.json
+++ b/core/new-gui/tsconfig.json
@@ -12,11 +12,12 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "target": "es2019",
+    "target": "ES2022",
     "typeRoots": ["node_modules/@types"],
-    "lib": ["es2019", "dom"],
+    "lib": ["ES2022", "dom"],
     "module": "esnext",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "useDefineForClassFields": false,
   },
   "angularCompilerOptions": {
     "strictTemplates": true


### PR DESCRIPTION
This PR fixes warnings during angular building. Specifically, it fixes the following two warnings:
1. `Workspace extension with invalid name (defaultProject) found.` `defaultProject` has been deprecated and we remove its usage.
2. 
```
TypeScript compiler options "target" and "useDefineForClassFields" are set to "ES2022" and "false" 
respectively by the Angular CLI. To control ECMA version and features use the Browerslist configuration. 
For more information, see https://angular.io/guide/build#configuring-browser-compatibility 
NOTE: You can set the "target" to "ES2022" in the project's tsconfig to remove this warning.
```
 We update to ES2022 standard.