### PR TITLE
Regard `Files` tab as the `Results` used to only store the workflows' outputs

### DIFF
--- a/core/gui/src/app/dashboard/user/component/dashboard.component.html
+++ b/core/gui/src/app/dashboard/user/component/dashboard.component.html
@@ -39,14 +39,14 @@
 
       <li
         nz-menu-item
-        nz-tooltip="Look up the user files"
+        nz-tooltip="Look up for workflow result files"
         nzMatchRouter="true"
         nzTooltipPlacement="right"
         routerLink="/dashboard/user-file">
         <span
           nz-icon
           nzType="folder-open"></span>
-        <span>Files</span>
+        <span>Results</span>
       </li>
 
       <li

--- a/core/gui/src/app/dashboard/user/component/user-file/user-file.component.html
+++ b/core/gui/src/app/dashboard/user/component/user-file/user-file.component.html
@@ -1,6 +1,6 @@
 <div class="section-container subsection-grid-container">
   <nz-card class="section-title">
-    <h2 class="page-title">Files</h2>
+    <h2 class="page-title">Results</h2>
     <div class="d-inline-block">
       <a
         [nzDropdownMenu]="menu"
@@ -45,17 +45,6 @@
           </li>
         </ul>
       </nz-dropdown-menu>
-      <button
-        (click)="openFileAddComponent()"
-        nz-button
-        nz-tooltip="Upload file"
-        title="Upload file"
-        nzTooltipPlacement="bottom">
-        <i
-          nz-icon
-          nzTheme="outline"
-          nzType="upload"></i>
-      </button>
     </div>
   </nz-card>
 
@@ -70,7 +59,7 @@
         [nzAutocomplete]="auto"
         nz-input
         nzBackdrop="false"
-        placeholder="Search User Files..."
+        placeholder="Search Workflow Result Files..."
         type="text" />
       <ng-template #suffixIconSearch>
         <i

--- a/core/gui/src/app/dashboard/user/component/user-file/user-file.component.ts
+++ b/core/gui/src/app/dashboard/user/component/user-file/user-file.component.ts
@@ -42,15 +42,6 @@ export class UserFileComponent implements OnInit {
     this.refreshDashboardFileEntries();
   }
 
-  public openFileAddComponent() {
-    const modalRef = this.modalService.create({
-      nzContent: NgbdModalFileAddComponent,
-      nzFooter: null,
-      nzTitle: "Add Files",
-    });
-    modalRef.afterClose.pipe(untilDestroyed(this)).subscribe(() => this.refreshDashboardFileEntries());
-  }
-
   public searchInputOnChange(value: string): void {
     this.isTyping = true;
     this.filteredFilenames = [];


### PR DESCRIPTION
This PR changes the `Files` tab to become the `Results` tab. It:
1. Disallow users to upload any file through `Results`
2. Still enable users to manage the saved workflow results.

Before the changes:
<img width="1715" alt="Screenshot 2024-03-28 at 11 51 02 PM" src="https://github.com/Texera/texera/assets/43344272/d834314d-8919-4f09-9312-617e24742540">

After the changes:
<img width="1724" alt="Screenshot 2024-03-28 at 11 48 47 PM" src="https://github.com/Texera/texera/assets/43344272/194c7815-34ba-4696-9830-f87135ba2ddd">

