### PR TITLE
Fix long "Running" workflow in admin dashboard

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
@@ -100,7 +100,7 @@ class WorkflowExecutionService(
     logger.info("Starting the workflow execution.")
     resultService.attachToExecution(executionStateStore, workflow.originalLogicalPlan, client)
     executionStateStore.metadataStore.updateState(metadataStore =>
-      updateWorkflowState(READY, metadataStore.withExecutionId(workflowContext.executionId))
+      updateWorkflowState(READY, metadataStore)
         .withFatalErrors(Seq.empty)
     )
     executionStateStore.statsStore.updateState(stats =>

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -192,6 +192,10 @@ class WorkflowService(
     }
 
     val executionStateStore = new ExecutionStateStore()
+    // assign execution id to find the execution from DB in case the constructor fails.
+    executionStateStore.metadataStore.updateState(state =>
+      state.withExecutionId(workflowContext.executionId)
+    )
     val errorHandler: Throwable => Unit = { t =>
       {
         logger.error("error during execution", t)


### PR DESCRIPTION
This PR addresses the issue of long "Running" workflows in the admin dashboard.
The root cause was we assigned the execution ID after compilation. If the compilation failed, we would update the execution to a "Failed" state in DB. However, we cannot find the execution in DB using an empty execution ID. 