### PR TITLE
Remove the file loading animation when creating the dataset

### DIFF
--- a/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-explorer.component.html
+++ b/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-explorer.component.html
@@ -21,7 +21,7 @@
   <nz-content
     [ngClass]="{'grayed-out': !isDisplayingDataset(), 'disabled-click': !isDisplayingDataset()}"
     style="background-color: white">
-    <nz-card *ngIf="!isCreatingDataset">
+    <nz-card *ngIf="isDisplayingDataset()">
       <div style="display: flex; justify-content: space-between; align-items: center">
         <div>
           <h3 class="file-title"><b>{{currentDisplayedFileName}}</b></h3>
@@ -85,6 +85,7 @@
       </div>
     </nz-card>
     <texera-user-dataset-file-renderer
+      *ngIf="isDisplayingDataset()"
       [isMaximized]="isMaximized"
       [did]="did"
       [dvid]="selectedVersion?.dvid"


### PR DESCRIPTION
Before the fix, there is a redundant file loading animation:

![2024-03-28 23 03 13](https://github.com/Texera/texera/assets/43344272/bd62b6e2-4d11-402f-96e6-fcb4d46e9e21)

After the fix, this animation is removed:
<img width="1709" alt="Screenshot 2024-03-28 at 11 04 24 PM" src="https://github.com/Texera/texera/assets/43344272/33758b1c-2565-44b2-b082-8d1da40d72e4">
