### PR TITLE
Fix set-based operators to be parallelizable

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/difference/DifferenceOpDesc.scala
@@ -25,9 +25,8 @@ class DifferenceOpDesc extends LogicalOp {
       )
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
-      .withPartitionRequirement(List(Option(HashPartition())))
+      .withPartitionRequirement(List(Option(HashPartition()), Option(HashPartition())))
       .withDerivePartition(_ => HashPartition())
-      .withParallelizable(false)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/intersect/IntersectOpDesc.scala
@@ -25,9 +25,8 @@ class IntersectOpDesc extends LogicalOp {
       )
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
-      .withPartitionRequirement(List(Option(HashPartition())))
+      .withPartitionRequirement(List(Option(HashPartition()), Option(HashPartition())))
       .withDerivePartition(_ => HashPartition())
-      .withParallelizable(false)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/symmetricDifference/SymmetricDifferenceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/symmetricDifference/SymmetricDifferenceOpDesc.scala
@@ -26,9 +26,8 @@ class SymmetricDifferenceOpDesc extends LogicalOp {
       )
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
-      .withPartitionRequirement(List(Option(HashPartition(List()))))
+      .withPartitionRequirement(List(Option(HashPartition()), Option(HashPartition())))
       .withDerivePartition(_ => HashPartition(List()))
-      .withParallelizable(false)
   }
 
   override def operatorInfo: OperatorInfo =


### PR DESCRIPTION
Previously in #2583 and #2582, we temporarily disabled the parallelizable parameter for set-based operators (Diff, SymmetricDiff, Intersect). The cause was the two ports had different partitionings, one was hash partition, but the other one was round robin. This PR fixes the issue by declaring both hash partitioning on both ports. Thus those operators are parallelizable again.