### PR TITLE
Disable Dragging Co-editor's Cursor On Joint Paper

### DIFF
--- a/core/gui/src/app/workspace/service/joint-ui/joint-ui.service.ts
+++ b/core/gui/src/app/workspace/service/joint-ui/joint-ui.service.ts
@@ -1077,7 +1077,6 @@ export class JointUIService {
       "ref-y": 20,
       stroke: coeditor.color,
     });
-    userCursor.set("interactive", false);
     return userCursor;
   }
 

--- a/core/gui/src/app/workspace/service/workflow-graph/model/coeditor-presence.service.ts
+++ b/core/gui/src/app/workspace/service/workflow-graph/model/coeditor-presence.service.ts
@@ -201,6 +201,7 @@ export class CoeditorPresenceService {
               userColor
             );
             this.jointGraph.addCell(newPoint);
+            this.jointGraphWrapper.getMainJointPaper().findViewByModel(newPoint.id).setInteractivity(false);
           }
         }
       } else existingPointer.remove();
@@ -213,6 +214,7 @@ export class CoeditorPresenceService {
           userColor
         );
         this.jointGraph.addCell(newPoint);
+        this.jointGraphWrapper.getMainJointPaper().findViewByModel(newPoint.id).setInteractivity(false);
       }
     }
   }


### PR DESCRIPTION
This PR actually fixes #2033. The previous PR #2490 does not fix the issue because it was setting the interactivity on the element, which has no effect. The interactivity option can only be set on the joint paper. Below is a demo to show the fix works.

![Screen Recording 2024-03-28 at 12 48 21](https://github.com/Texera/texera/assets/36582710/39c42cf8-398a-4ec2-8384-0d72ba96c2c0)
