### PR TITLE
Enable asynchronous workflow stats persistence

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/Utils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/Utils.scala
@@ -122,17 +122,14 @@ object Utils extends LazyLogging {
     */
   def maptoStatusCode(state: WorkflowAggregatedState): Byte = {
     state match {
-      case WorkflowAggregatedState.UNINITIALIZED                   => 0
-      case WorkflowAggregatedState.READY                           => 0
-      case WorkflowAggregatedState.RUNNING                         => 1
-      case WorkflowAggregatedState.PAUSING                         => ???
-      case WorkflowAggregatedState.PAUSED                          => 2
-      case WorkflowAggregatedState.RESUMING                        => ???
-      case WorkflowAggregatedState.COMPLETED                       => 3
-      case WorkflowAggregatedState.FAILED                          => 4
-      case WorkflowAggregatedState.UNKNOWN                         => ???
-      case WorkflowAggregatedState.KILLED                          => 5
-      case WorkflowAggregatedState.Unrecognized(unrecognizedValue) => ???
+      case WorkflowAggregatedState.UNINITIALIZED => 0
+      case WorkflowAggregatedState.READY         => 0
+      case WorkflowAggregatedState.RUNNING       => 1
+      case WorkflowAggregatedState.PAUSED        => 2
+      case WorkflowAggregatedState.COMPLETED     => 3
+      case WorkflowAggregatedState.FAILED        => 4
+      case WorkflowAggregatedState.KILLED        => 5
+      case other                                 => -1
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionStatsService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionStatsService.scala
@@ -146,7 +146,7 @@ class ExecutionStatsService(
     val defaultStats =
       OperatorRuntimeStats(WorkflowAggregatedState.UNINITIALIZED, 0, 0, 0, 0, 0, 0)
 
-    var newStateInfo = newStats
+    var statsMap = newStats
 
     // Find keys present in newState.operatorInfo but not in oldState.operatorInfo
     val newKeys = newStats.keys.toSet diff lastPersistedStats.keys.toSet
@@ -157,11 +157,11 @@ class ExecutionStatsService(
     // Find keys present in oldState.operatorInfo but not in newState.operatorInfo
     val oldKeys = lastPersistedStats.keys.toSet diff newStats.keys.toSet
     for (key <- oldKeys) {
-      newStateInfo = newStateInfo + (key -> lastPersistedStats(key))
+      statsMap = statsMap + (key -> lastPersistedStats(key))
     }
 
-    newStateInfo.keys.map { key =>
-      val newStats = newStateInfo(key)
+    statsMap.keys.map { key =>
+      val newStats = statsMap(key)
       val oldStats = lastPersistedStats(key)
       val res = OperatorRuntimeStats(
         newStats.state,


### PR DESCRIPTION
This PR makes the persistence of workflow statistics asynchronous, so that it does not block the websocket events. Additionally, it alters the behavior for mapping states to numbers in MySQL: previously, an absence of a mapping would result in an error, but now such cases are mapped to -1.

This PR should fix #2528, but it needs to be tested on the deployment.