### PR TITLE
Fix Naming of Materialization Write and Read Operators in Region Plan Generator

### DIFF
--- a/core/scripts/sql/update/12.sql
+++ b/core/scripts/sql/update/12.sql
@@ -1,0 +1,4 @@
+USE `texera_db`;
+
+ALTER TABLE texera_db.workflow_runtime_statistics
+    MODIFY COLUMN operator_id VARCHAR(512);


### PR DESCRIPTION
This PR fixes #2611. Cost-based RPG sometime does not work properly for the case of multiple operators connected after the same blocking output port. The reason is in cost-based RPG, a blocking output port is always materialized. The materialization should create a pair of cache read/write operators _for each link_ after a blocking output port. However, the current implementation is using operator name as the id of replaced cache read/write operators. This would cause duplicate creation of materialization write/read operators with the same Id, which causes unexpected behavior. Using the link to the materialization operators eliminates the problem.

As the name of materialization operators get longer after this change, an update to the `operator_id` field in `workflow_runtime_statistics` table is necessary.