### PR TITLE
Fix schema propagation port order

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/SchemaPropagationResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/SchemaPropagationResource.scala
@@ -53,7 +53,7 @@ class SchemaPropagationResource extends LazyLogging {
     val logicalInputSchemas = physicalInputSchemas
       .groupBy(_._1.logicalOpId)
       .view
-      .mapValues(_.flatMap(_._2.toList).toList.sortBy(_._1.id).map(_._2))
+      .mapValues(_.flatMap(_._2).toList.sortBy(_._1.id).map(_._2))
       .toMap
 
     // Prepare the response content by extracting attributes from the schemas,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/SchemaPropagationResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/SchemaPropagationResource.scala
@@ -44,15 +44,16 @@ class SchemaPropagationResource extends LazyLogging {
     val physicalInputSchemas = physicalPlan.operators.map { physicalOp =>
       physicalOp.id -> physicalOp.inputPorts.values
         .filterNot(_._1.id.internal)
-        .map(_._3.toOption)
-        .toList
+        .map{
+          case (port, _, schema )=> port.id-> schema.toOption
+        }
     }
 
     // Group the physical input schemas by their logical operation ID and consolidate the schemas
     val logicalInputSchemas = physicalInputSchemas
       .groupBy(_._1.logicalOpId)
       .view
-      .mapValues(_.flatMap(_._2).toList)
+      .mapValues(_.flatMap(_._2.toList).toList.sortBy(_._1.id).map(_._2))
       .toMap
 
     // Prepare the response content by extracting attributes from the schemas,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/SchemaPropagationResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/SchemaPropagationResource.scala
@@ -44,8 +44,8 @@ class SchemaPropagationResource extends LazyLogging {
     val physicalInputSchemas = physicalPlan.operators.map { physicalOp =>
       physicalOp.id -> physicalOp.inputPorts.values
         .filterNot(_._1.id.internal)
-        .map{
-          case (port, _, schema )=> port.id-> schema.toOption
+        .map {
+          case (port, _, schema) => port.id -> schema.toOption
         }
     }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/SchemaPropagationResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/SchemaPropagationResource.scala
@@ -49,7 +49,7 @@ class SchemaPropagationResource extends LazyLogging {
         }
     }
 
-    // Group the physical input schemas by their logical operation ID and consolidate the schemas
+    // Group the physical input schemas by their logical operator ID and consolidate the schemas
     val logicalInputSchemas = physicalInputSchemas
       .groupBy(_._1.logicalOpId)
       .view


### PR DESCRIPTION
Previously, when a logical operator has multiple input ports assigned to multiple physical operators (e.g., logical join with physical build and physical probe), the schema could be mistakenly propagated on those ports. The reason is that when we group the physical ports together into logical operators, it loses the order. This fix now let the groupby handle schema w.r.t the corresponding port id to ensure order.