### PR TITLE
Disable parallelization for diff and intersect operators

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpDesc.scala
@@ -27,6 +27,7 @@ class DifferenceOpDesc extends LogicalOp {
       .withOutputPorts(operatorInfo.outputPorts)
       .withPartitionRequirement(List(Option(HashPartition())))
       .withDerivePartition(_ => HashPartition())
+      .withParallelizable(false)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpDesc.scala
@@ -27,6 +27,7 @@ class IntersectOpDesc extends LogicalOp {
       .withOutputPorts(operatorInfo.outputPorts)
       .withPartitionRequirement(List(Option(HashPartition())))
       .withDerivePartition(_ => HashPartition())
+      .withParallelizable(false)
   }
 
   override def operatorInfo: OperatorInfo =


### PR DESCRIPTION
as title. This is only a temporary fix, these operators should be parallelizable with hash partitioning 