### PR TITLE
Allow the access propagation from workflow to dataset

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetAccessResource.scala
@@ -37,6 +37,7 @@ object DatasetAccessResource {
   def userHasReadAccess(ctx: DSLContext, did: UInteger, uid: UInteger): Boolean = {
     userHasWriteAccess(ctx, did, uid) ||
     datasetIsPublic(ctx, did) ||
+    getDatasetUserAccessPrivilege(ctx, did, uid) == DatasetUserAccessPrivilege.READ ||
     userHasWorkflowReadAccessThroughEnvironment(ctx, did, uid)
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetAccessResource.scala
@@ -8,12 +8,21 @@ import edu.uci.ics.texera.web.model.jooq.generated.tables.DatasetUserAccess.DATA
 import edu.uci.ics.texera.web.model.jooq.generated.tables.WorkflowUserAccess.WORKFLOW_USER_ACCESS
 import edu.uci.ics.texera.web.model.jooq.generated.tables.EnvironmentOfWorkflow.ENVIRONMENT_OF_WORKFLOW
 import edu.uci.ics.texera.web.model.jooq.generated.tables.DatasetOfEnvironment.DATASET_OF_ENVIRONMENT
-import edu.uci.ics.texera.web.model.jooq.generated.enums.{DatasetUserAccessPrivilege, WorkflowUserAccessPrivilege}
+import edu.uci.ics.texera.web.model.jooq.generated.enums.{
+  DatasetUserAccessPrivilege,
+  WorkflowUserAccessPrivilege
+}
 import edu.uci.ics.texera.web.model.jooq.generated.tables.Dataset.DATASET
-import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{DatasetDao, DatasetUserAccessDao, UserDao}
-import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.{Dataset, DatasetUserAccess, User}
-import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetAccessResource.{context, getOwner}
-import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetResource.DATASET_IS_PUBLIC
+import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{
+  DatasetDao,
+  DatasetUserAccessDao,
+  UserDao
+}
+import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.{DatasetUserAccess, User}
+import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetAccessResource.{
+  context,
+  getOwner
+}
 import org.jooq.DSLContext
 import org.jooq.types.UInteger
 
@@ -27,74 +36,103 @@ object DatasetAccessResource {
 
   def userHasReadAccess(ctx: DSLContext, did: UInteger, uid: UInteger): Boolean = {
     userHasWriteAccess(ctx, did, uid) ||
-      datasetIsPublic(ctx, did) ||
-      userHasWorkflowReadAccessThroughEnvironment(ctx, did, uid)
+    datasetIsPublic(ctx, did) ||
+    userHasWorkflowReadAccessThroughEnvironment(ctx, did, uid)
   }
 
   def userOwnDataset(ctx: DSLContext, did: UInteger, uid: UInteger): Boolean = {
-    ctx.selectOne()
+    ctx
+      .selectOne()
       .from(DATASET)
       .where(DATASET.DID.eq(did))
       .and(DATASET.OWNER_UID.eq(uid))
-      .fetch().isNotEmpty
+      .fetch()
+      .isNotEmpty
   }
 
   def userHasWriteAccess(ctx: DSLContext, did: UInteger, uid: UInteger): Boolean = {
     userOwnDataset(ctx, did, uid) ||
-      getDatasetUserAccessPrivilege(ctx, did, uid) == DatasetUserAccessPrivilege.WRITE ||
-      userHasWorkflowWriteAccessThroughEnvironment(ctx, did, uid)
+    getDatasetUserAccessPrivilege(ctx, did, uid) == DatasetUserAccessPrivilege.WRITE ||
+    userHasWorkflowWriteAccessThroughEnvironment(ctx, did, uid)
   }
 
   def datasetIsPublic(ctx: DSLContext, did: UInteger): Boolean = {
-    Option(ctx.select(DATASET.IS_PUBLIC)
-      .from(DATASET)
-      .where(DATASET.DID.eq(did))
-      .fetchOneInto(classOf[Boolean])).getOrElse(false)
+    Option(
+      ctx
+        .select(DATASET.IS_PUBLIC)
+        .from(DATASET)
+        .where(DATASET.DID.eq(did))
+        .fetchOneInto(classOf[Boolean])
+    ).getOrElse(false)
   }
 
-  def userHasWorkflowWriteAccessThroughEnvironment(ctx: DSLContext, did: UInteger, uid: UInteger): Boolean = {
-    ctx.select()
+  def userHasWorkflowWriteAccessThroughEnvironment(
+      ctx: DSLContext,
+      did: UInteger,
+      uid: UInteger
+  ): Boolean = {
+    ctx
+      .select()
       .from(WORKFLOW_USER_ACCESS)
-      .join(ENVIRONMENT_OF_WORKFLOW).on(ENVIRONMENT_OF_WORKFLOW.WID.eq(WORKFLOW_USER_ACCESS.WID))
-      .join(DATASET_OF_ENVIRONMENT).on(ENVIRONMENT_OF_WORKFLOW.EID.eq(DATASET_OF_ENVIRONMENT.EID))
+      .join(ENVIRONMENT_OF_WORKFLOW)
+      .on(ENVIRONMENT_OF_WORKFLOW.WID.eq(WORKFLOW_USER_ACCESS.WID))
+      .join(DATASET_OF_ENVIRONMENT)
+      .on(ENVIRONMENT_OF_WORKFLOW.EID.eq(DATASET_OF_ENVIRONMENT.EID))
       .where(DATASET_OF_ENVIRONMENT.DID.eq(did))
       .and(WORKFLOW_USER_ACCESS.UID.eq(uid))
       .and(WORKFLOW_USER_ACCESS.PRIVILEGE.eq(WorkflowUserAccessPrivilege.WRITE))
-      .fetch().isNotEmpty
+      .fetch()
+      .isNotEmpty
   }
 
-
-  def userHasWorkflowReadAccessThroughEnvironment(ctx: DSLContext, did: UInteger, uid: UInteger): Boolean = {
-    ctx.select()
+  def userHasWorkflowReadAccessThroughEnvironment(
+      ctx: DSLContext,
+      did: UInteger,
+      uid: UInteger
+  ): Boolean = {
+    ctx
+      .select()
       .from(WORKFLOW_USER_ACCESS)
-      .join(ENVIRONMENT_OF_WORKFLOW).on(ENVIRONMENT_OF_WORKFLOW.WID.eq(WORKFLOW_USER_ACCESS.WID))
-      .join(DATASET_OF_ENVIRONMENT).on(ENVIRONMENT_OF_WORKFLOW.EID.eq(DATASET_OF_ENVIRONMENT.EID))
+      .join(ENVIRONMENT_OF_WORKFLOW)
+      .on(ENVIRONMENT_OF_WORKFLOW.WID.eq(WORKFLOW_USER_ACCESS.WID))
+      .join(DATASET_OF_ENVIRONMENT)
+      .on(ENVIRONMENT_OF_WORKFLOW.EID.eq(DATASET_OF_ENVIRONMENT.EID))
       .where(DATASET_OF_ENVIRONMENT.DID.eq(did))
       .and(WORKFLOW_USER_ACCESS.UID.eq(uid))
-      .and(WORKFLOW_USER_ACCESS.PRIVILEGE.in(WorkflowUserAccessPrivilege.READ, WorkflowUserAccessPrivilege.WRITE))
-      .fetch().isNotEmpty
+      .and(
+        WORKFLOW_USER_ACCESS.PRIVILEGE
+          .in(WorkflowUserAccessPrivilege.READ, WorkflowUserAccessPrivilege.WRITE)
+      )
+      .fetch()
+      .isNotEmpty
   }
 
-
-  def getDatasetUserAccessPrivilege(ctx: DSLContext, did: UInteger, uid: UInteger): DatasetUserAccessPrivilege = {
-    Option(ctx.select(DATASET_USER_ACCESS.PRIVILEGE)
-      .from(DATASET_USER_ACCESS)
-      .where(DATASET_USER_ACCESS.DID.eq(did))
-      .and(DATASET_USER_ACCESS.UID.eq(uid))
-      .fetchOne())
+  def getDatasetUserAccessPrivilege(
+      ctx: DSLContext,
+      did: UInteger,
+      uid: UInteger
+  ): DatasetUserAccessPrivilege = {
+    Option(
+      ctx
+        .select(DATASET_USER_ACCESS.PRIVILEGE)
+        .from(DATASET_USER_ACCESS)
+        .where(DATASET_USER_ACCESS.DID.eq(did))
+        .and(DATASET_USER_ACCESS.UID.eq(uid))
+        .fetchOne()
+    )
       .map(_.getValue(DATASET_USER_ACCESS.PRIVILEGE))
       .getOrElse(DatasetUserAccessPrivilege.NONE)
   }
 
   def getOwner(ctx: DSLContext, did: UInteger): User = {
-    val ownerUid = ctx.select(DATASET.OWNER_UID)
+    val ownerUid = ctx
+      .select(DATASET.OWNER_UID)
       .from(DATASET)
       .where(DATASET.DID.eq(did))
       .fetchOneInto(classOf[UInteger])
     new UserDao(ctx.configuration()).fetchOneByUid(ownerUid)
   }
 }
-
 
 @Produces(Array(MediaType.APPLICATION_JSON))
 @RolesAllowed(Array("REGULAR", "ADMIN"))

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetAccessResource.scala
@@ -5,18 +5,14 @@ import edu.uci.ics.texera.web.SqlServer
 import edu.uci.ics.texera.web.model.common.AccessEntry
 import edu.uci.ics.texera.web.model.jooq.generated.Tables.USER
 import edu.uci.ics.texera.web.model.jooq.generated.tables.DatasetUserAccess.DATASET_USER_ACCESS
-import edu.uci.ics.texera.web.model.jooq.generated.enums.DatasetUserAccessPrivilege
+import edu.uci.ics.texera.web.model.jooq.generated.tables.WorkflowUserAccess.WORKFLOW_USER_ACCESS
+import edu.uci.ics.texera.web.model.jooq.generated.tables.EnvironmentOfWorkflow.ENVIRONMENT_OF_WORKFLOW
+import edu.uci.ics.texera.web.model.jooq.generated.tables.DatasetOfEnvironment.DATASET_OF_ENVIRONMENT
+import edu.uci.ics.texera.web.model.jooq.generated.enums.{DatasetUserAccessPrivilege, WorkflowUserAccessPrivilege}
 import edu.uci.ics.texera.web.model.jooq.generated.tables.Dataset.DATASET
-import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{
-  DatasetDao,
-  DatasetUserAccessDao,
-  UserDao
-}
+import edu.uci.ics.texera.web.model.jooq.generated.tables.daos.{DatasetDao, DatasetUserAccessDao, UserDao}
 import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.{Dataset, DatasetUserAccess, User}
-import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetAccessResource.{
-  context,
-  getOwner
-}
+import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetAccessResource.{context, getOwner}
 import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetResource.DATASET_IS_PUBLIC
 import org.jooq.DSLContext
 import org.jooq.types.UInteger
@@ -27,67 +23,78 @@ import javax.ws.rs.{DELETE, GET, PUT, Path, PathParam, Produces}
 import javax.ws.rs.core.{MediaType, Response}
 
 object DatasetAccessResource {
-  final private lazy val context = SqlServer.createDSLContext()
+  private lazy val context: DSLContext = SqlServer.createDSLContext()
 
   def userHasReadAccess(ctx: DSLContext, did: UInteger, uid: UInteger): Boolean = {
-    val userAccessible = ctx
-      .select()
-      .from(DATASET)
-      .leftJoin(DATASET_USER_ACCESS)
-      .on(DATASET.DID.eq(DATASET_USER_ACCESS.DID))
-      .where(
-        DATASET.DID
-          .eq(did)
-          .and(
-            DATASET.IS_PUBLIC
-              .eq(DATASET_IS_PUBLIC)
-              .or(DATASET.OWNER_UID.eq(uid))
-              .or(DATASET_USER_ACCESS.UID.eq(uid))
-          )
-      )
-      .fetchInto(classOf[Dataset])
-
-    userAccessible.size() != 0
+    userHasWriteAccess(ctx, did, uid) ||
+      datasetIsPublic(ctx, did) ||
+      userHasWorkflowReadAccessThroughEnvironment(ctx, did, uid)
   }
 
   def userOwnDataset(ctx: DSLContext, did: UInteger, uid: UInteger): Boolean = {
-    val record = ctx
-      .selectFrom(DATASET)
+    ctx.selectOne()
+      .from(DATASET)
       .where(DATASET.DID.eq(did))
       .and(DATASET.OWNER_UID.eq(uid))
-      .fetchOne()
-
-    record != null
+      .fetch().isNotEmpty
   }
 
   def userHasWriteAccess(ctx: DSLContext, did: UInteger, uid: UInteger): Boolean = {
-    getDatasetUserAccessPrivilege(ctx, did, uid).eq(
-      DatasetUserAccessPrivilege.WRITE
-    ) || userOwnDataset(ctx, did, uid)
+    userOwnDataset(ctx, did, uid) ||
+      getDatasetUserAccessPrivilege(ctx, did, uid) == DatasetUserAccessPrivilege.WRITE ||
+      userHasWorkflowWriteAccessThroughEnvironment(ctx, did, uid)
   }
-  def getDatasetUserAccessPrivilege(
-      ctx: DSLContext,
-      did: UInteger,
-      uid: UInteger
-  ): DatasetUserAccessPrivilege = {
-    val record = ctx
-      .selectFrom(DATASET_USER_ACCESS)
+
+  def datasetIsPublic(ctx: DSLContext, did: UInteger): Boolean = {
+    Option(ctx.select(DATASET.IS_PUBLIC)
+      .from(DATASET)
+      .where(DATASET.DID.eq(did))
+      .fetchOneInto(classOf[Boolean])).getOrElse(false)
+  }
+
+  def userHasWorkflowWriteAccessThroughEnvironment(ctx: DSLContext, did: UInteger, uid: UInteger): Boolean = {
+    ctx.select()
+      .from(WORKFLOW_USER_ACCESS)
+      .join(ENVIRONMENT_OF_WORKFLOW).on(ENVIRONMENT_OF_WORKFLOW.WID.eq(WORKFLOW_USER_ACCESS.WID))
+      .join(DATASET_OF_ENVIRONMENT).on(ENVIRONMENT_OF_WORKFLOW.EID.eq(DATASET_OF_ENVIRONMENT.EID))
+      .where(DATASET_OF_ENVIRONMENT.DID.eq(did))
+      .and(WORKFLOW_USER_ACCESS.UID.eq(uid))
+      .and(WORKFLOW_USER_ACCESS.PRIVILEGE.eq(WorkflowUserAccessPrivilege.WRITE))
+      .fetch().isNotEmpty
+  }
+
+
+  def userHasWorkflowReadAccessThroughEnvironment(ctx: DSLContext, did: UInteger, uid: UInteger): Boolean = {
+    ctx.select()
+      .from(WORKFLOW_USER_ACCESS)
+      .join(ENVIRONMENT_OF_WORKFLOW).on(ENVIRONMENT_OF_WORKFLOW.WID.eq(WORKFLOW_USER_ACCESS.WID))
+      .join(DATASET_OF_ENVIRONMENT).on(ENVIRONMENT_OF_WORKFLOW.EID.eq(DATASET_OF_ENVIRONMENT.EID))
+      .where(DATASET_OF_ENVIRONMENT.DID.eq(did))
+      .and(WORKFLOW_USER_ACCESS.UID.eq(uid))
+      .and(WORKFLOW_USER_ACCESS.PRIVILEGE.in(WorkflowUserAccessPrivilege.READ, WorkflowUserAccessPrivilege.WRITE))
+      .fetch().isNotEmpty
+  }
+
+
+  def getDatasetUserAccessPrivilege(ctx: DSLContext, did: UInteger, uid: UInteger): DatasetUserAccessPrivilege = {
+    Option(ctx.select(DATASET_USER_ACCESS.PRIVILEGE)
+      .from(DATASET_USER_ACCESS)
       .where(DATASET_USER_ACCESS.DID.eq(did))
       .and(DATASET_USER_ACCESS.UID.eq(uid))
-      .fetchOne()
-
-    if (record == null)
-      DatasetUserAccessPrivilege.NONE
-    else
-      record.getPrivilege
+      .fetchOne())
+      .map(_.getValue(DATASET_USER_ACCESS.PRIVILEGE))
+      .getOrElse(DatasetUserAccessPrivilege.NONE)
   }
 
   def getOwner(ctx: DSLContext, did: UInteger): User = {
-    val datasetDao = new DatasetDao(ctx.configuration())
-    val userDao = new UserDao(ctx.configuration())
-    userDao.fetchOneByUid(datasetDao.fetchOneByDid(did).getOwnerUid)
+    val ownerUid = ctx.select(DATASET.OWNER_UID)
+      .from(DATASET)
+      .where(DATASET.DID.eq(did))
+      .fetchOneInto(classOf[UInteger])
+    new UserDao(ctx.configuration()).fetchOneByUid(ownerUid)
   }
 }
+
 
 @Produces(Array(MediaType.APPLICATION_JSON))
 @RolesAllowed(Array("REGULAR", "ADMIN"))

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
@@ -526,7 +526,6 @@ class DatasetResource {
 
     publicDatasets.forEach { publicDataset =>
       if (!accessibleDatasets.exists(_.dataset.getDid == publicDataset.getDid)) {
-        // Assuming DashboardDataset has a property did for comparison
         val dashboardDataset = DashboardDataset(
           isOwner = false,
           dataset = publicDataset,


### PR DESCRIPTION
This PR modifies the access check of users accessing datasets. This modification allows: when Bob share its workflow with Alice, Alice can directly run the workflow and preview the dataset within the workspace.

After modification, the dataset access control rules are:

### 1. user is an owner of the dataset
ONLY IF `user.uid` == `dataset.owner_uid`

### 2. user has the write access to dataset
- user is the owner of the dataset
OR
- user has `WRITE` access on the `dataset_user_acess` table
OR
- user has `WRITE` access on some workflows, who also added the dataset to their environment at the same time

### 3. user has the read access to dataset
- user has the write access to dataset
OR
- dataset is public
OR
- user has `READ` access on the `dataset_user_acess` table
OR
- user has `READ` access on some workflows, who also added the dataset to their environment at the same time