### PR TITLE
Fix Operator Menu Overflow

### DIFF
--- a/core/gui/src/app/workspace/component/left-panel/operator-menu/operator-label/operator-label.component.scss
+++ b/core/gui/src/app/workspace/component/left-panel/operator-menu/operator-label/operator-label.component.scss
@@ -5,7 +5,7 @@
 .operator-label {
   white-space: nowrap;
   height: 32px;
-  line-height: 32px;
+  line-height: 30px;
   border-radius: 3px;
   border: 1px solid rgba(0, 0, 0, 0);
   transition:

--- a/core/gui/src/app/workspace/component/left-panel/operator-menu/operator-label/operator-label.component.scss
+++ b/core/gui/src/app/workspace/component/left-panel/operator-menu/operator-label/operator-label.component.scss
@@ -4,11 +4,8 @@
 
 .operator-label {
   white-space: nowrap;
-  width: 100%;
   height: 32px;
   line-height: 32px;
-  display: flex;
-  align-content: center;
   border-radius: 3px;
   border: 1px solid rgba(0, 0, 0, 0);
   transition:


### PR DESCRIPTION
Fix the operator menu item overflow caused by PR #2607.

| Before the fix| After the fix|
| ------------- | ------------- |
| ![329482488-786a9aff-308b-4171-a3d9-5a2573b675da](https://github.com/Texera/texera/assets/11544314/98961493-091d-4402-a2ff-9ae32f522dff) | ![image](https://github.com/Texera/texera/assets/11544314/0b97932e-5227-40ba-b2a0-b40f06bf2f00)  


