### PR TITLE
Remove partitioned limit per worker in Limit operator

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/limit/LimitOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/limit/LimitOpDesc.scala
@@ -4,13 +4,11 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.engine.architecture.deploysemantics.PhysicalOp
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfo
-import edu.uci.ics.amber.engine.common.AmberConfig
 import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import edu.uci.ics.amber.engine.common.workflow.{InputPort, OutputPort}
 import edu.uci.ics.texera.workflow.common.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.texera.workflow.common.operators.{LogicalOp, StateTransferFunc}
 import edu.uci.ics.texera.workflow.common.tuple.schema.Schema
-import edu.uci.ics.texera.workflow.operators.util.OperatorDescriptorUtils.equallyPartitionGoal
 
 import scala.util.{Success, Try}
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/limit/LimitOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/limit/LimitOpDesc.scala
@@ -25,13 +25,15 @@ class LimitOpDesc extends LogicalOp {
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity
   ): PhysicalOp = {
-    val limitPerWorker = equallyPartitionGoal(limit, AmberConfig.numWorkerPerOperatorByDefault)
     PhysicalOp
       .oneToOnePhysicalOp(
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecInitInfo((idx, _) => new LimitOpExec(limitPerWorker(idx)))
+        OpExecInitInfo((idx, numWorkers) => {
+          val limitPerWorker = equallyPartitionGoal(limit, numWorkers)
+          new LimitOpExec(limitPerWorker(idx))
+        })
       )
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/limit/LimitOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/limit/LimitOpDesc.scala
@@ -30,9 +30,8 @@ class LimitOpDesc extends LogicalOp {
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecInitInfo((idx, numWorkers) => {
-          val limitPerWorker = equallyPartitionGoal(limit, numWorkers)
-          new LimitOpExec(limitPerWorker(idx))
+        OpExecInitInfo((_, _) => {
+          new LimitOpExec(limit)
         })
       )
       .withInputPorts(operatorInfo.inputPorts)


### PR DESCRIPTION
After #2549, the limit operator now uses 1 worker, we don't need to partition the user-given limit among workers.