### PR TITLE
Refine the gui of inputing file name for source scan operator

### DIFF
--- a/core/amber/src/main/resources/application.conf
+++ b/core/amber/src/main/resources/application.conf
@@ -37,7 +37,7 @@ cache {
 }
 
 user-sys {
-    enabled = true
+    enabled = false
     google {
         clientId = ""
         smtp {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
@@ -265,7 +265,6 @@ object DatasetResource {
       did: UInteger,
       dvid: UInteger
   ): util.List[String] = {
-    val dataset = getDatasetByID(ctx, did, uid)
     val versionHash = getDatasetVersionHashByID(ctx, did, dvid, uid)
 
     val fileNodes = GitVersionControlLocalFileStorage.retrieveRootFileNodesOfVersion(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/type/FileNode.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/type/FileNode.java
@@ -11,7 +11,7 @@ import java.util.Set;
 public class FileNode {
   private final Path absoluteFilePath;
 
-  private final Path relativeFilePath;
+  private Path relativeFilePath;
   private final Set<FileNode> children;
 
   public FileNode(Path repoPath, Path path) {
@@ -35,6 +35,16 @@ public class FileNode {
   public Path getRelativePath() {
     return relativeFilePath;
   }
+
+  public void setRelativeFilePathParent(String parentDirName) {
+    // Create a new Path object for the parent directory name
+    Path parentDirPath = Path.of(parentDirName);
+
+    // Resolve the current relativeFilePath against the new parent directory
+    // This effectively adds the parentDirName as the new parent of the relativeFilePath
+    this.relativeFilePath = parentDirPath.resolve(this.relativeFilePath);
+  }
+
 
   public void addChildNode(FileNode child) {
     if (!child.getAbsolutePath().getParent().equals(this.absoluteFilePath)) {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/type/FileNode.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/type/FileNode.java
@@ -36,15 +36,6 @@ public class FileNode {
     return relativeFilePath;
   }
 
-  public void setRelativeFilePathParent(String parentDirName) {
-    // Create a new Path object for the parent directory name
-    Path parentDirPath = Path.of(parentDirName);
-
-    // Resolve the current relativeFilePath against the new parent directory
-    // This effectively adds the parentDirName as the new parent of the relativeFilePath
-    this.relativeFilePath = parentDirPath.resolve(this.relativeFilePath);
-  }
-
 
   public void addChildNode(FileNode child) {
     if (!child.getAbsolutePath().getParent().equals(this.absoluteFilePath)) {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/type/FileNode.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/type/FileNode.java
@@ -11,7 +11,7 @@ import java.util.Set;
 public class FileNode {
   private final Path absoluteFilePath;
 
-  private Path relativeFilePath;
+  private final Path relativeFilePath;
   private final Set<FileNode> children;
 
   public FileNode(Path repoPath, Path path) {
@@ -35,7 +35,6 @@ public class FileNode {
   public Path getRelativePath() {
     return relativeFilePath;
   }
-
 
   public void addChildNode(FileNode child) {
     if (!child.getAbsolutePath().getParent().equals(this.absoluteFilePath)) {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/environment/EnvironmentResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/environment/EnvironmentResource.scala
@@ -621,7 +621,6 @@ class EnvironmentResource {
           datasetVersionHash
         )
         val datasetName = entry.dataset.getName
-        fileTree.forEach(node => node.setRelativeFilePathParent(datasetName))
         result += DatasetFileNodes(datasetName, fileTree.asScala.toList)
       })
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/environment/EnvironmentResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/environment/EnvironmentResource.scala
@@ -3,17 +3,50 @@ package edu.uci.ics.texera.web.resource.dashboard.user.environment
 import edu.uci.ics.texera.Utils.withTransaction
 import edu.uci.ics.texera.web.SqlServer
 import edu.uci.ics.texera.web.auth.SessionUser
-import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.{Dataset, DatasetOfEnvironment, DatasetVersion, Environment}
+import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.{
+  Dataset,
+  DatasetOfEnvironment,
+  DatasetVersion,
+  Environment
+}
 import edu.uci.ics.texera.web.model.jooq.generated.tables.Environment.ENVIRONMENT
 import edu.uci.ics.texera.web.model.jooq.generated.tables.EnvironmentOfWorkflow.ENVIRONMENT_OF_WORKFLOW
 import edu.uci.ics.texera.web.model.jooq.generated.tables.DatasetOfEnvironment.DATASET_OF_ENVIRONMENT
-import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{DatasetDao, DatasetOfEnvironmentDao, DatasetVersionDao, EnvironmentDao, EnvironmentOfWorkflowDao}
-import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetResource.{DatasetVersionRootFileNodes, retrieveDatasetVersionFilePaths}
+import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{
+  DatasetDao,
+  DatasetOfEnvironmentDao,
+  DatasetVersionDao,
+  EnvironmentDao,
+  EnvironmentOfWorkflowDao
+}
+import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetResource.retrieveDatasetVersionFilePaths
 import edu.uci.ics.texera.web.resource.dashboard.user.dataset.`type`.{DatasetFileDesc, FileNode}
 import edu.uci.ics.texera.web.resource.dashboard.user.dataset.service.GitVersionControlLocalFileStorage
 import edu.uci.ics.texera.web.resource.dashboard.user.dataset.utils.PathUtils
-import edu.uci.ics.texera.web.resource.dashboard.user.dataset.{DatasetAccessResource, DatasetResource}
-import edu.uci.ics.texera.web.resource.dashboard.user.environment.EnvironmentResource.{DashboardEnvironment, DatasetFileNodes, DatasetID, DatasetOfEnvironmentAlreadyExistsMessage, DatasetOfEnvironmentDetails, DatasetOfEnvironmentDoseNotExistMessage, DatasetVersionID, EnvironmentIDs, UserNoPermissionExceptionMessage, WorkflowLink, context, doesDatasetExistInEnvironment, doesUserOwnEnvironment, getEnvironmentByEid, retrieveDatasetsAndVersions, retrieveDatasetsOfEnvironmentFileList, userHasReadAccessToEnvironment, userHasWriteAccessToEnvironment}
+import edu.uci.ics.texera.web.resource.dashboard.user.dataset.{
+  DatasetAccessResource,
+  DatasetResource
+}
+import edu.uci.ics.texera.web.resource.dashboard.user.environment.EnvironmentResource.{
+  DashboardEnvironment,
+  DatasetFileNodes,
+  DatasetID,
+  DatasetOfEnvironmentAlreadyExistsMessage,
+  DatasetOfEnvironmentDetails,
+  DatasetOfEnvironmentDoseNotExistMessage,
+  DatasetVersionID,
+  EnvironmentIDs,
+  UserNoPermissionExceptionMessage,
+  WorkflowLink,
+  context,
+  doesDatasetExistInEnvironment,
+  doesUserOwnEnvironment,
+  getEnvironmentByEid,
+  retrieveDatasetsAndVersions,
+  retrieveDatasetsOfEnvironmentFileList,
+  userHasReadAccessToEnvironment,
+  userHasWriteAccessToEnvironment
+}
 import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowAccessResource
 import io.dropwizard.auth.Auth
 import org.jooq.DSLContext
@@ -21,7 +54,6 @@ import org.jooq.types.UInteger
 
 import java.net.URLDecoder
 import java.nio.file.Paths
-import java.util
 import javax.annotation.security.RolesAllowed
 import javax.ws.rs.core.{MediaType, Response}
 import javax.ws.rs.{GET, POST, Path, PathParam, Produces}
@@ -569,9 +601,9 @@ class EnvironmentResource {
   @GET
   @Path("/{eid}/fileNodes")
   def getDatasetsFileNodeList(
-                               @Auth user: SessionUser,
-                               @PathParam("eid") eid: UInteger,
-                             ): List[DatasetFileNodes] = {
+      @Auth user: SessionUser,
+      @PathParam("eid") eid: UInteger
+  ): List[DatasetFileNodes] = {
     val uid = user.getUid
 
     withTransaction(context)(ctx => {

--- a/core/gui/src/app/app.module.ts
+++ b/core/gui/src/app/app.module.ts
@@ -133,6 +133,7 @@ import { NzTreeViewModule } from "ng-zorro-antd/tree-view";
 import { NzNoAnimationModule } from "ng-zorro-antd/core/no-animation";
 import { TreeModule } from "@ali-hm/angular-tree-component";
 import { EnvironmentComponent } from "./workspace/component/left-panel/environment/environment.component";
+import {FileSelectionComponent} from "./workspace/component/file-selection/file-selection.component";
 
 registerLocaleData(en);
 
@@ -201,6 +202,7 @@ registerLocaleData(en);
     ContextMenuComponent,
     CoeditorUserIconComponent,
     InputAutoCompleteComponent,
+    FileSelectionComponent,
     CollabWrapperComponent,
     HomeComponent,
     UserWorkflowListItemComponent,

--- a/core/gui/src/app/app.module.ts
+++ b/core/gui/src/app/app.module.ts
@@ -133,7 +133,7 @@ import { NzTreeViewModule } from "ng-zorro-antd/tree-view";
 import { NzNoAnimationModule } from "ng-zorro-antd/core/no-animation";
 import { TreeModule } from "@ali-hm/angular-tree-component";
 import { EnvironmentComponent } from "./workspace/component/left-panel/environment/environment.component";
-import {FileSelectionComponent} from "./workspace/component/file-selection/file-selection.component";
+import { FileSelectionComponent } from "./workspace/component/file-selection/file-selection.component";
 
 registerLocaleData(en);
 

--- a/core/gui/src/app/common/type/datasetVersionFileTree.ts
+++ b/core/gui/src/app/common/type/datasetVersionFileTree.ts
@@ -47,6 +47,7 @@ export function getPathsFromTreeNode(node: DatasetVersionFileTreeNode): string[]
   return gatherPaths(node, node.parentDir === "/" ? "/" + node.name : node.parentDir + "/" + node.name);
 }
 
+// This class convert a list of DatasetVersionTreeNode into a hash map, recursively containing all the paths
 export class DatasetVersionFileTreeManager {
   private root: DatasetVersionFileTreeNode = { name: "/", type: "directory", children: [], parentDir: "" };
   private treeNodesMap: Map<string, DatasetVersionFileTreeNode> = new Map<string, DatasetVersionFileTreeNode>();

--- a/core/gui/src/app/common/type/datasetVersionFileTree.ts
+++ b/core/gui/src/app/common/type/datasetVersionFileTree.ts
@@ -219,17 +219,27 @@ export function parseFileNodesToTreeNodes(
   fileNodes: FileNode[],
   datasetName: string = ""
 ): DatasetVersionFileTreeNode[] {
-  return fileNodes.map(fileNode => {
-    const splitPath = fileNode.path.split("/");
-    const name = splitPath.pop() || ""; // Get the last segment as name
-    const parentDir = splitPath.length > 0 ? "/" + datasetName + "/" + splitPath.join("/") : "/" + datasetName; // Join the rest as parent directory
+  // Ensure datasetName is formatted correctly as a path prefix
+  const datasetPrefix = datasetName ? `/${datasetName}` : "";
 
+  return fileNodes.map(fileNode => {
+    // Split the path to work with its segments
+    const splitPath = fileNode.path.split("/");
+    const name = splitPath.pop() || ""; // Get the last segment as the name
+
+    // Construct the parentDir
+    // If there are remaining segments, join them as the path, prefixed by the datasetPrefix
+    // Otherwise, use the datasetPrefix directly (or just "/" if datasetName is empty)
+    const parentDir = splitPath.length > 0 ? `${datasetPrefix}/${splitPath.join("/")}` : datasetPrefix || "/";
+
+    // Define the new tree node
     const treeNode: DatasetVersionFileTreeNode = {
-      name: name,
+      name,
       type: fileNode.isFile ? "file" : "directory",
-      parentDir: parentDir,
+      parentDir,
     };
 
+    // Recursively process children if it's a directory
     if (!fileNode.isFile && fileNode.children) {
       treeNode.children = parseFileNodesToTreeNodes(fileNode.children, datasetName);
     }

--- a/core/gui/src/app/common/type/datasetVersionFileTree.ts
+++ b/core/gui/src/app/common/type/datasetVersionFileTree.ts
@@ -213,14 +213,16 @@ export function parseFileUploadItemToTreeNodes(fileUploadItems: FileUploadItem[]
   return root.children ?? []; // Return the top-level nodes (excluding the root)
 }
 
+// parse the file nodes passed by the backend to tree nodes that are displayable in frontend
+// datasetName is an optional parameter, when given, the datasetName should be the prefix of every parentDir
 export function parseFileNodesToTreeNodes(
   fileNodes: FileNode[],
-  parentPath: string = ""
+  datasetName: string = ""
 ): DatasetVersionFileTreeNode[] {
   return fileNodes.map(fileNode => {
     const splitPath = fileNode.path.split("/");
     const name = splitPath.pop() || ""; // Get the last segment as name
-    const parentDir = splitPath.length > 0 ? "/" + splitPath.join("/") : "/"; // Join the rest as parent directory
+    const parentDir = splitPath.length > 0 ? "/" + datasetName + "/" + splitPath.join("/") : "/" + datasetName; // Join the rest as parent directory
 
     const treeNode: DatasetVersionFileTreeNode = {
       name: name,
@@ -229,7 +231,7 @@ export function parseFileNodesToTreeNodes(
     };
 
     if (!fileNode.isFile && fileNode.children) {
-      treeNode.children = parseFileNodesToTreeNodes(fileNode.children, fileNode.path);
+      treeNode.children = parseFileNodesToTreeNodes(fileNode.children, datasetName);
     }
 
     return treeNode;

--- a/core/gui/src/app/common/type/datasetVersionFileTree.ts
+++ b/core/gui/src/app/common/type/datasetVersionFileTree.ts
@@ -12,6 +12,10 @@ export interface DatasetVersionFileTreeNode {
   parentDir: string;
 }
 
+export interface EnvironmentDatasetFileNodes {
+  datasetName: string;
+  fileNodes: DatasetVersionFileTreeNode[];
+}
 export function getFullPathFromFileTreeNode(node: DatasetVersionFileTreeNode): string {
   if (node.parentDir == "/") {
     // make sure the files/directory located at the root layer has '/' as the prefix

--- a/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-explorer.component.ts
+++ b/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-explorer.component.ts
@@ -181,6 +181,7 @@ export class UserDatasetExplorerComponent implements OnInit {
   }
 
   loadFileContent(node: DatasetVersionFileTreeNode) {
+    console.log(node);
     this.currentDisplayedFileName = getFullPathFromFileTreeNode(node);
   }
 

--- a/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.html
+++ b/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.html
@@ -1,5 +1,6 @@
 <div class="file-tree-container">
   <tree-root
+    #tree
     [nodes]="fileTreeNodes"
     [options]="fileTreeDisplayOptions">
     <ng-template

--- a/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.ts
+++ b/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-version-filetree/user-dataset-version-filetree.component.ts
@@ -1,5 +1,15 @@
 import { UntilDestroy } from "@ngneat/until-destroy";
-import { Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges } from "@angular/core";
+import {
+  AfterViewInit,
+  Component,
+  EventEmitter,
+  Input,
+  OnChanges,
+  OnInit,
+  Output,
+  SimpleChanges,
+  ViewChild,
+} from "@angular/core";
 import {
   DatasetVersionFileTreeNode,
   getFullPathFromFileTreeNode,
@@ -12,12 +22,17 @@ import { ITreeOptions, TREE_ACTIONS } from "@ali-hm/angular-tree-component";
   templateUrl: "./user-dataset-version-filetree.component.html",
   styleUrls: ["./user-dataset-version-filetree.component.scss"],
 })
-export class UserDatasetVersionFiletreeComponent {
+export class UserDatasetVersionFiletreeComponent implements AfterViewInit {
   @Input()
   public isTreeNodeDeletable: boolean = false;
 
   @Input()
   public fileTreeNodes: DatasetVersionFileTreeNode[] = [];
+
+  @Input()
+  public isExpandAllAfterViewInit = false;
+
+  @ViewChild("tree") tree: any;
 
   public fileTreeDisplayOptions: ITreeOptions = {
     displayField: "name",
@@ -46,5 +61,11 @@ export class UserDatasetVersionFiletreeComponent {
   onNodeDeleted(node: DatasetVersionFileTreeNode): void {
     // look up for the DatasetVersionFileTreeNode
     this.deletedTreeNode.emit(node);
+  }
+
+  ngAfterViewInit(): void {
+    if (this.isExpandAllAfterViewInit) {
+      this.tree.treeModel.expandAll();
+    }
   }
 }

--- a/core/gui/src/app/dashboard/user/service/user-environment/environment.service.ts
+++ b/core/gui/src/app/dashboard/user/service/user-environment/environment.service.ts
@@ -7,12 +7,15 @@ import { catchError, filter, map } from "rxjs/operators";
 import { AppSettings } from "../../../../common/app-setting";
 import { DatasetOfEnvironment, DatasetOfEnvironmentDetails, Environment } from "../../../../common/type/environment";
 import { DashboardDataset } from "../../type/dashboard-dataset.interface";
-import { DATASET_BASE_URL } from "../user-dataset/dataset.service";
+import {DATASET_BASE_URL, DATASET_VERSION_BASE_URL} from "../user-dataset/dataset.service";
+import {DatasetVersionFileTreeNode, EnvironmentDatasetFileNodes, parseFileNodesToTreeNodes} from "../../../../common/type/datasetVersionFileTree";
+import {FileNode} from "../../../../common/type/fileNode";
 
 export const ENVIRONMENT_BASE_URL = "environment";
 export const ENVIRONMENT_CREATE_URL = ENVIRONMENT_BASE_URL + "/create";
 export const ENVIRONMENT_DELETE_URL = ENVIRONMENT_BASE_URL + "/delete";
 export const ENVIRONMENT_GET_DATASETS_FILELIST = "files";
+export const ENVIRONMENT_GET_DATASETS_FILENODE_LIST = "fileNodes";
 export const ENVIRONMENT_DATASET_RETRIEVAL_URL = "dataset";
 export const ENVIRONMENT_DATASET_DETAILS_RETRIEVAL_URL = ENVIRONMENT_DATASET_RETRIEVAL_URL + "/details";
 
@@ -71,6 +74,27 @@ export class EnvironmentService {
     return this.http.post<Response>(`${AppSettings.getApiEndpoint()}/${ENVIRONMENT_DELETE_URL}`, {
       eids: eids,
     });
+  }
+
+  public getDatasetsFileNodeList(eid: number): Observable<DatasetVersionFileTreeNode[]> {
+    return this.http
+        .get<{
+          datasetName: string,
+          fileNodes: FileNode[];
+        }[]>(`${AppSettings.getApiEndpoint()}/${ENVIRONMENT_BASE_URL}/${eid}/${ENVIRONMENT_GET_DATASETS_FILENODE_LIST}`)
+        .pipe(map(response => {
+          let nodes: DatasetVersionFileTreeNode[] = [];
+          response.forEach(entry => {
+            const datasetDirectoryNode: DatasetVersionFileTreeNode = {
+              name: entry.datasetName,
+              type: 'directory',
+              parentDir: '/',
+              children: parseFileNodesToTreeNodes(entry.fileNodes)
+            };
+            nodes.push(datasetDirectoryNode);
+          });
+          return nodes;
+        }));
   }
 
   public getDatasetsFileList(eid: number, query: String): Observable<ReadonlyArray<string>> {

--- a/core/gui/src/app/dashboard/user/service/user-environment/environment.service.ts
+++ b/core/gui/src/app/dashboard/user/service/user-environment/environment.service.ts
@@ -99,7 +99,6 @@ export class EnvironmentService {
               children: parseFileNodesToTreeNodes(entry.fileNodes, entry.datasetName),
             };
             nodes.push(datasetDirectoryNode);
-            console.log(nodes)
           });
           return nodes;
         })

--- a/core/gui/src/app/dashboard/user/service/user-environment/environment.service.ts
+++ b/core/gui/src/app/dashboard/user/service/user-environment/environment.service.ts
@@ -96,9 +96,10 @@ export class EnvironmentService {
               name: entry.datasetName,
               type: "directory",
               parentDir: "/",
-              children: parseFileNodesToTreeNodes(entry.fileNodes),
+              children: parseFileNodesToTreeNodes(entry.fileNodes, entry.datasetName),
             };
             nodes.push(datasetDirectoryNode);
+            console.log(nodes)
           });
           return nodes;
         })

--- a/core/gui/src/app/dashboard/user/service/user-environment/environment.service.ts
+++ b/core/gui/src/app/dashboard/user/service/user-environment/environment.service.ts
@@ -7,9 +7,13 @@ import { catchError, filter, map } from "rxjs/operators";
 import { AppSettings } from "../../../../common/app-setting";
 import { DatasetOfEnvironment, DatasetOfEnvironmentDetails, Environment } from "../../../../common/type/environment";
 import { DashboardDataset } from "../../type/dashboard-dataset.interface";
-import {DATASET_BASE_URL, DATASET_VERSION_BASE_URL} from "../user-dataset/dataset.service";
-import {DatasetVersionFileTreeNode, EnvironmentDatasetFileNodes, parseFileNodesToTreeNodes} from "../../../../common/type/datasetVersionFileTree";
-import {FileNode} from "../../../../common/type/fileNode";
+import { DATASET_BASE_URL, DATASET_VERSION_BASE_URL } from "../user-dataset/dataset.service";
+import {
+  DatasetVersionFileTreeNode,
+  EnvironmentDatasetFileNodes,
+  parseFileNodesToTreeNodes,
+} from "../../../../common/type/datasetVersionFileTree";
+import { FileNode } from "../../../../common/type/fileNode";
 
 export const ENVIRONMENT_BASE_URL = "environment";
 export const ENVIRONMENT_CREATE_URL = ENVIRONMENT_BASE_URL + "/create";
@@ -78,23 +82,27 @@ export class EnvironmentService {
 
   public getDatasetsFileNodeList(eid: number): Observable<DatasetVersionFileTreeNode[]> {
     return this.http
-        .get<{
-          datasetName: string,
+      .get<
+        {
+          datasetName: string;
           fileNodes: FileNode[];
-        }[]>(`${AppSettings.getApiEndpoint()}/${ENVIRONMENT_BASE_URL}/${eid}/${ENVIRONMENT_GET_DATASETS_FILENODE_LIST}`)
-        .pipe(map(response => {
+        }[]
+      >(`${AppSettings.getApiEndpoint()}/${ENVIRONMENT_BASE_URL}/${eid}/${ENVIRONMENT_GET_DATASETS_FILENODE_LIST}`)
+      .pipe(
+        map(response => {
           let nodes: DatasetVersionFileTreeNode[] = [];
           response.forEach(entry => {
             const datasetDirectoryNode: DatasetVersionFileTreeNode = {
               name: entry.datasetName,
-              type: 'directory',
-              parentDir: '/',
-              children: parseFileNodesToTreeNodes(entry.fileNodes)
+              type: "directory",
+              parentDir: "/",
+              children: parseFileNodesToTreeNodes(entry.fileNodes),
             };
             nodes.push(datasetDirectoryNode);
           });
           return nodes;
-        }));
+        })
+      );
   }
 
   public getDatasetsFileList(eid: number, query: String): Observable<ReadonlyArray<string>> {

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -1,5 +1,6 @@
 <input
   nz-input
+  placeholder="Search for files from datasets..."
   [(ngModel)]="filterText"
   (ngModelChange)="filterFileTreeNodes()" />
 

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -1,0 +1,11 @@
+<input
+  nz-input
+  [(ngModel)]="filterText"
+  (ngModelChange)="filterFileTreeNodes()"
+/>
+
+<texera-user-dataset-version-filetree
+  [fileTreeNodes]="suggestedFileTreeNodes"
+  (selectedTreeNode)="onFileTreeNodeSelected($event)"
+>
+</texera-user-dataset-version-filetree>

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -1,11 +1,10 @@
 <input
   nz-input
   [(ngModel)]="filterText"
-  (ngModelChange)="filterFileTreeNodes()"
-/>
+  (ngModelChange)="filterFileTreeNodes()" />
 
 <texera-user-dataset-version-filetree
+  [isExpandAllAfterViewInit]="true"
   [fileTreeNodes]="suggestedFileTreeNodes"
-  (selectedTreeNode)="onFileTreeNodeSelected($event)"
->
+  (selectedTreeNode)="onFileTreeNodeSelected($event)">
 </texera-user-dataset-version-filetree>

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -22,6 +22,7 @@ export class FileSelectionComponent {
   constructor(private modalRef: NzModalRef) {}
 
   ngOnInit() {
+    console.log(this.fileTreeNodes);
     this.suggestedFileTreeNodes = [...this.fileTreeNodes]; // Initially, suggested nodes are all nodes
   }
 
@@ -64,7 +65,8 @@ export class FileSelectionComponent {
   }
 
   onFileTreeNodeSelected(node: DatasetVersionFileTreeNode) {
-    const selectedNodePath = getFullPathFromFileTreeNode(node).replace(/^\/+/, "");
+    const selectedNodePath = getFullPathFromFileTreeNode(node);
+    console.log("before pruning: ", selectedNodePath)
     this.modalRef.close(selectedNodePath);
   }
 }

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -1,0 +1,36 @@
+import {Component, inject, Input} from '@angular/core';
+import {NZ_MODAL_DATA, NzModalRef} from 'ng-zorro-antd/modal';
+import { UntilDestroy } from "@ngneat/until-destroy";
+import {DatasetVersionFileTreeNode, EnvironmentDatasetFileNodes, getFullPathFromFileTreeNode} from "../../../common/type/datasetVersionFileTree";
+
+@UntilDestroy()
+@Component({
+  selector: 'texera-file-selection-model',
+  templateUrl: "file-selection.component.html",
+  styleUrls: ["file-selection.component.scss"]
+})
+export class FileSelectionComponent {
+  readonly fileTreeNodes: ReadonlyArray<DatasetVersionFileTreeNode> = inject(NZ_MODAL_DATA).fileTreeNodes;
+  suggestedFileTreeNodes: DatasetVersionFileTreeNode[] = [];
+  filterText: string = '';
+
+  constructor(private modalRef: NzModalRef) {}
+
+  ngOnInit() {
+    this.suggestedFileTreeNodes = [...this.fileTreeNodes]; // Initially, suggested nodes are all nodes
+  }
+
+  filterFileTreeNodes() {
+    if (!this.filterText) {
+      this.suggestedFileTreeNodes = [...this.fileTreeNodes];
+    } else {
+      const lowerCaseFilterText = this.filterText.toLowerCase();
+      this.suggestedFileTreeNodes = this.fileTreeNodes.filter(node =>
+        getFullPathFromFileTreeNode(node).toLowerCase().includes(lowerCaseFilterText));
+    }
+  }
+
+  onFileTreeNodeSelected(node: DatasetVersionFileTreeNode) {
+    this.modalRef.close(getFullPathFromFileTreeNode(node));
+  }
+}

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -22,7 +22,6 @@ export class FileSelectionComponent {
   constructor(private modalRef: NzModalRef) {}
 
   ngOnInit() {
-    console.log(this.fileTreeNodes);
     this.suggestedFileTreeNodes = [...this.fileTreeNodes]; // Initially, suggested nodes are all nodes
   }
 
@@ -66,7 +65,6 @@ export class FileSelectionComponent {
 
   onFileTreeNodeSelected(node: DatasetVersionFileTreeNode) {
     const selectedNodePath = getFullPathFromFileTreeNode(node);
-    console.log("before pruning: ", selectedNodePath)
     this.modalRef.close(selectedNodePath);
   }
 }

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -1,18 +1,23 @@
-import {Component, inject, Input} from '@angular/core';
-import {NZ_MODAL_DATA, NzModalRef} from 'ng-zorro-antd/modal';
+import { Component, inject, Input } from "@angular/core";
+import { NZ_MODAL_DATA, NzModalRef } from "ng-zorro-antd/modal";
 import { UntilDestroy } from "@ngneat/until-destroy";
-import {DatasetVersionFileTreeManager, DatasetVersionFileTreeNode, EnvironmentDatasetFileNodes, getFullPathFromFileTreeNode} from "../../../common/type/datasetVersionFileTree";
+import {
+  DatasetVersionFileTreeManager,
+  DatasetVersionFileTreeNode,
+  EnvironmentDatasetFileNodes,
+  getFullPathFromFileTreeNode,
+} from "../../../common/type/datasetVersionFileTree";
 
 @UntilDestroy()
 @Component({
-  selector: 'texera-file-selection-model',
+  selector: "texera-file-selection-model",
   templateUrl: "file-selection.component.html",
-  styleUrls: ["file-selection.component.scss"]
+  styleUrls: ["file-selection.component.scss"],
 })
 export class FileSelectionComponent {
   readonly fileTreeNodes: ReadonlyArray<DatasetVersionFileTreeNode> = inject(NZ_MODAL_DATA).fileTreeNodes;
   suggestedFileTreeNodes: DatasetVersionFileTreeNode[] = [];
-  filterText: string = '';
+  filterText: string = "";
 
   constructor(private modalRef: NzModalRef) {}
 
@@ -36,8 +41,10 @@ export class FileSelectionComponent {
         }
 
         // If the node is a directory, check its children
-        if (node.type === 'directory' && node.children) {
-          const filteredChildren = node.children.map(child => filterNodes(child)).filter(child => child !== null) as DatasetVersionFileTreeNode[];
+        if (node.type === "directory" && node.children) {
+          const filteredChildren = node.children
+            .map(child => filterNodes(child))
+            .filter(child => child !== null) as DatasetVersionFileTreeNode[];
 
           if (filteredChildren.length > 0) {
             // If any children match, return the current node with filtered children
@@ -50,10 +57,11 @@ export class FileSelectionComponent {
       };
 
       // Apply filter to each root node and remove any that are null after filtering
-      this.suggestedFileTreeNodes = this.fileTreeNodes.map(node => filterNodes(node)).filter(node => node !== null) as DatasetVersionFileTreeNode[];
+      this.suggestedFileTreeNodes = this.fileTreeNodes
+        .map(node => filterNodes(node))
+        .filter(node => node !== null) as DatasetVersionFileTreeNode[];
     }
   }
-
 
   onFileTreeNodeSelected(node: DatasetVersionFileTreeNode) {
     const selectedNodePath = getFullPathFromFileTreeNode(node).replace(/^\/+/, "");

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.html
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.html
@@ -1,11 +1,11 @@
 <input
-  (input)="autocomplete()"
-  (focus)="autocomplete()"
   nz-input
+  [readOnly]="isFileSelectionEnabled"
   required
-  [nzAutocomplete]="auto"
   [formControl]="formControl"
-  [formlyAttributes]="field" />
+  [formlyAttributes]="field"
+  (click)="isFileSelectionEnabled && onClickOpenFileSelectionModal()"
+/>
 <div
   class="alert alert-danger"
   role="alert"

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.html
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.html
@@ -4,8 +4,7 @@
   required
   [formControl]="formControl"
   [formlyAttributes]="field"
-  (click)="isFileSelectionEnabled && onClickOpenFileSelectionModal()"
-/>
+  (click)="isFileSelectionEnabled && onClickOpenFileSelectionModal()" />
 <div
   class="alert alert-danger"
   role="alert"

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.spec.ts
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed, waitForAsync } from "@angular/core/testing";
 import { FormControl, ReactiveFormsModule } from "@angular/forms";
 import { InputAutoCompleteComponent } from "./input-autocomplete.component";
 import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { NzModalService } from "ng-zorro-antd/modal";
 
 describe("InputAutoCompleteComponent", () => {
   let component: InputAutoCompleteComponent;
@@ -11,6 +12,7 @@ describe("InputAutoCompleteComponent", () => {
     TestBed.configureTestingModule({
       declarations: [InputAutoCompleteComponent],
       imports: [ReactiveFormsModule, HttpClientTestingModule],
+      providers: [NzModalService],
     }).compileComponents();
   }));
 

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
@@ -52,7 +52,7 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
                   },
                 });
                 // Handle the selection from the modal
-                modal.afterClose.subscribe(result => {
+                modal.afterClose.pipe(untilDestroyed(this)).subscribe(result => {
                   if (result) {
                     this.formControl.setValue(result); // Assuming 'result' is the selected value
                   }

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
@@ -29,42 +29,6 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
     super();
   }
 
-  autocomplete(): void {
-    // currently it's a hard-code DatasetFile autocomplete
-    // TODO: generalize this callback function with a formly hook.
-    const value = this.field.formControl.value.trim();
-    const wid = this.workflowActionService.getWorkflowMetadata()?.wid;
-    if (wid) {
-      // fetch the wid first
-      this.workflowPersistService
-        .retrieveWorkflowEnvironment(wid)
-        .pipe(untilDestroyed(this))
-        .subscribe({
-          next: env => {
-            // then we fetch the file list inorder to do the autocomplete, perform auto-complete based on the current input
-            const eid = env.eid;
-            if (eid) {
-              let query = value;
-              if (value.length == 0) {
-                query = "";
-              }
-              this.environmentService
-                .getDatasetsFileList(eid, query)
-                .pipe(debounceTime(300))
-                .pipe(untilDestroyed(this))
-                .subscribe(suggestedFiles => {
-                  // check if there is a difference between new and previous suggestion
-                  const updated =
-                    this.suggestions.length != suggestedFiles.length ||
-                    this.suggestions.some((e, i) => e !== suggestedFiles[i]);
-                  if (updated) this.suggestions = [...suggestedFiles];
-                });
-            }
-          },
-        });
-    }
-  }
-
   onClickOpenFileSelectionModal(): void {
     const wid = this.workflowActionService.getWorkflowMetadata()?.wid;
     if (wid) {
@@ -80,7 +44,6 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
                 .getDatasetsFileNodeList(eid)
                 .pipe(untilDestroyed(this))
                 .subscribe(fileNodes => {
-                  console.log("fileNodes: ", fileNodes);
                   const modal = this.modalService.create({
                     nzTitle: "Please select one file from datasets",
                     nzContent: FileSelectionComponent,

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
@@ -6,9 +6,9 @@ import { map } from "rxjs";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 import { EnvironmentService } from "../../../dashboard/user/service/user-environment/environment.service";
 import { WorkflowPersistService } from "../../../common/service/workflow-persist/workflow-persist.service";
-import {NzModalService} from "ng-zorro-antd/modal";
-import {FileSelectionComponent} from "../file-selection/file-selection.component";
-import {environment} from "../../../../environments/environment";
+import { NzModalService } from "ng-zorro-antd/modal";
+import { FileSelectionComponent } from "../file-selection/file-selection.component";
+import { environment } from "../../../../environments/environment";
 
 @UntilDestroy()
 @Component({
@@ -19,8 +19,6 @@ import {environment} from "../../../../environments/environment";
 export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
   // the autocomplete selection list
   public suggestions: string[] = [];
-
-
 
   constructor(
     private modalService: NzModalService,
@@ -82,15 +80,14 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
                 .getDatasetsFileNodeList(eid)
                 .pipe(untilDestroyed(this))
                 .subscribe(fileNodes => {
-
                   console.log("fileNodes: ", fileNodes);
                   const modal = this.modalService.create({
-                    nzTitle: `Please select one file from datasets`,
+                    nzTitle: "Please select one file from datasets",
                     nzContent: FileSelectionComponent,
                     nzFooter: null,
                     nzData: {
-                      fileTreeNodes: fileNodes
-                    }
+                      fileTreeNodes: fileNodes,
+                    },
                   });
                   // Handle the selection from the modal
                   modal.afterClose.subscribe(result => {
@@ -98,7 +95,7 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
                       this.formControl.setValue(result); // Assuming 'result' is the selected value
                     }
                   });
-                })
+                });
             }
           },
         });

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
@@ -35,32 +35,30 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
       this.workflowPersistService
         .retrieveWorkflowEnvironment(wid)
         .pipe(untilDestroyed(this))
-        .subscribe({
-          next: env => {
-            // then we fetch the file list inorder to do the autocomplete, perform auto-complete based on the current input
-            const eid = env.eid;
-            if (eid) {
-              this.environmentService
-                .getDatasetsFileNodeList(eid)
-                .pipe(untilDestroyed(this))
-                .subscribe(fileNodes => {
-                  const modal = this.modalService.create({
-                    nzTitle: "Please select one file from datasets",
-                    nzContent: FileSelectionComponent,
-                    nzFooter: null,
-                    nzData: {
-                      fileTreeNodes: fileNodes,
-                    },
-                  });
-                  // Handle the selection from the modal
-                  modal.afterClose.subscribe(result => {
-                    if (result) {
-                      this.formControl.setValue(result); // Assuming 'result' is the selected value
-                    }
-                  });
+        .subscribe(env => {
+          // then we fetch the file list inorder to do the autocomplete, perform auto-complete based on the current input
+          const eid = env.eid;
+          if (eid) {
+            this.environmentService
+              .getDatasetsFileNodeList(eid)
+              .pipe(untilDestroyed(this))
+              .subscribe(fileNodes => {
+                const modal = this.modalService.create({
+                  nzTitle: "Please select one file from datasets",
+                  nzContent: FileSelectionComponent,
+                  nzFooter: null,
+                  nzData: {
+                    fileTreeNodes: fileNodes,
+                  },
                 });
-            }
-          },
+                // Handle the selection from the modal
+                modal.afterClose.subscribe(result => {
+                  if (result) {
+                    this.formControl.setValue(result); // Assuming 'result' is the selected value
+                  }
+                });
+              });
+          }
         });
     }
   }

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
@@ -6,6 +6,9 @@ import { map } from "rxjs";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 import { EnvironmentService } from "../../../dashboard/user/service/user-environment/environment.service";
 import { WorkflowPersistService } from "../../../common/service/workflow-persist/workflow-persist.service";
+import {NzModalService} from "ng-zorro-antd/modal";
+import {FileSelectionComponent} from "../file-selection/file-selection.component";
+import {environment} from "../../../../environments/environment";
 
 @UntilDestroy()
 @Component({
@@ -17,7 +20,10 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
   // the autocomplete selection list
   public suggestions: string[] = [];
 
+
+
   constructor(
+    private modalService: NzModalService,
     public environmentService: EnvironmentService,
     public workflowActionService: WorkflowActionService,
     public workflowPersistService: WorkflowPersistService
@@ -59,5 +65,47 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
           },
         });
     }
+  }
+
+  onClickOpenFileSelectionModal(): void {
+    const wid = this.workflowActionService.getWorkflowMetadata()?.wid;
+    if (wid) {
+      this.workflowPersistService
+        .retrieveWorkflowEnvironment(wid)
+        .pipe(untilDestroyed(this))
+        .subscribe({
+          next: env => {
+            // then we fetch the file list inorder to do the autocomplete, perform auto-complete based on the current input
+            const eid = env.eid;
+            if (eid) {
+              this.environmentService
+                .getDatasetsFileNodeList(eid)
+                .pipe(untilDestroyed(this))
+                .subscribe(fileNodes => {
+
+                  console.log("fileNodes: ", fileNodes);
+                  const modal = this.modalService.create({
+                    nzTitle: `Please select one file from datasets`,
+                    nzContent: FileSelectionComponent,
+                    nzFooter: null,
+                    nzData: {
+                      fileTreeNodes: fileNodes
+                    }
+                  });
+                  // Handle the selection from the modal
+                  modal.afterClose.subscribe(result => {
+                    if (result) {
+                      this.formControl.setValue(result); // Assuming 'result' is the selected value
+                    }
+                  });
+                })
+            }
+          },
+        });
+    }
+  }
+
+  get isFileSelectionEnabled(): boolean {
+    return environment.userSystemEnabled;
   }
 }

--- a/core/gui/src/app/workspace/component/left-panel/environment/environment.component.ts
+++ b/core/gui/src/app/workspace/component/left-panel/environment/environment.component.ts
@@ -117,6 +117,7 @@ export class EnvironmentComponent implements OnInit {
                   .pipe(untilDestroyed(this))
                   .subscribe({
                     next: datasetFileTree => {
+                      console.log(datasetFileTree)
                       this.datasetsOfEnvironment.set(did, [entry, datasetFileTree]);
                       this.datasetFileTrees.push([did, entry.dataset.name, datasetFileTree]);
                     },

--- a/core/gui/src/app/workspace/component/left-panel/environment/environment.component.ts
+++ b/core/gui/src/app/workspace/component/left-panel/environment/environment.component.ts
@@ -117,7 +117,7 @@ export class EnvironmentComponent implements OnInit {
                   .pipe(untilDestroyed(this))
                   .subscribe({
                     next: datasetFileTree => {
-                      console.log(datasetFileTree)
+                      console.log(datasetFileTree);
                       this.datasetsOfEnvironment.set(did, [entry, datasetFileTree]);
                       this.datasetFileTrees.push([did, entry.dataset.name, datasetFileTree]);
                     },

--- a/core/gui/src/app/workspace/component/left-panel/environment/environment.component.ts
+++ b/core/gui/src/app/workspace/component/left-panel/environment/environment.component.ts
@@ -117,7 +117,6 @@ export class EnvironmentComponent implements OnInit {
                   .pipe(untilDestroyed(this))
                   .subscribe({
                     next: datasetFileTree => {
-                      console.log(datasetFileTree);
                       this.datasetsOfEnvironment.set(did, [entry, datasetFileTree]);
                       this.datasetFileTrees.push([did, entry.dataset.name, datasetFileTree]);
                     },


### PR DESCRIPTION
This PR refines the UI of user inputing file name for the source operator to scan.

### The Old UI

In the old UI, it is hard for user to select the file from the autocomplete list, as it is purely text-based.
<img width="536" alt="Screenshot 2024-04-01 at 10 28 14 AM" src="https://github.com/Texera/texera/assets/43344272/54f31709-12e3-41c4-8e9f-ea35730a9d03">


### The new UI

#### 1. When user system mode is on
The input box is readonly, and when user click the input box, a pop-up window is shown. Users can search the file they would like to scan and select from the file tree:
![2024-04-01 10 42 00](https://github.com/Texera/texera/assets/43344272/561bacb3-bc64-4750-aa00-c53416754ebe)



#### 2. When user system mode is off
The UI stay the same with the old UI.
