### PR TITLE
Clear the workflow metadata when workspace view destroy

### DIFF
--- a/core/new-gui/src/app/workspace/component/workspace.component.ts
+++ b/core/new-gui/src/app/workspace/component/workspace.component.ts
@@ -119,6 +119,7 @@ export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
+    this.workflowActionService.setWorkflowMetadata(undefined);
     this.workflowActionService.destroySharedModel();
     this.workflowWebsocketService.closeWebsocket();
   }


### PR DESCRIPTION
This PR resolves the issue that:
when switching from workspace of workflow with wid `a`, to workspace of workflow with wid `b`. wid `a` is showing up when components in the workspace(e.g. left-panel) try to retrieve the wid from the workflowActionService.

## How the fix is done

Add one line in the `ngOnDestroy` of `workspace.component`, to set the workflowMetadata as the `DEFAULT_WORKFLOW`