### PR TITLE
Fix HideAnnotation

### DIFF
--- a/core/gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
+++ b/core/gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
@@ -22,7 +22,8 @@ import {
   AttributeTypeConstRule,
   AttributeTypeEnumRule,
   AttributeTypeRuleSet,
-  CustomJSONSchema7, hideTypes,
+  CustomJSONSchema7,
+  hideTypes,
 } from "../../../types/custom-json-schema.interface";
 import { isDefined } from "../../../../common/util/predicate";
 import { ExecutionState, OperatorState, OperatorStatistics } from "src/app/workspace/types/execute-workflow.interface";
@@ -33,7 +34,8 @@ import {
   SchemaPropagationService,
 } from "../../../service/dynamic-schema/schema-propagation/schema-propagation.service";
 import {
-  createOutputFormChangeEventStream, createShouldHideFieldFunc,
+  createOutputFormChangeEventStream,
+  createShouldHideFieldFunc,
   setChildTypeDependency,
   setHideExpression,
 } from "src/app/common/formly/formly-utils";
@@ -424,7 +426,7 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
             mapSource.hideType,
             mapSource.hideExpectedValue,
             mapSource.hideOnNull
-          )
+          ),
         };
       }
 

--- a/core/gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
+++ b/core/gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.ts
@@ -22,7 +22,7 @@ import {
   AttributeTypeConstRule,
   AttributeTypeEnumRule,
   AttributeTypeRuleSet,
-  CustomJSONSchema7,
+  CustomJSONSchema7, hideTypes,
 } from "../../../types/custom-json-schema.interface";
 import { isDefined } from "../../../../common/util/predicate";
 import { ExecutionState, OperatorState, OperatorStatistics } from "src/app/workspace/types/execute-workflow.interface";
@@ -33,7 +33,7 @@ import {
   SchemaPropagationService,
 } from "../../../service/dynamic-schema/schema-propagation/schema-propagation.service";
 import {
-  createOutputFormChangeEventStream,
+  createOutputFormChangeEventStream, createShouldHideFieldFunc,
   setChildTypeDependency,
   setHideExpression,
 } from "src/app/common/formly/formly-utils";
@@ -366,7 +366,7 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
       mapSource: CustomJSONSchema7
     ): FormlyFieldConfig => {
       // apply the overridden css style if applicable
-      mappedField.expressionProperties = {
+      mappedField.expressions = {
         "templateOptions.attributes": () => {
           if (
             isDefined(mappedField) &&
@@ -382,7 +382,8 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
 
       // Disable dummy operator for user
       if (mappedField.key === "dummyOperator") {
-        mappedField.expressionProperties = {
+        mappedField.expressions = {
+          ...mappedField.expressions,
           "templateOptions.disabled": () => true,
           "templateOptions.readonly": () => true,
         };
@@ -390,7 +391,8 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
 
       // Disable dummy property and value fields for user
       if (mappedField.key === "dummyProperty" || mappedField.key === "dummyValue") {
-        mappedField.expressionProperties = {
+        mappedField.expressions = {
+          ...mappedField.expressions,
           "templateOptions.readonly": () => true,
           "templateOptions.disabled": () => true,
         };
@@ -398,15 +400,31 @@ export class OperatorPropertyEditFrameComponent implements OnInit, OnChanges, On
 
       // Disable dummy property list for all operators, except for dummy operator.
       if (mappedField.key === "dummyPropertyList") {
-        mappedField.hide = true;
-        if (this.currentOperatorSchema?.operatorType === "Dummy") {
-          mappedField.hide = false;
-        }
-        mappedField.expressionProperties = {
+        mappedField.hide = this.currentOperatorSchema?.operatorType !== "Dummy";
+        mappedField.expressions = {
+          ...mappedField.expressions,
           "templateOptions.disabled": () => true,
           "templateOptions.readonly": () => true,
           "templateOptions.canRemove": () => false,
           "templateOptions.canAdd": () => false,
+        };
+      }
+
+      // conditionally hide the field according to the schema
+      if (
+        isDefined(mapSource.hideExpectedValue) &&
+        isDefined(mapSource.hideTarget) &&
+        isDefined(mapSource.hideType) &&
+        hideTypes.includes(mapSource.hideType)
+      ) {
+        mappedField.expressions = {
+          ...mappedField.expressions,
+          hide: createShouldHideFieldFunc(
+            mapSource.hideTarget,
+            mapSource.hideType,
+            mapSource.hideExpectedValue,
+            mapSource.hideOnNull
+          )
         };
       }
 


### PR DESCRIPTION
This PR fixes #2436. The HideAnnotation feature's frontend handler function was accidentally removed when bumping formly version in #2014. In this PR we add the handler function back, and we also update the deprecated API (`FormlyFieldConfig.expressionProperties`) to use the latest version: `FormlyFieldConfig.expression`.