### PR TITLE
Fix "head of empty list" error for stats report

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/execution/RegionExecution.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/execution/RegionExecution.scala
@@ -2,6 +2,7 @@ package edu.uci.ics.amber.engine.architecture.controller.execution
 
 import com.rits.cloning.Cloner
 import edu.uci.ics.amber.engine.architecture.scheduling.Region
+import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerStatistics
 import edu.uci.ics.amber.engine.common.virtualidentity.PhysicalOpIdentity
 import edu.uci.ics.amber.engine.common.workflow.PhysicalLink
 import edu.uci.ics.texera.web.workflowruntimestate.{OperatorMetrics, WorkflowAggregatedState}
@@ -10,6 +11,8 @@ import scala.collection.mutable
 
 object Cloning {
   val cloner = new Cloner()
+  // prevent cloner from cloning scala Nil, which it cannot handle properly
+  cloner.dontClone(classOf[WorkerStatistics])
 }
 case class RegionExecution(region: Region) {
 


### PR DESCRIPTION
If a workflow has multiple regions where operators are shared across different regions, we replicate the `OperatorExecution` object to transfer the operator's execution state to subsequent regions. However, the deep cloning library we use, designed for Java, struggles with Scala-specific objects like `Nil` (an empty list). Consequently, if the `inputTupleCount` in `WorkerStatistics` is set to `Nil`, the resulting cloned object becomes corrupted.

Then we will encounter the following error:
![CleanShot 2024-04-08 at 00 23 08](https://github.com/Texera/texera/assets/13672781/2b624a8a-93d4-4db9-ae49-e9deb1ba7b99)


This PR explicitly prevents `WorkerStatistics` to be deepcloned to solve the issue mentioned above. As the class itself is also immutable, we don't need to clone it in the first place.

This PR also involves some readability improvements for computing the aggregated stats.