### PR TITLE
Fix incorrect execution state aggregation for multi-region workflows

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/execution/WorkflowExecution.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/execution/WorkflowExecution.scala
@@ -116,6 +116,7 @@ case class WorkflowExecution() {
       return WorkflowAggregatedState.COMPLETED
     }
     val unCompletedOpStates = regionExecutions.values
+      .filter(_.getState != COMPLETED)
       .flatMap(_.getAllOperatorExecutions.map(_._2.getState))
       .filter(_ != COMPLETED)
     if (unCompletedOpStates.forall(_ == UNINITIALIZED)) {


### PR DESCRIPTION
If the workflow has 2 regions and operator A is shared between regions, then the aggregated workflow execution state also considers the execution state of A in the previous region. This behavior prevents the workflow from being paused on the frontend for multi-region workflows.

This PR removes the operators in a completed region so that the same operator will not be considered twice.