### PR TITLE
Remove "no dot in column names" enforcement for mongo sink

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/storage/MongoDBSinkStorage.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/storage/MongoDBSinkStorage.scala
@@ -91,10 +91,7 @@ class MongoDBSinkStorage(id: String) extends SinkStorageReader {
   override def getSchema: Schema = schema
 
   override def setSchema(schema: Schema): Unit = {
-    // For backward compatibility of old mongoDB(version < 5)
-    schema.getAttributeNames.foreach(name =>
-      assert(!name.matches(".*[\\$\\.].*"), s"illegal attribute name '$name' for mongo DB")
-    )
+    // Now we require mongodb version > 5 to support "." in field names
     this.schema = schema
   }
 }


### PR DESCRIPTION
Since all of our deployments use mongoDB > 5.0, we no longer need to maintain the backward compatibility for old MongoDB. Also, this change enables the flatten operation on jsonl files.