### PR TITLE
Make classifiers logs out evaluations per class instead of an average

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnAdaptiveBoostingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnAdaptiveBoostingOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnAdaptiveBoostingOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.ensemble import AdaBoostClassifier"
-  name = "Adaptive Boosting"
+  modelName = "Adaptive Boosting"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnAdaptiveBoostingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnAdaptiveBoostingOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnAdaptiveBoostingOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.ensemble import AdaBoostClassifier"
-  modelUserFriendlyName = "Adaptive Boosting"
+  override def getImportStatements = "from sklearn.ensemble import AdaBoostClassifier"
+  override def getUserFriendlyModelName = "Adaptive Boosting"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnAdaptiveBoostingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnAdaptiveBoostingOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnAdaptiveBoostingOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.ensemble import AdaBoostClassifier"
-  modelName = "Adaptive Boosting"
+  modelImportStatement = "from sklearn.ensemble import AdaBoostClassifier"
+  modelUserFriendlyName = "Adaptive Boosting"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnBaggingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnBaggingOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnBaggingOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.ensemble import BaggingClassifier"
-  name = "Bagging"
+  modelName = "Bagging"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnBaggingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnBaggingOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnBaggingOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.ensemble import BaggingClassifier"
-  modelUserFriendlyName = "Bagging"
+  override def getImportStatements = "from sklearn.ensemble import BaggingClassifier"
+  override def getUserFriendlyModelName = "Bagging"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnBaggingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnBaggingOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnBaggingOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.ensemble import BaggingClassifier"
-  modelName = "Bagging"
+  modelImportStatement = "from sklearn.ensemble import BaggingClassifier"
+  modelUserFriendlyName = "Bagging"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnBernoulliNaiveBayesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnBernoulliNaiveBayesOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnBernoulliNaiveBayesOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.naive_bayes import BernoulliNB"
-  modelName = "Bernoulli Naive Bayes"
+  modelImportStatement = "from sklearn.naive_bayes import BernoulliNB"
+  modelUserFriendlyName = "Bernoulli Naive Bayes"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnBernoulliNaiveBayesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnBernoulliNaiveBayesOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnBernoulliNaiveBayesOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.naive_bayes import BernoulliNB"
-  name = "Bernoulli Naive Bayes"
+  modelName = "Bernoulli Naive Bayes"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnBernoulliNaiveBayesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnBernoulliNaiveBayesOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnBernoulliNaiveBayesOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.naive_bayes import BernoulliNB"
-  modelUserFriendlyName = "Bernoulli Naive Bayes"
+  override def getImportStatements = "from sklearn.naive_bayes import BernoulliNB"
+  override def getUserFriendlyModelName = "Bernoulli Naive Bayes"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnComplementNaiveBayesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnComplementNaiveBayesOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnComplementNaiveBayesOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.naive_bayes import ComplementNB"
-  modelUserFriendlyName = "Complement Naive Bayes"
+  override def getImportStatements = "from sklearn.naive_bayes import ComplementNB"
+  override def getUserFriendlyModelName = "Complement Naive Bayes"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnComplementNaiveBayesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnComplementNaiveBayesOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnComplementNaiveBayesOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.naive_bayes import ComplementNB"
-  name = "Complement Naive Bayes"
+  modelName = "Complement Naive Bayes"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnComplementNaiveBayesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnComplementNaiveBayesOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnComplementNaiveBayesOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.naive_bayes import ComplementNB"
-  modelName = "Complement Naive Bayes"
+  modelImportStatement = "from sklearn.naive_bayes import ComplementNB"
+  modelUserFriendlyName = "Complement Naive Bayes"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnDecisionTreeOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnDecisionTreeOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnDecisionTreeOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.tree import DecisionTreeClassifier"
-  modelName = "Decision Tree"
+  modelImportStatement = "from sklearn.tree import DecisionTreeClassifier"
+  modelUserFriendlyName = "Decision Tree"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnDecisionTreeOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnDecisionTreeOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnDecisionTreeOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.tree import DecisionTreeClassifier"
-  name = "Decision Tree"
+  modelName = "Decision Tree"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnDecisionTreeOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnDecisionTreeOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnDecisionTreeOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.tree import DecisionTreeClassifier"
-  modelUserFriendlyName = "Decision Tree"
+  override def getImportStatements = "from sklearn.tree import DecisionTreeClassifier"
+  override def getUserFriendlyModelName = "Decision Tree"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnDummyClassifierOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnDummyClassifierOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnDummyClassifierOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.dummy import dummy"
-  modelName = "Dummy Classifier"
+  modelImportStatement = "from sklearn.dummy import dummy"
+  modelUserFriendlyName = "Dummy Classifier"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnDummyClassifierOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnDummyClassifierOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnDummyClassifierOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.dummy import dummy"
-  name = "Dummy Classifier"
+  modelName = "Dummy Classifier"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnDummyClassifierOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnDummyClassifierOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnDummyClassifierOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.dummy import dummy"
-  modelUserFriendlyName = "Dummy Classifier"
+  override def getImportStatements = "from sklearn.dummy import dummy"
+  override def getUserFriendlyModelName = "Dummy Classifier"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnExtraTreeOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnExtraTreeOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnExtraTreeOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.tree import ExtraTreeClassifier"
-  name = "Extra Tree"
+  modelName = "Extra Tree"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnExtraTreeOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnExtraTreeOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnExtraTreeOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.tree import ExtraTreeClassifier"
-  modelName = "Extra Tree"
+  modelImportStatement = "from sklearn.tree import ExtraTreeClassifier"
+  modelUserFriendlyName = "Extra Tree"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnExtraTreeOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnExtraTreeOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnExtraTreeOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.tree import ExtraTreeClassifier"
-  modelUserFriendlyName = "Extra Tree"
+  override def getImportStatements = "from sklearn.tree import ExtraTreeClassifier"
+  override def getUserFriendlyModelName = "Extra Tree"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnExtraTreesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnExtraTreesOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnExtraTreesOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.ensemble import ExtraTreesClassifier"
-  modelName = "Extra Trees"
+  modelImportStatement = "from sklearn.ensemble import ExtraTreesClassifier"
+  modelUserFriendlyName = "Extra Trees"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnExtraTreesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnExtraTreesOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnExtraTreesOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.ensemble import ExtraTreesClassifier"
-  name = "Extra Trees"
+  modelName = "Extra Trees"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnExtraTreesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnExtraTreesOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnExtraTreesOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.ensemble import ExtraTreesClassifier"
-  modelUserFriendlyName = "Extra Trees"
+  override def getImportStatements = "from sklearn.ensemble import ExtraTreesClassifier"
+  override def getUserFriendlyModelName = "Extra Trees"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnGaussianNaiveBayesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnGaussianNaiveBayesOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnGaussianNaiveBayesOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.naive_bayes import GaussianNB"
-  modelName = "Gaussian Naive Bayes"
+  modelImportStatement = "from sklearn.naive_bayes import GaussianNB"
+  modelUserFriendlyName = "Gaussian Naive Bayes"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnGaussianNaiveBayesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnGaussianNaiveBayesOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnGaussianNaiveBayesOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.naive_bayes import GaussianNB"
-  name = "Gaussian Naive Bayes"
+  modelName = "Gaussian Naive Bayes"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnGaussianNaiveBayesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnGaussianNaiveBayesOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnGaussianNaiveBayesOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.naive_bayes import GaussianNB"
-  modelUserFriendlyName = "Gaussian Naive Bayes"
+  override def getImportStatements = "from sklearn.naive_bayes import GaussianNB"
+  override def getUserFriendlyModelName = "Gaussian Naive Bayes"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnGradientBoostingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnGradientBoostingOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnGradientBoostingOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.ensemble import GradientBoostingClassifier"
-  name = "Gradient Boosting"
+  modelName = "Gradient Boosting"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnGradientBoostingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnGradientBoostingOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnGradientBoostingOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.ensemble import GradientBoostingClassifier"
-  modelUserFriendlyName = "Gradient Boosting"
+  override def getImportStatements = "from sklearn.ensemble import GradientBoostingClassifier"
+  override def getUserFriendlyModelName = "Gradient Boosting"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnGradientBoostingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnGradientBoostingOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnGradientBoostingOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.ensemble import GradientBoostingClassifier"
-  modelName = "Gradient Boosting"
+  modelImportStatement = "from sklearn.ensemble import GradientBoostingClassifier"
+  modelUserFriendlyName = "Gradient Boosting"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnKNNOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnKNNOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnKNNOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.neighbors import KNeighborsClassifier"
-  modelUserFriendlyName = "K-nearest Neighbors"
+  override def getImportStatements = "from sklearn.neighbors import KNeighborsClassifier"
+  override def getUserFriendlyModelName = "K-nearest Neighbors"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnKNNOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnKNNOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnKNNOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.neighbors import KNeighborsClassifier"
-  modelName = "K-nearest Neighbors"
+  modelImportStatement = "from sklearn.neighbors import KNeighborsClassifier"
+  modelUserFriendlyName = "K-nearest Neighbors"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnKNNOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnKNNOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnKNNOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.neighbors import KNeighborsClassifier"
-  name = "K-nearest Neighbors"
+  modelName = "K-nearest Neighbors"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLinearRegressionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLinearRegressionOpDesc.scala
@@ -2,6 +2,6 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnLinearRegressionOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.linear_model import LinearRegression"
-  name = "Linear Regression"
+  modelName = "Linear Regression"
   classification = false
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLinearRegressionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLinearRegressionOpDesc.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnLinearRegressionOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.linear_model import LinearRegression"
-  modelName = "Linear Regression"
+  modelImportStatement = "from sklearn.linear_model import LinearRegression"
+  modelUserFriendlyName = "Linear Regression"
   classification = false
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLinearRegressionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLinearRegressionOpDesc.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnLinearRegressionOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.linear_model import LinearRegression"
-  modelUserFriendlyName = "Linear Regression"
+  override def getImportStatements = "from sklearn.linear_model import LinearRegression"
+  override def getUserFriendlyModelName = "Linear Regression"
   classification = false
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLinearSVMOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLinearSVMOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnLinearSVMOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.svm import LinearSVC"
-  modelUserFriendlyName = "Linear Support Vector Machine"
+  override def getImportStatements = "from sklearn.svm import LinearSVC"
+  override def getUserFriendlyModelName = "Linear Support Vector Machine"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLinearSVMOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLinearSVMOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnLinearSVMOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.svm import LinearSVC"
-  name = "Linear Support Vector Machine"
+  modelName = "Linear Support Vector Machine"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLinearSVMOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLinearSVMOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnLinearSVMOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.svm import LinearSVC"
-  modelName = "Linear Support Vector Machine"
+  modelImportStatement = "from sklearn.svm import LinearSVC"
+  modelUserFriendlyName = "Linear Support Vector Machine"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLogisticRegressionCVOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLogisticRegressionCVOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnLogisticRegressionCVOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.linear_model import LogisticRegressionCV"
-  name = "Logistic Regression Cross Validation"
+  modelName = "Logistic Regression Cross Validation"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLogisticRegressionCVOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLogisticRegressionCVOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnLogisticRegressionCVOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.linear_model import LogisticRegressionCV"
-  modelUserFriendlyName = "Logistic Regression Cross Validation"
+  override def getImportStatements = "from sklearn.linear_model import LogisticRegressionCV"
+  override def getUserFriendlyModelName = "Logistic Regression Cross Validation"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLogisticRegressionCVOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLogisticRegressionCVOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnLogisticRegressionCVOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.linear_model import LogisticRegressionCV"
-  modelName = "Logistic Regression Cross Validation"
+  modelImportStatement = "from sklearn.linear_model import LogisticRegressionCV"
+  modelUserFriendlyName = "Logistic Regression Cross Validation"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLogisticRegressionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLogisticRegressionOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnLogisticRegressionOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.linear_model import LogisticRegression"
-  modelName = "Logistic Regression"
+  modelImportStatement = "from sklearn.linear_model import LogisticRegression"
+  modelUserFriendlyName = "Logistic Regression"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLogisticRegressionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLogisticRegressionOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnLogisticRegressionOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.linear_model import LogisticRegression"
-  modelUserFriendlyName = "Logistic Regression"
+  override def getImportStatements = "from sklearn.linear_model import LogisticRegression"
+  override def getUserFriendlyModelName = "Logistic Regression"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLogisticRegressionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnLogisticRegressionOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnLogisticRegressionOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.linear_model import LogisticRegression"
-  name = "Logistic Regression"
+  modelName = "Logistic Regression"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMLOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMLOpDesc.scala
@@ -9,10 +9,6 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.{AttributeType, Schema}
 
 abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
 
-  def getImportStatements = ""
-
-  def getUserFriendlyModelName = ""
-
   @JsonIgnore
   var classification: Boolean = true
 
@@ -20,6 +16,10 @@ abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
   @JsonPropertyDescription("attribute in your dataset corresponding to target")
   @AutofillAttributeName
   var target: String = _
+
+  def getImportStatements = ""
+
+  def getUserFriendlyModelName = ""
 
   override def generatePythonCode(): String =
     s"""$getImportStatements

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMLOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMLOpDesc.scala
@@ -9,11 +9,9 @@ import edu.uci.ics.texera.workflow.common.tuple.schema.{AttributeType, Schema}
 
 abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
 
-  @JsonIgnore
-  var modelImportStatement = ""
+  def getImportStatements = ""
 
-  @JsonIgnore
-  var modelUserFriendlyName = ""
+  def getUserFriendlyModelName = ""
 
   @JsonIgnore
   var classification: Boolean = true
@@ -24,7 +22,7 @@ abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
   var target: String = _
 
   override def generatePythonCode(): String =
-    s"""$modelImportStatement
+    s"""$getImportStatements
        |from sklearn.metrics import accuracy_score, f1_score, precision_score, recall_score, mean_absolute_error, r2_score
        |import numpy as np
        |from pytexera import *
@@ -34,7 +32,7 @@ abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
        |        Y = table["$target"]
        |        X = table.drop("$target", axis=1)
        |        if port == 0:
-       |            self.model = ${modelImportStatement.split(" ").last}().fit(X, Y)
+       |            self.model = ${getImportStatements.split(" ").last}().fit(X, Y)
        |        else:
        |            predictions = self.model.predict(X)
        |            if ${if (classification) "True"
@@ -47,17 +45,17 @@ abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
        |                recalls = recall_score(Y, predictions, average=None)
        |                for i, class_name in enumerate(np.unique(Y)):
        |                    print("Class", repr(class_name), " - F1:", f1s[i], ", Precision:", precisions[i], ", Recall:", recalls[i])
-       |                yield {"model_name" : "$modelUserFriendlyName", "model" : self.model}
+       |                yield {"model_name" : "$getUserFriendlyModelName", "model" : self.model}
        |            else:
        |                mae = mean_absolute_error(Y, predictions)
        |                r2 = r2_score(Y, predictions)
        |                print("MAE:", mae, ", R2:", r2)
-       |                yield {"model_name" : "$modelUserFriendlyName", "model" : self.model}""".stripMargin
+       |                yield {"model_name" : "$getUserFriendlyModelName", "model" : self.model}""".stripMargin
 
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
-      modelUserFriendlyName,
-      "Sklearn " + modelUserFriendlyName + " Operator",
+      getUserFriendlyModelName,
+      "Sklearn " + getUserFriendlyModelName + " Operator",
       OperatorGroupConstants.SKLEARN_GROUP,
       inputPorts = List(
         InputPort(PortIdentity(), "training"),

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMLOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMLOpDesc.scala
@@ -26,7 +26,6 @@ abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
   override def generatePythonCode(): String =
     s"""$model
        |from sklearn.metrics import accuracy_score, f1_score, precision_score, recall_score, mean_absolute_error, r2_score
-       |import pandas as pd
        |from pytexera import *
        |class ProcessTableOperator(UDFTableOperator):
        |    @overrides
@@ -66,9 +65,10 @@ abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
     )
 
   override def getOutputSchema(schemas: Array[Schema]): Schema = {
-   Schema
+    Schema
       .builder()
       .add("model_name", AttributeType.STRING)
-      .add("model", AttributeType.BINARY).build()
+      .add("model", AttributeType.BINARY)
+      .build()
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMultiLayerPerceptronOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMultiLayerPerceptronOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnMultiLayerPerceptronOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.neural_network import MLPClassifier"
-  modelName = "Multi-layer Perceptron"
+  modelImportStatement = "from sklearn.neural_network import MLPClassifier"
+  modelUserFriendlyName = "Multi-layer Perceptron"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMultiLayerPerceptronOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMultiLayerPerceptronOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnMultiLayerPerceptronOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.neural_network import MLPClassifier"
-  name = "Multi-layer Perceptron"
+  modelName = "Multi-layer Perceptron"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMultiLayerPerceptronOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMultiLayerPerceptronOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnMultiLayerPerceptronOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.neural_network import MLPClassifier"
-  modelUserFriendlyName = "Multi-layer Perceptron"
+  override def getImportStatements = "from sklearn.neural_network import MLPClassifier"
+  override def getUserFriendlyModelName = "Multi-layer Perceptron"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMultinomialNaiveBayesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMultinomialNaiveBayesOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnMultinomialNaiveBayesOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.naive_bayes import MultinomialNB"
-  modelUserFriendlyName = "Multinomial Naive Bayes"
+  override def getImportStatements = "from sklearn.naive_bayes import MultinomialNB"
+  override def getUserFriendlyModelName = "Multinomial Naive Bayes"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMultinomialNaiveBayesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMultinomialNaiveBayesOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnMultinomialNaiveBayesOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.naive_bayes import MultinomialNB"
-  name = "Multinomial Naive Bayes"
+  modelName = "Multinomial Naive Bayes"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMultinomialNaiveBayesOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMultinomialNaiveBayesOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnMultinomialNaiveBayesOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.naive_bayes import MultinomialNB"
-  modelName = "Multinomial Naive Bayes"
+  modelImportStatement = "from sklearn.naive_bayes import MultinomialNB"
+  modelUserFriendlyName = "Multinomial Naive Bayes"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnNearestCentroidOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnNearestCentroidOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnNearestCentroidOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.neighbors import NearestCentroid"
-  modelName = "Nearest Centroid"
+  modelImportStatement = "from sklearn.neighbors import NearestCentroid"
+  modelUserFriendlyName = "Nearest Centroid"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnNearestCentroidOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnNearestCentroidOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnNearestCentroidOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.neighbors import NearestCentroid"
-  name = "Nearest Centroid"
+  modelName = "Nearest Centroid"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnNearestCentroidOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnNearestCentroidOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnNearestCentroidOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.neighbors import NearestCentroid"
-  modelUserFriendlyName = "Nearest Centroid"
+  override def getImportStatements = "from sklearn.neighbors import NearestCentroid"
+  override def getUserFriendlyModelName = "Nearest Centroid"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPassiveAggressiveOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPassiveAggressiveOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnPassiveAggressiveOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.linear_model import PassiveAggressiveClassifier"
-  modelUserFriendlyName = "Passive Aggressive"
+  override def getImportStatements = "from sklearn.linear_model import PassiveAggressiveClassifier"
+  override def getUserFriendlyModelName = "Passive Aggressive"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPassiveAggressiveOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPassiveAggressiveOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnPassiveAggressiveOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.linear_model import PassiveAggressiveClassifier"
-  modelName = "Passive Aggressive"
+  modelImportStatement = "from sklearn.linear_model import PassiveAggressiveClassifier"
+  modelUserFriendlyName = "Passive Aggressive"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPassiveAggressiveOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPassiveAggressiveOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnPassiveAggressiveOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.linear_model import PassiveAggressiveClassifier"
-  name = "Passive Aggressive"
+  modelName = "Passive Aggressive"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPerceptronOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPerceptronOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnPerceptronOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.linear_model import Perceptron"
-  modelUserFriendlyName = "Linear Perceptron"
+  override def getImportStatements = "from sklearn.linear_model import Perceptron"
+  override def getUserFriendlyModelName = "Linear Perceptron"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPerceptronOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPerceptronOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnPerceptronOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.linear_model import Perceptron"
-  modelName = "Linear Perceptron"
+  modelImportStatement = "from sklearn.linear_model import Perceptron"
+  modelUserFriendlyName = "Linear Perceptron"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPerceptronOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPerceptronOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnPerceptronOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.linear_model import Perceptron"
-  name = "Linear Perceptron"
+  modelName = "Linear Perceptron"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnProbabilityCalibrationOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnProbabilityCalibrationOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnProbabilityCalibrationOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.calibration import CalibratedClassifierCV"
-  modelUserFriendlyName = "Probability Calibration"
+  override def getImportStatements = "from sklearn.calibration import CalibratedClassifierCV"
+  override def getUserFriendlyModelName = "Probability Calibration"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnProbabilityCalibrationOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnProbabilityCalibrationOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnProbabilityCalibrationOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.calibration import CalibratedClassifierCV"
-  name = "Probability Calibration"
+  modelName = "Probability Calibration"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnProbabilityCalibrationOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnProbabilityCalibrationOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnProbabilityCalibrationOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.calibration import CalibratedClassifierCV"
-  modelName = "Probability Calibration"
+  modelImportStatement = "from sklearn.calibration import CalibratedClassifierCV"
+  modelUserFriendlyName = "Probability Calibration"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRandomForestOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRandomForestOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnRandomForestOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.ensemble import RandomForestClassifier"
-  modelName = "Random Forest"
+  modelImportStatement = "from sklearn.ensemble import RandomForestClassifier"
+  modelUserFriendlyName = "Random Forest"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRandomForestOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRandomForestOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnRandomForestOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.ensemble import RandomForestClassifier"
-  name = "Random Forest"
+  modelName = "Random Forest"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRandomForestOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRandomForestOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnRandomForestOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.ensemble import RandomForestClassifier"
-  modelUserFriendlyName = "Random Forest"
+  override def getImportStatements = "from sklearn.ensemble import RandomForestClassifier"
+  override def getUserFriendlyModelName = "Random Forest"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRidgeCVOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRidgeCVOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnRidgeCVOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.linear_model import RidgeClassifierCV"
-  modelUserFriendlyName = "Ridge Regression Cross Validation"
+  override def getImportStatements = "from sklearn.linear_model import RidgeClassifierCV"
+  override def getUserFriendlyModelName = "Ridge Regression Cross Validation"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRidgeCVOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRidgeCVOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnRidgeCVOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.linear_model import RidgeClassifierCV"
-  name = "Ridge Regression Cross Validation"
+  modelName = "Ridge Regression Cross Validation"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRidgeCVOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRidgeCVOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnRidgeCVOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.linear_model import RidgeClassifierCV"
-  modelName = "Ridge Regression Cross Validation"
+  modelImportStatement = "from sklearn.linear_model import RidgeClassifierCV"
+  modelUserFriendlyName = "Ridge Regression Cross Validation"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRidgeOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRidgeOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnRidgeOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.linear_model import RidgeClassifier"
-  modelUserFriendlyName = "Ridge Regression"
+  override def getImportStatements = "from sklearn.linear_model import RidgeClassifier"
+  override def getUserFriendlyModelName = "Ridge Regression"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRidgeOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRidgeOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnRidgeOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.linear_model import RidgeClassifier"
-  name = "Ridge Regression"
+  modelName = "Ridge Regression"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRidgeOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnRidgeOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnRidgeOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.linear_model import RidgeClassifier"
-  modelName = "Ridge Regression"
+  modelImportStatement = "from sklearn.linear_model import RidgeClassifier"
+  modelUserFriendlyName = "Ridge Regression"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnSDGOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnSDGOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnSDGOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.linear_model import SGDClassifier"
-  modelName = "Stochastic Gradient Descent"
+  modelImportStatement = "from sklearn.linear_model import SGDClassifier"
+  modelUserFriendlyName = "Stochastic Gradient Descent"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnSDGOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnSDGOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnSDGOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.linear_model import SGDClassifier"
-  name = "Stochastic Gradient Descent"
+  modelName = "Stochastic Gradient Descent"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnSDGOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnSDGOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnSDGOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.linear_model import SGDClassifier"
-  modelUserFriendlyName = "Stochastic Gradient Descent"
+  override def getImportStatements = "from sklearn.linear_model import SGDClassifier"
+  override def getUserFriendlyModelName = "Stochastic Gradient Descent"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnSVMOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnSVMOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnSVMOpDesc extends SklearnMLOpDesc {
-  model = "from sklearn.svm import SVC"
-  modelName = "Support Vector Machine"
+  modelImportStatement = "from sklearn.svm import SVC"
+  modelUserFriendlyName = "Support Vector Machine"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnSVMOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnSVMOpDesc.scala
@@ -1,6 +1,6 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnSVMOpDesc extends SklearnMLOpDesc {
-  modelImportStatement = "from sklearn.svm import SVC"
-  modelUserFriendlyName = "Support Vector Machine"
+  override def getImportStatements = "from sklearn.svm import SVC"
+  override def getUserFriendlyModelName = "Support Vector Machine"
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnSVMOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnSVMOpDesc.scala
@@ -2,5 +2,5 @@ package edu.uci.ics.texera.workflow.operators.sklearn
 
 class SklearnSVMOpDesc extends SklearnMLOpDesc {
   model = "from sklearn.svm import SVC"
-  name = "Support Vector Machine"
+  modelName = "Support Vector Machine"
 }


### PR DESCRIPTION
The way we used for evaluations including f1_score, precision, and recall are all using the `micro` average method. This way for multi-class usage, the evaluations for each individual class are aggregated, resulting the same value for all evaluations. 

This PR changes this behavior and lets each class's individual evaluations be logged out on the console. And it also removes those evaluations from the output tuple as it is not useful.

![CleanShot 2024-05-10 at 12 10 38](https://github.com/Texera/texera/assets/17627829/dbe749a4-7797-4f99-9002-068c2dc1332d)

![CleanShot 2024-05-10 at 12 06 29](https://github.com/Texera/texera/assets/17627829/1e445d82-9c0e-412e-ba4b-65d735662662)

