### PR TITLE
Fix the issue that dataset file preview is wrong when switching between versions

### DIFF
--- a/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-explorer.component.html
+++ b/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-explorer.component.html
@@ -77,7 +77,6 @@
       </div>
     </nz-card>
     <texera-user-dataset-file-renderer
-      *ngIf="!isCreatingDataset"
       [isMaximized]="isMaximized"
       [did]="did"
       [dvid]="selectedVersion?.dvid"

--- a/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.ts
+++ b/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.ts
@@ -109,7 +109,7 @@ export class UserDatasetFileRendererComponent implements OnInit, OnChanges, OnDe
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.did || changes.dvid || changes.filePath) {
+    if ((changes.did && changes.dvid) || changes.filePath) {
       this.reloadFileContent();
     }
   }


### PR DESCRIPTION
This PR fixes the issue that: when switching between different version, say `v2` and `v1` of dataset `d`, the file content being previewed might not be the one that is currently selected. 

## How the fix is done

By changing the reloading condition of `file-renderer` component, the renderer will shift the preview only when the version switching is finished.