### PR TITLE
Fix Read Only Projects

### DIFF
--- a/core/gui/src/app/dashboard/user/component/user-project/user-project-section/user-project-section.component.html
+++ b/core/gui/src/app/dashboard/user/component/user-project/user-project-section/user-project-section.component.html
@@ -62,7 +62,9 @@
     </ng-template>
   </nz-card>
 
-  <texera-saved-workflow-section [pid]="pid"></texera-saved-workflow-section>
+  <texera-saved-workflow-section
+    [pid]="pid"
+    [accessLevel]="accessLevel"></texera-saved-workflow-section>
 </div>
 
 <div>

--- a/core/gui/src/app/dashboard/user/component/user-project/user-project-section/user-project-section.component.ts
+++ b/core/gui/src/app/dashboard/user/component/user-project/user-project-section/user-project-section.component.ts
@@ -26,6 +26,7 @@ export class UserProjectSectionComponent implements OnInit {
   public description: string = "";
   public ownerID: number = 0;
   public creationTime: number = 0;
+  public accessLevel: string = "READ";
   public color: string | null = null;
 
   // information for modifying project color
@@ -259,6 +260,7 @@ export class UserProjectSectionComponent implements OnInit {
               this.description = userProject.description;
               this.ownerID = userProject.ownerID;
               this.creationTime = userProject.creationTime;
+              this.accessLevel = userProject.accessLevel;
               if (userProject.color != null) {
                 this.color = userProject.color;
                 this.inputColor = "#" + userProject.color;

--- a/core/gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.html
+++ b/core/gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.html
@@ -7,6 +7,7 @@
       <texera-sort-button (sortMethodChange)="sortMethod = $event; search()"></texera-sort-button>
       <button
         (click)="onClickCreateNewWorkflowFromDashboard()"
+        [disabled]="accessLevel === 'READ'"
         nz-button
         title="Create a new workflow"
         nz-tooltip="Create a new workflow"
@@ -19,6 +20,7 @@
       </button>
       <nz-upload [nzBeforeUpload]="onClickUploadExistingWorkflowFromLocal">
         <button
+          [disabled]="accessLevel === 'READ'"
           nz-button
           title="Upload ZIP/JSON file as workflow"
           nz-tooltip="Upload ZIP/JSON file as workflow"
@@ -73,6 +75,7 @@
 
       <button
         *ngIf="pid !== undefined"
+        [disabled]="accessLevel === 'READ'"
         (click)="onClickOpenAddWorkflow()"
         nz-button
         title="Add workflow(s) to project"
@@ -86,6 +89,7 @@
       </button>
       <button
         *ngIf="pid !== undefined"
+        [disabled]="accessLevel === 'READ'"
         (click)="onClickOpenRemoveWorkflow()"
         nz-button
         title="Remove workflow(s) from project"

--- a/core/gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
+++ b/core/gui/src/app/dashboard/user/component/user-workflow/user-workflow.component.ts
@@ -22,11 +22,7 @@ import { SearchService } from "../../service/search.service";
 import { SortMethod } from "../../type/sort-method";
 import { isDefined } from "../../../../common/util/predicate";
 import { UserProjectService } from "../../service/user-project/user-project.service";
-import { filter, map, mergeMap, tap } from "rxjs/operators";
-import { DashboardDataset } from "../../type/dashboard-dataset.interface";
-import { DashboardWorkflow } from "../../type/dashboard-workflow.interface";
-
-export const ROUTER_WORKFLOW_CREATE_NEW_URL = "/";
+import { map, mergeMap, tap } from "rxjs/operators";
 /**
  * Saved-workflow-section component contains information and functionality
  * of the saved workflows section and is re-used in the user projects section when a project is clicked
@@ -86,6 +82,7 @@ export class UserWorkflowComponent implements AfterViewInit {
 
   // receive input from parent components (UserProjectSection), if any
   @Input() public pid?: number = undefined;
+  @Input() public accessLevel?: string = undefined;
   public sortMethod = SortMethod.EditTimeDesc;
   lastSortMethod: SortMethod | null = null;
 


### PR DESCRIPTION
This PR fixes issue #2565: users can add, remove, or upload workflows to read projects.

![image](https://github.com/Texera/texera/assets/11544314/97b7c090-f784-4ad3-9661-835c22702def)
