### PR TITLE
Add seed attribute to train/test split opeator

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/split/SplitOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/split/SplitOpDesc.scala
@@ -1,10 +1,9 @@
 package edu.uci.ics.texera.workflow.operators.split
 
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonPropertyDescription}
+import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.google.common.base.Preconditions
 import edu.uci.ics.amber.engine.architecture.deploysemantics.{PhysicalOp, SchemaPropagationFunc}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfo
-import edu.uci.ics.amber.engine.common.AmberConfig
 import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import edu.uci.ics.amber.engine.common.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.texera.workflow.common.metadata.{OperatorGroupConstants, OperatorInfo}
@@ -19,9 +18,9 @@ class SplitOpDesc extends LogicalOp {
   @JsonPropertyDescription("percentage of training split data (default 80%)")
   var k: Int = 80
 
-  // Store random seeds for each executor to satisfy the fault tolerance requirement.
-  @JsonIgnore
-  val seeds: Array[Int] = Array.fill(AmberConfig.numWorkerPerOperatorByDefault)(Random.nextInt())
+  @JsonProperty(value = "random seed", required = false)
+  @JsonPropertyDescription("Random seed for split")
+  var seed: Int = Random.nextInt()
 
   override def getPhysicalOp(
       workflowId: WorkflowIdentity,
@@ -32,10 +31,11 @@ class SplitOpDesc extends LogicalOp {
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecInitInfo((idx, _) => new SplitOpExec(k, idx, seeds.apply))
+        OpExecInitInfo((_, _) => new SplitOpExec(k, seed))
       )
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
+      .withParallelizable(false)
       .withPropagateSchema(
         SchemaPropagationFunc(inputSchemas =>
           operatorInfo.outputPorts

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/split/SplitOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/split/SplitOpExec.scala
@@ -9,11 +9,10 @@ import scala.util.Random
 
 class SplitOpExec(
     k: Int,
-    worker: Int,
-    getSeed: Int => Int
+    seed: Int
 ) extends OperatorExecutor {
 
-  lazy val random = new Random(getSeed(worker))
+  lazy val random = new Random(seed)
 
   override def processTupleMultiPort(
       tuple: Tuple,


### PR DESCRIPTION
This PR adds the random `seed` as an attribute of train/test split to provide reproducibility of its output.