### PR TITLE
Make mongo collection cleanup upon server restart configurable

### DIFF
--- a/core/amber/src/main/resources/application.conf
+++ b/core/amber/src/main/resources/application.conf
@@ -64,6 +64,7 @@ web-server {
     workflow-state-cleanup-in-seconds = 30
     python-console-buffer-size = 100
     workflow-result-pulling-in-seconds = 3
+    clean-all-execution-results-on-server-start = false
 }
 
 fault-tolerance {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberConfig.scala
@@ -98,6 +98,8 @@ object AmberConfig {
     getConfSource.getInt("web-server.workflow-state-cleanup-in-seconds")
   val workflowVersionCollapseIntervalInMinutes: Int =
     getConfSource.getInt("user-sys.version-time-limit-in-minutes")
+  val cleanupAllExecutionResults: Boolean =
+    getConfSource.getBoolean("web-server.clean-all-execution-results-on-server-start")
 
   // JDBC configuration
   val jdbcConfig: Config = getConfSource.getConfig("jdbc")


### PR DESCRIPTION
as title. By default, the configuration is set to false, which means the server will not clean up the "running" execution results.