### PR TITLE
Fix the issue of retrieving the incorrect wid when version-list component is initializing

### DIFF
--- a/core/new-gui/src/app/workspace/component/left-panel/left-panel.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/left-panel/left-panel.component.spec.ts
@@ -6,6 +6,7 @@ import { WorkflowActionService } from "../../service/workflow-graph/model/workfl
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { OperatorMetadataService } from "../../service/operator-metadata/operator-metadata.service";
 import { StubOperatorMetadataService } from "../../service/operator-metadata/stub-operator-metadata.service";
+import { RouterTestingModule } from "@angular/router/testing";
 
 describe("LeftPanelComponent", () => {
   let component: LeftPanelComponent;
@@ -15,7 +16,7 @@ describe("LeftPanelComponent", () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule],
+      imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
       providers: [
         {
           provide: OperatorMetadataService,

--- a/core/new-gui/src/app/workspace/component/left-panel/versions-list/versions-list.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/left-panel/versions-list/versions-list.component.spec.ts
@@ -6,7 +6,7 @@ import { FormlyModule } from "@ngx-formly/core";
 import { TEXERA_FORMLY_CONFIG } from "../../../../common/formly/formly-config";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { VersionsListComponent } from "./versions-list.component";
-import {RouterTestingModule} from "@angular/router/testing";
+import { RouterTestingModule } from "@angular/router/testing";
 
 describe("VersionsListDisplayComponent", () => {
   let component: VersionsListComponent;

--- a/core/new-gui/src/app/workspace/component/left-panel/versions-list/versions-list.component.spec.ts
+++ b/core/new-gui/src/app/workspace/component/left-panel/versions-list/versions-list.component.spec.ts
@@ -6,6 +6,7 @@ import { FormlyModule } from "@ngx-formly/core";
 import { TEXERA_FORMLY_CONFIG } from "../../../../common/formly/formly-config";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
 import { VersionsListComponent } from "./versions-list.component";
+import {RouterTestingModule} from "@angular/router/testing";
 
 describe("VersionsListDisplayComponent", () => {
   let component: VersionsListComponent;
@@ -22,6 +23,7 @@ describe("VersionsListDisplayComponent", () => {
         FormlyModule.forRoot(TEXERA_FORMLY_CONFIG),
         ReactiveFormsModule,
         HttpClientTestingModule,
+        RouterTestingModule.withRoutes([]),
       ],
     }).compileComponents();
   }));

--- a/core/new-gui/src/app/workspace/component/left-panel/versions-list/versions-list.component.ts
+++ b/core/new-gui/src/app/workspace/component/left-panel/versions-list/versions-list.component.ts
@@ -3,6 +3,7 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { WorkflowActionService } from "../../../service/workflow-graph/model/workflow-action.service";
 import { WorkflowVersionService } from "../../../../dashboard/user/service/workflow-version/workflow-version.service";
 import { WorkflowVersionCollapsableEntry } from "../../../../dashboard/user/type/workflow-version-entry";
+import {ActivatedRoute} from "@angular/router";
 
 @UntilDestroy()
 @Component({
@@ -16,7 +17,8 @@ export class VersionsListComponent implements OnInit {
 
   constructor(
     private workflowActionService: WorkflowActionService,
-    public workflowVersionService: WorkflowVersionService
+    public workflowVersionService: WorkflowVersionService,
+    public route: ActivatedRoute
   ) {}
 
   collapse(index: number, $event: boolean): void {
@@ -39,7 +41,7 @@ export class VersionsListComponent implements OnInit {
     const elements = this.workflowActionService.getJointGraphWrapper().getCurrentHighlights();
     this.workflowActionService.getJointGraphWrapper().unhighlightElements(elements);
     // gets the versions result and updates the workflow versions table displayed on the form
-    const wid = this.workflowActionService.getWorkflowMetadata()?.wid;
+    const wid = this.route.snapshot.params.id;
     if (wid === undefined) {
       return;
     }

--- a/core/new-gui/src/app/workspace/component/left-panel/versions-list/versions-list.component.ts
+++ b/core/new-gui/src/app/workspace/component/left-panel/versions-list/versions-list.component.ts
@@ -3,7 +3,7 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { WorkflowActionService } from "../../../service/workflow-graph/model/workflow-action.service";
 import { WorkflowVersionService } from "../../../../dashboard/user/service/workflow-version/workflow-version.service";
 import { WorkflowVersionCollapsableEntry } from "../../../../dashboard/user/type/workflow-version-entry";
-import {ActivatedRoute} from "@angular/router";
+import { ActivatedRoute } from "@angular/router";
 
 @UntilDestroy()
 @Component({


### PR DESCRIPTION
The PR fixes the issue that:

When version-list component is initializing, the retrieved `wid` using `workflowActionService` may retrieve the `wid` of the previous workflow, instead of current workflow's `wid`.

## How the fix is done.

`wid` is fetched from URL using:

```typescript
const wid = this.route.snapshot.params.id;
```