### PR TITLE
Replace Gmail Service OAuth with SMTP

### DIFF
--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -126,8 +126,6 @@ val googleServiceDependencies = Seq(
   "com.google.api-client" % "google-api-client" % "2.2.0" exclude ("com.google.guava", "guava"),
   "com.google.apis" % "google-api-services-sheets" % "v4-rev612-1.25.0" exclude ("com.google.guava", "guava"),
   "com.google.apis" % "google-api-services-drive" % "v3-rev197-1.25.0" exclude ("com.google.guava", "guava"),
-  "com.google.apis" % "google-api-services-gmail" % "v1-rev20230925-2.0.0",
-  "com.google.auth" % "google-auth-library-oauth2-http" % "1.19.0",
   "com.sun.mail" % "javax.mail" % "1.6.2"
 )
 

--- a/core/amber/src/main/resources/application.conf
+++ b/core/amber/src/main/resources/application.conf
@@ -37,10 +37,13 @@ cache {
 }
 
 user-sys {
-    enabled = false
-    google{
+    enabled = true
+    google {
         clientId = ""
-        clientSecret = ""
+        smtp {
+            gmail = ""
+            password = ""
+        }
     }
     version-time-limit-in-minutes = 60
     jwt {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberConfig.scala
@@ -88,7 +88,8 @@ object AmberConfig {
   val isUserSystemEnabled: Boolean = getConfSource.getBoolean("user-sys.enabled")
   val jWTConfig: Config = getConfSource.getConfig("user-sys.jwt")
   val googleClientId: String = getConfSource.getString("user-sys.google.clientId")
-  val googleClientSecret: String = getConfSource.getString("user-sys.google.clientSecret")
+  val gmail: String = getConfSource.getString("user-sys.google.smtp.gmail")
+  val smtpPassword: String = getConfSource.getString("user-sys.google.smtp.password")
 
   // Web server configuration
   val operatorConsoleBufferSize: Int = getConfSource.getInt("web-server.python-console-buffer-size")

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
@@ -1,94 +1,25 @@
 package edu.uci.ics.texera.web.resource
 
-import com.google.api.client.googleapis.auth.oauth2.{
-  GoogleAuthorizationCodeTokenRequest,
-  GoogleIdTokenVerifier,
-  GoogleRefreshTokenRequest
-}
-import com.google.api.client.http.javanet.NetHttpTransport
-import com.google.api.client.json.gson.GsonFactory
-import com.google.api.services.gmail.Gmail
-import com.google.api.services.gmail.model.Message
-import com.google.auth.http.HttpCredentialsAdapter
-import com.google.auth.oauth2.{AccessToken, GoogleCredentials}
 import edu.uci.ics.amber.engine.common.AmberConfig
-import edu.uci.ics.texera.Utils
 import edu.uci.ics.texera.web.auth.SessionUser
 import io.dropwizard.auth.Auth
-import org.apache.commons.codec.binary.Base64
 
-import java.io.ByteArrayOutputStream
-import java.nio.file.Files
-import java.util.{Collections, Properties}
+import java.util.Properties
 import javax.annotation.security.RolesAllowed
-import javax.mail.Session
 import javax.mail.internet.{InternetAddress, MimeMessage}
+import javax.mail.{PasswordAuthentication, Session, Transport}
 import javax.ws.rs._
 
 case class EmailMessage(receiver: String, subject: String, content: String)
 @Path("/gmail")
 class GmailResource {
-  final private lazy val path =
-    Utils.amberHomePath.resolve("src").resolve("main").resolve("resources").resolve("gmail")
-  final private lazy val clientId = AmberConfig.googleClientId
-  final private lazy val clientSecret =
-    AmberConfig.googleClientSecret
+  final private lazy val gmail = AmberConfig.gmail
+  final private lazy val password = AmberConfig.smtpPassword
 
-  /**
-    * Use the authorization code to get the refresh token and save it to the file.
-    */
-  @POST
-  @RolesAllowed(Array("ADMIN"))
-  @Path("/sender/auth")
-  def saveRefreshToken(code: String): Unit = {
-    this.revokeAuth()
-    val token = new GoogleAuthorizationCodeTokenRequest(
-      new NetHttpTransport(),
-      new GsonFactory(),
-      clientId,
-      clientSecret,
-      code,
-      "postmessage"
-    ).execute()
-
-    Files.write(
-      path.resolve("refreshToken"),
-      token.getRefreshToken.getBytes
-    )
-
-    Files.write(
-      path.resolve("senderEmail"),
-      new GoogleIdTokenVerifier.Builder(new NetHttpTransport, GsonFactory.getDefaultInstance)
-        .setAudience(Collections.singletonList(clientId))
-        .build()
-        .verify(token.getIdToken)
-        .getPayload
-        .getEmail
-        .getBytes
-    )
-  }
-
-  /**
-    * Delete all the files related to the sender.
-    */
-  @DELETE
-  @RolesAllowed(Array("ADMIN"))
-  @Path("/sender/revoke")
-  def revokeAuth(): Unit = {
-    if (Files.exists(path.resolve("senderEmail"))) Files.delete(path.resolve("senderEmail"))
-    if (Files.exists(path.resolve("refreshToken"))) Files.delete(path.resolve("refreshToken"))
-    if (Files.exists(path.resolve("accessToken"))) Files.delete(path.resolve("accessToken"))
-  }
-
-  /**
-    * Get the sender email.
-    */
   @GET
   @RolesAllowed(Array("ADMIN"))
   @Path("/sender/email")
-  def getSenderEmail: String = {
-    new String(Files.readAllBytes(path.resolve("senderEmail")))
-  }
+  def getSenderEmail: String = gmail
 
   /**
     * Send an email to the user.
@@ -97,27 +28,22 @@ class GmailResource {
   @RolesAllowed(Array("REGULAR", "ADMIN"))
   @Path("/send")
   def sendEmail(emailMessage: EmailMessage, @Auth user: SessionUser): Unit = {
-    val accessTokenPath = path.resolve("accessToken")
-    if (!Files.exists(accessTokenPath)) {
-      Files.write(
-        accessTokenPath,
-        new GoogleRefreshTokenRequest(
-          new NetHttpTransport(),
-          new GsonFactory(),
-          new String(Files.readAllBytes(path.resolve("refreshToken"))),
-          clientId,
-          clientSecret
-        ).execute().getAccessToken.getBytes
+    val prop = new Properties()
+    prop.put("mail.smtp.host", "smtp.gmail.com")
+    prop.put("mail.smtp.port", "465")
+    prop.put("mail.smtp.auth", "true")
+    prop.put("mail.smtp.socketFactory.port", "465")
+    prop.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory")
+
+    val email = new MimeMessage(
+      Session.getInstance(
+        prop,
+        new javax.mail.Authenticator() {
+          override def getPasswordAuthentication: PasswordAuthentication =
+            new PasswordAuthentication(gmail, password)
+        }
       )
-    }
-    val accessToken = new String(Files.readAllBytes(accessTokenPath))
-    val credentials = GoogleCredentials.create(new AccessToken(accessToken, null))
-    val service = new Gmail.Builder(
-      new NetHttpTransport(),
-      GsonFactory.getDefaultInstance,
-      new HttpCredentialsAdapter(credentials)
-    ).setApplicationName("Gmail samples").build()
-    val email = new MimeMessage(Session.getDefaultInstance(new Properties(), null))
+    )
     email.setFrom(new InternetAddress("me"))
     email.addRecipient(
       javax.mail.Message.RecipientType.TO,
@@ -125,10 +51,6 @@ class GmailResource {
     )
     email.setSubject(emailMessage.subject)
     email.setText(emailMessage.content)
-    val buffer = new ByteArrayOutputStream()
-    email.writeTo(buffer)
-    val message = new Message()
-    message.setRaw(Base64.encodeBase64URLSafeString(buffer.toByteArray))
-    service.users().messages().send("me", message).execute()
+    Transport.send(email)
   }
 }

--- a/core/gui/src/app/dashboard/admin/component/gmail/gmail.component.html
+++ b/core/gui/src/app/dashboard/admin/component/gmail/gmail.component.html
@@ -8,104 +8,67 @@
   </h2>
 </nz-card>
 
-<div
-  nz-row
-  style="margin: 5px">
-  <div
-    nz-col
-    nzSpan="12">
-    <nz-card
-      style="margin: 5px; height: 100%"
-      nzTitle="Authorization">
-      <div *ngIf="email; else loggedOut">
-        <nz-alert
-          nzType="success"
-          nzMessage="Authorized with Email: {{email}}"></nz-alert>
-      </div>
-      <ng-template #loggedOut>
-        <nz-alert
-          nzType="error"
-          nzMessage="Not Authorized!"></nz-alert>
-      </ng-template>
+<nz-card
+  style="margin: 5px; height: 100%"
+  nzTitle="Send Email">
+  <form
+    nz-form
+    [formGroup]="validateForm"
+    (ngSubmit)="sendTestEmail()">
+    <nz-form-item>
+      <nz-form-label [nzSpan]="6">Sender</nz-form-label>
+      <nz-form-control style="font-size: 14px"> {{email}} </nz-form-control>
+    </nz-form-item>
+
+    <nz-form-item>
+      <nz-form-label
+        [nzSpan]="6"
+        nzRequired
+        >Recipient</nz-form-label
+      >
+      <nz-form-control nzHasFeedback>
+        <input
+          nz-input
+          formControlName="email"
+          placeholder="Email"
+          type="email" />
+      </nz-form-control>
+    </nz-form-item>
+
+    <nz-form-item>
+      <nz-form-label
+        [nzSpan]="6"
+        nzRequired
+        >Subject</nz-form-label
+      >
+      <nz-form-control nzHasFeedback>
+        <input
+          nz-input
+          formControlName="subject" />
+      </nz-form-control>
+    </nz-form-item>
+
+    <nz-form-item>
+      <nz-form-label
+        [nzSpan]="6"
+        nzRequired
+        >Content</nz-form-label
+      >
+      <nz-form-control nzHasFeedback>
+        <textarea
+          formControlName="content"
+          nz-input
+          rows="3"></textarea>
+      </nz-form-control>
+    </nz-form-item>
+    <nz-form-item>
       <button
-        (click)="revokeAuth()"
         nz-button
         nzType="primary"
-        style="width: 100%; margin-top: 10px"
-        nzDanger
-        [disabled]="!email">
-        Revoke
+        [disabled]="!validateForm.valid"
+        style="width: 100%">
+        Submit
       </button>
-      <button
-        (click)="auth()"
-        nz-button
-        nzType="primary"
-        style="width: 100%; margin-top: 10px">
-        Authorize
-      </button>
-    </nz-card>
-  </div>
-  <div
-    nz-col
-    nzSpan="12">
-    <nz-card
-      style="margin: 5px; height: 100%"
-      nzTitle="Send Email">
-      <form
-        nz-form
-        [formGroup]="validateForm"
-        (ngSubmit)="sendTestEmail()">
-        <nz-form-item>
-          <nz-form-label
-            [nzSpan]="6"
-            nzRequired
-            >E-mail</nz-form-label
-          >
-          <nz-form-control nzHasFeedback>
-            <input
-              nz-input
-              formControlName="email"
-              placeholder="Recipient"
-              type="email" />
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label
-            [nzSpan]="6"
-            nzRequired
-            >Subject</nz-form-label
-          >
-          <nz-form-control nzHasFeedback>
-            <input
-              nz-input
-              formControlName="subject" />
-          </nz-form-control>
-        </nz-form-item>
-
-        <nz-form-item>
-          <nz-form-label
-            [nzSpan]="6"
-            nzRequired
-            >Content</nz-form-label
-          >
-          <nz-form-control nzHasFeedback>
-            <textarea
-              formControlName="content"
-              nz-input
-              rows="3"></textarea>
-          </nz-form-control>
-        </nz-form-item>
-        <nz-form-item>
-          <button
-            nz-button
-            nzType="primary"
-            [disabled]="!validateForm.valid"
-            style="width: 100%">
-            Submit
-          </button>
-        </nz-form-item>
-      </form>
-    </nz-card>
-  </div>
-</div>
+    </nz-form-item>
+  </form>
+</nz-card>

--- a/core/gui/src/app/dashboard/admin/component/gmail/gmail.component.scss
+++ b/core/gui/src/app/dashboard/admin/component/gmail/gmail.component.scss
@@ -1,7 +1,3 @@
-.login-form-button {
-  width: 100%;
-}
-
 .form {
   border: 2px solid black;
   border-radius: 5px;

--- a/core/gui/src/app/dashboard/admin/component/gmail/gmail.component.ts
+++ b/core/gui/src/app/dashboard/admin/component/gmail/gmail.component.ts
@@ -22,20 +22,7 @@ export class GmailComponent implements OnInit {
       subject: [null, [Validators.required]],
       content: [null, [Validators.required]],
     });
-    this.gmailAuthService.authSender();
     this.getSenderEmail();
-  }
-
-  public auth() {
-    this.gmailAuthService.client.requestCode();
-    this.gmailAuthService.googleCredentialResponse.pipe(untilDestroyed(this)).subscribe(() => this.getSenderEmail());
-  }
-
-  public revokeAuth() {
-    this.gmailAuthService
-      .revokeAuth()
-      .pipe(untilDestroyed(this))
-      .subscribe(() => this.getSenderEmail());
   }
 
   getSenderEmail() {

--- a/core/gui/src/app/dashboard/admin/service/gmail.service.ts
+++ b/core/gui/src/app/dashboard/admin/service/gmail.service.ts
@@ -1,40 +1,17 @@
 import { Injectable } from "@angular/core";
 import { HttpClient, HttpErrorResponse } from "@angular/common/http";
 import { AppSettings } from "../../../common/app-setting";
-import { Subject } from "rxjs";
-import { CredentialResponse } from "../../../common/service/user/google-auth.service";
 import { NotificationService } from "../../../common/service/notification/notification.service";
-declare var window: any;
 @Injectable({
   providedIn: "root",
 })
 export class GmailService {
   public client: any;
-  private _googleCredentialResponse = new Subject<CredentialResponse>();
   constructor(
     private http: HttpClient,
     private notificationService: NotificationService
   ) {}
-  public authSender() {
-    this.http
-      .get(`${AppSettings.getApiEndpoint()}/auth/google/clientid`, { responseType: "text" })
-      .subscribe(response => {
-        this.client = window.google.accounts.oauth2.initCodeClient({
-          access_type: "offline",
-          scope: "email https://www.googleapis.com/auth/gmail.send",
-          client_id: response,
-          callback: (auth: any) => {
-            this.http
-              .post(`${AppSettings.getApiEndpoint()}/gmail/sender/auth`, `${auth.code}`)
-              .subscribe(() => this._googleCredentialResponse.next(auth));
-          },
-        });
-      });
-  }
 
-  public revokeAuth() {
-    return this.http.delete(`${AppSettings.getApiEndpoint()}/gmail/sender/revoke`);
-  }
   public getSenderEmail() {
     return this.http.get(`${AppSettings.getApiEndpoint()}/gmail/sender/email`, { responseType: "text" });
   }
@@ -50,9 +27,5 @@ export class GmailService {
           }
         },
       });
-  }
-
-  get googleCredentialResponse() {
-    return this._googleCredentialResponse.asObservable();
   }
 }


### PR DESCRIPTION
Since the Google OAuth Screen is not very easy to use we need to reverify every several days such that we decided to replace the OAuth with SMTP. 

After this PR, we just need to fill in the Gmail username and app password in the config file to use the Gmail service.

App password can be generated from https://myaccount.google.com/apppasswords