### PR TITLE
Enable Fine-grained Property Panel Shared Editing

### DIFF
--- a/core/gui/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
+++ b/core/gui/src/app/workspace/service/workflow-graph/model/workflow-graph.ts
@@ -811,14 +811,12 @@ export class WorkflowGraph {
     if (!this.hasOperator(operatorID)) {
       throw new Error(`operator with ID ${operatorID} doesn't exist`);
     }
-    //
-    // const previousProperty = this.getSharedOperatorType(operatorID).get(
-    //   "operatorProperties"
-    // ) as YType<OperatorPropertiesType>;
+
+    const previousProperty = this.getSharedOperatorType(operatorID).get(
+      "operatorProperties"
+    ) as YType<OperatorPropertiesType>;
     // set the new copy back to the operator ID map
-    // TODO: we temporarily disable this due to Yjs update causing issues in Formly.
-    this.getSharedOperatorType(operatorID).set("operatorProperties", createYTypeFromObject(newProperty));
-    // updateYTypeFromObject(previousProperty, newProperty);
+    updateYTypeFromObject(previousProperty, newProperty);
   }
 
   public setPortProperty(operatorPortID: LogicalPort, newProperty: object) {


### PR DESCRIPTION
#2014 disabled `UpdateYTypeFromObject` when updating the content of the properties of an operator. This caused the issues described in #2608 / #2613. This PR enables this function again because we cannot see the incompatibility problem with formly and `UpdateYTypeFromObject` anymore, and enabling this update logic will solve the issue of UDF code not being saved.