### PR TITLE
Hide the dummy operator in the operator list

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/dummy/DummyOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/dummy/DummyOpDesc.scala
@@ -40,7 +40,7 @@ class DummyOpDesc extends LogicalOp with PortDescriptor {
     OperatorInfo(
       "Dummy",
       "A dummy operator used as a placeholder.",
-      null,
+      OperatorGroupConstants.UTILITY_GROUP,
       inputPortInfo,
       outputPortInfo,
       dynamicInputPorts = true,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/dummy/DummyOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/dummy/DummyOpDesc.scala
@@ -40,7 +40,7 @@ class DummyOpDesc extends LogicalOp with PortDescriptor {
     OperatorInfo(
       "Dummy",
       "A dummy operator used as a placeholder.",
-      OperatorGroupConstants.UTILITY_GROUP,
+      null,
       inputPortInfo,
       outputPortInfo,
       dynamicInputPorts = true,

--- a/core/gui/src/app/workspace/component/left-panel/operator-menu/operator-menu.component.ts
+++ b/core/gui/src/app/workspace/component/left-panel/operator-menu/operator-menu.component.ts
@@ -126,7 +126,9 @@ export class OperatorMenuComponent implements OnInit {
   private processOperatorMetadata(operatorMetadata: OperatorMetadata): void {
     operatorMetadata = {
       ...operatorMetadata,
-      operators: operatorMetadata.operators.filter(operatorSchema => operatorSchema.operatorType != "PythonUDF"),
+      operators: operatorMetadata.operators
+        .filter(operatorSchema => operatorSchema.operatorType != "PythonUDF")
+        .filter(operatorSchema => operatorSchema.operatorType != "Dummy"),
     };
     this.operatorSchemaList = operatorMetadata.operators;
     this.groupNamesOrdered = getGroupNamesSorted(operatorMetadata.groups);


### PR DESCRIPTION
As the title suggests, we do not want to show this operator to the user as it is only supposed to be created by a converter. Closed Issue #2521.