### PR TITLE
Fix file scan with filename

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/FileScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/FileScanSourceOpDesc.scala
@@ -24,11 +24,11 @@ class FileScanSourceOpDesc extends ScanSourceOpDesc with TextSourceOpDesc {
       new JsonSchemaString(path = HideAnnotation.hideExpectedValue, value = "binary")
     )
   )
-  var encoding: FileDecodingMethod = FileDecodingMethod.UTF_8
+  private val encoding: FileDecodingMethod = FileDecodingMethod.UTF_8
 
   @JsonProperty(defaultValue = "false")
   @JsonSchemaTitle("Extract")
-  var extract: Boolean = false
+  val extract: Boolean = false
 
   @JsonProperty(defaultValue = "false")
   @JsonSchemaTitle("Include Filename")
@@ -39,7 +39,7 @@ class FileScanSourceOpDesc extends ScanSourceOpDesc with TextSourceOpDesc {
       new JsonSchemaString(path = HideAnnotation.hideExpectedValue, value = "false")
     )
   )
-  var outputFileName: Boolean = false
+  val outputFileName: Boolean = false
 
   fileTypeName = Option("")
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/FileScanSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/FileScanSourceOpExec.scala
@@ -47,15 +47,14 @@ class FileScanSourceOpExec private[scan] (
       fileEntries.zipAll(filenameIt, null, null).map {
         case (entry, fileName) =>
           val fields: mutable.ListBuffer[Any] = mutable.ListBuffer()
+          if (outputFileName) {
+            fields.addOne(fileName)
+          }
           fields.addOne(fileAttributeType match {
             case FileAttributeType.SINGLE_STRING =>
               new String(toByteArray(entry), fileEncoding.getCharset)
             case _ => parseField(toByteArray(entry), fileAttributeType.getType)
           })
-          if (outputFileName) {
-            fields.addOne(fileName)
-          }
-
           TupleLike(fields.toSeq: _*)
       }
     } else {


### PR DESCRIPTION
When file scan an archive file, the option `Include Filename` can be selected. However, the order of the generated fields is different from what it was required in the schema. This PR moves the filename field's order so that it matches the schema.