### PR TITLE
Add the `singleFileUploadMaximumSizeMB` in gui configuration to limit uploaded file size

### DIFF
--- a/core/gui/src/app/dashboard/user/component/files-uploader/files-uploader.component.ts
+++ b/core/gui/src/app/dashboard/user/component/files-uploader/files-uploader.component.ts
@@ -5,12 +5,8 @@ import { UserFileUploadService } from "../../service/user-file/user-file-upload.
 import {
   DatasetVersionFileTreeManager,
   DatasetVersionFileTreeNode,
-  getFullPathFromFileTreeNode,
   getPathsFromTreeNode,
-  parseFileUploadItemToTreeNodes,
 } from "../../../../common/type/datasetVersionFileTree";
-import { NzUploadChangeParam, NzUploadFile } from "ng-zorro-antd/upload";
-import { environments } from "eslint-plugin-prettier";
 import { environment } from "../../../../../environments/environment";
 import { NotificationService } from "../../../../common/service/notification/notification.service";
 
@@ -63,10 +59,10 @@ export class FilesUploaderComponent {
           const fileEntry = droppedFile.fileEntry as FileSystemFileEntry;
           fileEntry.file(file => {
             // Check the file size here
-            if (file.size > environment.singleFileUploadSizeLimitMB * 1024 * 1024) {
+            if (file.size > environment.singleFileUploadMaximumSizeMB * 1024 * 1024) {
               // If the file is too large, reject the promise
               this.notificationService.error(
-                `File ${file.name}'s size exceeds the maximum limit of ${environment.singleFileUploadSizeLimitMB}MB.`
+                `File ${file.name}'s size exceeds the maximum limit of ${environment.singleFileUploadMaximumSizeMB}MB.`
               );
               reject(null);
             } else {

--- a/core/gui/src/app/dashboard/user/component/files-uploader/files-uploader.component.ts
+++ b/core/gui/src/app/dashboard/user/component/files-uploader/files-uploader.component.ts
@@ -10,6 +10,9 @@ import {
   parseFileUploadItemToTreeNodes,
 } from "../../../../common/type/datasetVersionFileTree";
 import { NzUploadChangeParam, NzUploadFile } from "ng-zorro-antd/upload";
+import { environments } from "eslint-plugin-prettier";
+import { environment } from "../../../../../environments/environment";
+import { NotificationService } from "../../../../common/service/notification/notification.service";
 
 @Component({
   selector: "texera-user-files-uploader",
@@ -39,6 +42,8 @@ export class FilesUploaderComponent {
   fileUploadBannerType: "error" | "success" | "info" | "warning" = "success";
   fileUploadBannerMessage: string = "";
 
+  constructor(private notificationService: NotificationService) {}
+
   hideBanner() {
     this.fileUploadingFinished = false;
   }
@@ -50,14 +55,25 @@ export class FilesUploaderComponent {
   }
 
   public fileDropped(files: NgxFileDropEntry[]) {
-    // here I use promise to ensure the atomicity of files uploading
+    // this promise create the FileEntry from each of the NgxFileDropEntry
+    // this filePromises is used to ensure the atomicity of file upload
     const filePromises = files.map(droppedFile => {
       return new Promise<FileUploadItem | null>((resolve, reject) => {
         if (droppedFile.fileEntry.isFile) {
           const fileEntry = droppedFile.fileEntry as FileSystemFileEntry;
           fileEntry.file(file => {
-            const fileUploadItem = UserFileUploadService.createFileUploadItemWithPath(file, droppedFile.relativePath);
-            resolve(fileUploadItem);
+            // Check the file size here
+            if (file.size > environment.singleFileUploadSizeLimitMB * 1024 * 1024) {
+              // If the file is too large, reject the promise
+              this.notificationService.error(
+                `File ${file.name}'s size exceeds the maximum limit of ${environment.singleFileUploadSizeLimitMB}MB.`
+              );
+              reject(null);
+            } else {
+              // If the file size is within the limit, proceed
+              const fileUploadItem = UserFileUploadService.createFileUploadItemWithPath(file, droppedFile.relativePath);
+              resolve(fileUploadItem);
+            }
           }, reject);
         } else {
           resolve(null);
@@ -67,6 +83,7 @@ export class FilesUploaderComponent {
 
     Promise.allSettled(filePromises)
       .then(results => {
+        // once all FileUploadItems are created/some of them are rejected, enter this block
         const successfulUploads = results
           .filter((result): result is PromiseFulfilledResult<FileUploadItem | null> => result.status === "fulfilled")
           .map(result => result.value)

--- a/core/gui/src/environments/environment.default.ts
+++ b/core/gui/src/environments/environment.default.ts
@@ -94,7 +94,7 @@ export const defaultEnvironment = {
 
   /**
    */
-  singleFileUploadSizeLimitMB: 20,
+  singleFileUploadMaximumSizeMB: 20,
 };
 
 export type AppEnv = typeof defaultEnvironment;

--- a/core/gui/src/environments/environment.default.ts
+++ b/core/gui/src/environments/environment.default.ts
@@ -91,6 +91,10 @@ export const defaultEnvironment = {
    * reverse proxy set up for y-websocket.
    */
   productionSharedEditingServer: false,
+
+  /**
+   */
+  singleFileUploadSizeLimitMB: 20,
 };
 
 export type AppEnv = typeof defaultEnvironment;


### PR DESCRIPTION
This PR adds a new configuration item, `singleFileUploadMaximumSizeMB`, to the frontend configuration file. When users upload file during the creation of new dataset/version, the file size will be restricted to be under this limit.