### PR TITLE
Generate dataset version name based on number of versions and user-provided description

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
@@ -143,7 +143,11 @@ object DatasetResource {
   }
 
   // the format of dataset version name is: v{#n} - {user provided dataset version name}. e.g. v10 - new version
-  private def generateDatasetVersionName(ctx: DSLContext, did: UInteger, userProvidedVersionName: String): String = {
+  private def generateDatasetVersionName(
+      ctx: DSLContext,
+      did: UInteger,
+      userProvidedVersionName: String
+  ): String = {
     val numberOfExistingVersions = ctx
       .selectFrom(DATASET_VERSION)
       .where(DATASET_VERSION.DID.eq(did))
@@ -188,11 +192,11 @@ object DatasetResource {
   // it returns the created dataset version if creation succeed, else return None
   // concurrency control is performed here: the thread has to have the lock in order to create the new version
   private def createNewDatasetVersion(
-                                       ctx: DSLContext,
-                                       did: UInteger,
-                                       uid: UInteger,
-                                       userProvidedVersionName: String,
-                                       multiPart: FormDataMultiPart
+      ctx: DSLContext,
+      did: UInteger,
+      uid: UInteger,
+      userProvidedVersionName: String,
+      multiPart: FormDataMultiPart
   ): Option[DashboardDatasetVersion] = {
 
     // Acquire or Create the lock for dataset of {did}

--- a/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.ts
+++ b/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.ts
@@ -58,7 +58,7 @@ export class UserDatasetVersionCreatorComponent implements OnInit {
       ? [
           // Fields when isCreatingVersion is true
           {
-            key: "name",
+            key: "versionDescription",
             type: "input",
             defaultValue: "",
             templateOptions: {
@@ -86,7 +86,7 @@ export class UserDatasetVersionCreatorComponent implements OnInit {
             },
           },
           {
-            key: "versionName",
+            key: "versionDescription",
             type: "input",
             defaultValue: "",
             templateOptions: {
@@ -136,13 +136,13 @@ export class UserDatasetVersionCreatorComponent implements OnInit {
 
     this.isUploading = true;
     if (this.isCreatingVersion && this.baseVersion) {
-      const versionName = this.form.get("name")?.value;
+      const versionName = this.form.get("versionDescription")?.value;
       this.datasetService
         .createDatasetVersion(this.baseVersion?.did, versionName, this.removedFilePaths, this.newUploadFiles)
         .pipe(untilDestroyed(this))
         .subscribe({
           next: res => {
-            this.notificationService.success(`Version '${versionName}' Created`);
+            this.notificationService.success("Version Created");
             this.datasetOrVersionCreationID.emit(res.dvid);
             this.isUploading = false;
           },
@@ -161,7 +161,7 @@ export class UserDatasetVersionCreatorComponent implements OnInit {
         creationTime: undefined,
         versionHierarchy: undefined,
       };
-      const initialVersionName = this.form.get("versionName")?.value;
+      const initialVersionName = this.form.get("versionDescription")?.value;
 
       // do the name sanitization
 

--- a/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.ts
+++ b/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.ts
@@ -58,11 +58,11 @@ export class UserDatasetVersionCreatorComponent implements OnInit {
       ? [
           // Fields when isCreatingVersion is true
           {
-            key: "describe the new version",
+            key: "name",
             type: "input",
             defaultValue: "",
             templateOptions: {
-              label: "Name",
+              label: "Describe the new version",
               required: false,
             },
           },
@@ -86,7 +86,7 @@ export class UserDatasetVersionCreatorComponent implements OnInit {
             },
           },
           {
-            key: "versionDescription",
+            key: "versionName",
             type: "input",
             defaultValue: "",
             templateOptions: {

--- a/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.ts
+++ b/core/gui/src/app/dashboard/user/component/user-dataset/user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component.ts
@@ -58,11 +58,12 @@ export class UserDatasetVersionCreatorComponent implements OnInit {
       ? [
           // Fields when isCreatingVersion is true
           {
-            key: "name",
+            key: "describe the new version",
             type: "input",
+            defaultValue: "",
             templateOptions: {
               label: "Name",
-              required: true,
+              required: false,
             },
           },
         ]
@@ -85,12 +86,12 @@ export class UserDatasetVersionCreatorComponent implements OnInit {
             },
           },
           {
-            key: "versionName",
+            key: "versionDescription",
             type: "input",
-            defaultValue: "v1",
+            defaultValue: "",
             templateOptions: {
-              label: "Initial Version Name",
-              required: true,
+              label: "Version Description",
+              required: false,
             },
           },
         ];


### PR DESCRIPTION
This PR introduces the generation of dataset version name.

When creating a new version of a dataset, the dataset version name is **no longer required**

The generation rule and format are as follows:
Assume there are `n` existing versions:
- If user provides the version description, the version name would be `v{n+1} - {user-provided description}`
- if user doesn't provide anything, the version name would simply be `v{n+1}`

The generation happens on the backend.