### PR TITLE
Fix missing schema auto fill on ScatterPlot

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/PythonOperatorDescriptor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/PythonOperatorDescriptor.scala
@@ -1,7 +1,10 @@
 package edu.uci.ics.texera.workflow.common.operators
 
 import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalOp, SchemaPropagationFunc}
-import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{OpExecInitInfo, OpExecInitInfoWithCode}
+import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{
+  OpExecInitInfo,
+  OpExecInitInfoWithCode
+}
 import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 
 trait PythonOperatorDescriptor extends LogicalOp {
@@ -9,52 +12,41 @@ trait PythonOperatorDescriptor extends LogicalOp {
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity
   ): PhysicalOp = {
+    val opExecInitInfo = OpExecInitInfoWithCode((_, _) => (generatePythonCode(), "python"))
 
-
-    if (asSource()) {
-      PhysicalOp
-        .sourcePhysicalOp(
-          workflowId,
-          executionId,
-          operatorIdentifier,
-          OpExecInitInfoWithCode((_,_ ) => {(generatePythonCode(), "python")})
-        )
-        .withInputPorts(operatorInfo.inputPorts)
-        .withOutputPorts(operatorInfo.outputPorts)
-        .withParallelizable(parallelizable())
-        .withPropagateSchema(
-          SchemaPropagationFunc(inputSchemas =>
-            Map(
-              operatorInfo.outputPorts.head.id -> getOutputSchema(
-                operatorInfo.inputPorts.map(_.id).map(inputSchemas(_)).toArray
-              )
-            )
-          )
-        )
+    val physicalOp = if (asSource()) {
+      PhysicalOp.sourcePhysicalOp(
+        workflowId,
+        executionId,
+        operatorIdentifier,
+        opExecInitInfo
+      )
     } else {
-      PhysicalOp
-        .oneToOnePhysicalOp(
-          workflowId,
-          executionId,
-          operatorIdentifier,
-          OpExecInitInfoWithCode((_,_ ) => {(generatePythonCode(), "python")})
-        )
-        .withInputPorts(operatorInfo.inputPorts)
-        .withOutputPorts(operatorInfo.outputPorts)
-        .withParallelizable(parallelizable())
-        .withPropagateSchema(
-          SchemaPropagationFunc(inputSchemas =>
-            Map(
-              operatorInfo.outputPorts.head.id -> getOutputSchema(
-                operatorInfo.inputPorts.map(_.id).map(inputSchemas(_)).toArray
-              )
+      PhysicalOp.oneToOnePhysicalOp(
+        workflowId,
+        executionId,
+        operatorIdentifier,
+        opExecInitInfo
+      )
+    }
+
+    physicalOp
+      .withInputPorts(operatorInfo.inputPorts)
+      .withOutputPorts(operatorInfo.outputPorts)
+      .withParallelizable(parallelizable())
+      .withPropagateSchema(
+        SchemaPropagationFunc(inputSchemas =>
+          Map(
+            operatorInfo.outputPorts.head.id -> getOutputSchema(
+              operatorInfo.inputPorts.map(_.id).map(inputSchemas(_)).toArray
             )
           )
         )
-    }
+      )
   }
 
   def parallelizable(): Boolean = false
+
   def asSource(): Boolean = false
 
   /**

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/PythonOperatorDescriptor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/PythonOperatorDescriptor.scala
@@ -1,10 +1,7 @@
 package edu.uci.ics.texera.workflow.common.operators
 
+import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfoWithCode
 import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalOp, SchemaPropagationFunc}
-import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{
-  OpExecInitInfo,
-  OpExecInitInfoWithCode
-}
 import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 
 trait PythonOperatorDescriptor extends LogicalOp {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/PythonOperatorDescriptor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/operators/PythonOperatorDescriptor.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.texera.workflow.common.operators
 
 import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalOp, SchemaPropagationFunc}
-import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfo
+import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.{OpExecInitInfo, OpExecInitInfoWithCode}
 import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 
 trait PythonOperatorDescriptor extends LogicalOp {
@@ -10,14 +10,14 @@ trait PythonOperatorDescriptor extends LogicalOp {
       executionId: ExecutionIdentity
   ): PhysicalOp = {
 
-    val generatedCode = generatePythonCode()
+
     if (asSource()) {
       PhysicalOp
         .sourcePhysicalOp(
           workflowId,
           executionId,
           operatorIdentifier,
-          OpExecInitInfo(generatedCode, "python")
+          OpExecInitInfoWithCode((_,_ ) => {(generatePythonCode(), "python")})
         )
         .withInputPorts(operatorInfo.inputPorts)
         .withOutputPorts(operatorInfo.outputPorts)
@@ -37,7 +37,7 @@ trait PythonOperatorDescriptor extends LogicalOp {
           workflowId,
           executionId,
           operatorIdentifier,
-          OpExecInitInfo(generatedCode, "python")
+          OpExecInitInfoWithCode((_,_ ) => {(generatePythonCode(), "python")})
         )
         .withInputPorts(operatorInfo.inputPorts)
         .withOutputPorts(operatorInfo.outputPorts)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/scatterplot/ScatterplotOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/scatterplot/ScatterplotOpDesc.scala
@@ -3,13 +3,11 @@ package edu.uci.ics.texera.workflow.operators.visualization.scatterplot
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.engine.common.workflow.{InputPort, OutputPort}
+import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.texera.workflow.common.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.texera.workflow.common.operators.PythonOperatorDescriptor
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
-import edu.uci.ics.texera.workflow.operators.visualization.{
-  VisualizationConstants,
-  VisualizationOperator
-}
+import edu.uci.ics.texera.workflow.operators.visualization.{VisualizationConstants, VisualizationOperator}
 
 @JsonSchemaInject(
   json =
@@ -29,12 +27,14 @@ class ScatterplotOpDesc extends VisualizationOperator with PythonOperatorDescrip
   @JsonProperty(required = true)
   @JsonSchemaTitle("X-Column")
   @JsonPropertyDescription("X Column")
-  var xColumn: String = ""
+  @AutofillAttributeName
+  private val xColumn: String = ""
 
   @JsonProperty(required = true)
   @JsonSchemaTitle("Y-Column")
   @JsonPropertyDescription("Y Column")
-  var yColumn: String = ""
+  @AutofillAttributeName
+  private val yColumn: String = ""
 
   override def chartType: String = VisualizationConstants.HTML_VIZ
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/scatterplot/ScatterplotOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/visualization/scatterplot/ScatterplotOpDesc.scala
@@ -7,7 +7,10 @@ import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttribute
 import edu.uci.ics.texera.workflow.common.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.texera.workflow.common.operators.PythonOperatorDescriptor
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
-import edu.uci.ics.texera.workflow.operators.visualization.{VisualizationConstants, VisualizationOperator}
+import edu.uci.ics.texera.workflow.operators.visualization.{
+  VisualizationConstants,
+  VisualizationOperator
+}
 
 @JsonSchemaInject(
   json =


### PR DESCRIPTION
The Scatterplot Operator is missing the feature to auto-fill schema. This PR adds the annotation `AutofillAttributeName` to enable it.