### PR TITLE
Keep the feature names and report the feature mismatch errors in ML prediction operator

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
@@ -25,7 +25,7 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
        |        if port == 0:
        |            self.model = tuple_["$model"]
        |        else:
-       |            tuple_["$resultAttribute"] = str(self.model.predict([tuple_])[0])
+       |            tuple_["$resultAttribute"] = str(self.model.predict(Table.from_tuple_likes([tuple_]))[0])
        |            yield tuple_""".stripMargin
 
   override def operatorInfo: OperatorInfo =


### PR DESCRIPTION
After this PR, it will report errors to the user when the order of features mismatches for ML prediction operator. 
<img width="778" alt="Screenshot 2024-05-06 at 6 16 03 PM" src="https://github.com/Texera/texera/assets/11544314/17f31978-a8b0-4292-b846-cc4734b77358">
