### PR TITLE
Fix schema propagation for native python op

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/PythonOperatorDescriptor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/PythonOperatorDescriptor.scala
@@ -1,7 +1,10 @@
 package edu.uci.ics.texera.workflow.common.operators
 
 import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalOp, SchemaPropagationFunc}
-import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{OpExecInitInfo, OpExecInitInfoWithCode}
+import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{
+  OpExecInitInfo,
+  OpExecInitInfoWithCode
+}
 import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 
 trait PythonOperatorDescriptor extends LogicalOp {
@@ -9,52 +12,41 @@ trait PythonOperatorDescriptor extends LogicalOp {
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity
   ): PhysicalOp = {
+    val opExecInitInfo = OpExecInitInfoWithCode((_, _) => (generatePythonCode(), "python"))
 
-
-    if (asSource()) {
-      PhysicalOp
-        .sourcePhysicalOp(
-          workflowId,
-          executionId,
-          operatorIdentifier,
-          OpExecInitInfoWithCode((_,_ ) => {(generatePythonCode(), "python")})
-        )
-        .withInputPorts(operatorInfo.inputPorts)
-        .withOutputPorts(operatorInfo.outputPorts)
-        .withParallelizable(parallelizable())
-        .withPropagateSchema(
-          SchemaPropagationFunc(inputSchemas =>
-            Map(
-              operatorInfo.outputPorts.head.id -> getOutputSchema(
-                operatorInfo.inputPorts.map(_.id).map(inputSchemas(_)).toArray
-              )
-            )
-          )
-        )
+    val physicalOp = if (asSource()) {
+      PhysicalOp.sourcePhysicalOp(
+        workflowId,
+        executionId,
+        operatorIdentifier,
+        opExecInitInfo
+      )
     } else {
-      PhysicalOp
-        .oneToOnePhysicalOp(
-          workflowId,
-          executionId,
-          operatorIdentifier,
-          OpExecInitInfoWithCode((_,_ ) => {(generatePythonCode(), "python")})
-        )
-        .withInputPorts(operatorInfo.inputPorts)
-        .withOutputPorts(operatorInfo.outputPorts)
-        .withParallelizable(parallelizable())
-        .withPropagateSchema(
-          SchemaPropagationFunc(inputSchemas =>
-            Map(
-              operatorInfo.outputPorts.head.id -> getOutputSchema(
-                operatorInfo.inputPorts.map(_.id).map(inputSchemas(_)).toArray
-              )
+      PhysicalOp.oneToOnePhysicalOp(
+        workflowId,
+        executionId,
+        operatorIdentifier,
+        opExecInitInfo
+      )
+    }
+
+    physicalOp
+      .withInputPorts(operatorInfo.inputPorts)
+      .withOutputPorts(operatorInfo.outputPorts)
+      .withParallelizable(parallelizable())
+      .withPropagateSchema(
+        SchemaPropagationFunc(inputSchemas =>
+          Map(
+            operatorInfo.outputPorts.head.id -> getOutputSchema(
+              operatorInfo.inputPorts.map(_.id).map(inputSchemas(_)).toArray
             )
           )
         )
-    }
+      )
   }
 
   def parallelizable(): Boolean = false
+
   def asSource(): Boolean = false
 
   /**

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/PythonOperatorDescriptor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/PythonOperatorDescriptor.scala
@@ -1,10 +1,7 @@
 package edu.uci.ics.texera.workflow.common.operators
 
+import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfoWithCode
 import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalOp, SchemaPropagationFunc}
-import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{
-  OpExecInitInfo,
-  OpExecInitInfoWithCode
-}
 import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 
 trait PythonOperatorDescriptor extends LogicalOp {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/PythonOperatorDescriptor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/PythonOperatorDescriptor.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.texera.workflow.common.operators
 
 import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalOp, SchemaPropagationFunc}
-import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfo
+import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{OpExecInitInfo, OpExecInitInfoWithCode}
 import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 
 trait PythonOperatorDescriptor extends LogicalOp {
@@ -10,14 +10,14 @@ trait PythonOperatorDescriptor extends LogicalOp {
       executionId: ExecutionIdentity
   ): PhysicalOp = {
 
-    val generatedCode = generatePythonCode()
+
     if (asSource()) {
       PhysicalOp
         .sourcePhysicalOp(
           workflowId,
           executionId,
           operatorIdentifier,
-          OpExecInitInfo(generatedCode, "python")
+          OpExecInitInfoWithCode((_,_ ) => {(generatePythonCode(), "python")})
         )
         .withInputPorts(operatorInfo.inputPorts)
         .withOutputPorts(operatorInfo.outputPorts)
@@ -37,7 +37,7 @@ trait PythonOperatorDescriptor extends LogicalOp {
           workflowId,
           executionId,
           operatorIdentifier,
-          OpExecInitInfo(generatedCode, "python")
+          OpExecInitInfoWithCode((_,_ ) => {(generatePythonCode(), "python")})
         )
         .withInputPorts(operatorInfo.inputPorts)
         .withOutputPorts(operatorInfo.outputPorts)


### PR DESCRIPTION
The native Python operators conduct early code generation, which causes the schema propagation to fail when operator is not properly configured. This PR makes the code gen become lazy, which will not affect the construction of a physical plan, thus will not affect the schema propagation. 