### PR TITLE
Fix dataset list item style in search and clear some unused styles & logs

### DIFF
--- a/core/gui/src/app/dashboard/user/component/search-results/search-results.component.html
+++ b/core/gui/src/app/dashboard/user/component/search-results/search-results.component.html
@@ -74,7 +74,7 @@
           <nz-content>
             <texera-user-dataset-list-item
               [editable]="editable"
-              [entry]="entry"
+              [entry]="entry.dataset"
               (deleted)="deleted.emit(entry)"
               (refresh)="modified.emit(entry)">
             </texera-user-dataset-list-item> </nz-content

--- a/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset.component.scss
+++ b/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset.component.scss
@@ -5,7 +5,3 @@
   height: 55px;
   overflow-y: hidden;
 }
-
-.section-list-container {
-  padding-top: 2px;
-}


### PR DESCRIPTION
This PR fixes the issues that when searching dataset in `Search` section, the list item is not clickable:

## Before fix
<img width="1336" alt="Screenshot 2024-04-03 at 9 55 17 AM" src="https://github.com/Texera/texera/assets/43344272/e1bc75fb-622e-4ef3-8484-645c4a823cb1">

## After fix
<img width="515" alt="Screenshot 2024-04-03 at 9 56 34 AM" src="https://github.com/Texera/texera/assets/43344272/581e1d7a-a732-4e39-ab2c-5e6bfb14193a">
