### PR TITLE
Fix side-effects of storing statistics after supporting asynchronous workflow stats update

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionStatsService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionStatsService.scala
@@ -134,6 +134,7 @@ class ExecutionStatsService(
           if (AmberConfig.isUserSystemEnabled) {
             statsPersistThread.execute(() => {
               storeRuntimeStatistics(computeStatsDiff(evt.operatorStatistics))
+              lastPersistedStats = evt.operatorStatistics
             })
           }
         })


### PR DESCRIPTION
This PR addresses the unintended consequence of #2529. Prior to #2529, the stored statistics represented the "differences" between the new and old statistics. However, after #2529, the stored statistics were changed to reflect the aggregated sum of the statistics. This was an unintended side-effect, which I have fixed in this PR.