### PR TITLE
Rearrange operators into sub-menus

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/OperatorGroupConstants.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/OperatorGroupConstants.scala
@@ -5,7 +5,6 @@ object OperatorGroupConstants {
   final val DATABASE_GROUP = "Database Connector"
   final val SEARCH_GROUP = "Search"
   final val CLEANING_GROUP = "Data Cleaning"
-  final val MACHINE_LEARNING_GROUP = "Machine Learning"
   final val JOIN_GROUP = "Join"
   final val SET_GROUP = "Set"
   final val AGGREGATE_GROUP = "Aggregate"
@@ -13,12 +12,12 @@ object OperatorGroupConstants {
   final val UTILITY_GROUP = "Utilities"
   final val API_GROUP = "External API"
   final val VISUALIZATION_GROUP = "Visualization"
+  final val MACHINE_LEARNING_GROUP = "Machine Learning"
   final val HUGGINGFACE_GROUP = "Hugging Face"
   final val SKLEARN_GROUP = "Sklearn"
   final val UDF_GROUP = "User-defined Functions"
   final val PYTHON_GROUP = "Python"
   final val JAVA_GROUP = "Java"
-
 
   /**
     * The order of the groups to show up in the frontend operator panel.
@@ -28,7 +27,10 @@ object OperatorGroupConstants {
     GroupInfo(INPUT_GROUP),
     GroupInfo(DATABASE_GROUP),
     GroupInfo(SEARCH_GROUP),
-    GroupInfo(CLEANING_GROUP, List(GroupInfo(JOIN_GROUP), GroupInfo(AGGREGATE_GROUP), GroupInfo(SORT_GROUP))),
+    GroupInfo(
+      CLEANING_GROUP,
+      List(GroupInfo(JOIN_GROUP), GroupInfo(AGGREGATE_GROUP), GroupInfo(SORT_GROUP))
+    ),
     GroupInfo(MACHINE_LEARNING_GROUP, List(GroupInfo(SKLEARN_GROUP), GroupInfo(HUGGINGFACE_GROUP))),
     GroupInfo(UTILITY_GROUP),
     GroupInfo(API_GROUP),

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/OperatorGroupConstants.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/OperatorGroupConstants.scala
@@ -12,10 +12,13 @@ object OperatorGroupConstants {
   final val SORT_GROUP = "Sort"
   final val UTILITY_GROUP = "Utilities"
   final val API_GROUP = "External API"
-  final val UDF_GROUP = "User-defined Functions"
   final val VISUALIZATION_GROUP = "Visualization"
   final val HUGGINGFACE_GROUP = "Hugging Face"
   final val SKLEARN_GROUP = "Sklearn"
+  final val UDF_GROUP = "User-defined Functions"
+  final val PYTHON_GROUP = "Python"
+  final val JAVA_GROUP = "Java"
+
 
   /**
     * The order of the groups to show up in the frontend operator panel.
@@ -25,15 +28,11 @@ object OperatorGroupConstants {
     GroupInfo(INPUT_GROUP),
     GroupInfo(DATABASE_GROUP),
     GroupInfo(SEARCH_GROUP),
-    GroupInfo(CLEANING_GROUP),
+    GroupInfo(CLEANING_GROUP, List(GroupInfo(JOIN_GROUP), GroupInfo(AGGREGATE_GROUP), GroupInfo(SORT_GROUP))),
     GroupInfo(MACHINE_LEARNING_GROUP, List(GroupInfo(SKLEARN_GROUP), GroupInfo(HUGGINGFACE_GROUP))),
-    GroupInfo(JOIN_GROUP),
-    GroupInfo(SET_GROUP),
-    GroupInfo(AGGREGATE_GROUP),
-    GroupInfo(SORT_GROUP),
     GroupInfo(UTILITY_GROUP),
     GroupInfo(API_GROUP),
-    GroupInfo(UDF_GROUP),
+    GroupInfo(UDF_GROUP, List(GroupInfo(PYTHON_GROUP), GroupInfo(JAVA_GROUP))),
     GroupInfo(VISUALIZATION_GROUP)
   )
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/java/JavaUDFOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/java/JavaUDFOpDesc.scala
@@ -144,7 +144,7 @@ class JavaUDFOpDesc extends LogicalOp {
     OperatorInfo(
       "Java UDF",
       "User-defined function operator in Java script",
-      OperatorGroupConstants.UDF_GROUP,
+      OperatorGroupConstants.JAVA_GROUP,
       inputPortInfo,
       outputPortInfo,
       dynamicInputPorts = true,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/DualInputPortsPythonUDFOpDescV2.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/DualInputPortsPythonUDFOpDescV2.scala
@@ -113,7 +113,7 @@ class DualInputPortsPythonUDFOpDescV2 extends LogicalOp {
     OperatorInfo(
       "2-in Python UDF",
       "User-defined function operator in Python script",
-      OperatorGroupConstants.UDF_GROUP,
+      OperatorGroupConstants.PYTHON_GROUP,
       inputPorts = List(
         InputPort(PortIdentity(), displayName = "model", allowMultiLinks = true),
         InputPort(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonLambdaFunctionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonLambdaFunctionOpDesc.scala
@@ -44,7 +44,7 @@ class PythonLambdaFunctionOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Python Lambda Function",
       "Modify or add a new column with more ease",
-      OperatorGroupConstants.UDF_GROUP,
+      OperatorGroupConstants.PYTHON_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort()),
       supportReconfiguration = true

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonTableReducerOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonTableReducerOpDesc.scala
@@ -24,7 +24,7 @@ class PythonTableReducerOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Python Table Reducer",
       "Reduce Table to Tuple",
-      OperatorGroupConstants.UDF_GROUP,
+      OperatorGroupConstants.PYTHON_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort())
     )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonUDFOpDescV2.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/PythonUDFOpDescV2.scala
@@ -152,7 +152,7 @@ class PythonUDFOpDescV2 extends LogicalOp {
     OperatorInfo(
       "Python UDF",
       "User-defined function operator in Python script",
-      OperatorGroupConstants.UDF_GROUP,
+      OperatorGroupConstants.PYTHON_GROUP,
       inputPortInfo,
       outputPortInfo,
       dynamicInputPorts = true,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/source/PythonUDFSourceOpDescV2.java
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/python/source/PythonUDFSourceOpDescV2.java
@@ -97,7 +97,7 @@ public class PythonUDFSourceOpDescV2 extends SourceOperatorDescriptor {
         return new OperatorInfo(
                 "1-out Python UDF",
                 "User-defined function operator in Python script",
-                OperatorGroupConstants.UDF_GROUP(),
+                OperatorGroupConstants.PYTHON_GROUP(),
                 asScala(new ArrayList<InputPort>()).toList(),
                 asScala(singletonList(new OutputPort(new PortIdentity(0, false), "", false))).toList(),
                 false,


### PR DESCRIPTION
This PR 
- moves `Aggregate`, `Join` and `Sort` as sub-menus under `Data Cleaning`.
![CleanShot 2024-05-11 at 22 17 47](https://github.com/Texera/texera/assets/17627829/06e32be9-aaca-4076-9258-0edc4c24fafa)

- creates new sub-menus `Python` and `Java` for respective UDFs.
![CleanShot 2024-05-11 at 22 17 55](https://github.com/Texera/texera/assets/17627829/6a11dae5-fd78-46d0-99ed-39524a1e625c)
