### PR TITLE
Fix null schema exception when MongoDB CacheSource starts

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/storage/MongoDBSinkStorage.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/storage/MongoDBSinkStorage.scala
@@ -88,10 +88,16 @@ class MongoDBSinkStorage(id: String) extends SinkStorageReader {
     mkTupleIterable(cursor)
   }
 
-  override def getSchema: Schema = schema
+  override def getSchema: Schema = {
+    synchronized {
+      schema
+    }
+  }
 
   override def setSchema(schema: Schema): Unit = {
     // Now we require mongodb version > 5 to support "." in field names
-    this.schema = schema
+    synchronized {
+      this.schema = schema
+    }
   }
 }


### PR DESCRIPTION
For sink storage, the set/get schema can be called in different threads, thus a race condition may happen and the getter returns null as the schema. This PR makes the set/get calls synchronized.