### PR TITLE
Apply debounce time on all changes triggering schema propagation

### DIFF
--- a/core/gui/src/app/workspace/service/dynamic-schema/auto-attribute-correction/auto-attribute-correction.service.spec.ts
+++ b/core/gui/src/app/workspace/service/dynamic-schema/auto-attribute-correction/auto-attribute-correction.service.spec.ts
@@ -28,7 +28,6 @@ import {
 } from "../schema-propagation/schema-propagation.service";
 
 describe("AutoAttributeCorrectionService", () => {
-  let httpClient: HttpClient;
   let httpTestingController: HttpTestingController;
 
   beforeEach(() => {
@@ -46,7 +45,6 @@ describe("AutoAttributeCorrectionService", () => {
       ],
     });
 
-    httpClient = TestBed.inject(HttpClient);
     httpTestingController = TestBed.inject(HttpTestingController);
     environment.schemaPropagationEnabled = true;
   });
@@ -62,7 +60,7 @@ describe("AutoAttributeCorrectionService", () => {
     workflowActionService.addOperator(mockSentimentOperatorA, mockPoint);
     workflowActionService.addOperator(mockSentimentOperatorB, mockPoint);
     workflowActionService.addLink(mockLinkAtoB);
-
+    tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS + 1);
     const req1 = httpTestingController.expectOne(
       `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/${DEFAULT_WORKFLOW.wid}`
     );
@@ -75,7 +73,7 @@ describe("AutoAttributeCorrectionService", () => {
 
     // trigger inputSchemaChangeStream
     workflowActionService.setOperatorProperty(mockSentimentOperatorA.operatorID, { testAttr: "test" });
-    tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
+    tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS + 1);
     const req2 = httpTestingController.expectOne(
       `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/${DEFAULT_WORKFLOW.wid}`
     );
@@ -100,7 +98,7 @@ describe("AutoAttributeCorrectionService", () => {
     workflowActionService.addOperator(mockSentimentOperatorA, mockPoint);
     workflowActionService.addOperator(mockSentimentOperatorB, mockPoint);
     workflowActionService.addLink(mockLinkAtoB);
-
+    tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS + 1);
     const req1 = httpTestingController.expectOne(
       `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/${DEFAULT_WORKFLOW.wid}`
     );
@@ -140,11 +138,13 @@ describe("AutoAttributeCorrectionService", () => {
     workflowActionService.addOperator(mockSentimentOperatorB, mockPoint);
     workflowActionService.addOperator(mockSentimentOperatorC, mockPoint);
     workflowActionService.addLink(mockLinkAtoB);
+    tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS + 1);
     httpTestingController.expectOne(
       `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/${DEFAULT_WORKFLOW.wid}`
     );
     workflowActionService.addLink(mockLinkBtoC);
 
+    tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS + 1);
     const req1 = httpTestingController.expectOne(
       `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/${DEFAULT_WORKFLOW.wid}`
     );
@@ -157,7 +157,7 @@ describe("AutoAttributeCorrectionService", () => {
 
     // trigger inputSchemaChangeStream
     workflowActionService.setOperatorProperty(mockSentimentOperatorA.operatorID, { testAttr: "test" });
-    tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS);
+    tick(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS + 1);
     const req2 = httpTestingController.expectOne(
       `${AppSettings.getApiEndpoint()}/${SCHEMA_PROPAGATION_ENDPOINT}/${DEFAULT_WORKFLOW.wid}`
     );

--- a/core/gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.ts
+++ b/core/gui/src/app/workspace/service/dynamic-schema/schema-propagation/schema-propagation.service.ts
@@ -49,12 +49,10 @@ export class SchemaPropagationService {
     merge(
       this.workflowActionService.getTexeraGraph().getLinkAddStream(),
       this.workflowActionService.getTexeraGraph().getLinkDeleteStream(),
-      this.workflowActionService
-        .getTexeraGraph()
-        .getOperatorPropertyChangeStream()
-        .pipe(debounceTime(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS)),
+      this.workflowActionService.getTexeraGraph().getOperatorPropertyChangeStream(),
       this.workflowActionService.getTexeraGraph().getDisabledOperatorsChangedStream()
     )
+      .pipe(debounceTime(SCHEMA_PROPAGATION_DEBOUNCE_TIME_MS))
       .pipe(
         mergeMap(() => this.invokeSchemaPropagationAPI()),
         filter(response => response.code === 0)


### PR DESCRIPTION
Schema propagation is executed too frequently during workflow reloading. There was a debounce time but it did not apply to disable operator changes, or link changes. This PR moves the debounce time to apply to all related events.