### PR TITLE
Make newly-created workflow persist to the database directly

### DIFF
--- a/core/gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
+++ b/core/gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, Input, ViewChild } from "@angular/core";
 import { Router } from "@angular/router";
 import { NzModalService } from "ng-zorro-antd/modal";
-import {firstValueFrom, of} from "rxjs";
+import { firstValueFrom, of } from "rxjs";
 import {
   DEFAULT_WORKFLOW_NAME,
   WorkflowPersistService,
@@ -21,8 +21,10 @@ import { SearchResultsComponent } from "../search-results/search-results.compone
 import { SearchService } from "../../service/search.service";
 import { SortMethod } from "../../type/sort-method";
 import { isDefined } from "../../../../common/util/predicate";
-import {UserProjectService} from "../../service/user-project/user-project.service";
-import {filter, map, mergeMap, tap} from "rxjs/operators";
+import { UserProjectService } from "../../service/user-project/user-project.service";
+import { filter, map, mergeMap, tap } from "rxjs/operators";
+import { DashboardDataset } from "../../type/dashboard-dataset.interface";
+import { DashboardWorkflow } from "../../type/dashboard-workflow.interface";
 
 export const ROUTER_WORKFLOW_CREATE_NEW_URL = "/";
 /**
@@ -190,23 +192,29 @@ export class UserWorkflowComponent implements AfterViewInit {
    * create a new workflow. will redirect to a pre-emptied workspace
    */
   public onClickCreateNewWorkflowFromDashboard(): void {
-    const emptyWorkflowContent = {operators: [], commentBoxes: [], groups: [], links: [], operatorPositions: {}};
+    const emptyWorkflowContent: WorkflowContent = {
+      operators: [],
+      commentBoxes: [],
+      groups: [],
+      links: [],
+      operatorPositions: {},
+    };
     let localPid = this.pid;
-    this.workflowPersistService.createWorkflow(emptyWorkflowContent, DEFAULT_WORKFLOW_NAME)
+    this.workflowPersistService
+      .createWorkflow(emptyWorkflowContent, DEFAULT_WORKFLOW_NAME)
       .pipe(
         tap(createdWorkflow => {
           if (!createdWorkflow.workflow.wid) {
-            throw new Error('Workflow creation failed.');
+            throw new Error("Workflow creation failed.");
           }
         }),
         mergeMap(createdWorkflow => {
           // Check if localPid is defined; if so, add the workflow to the project
           if (localPid) {
-            return this.userProjectService.addWorkflowToProject(localPid, createdWorkflow.workflow.wid!)
-              .pipe(
-                // Regardless of the project addition outcome, pass the wid downstream
-                map(() => createdWorkflow.workflow.wid)
-              );
+            return this.userProjectService.addWorkflowToProject(localPid, createdWorkflow.workflow.wid!).pipe(
+              // Regardless of the project addition outcome, pass the wid downstream
+              map(() => createdWorkflow.workflow.wid)
+            );
           } else {
             // If there's no localPid, skip adding to the project and directly pass the wid downstream
             return of(createdWorkflow.workflow.wid);
@@ -215,11 +223,11 @@ export class UserWorkflowComponent implements AfterViewInit {
         untilDestroyed(this)
       )
       .subscribe({
-        next: (wid) => {
+        next: (wid: number | undefined) => {
           // Use the wid here for navigation
           this.router.navigate([this.ROUTER_WORKFLOW_BASE_URL, wid]).then(null);
         },
-        error: err => this.notificationService.error(`Workflow creation failed: ${err.message}`),
+        error: (err: unknown) => this.notificationService.error("Workflow creation failed"),
       });
   }
 


### PR DESCRIPTION
This PR refines the logic of workflow creation.

In the old workflow creation logic, workflow is physically created(persisted in the database) ONLY after the first modification, including renaming title, add operators. 

In the new workflow creation logic, workflow is physically created when user click the `Create Workflow` button.
![2024-03-30 13 38 07](https://github.com/Texera/texera/assets/43344272/fead9b06-943e-4aaa-8541-bab92bd4ced7)
