### PR TITLE
Modify the VirtualDocument API semantic

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/storage/VirtualDocument.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/storage/VirtualDocument.scala
@@ -11,27 +11,38 @@ import java.net.URI
   */
 abstract class VirtualDocument[T >: Null <: AnyRef] {
 
+  /**
+    * get the URI of corresponding document
+    * @return the URI of the document
+    */
   def getURI: URI
 
   /**
-    * read ith item and return
+    * find ith item and return
     * @param i index starting from 0
     * @return data item of type T
     */
-  def readItem(i: Int): T =
+  def getItem(i: Int): T =
     throw new UnsupportedOperationException("readItem method is not supported")
 
   /**
-    * iterate over whole document using iterator
+    * get a iterator that iterates all indexed items
     * @return an iterator that return data item of type T
     */
-  def read(): Iterator[T] = throw new UnsupportedOperationException("read method is not supported")
+  def get(): Iterator[T] = throw new UnsupportedOperationException("read method is not supported")
 
   /**
     * append one data item to the document
     * @param item the data item
     */
   def writeItem(item: T): Unit =
+    throw new UnsupportedOperationException("writeItem method is not supported")
+
+  /**
+    * write ith item
+    * @param item the data item
+    */
+  def writeItem(i: Int, item: T): Unit =
     throw new UnsupportedOperationException("writeItem method is not supported")
 
   /**
@@ -45,17 +56,20 @@ abstract class VirtualDocument[T >: Null <: AnyRef] {
     * append the file content with an opened input stream
     * @param inputStream the data source input stream
     */
-  def writeWithStream(inputStream: InputStream): Unit =
+  def write(inputStream: InputStream): Unit =
     throw new UnsupportedOperationException("writeWithStream method is not supported")
 
   /**
-    * read the document as an input stream
-    *
+    * convert document as an input stream
     * @return the input stream
     */
   def asInputStream(): InputStream =
     throw new UnsupportedOperationException("asInputStream method is not supported")
 
+  /**
+    * convert document as a File
+    * @return
+    */
   def asFile(): File = throw new UnsupportedOperationException("asFile method is not supported")
 
   /**

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/storage/VirtualDocument.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/storage/VirtualDocument.scala
@@ -42,7 +42,7 @@ abstract class VirtualDocument[T >: Null <: AnyRef] {
     throw new UnsupportedOperationException("write method is not supported")
 
   /**
-    * overwrite the file content with an opened input stream
+    * append the file content with an opened input stream
     * @param inputStream the data source input stream
     */
   def writeWithStream(inputStream: InputStream): Unit =

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/storage/VirtualDocument.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/storage/VirtualDocument.scala
@@ -23,54 +23,54 @@ abstract class VirtualDocument[T >: Null <: AnyRef] {
     * @return data item of type T
     */
   def getItem(i: Int): T =
-    throw new UnsupportedOperationException("readItem method is not supported")
+    throw new NotImplementedError("getItem method is not implemented")
 
   /**
     * get a iterator that iterates all indexed items
     * @return an iterator that return data item of type T
     */
-  def get(): Iterator[T] = throw new UnsupportedOperationException("read method is not supported")
+  def get(): Iterator[T] = throw new NotImplementedError("get method is not implemented")
 
   /**
     * append one data item to the document
     * @param item the data item
     */
-  def writeItem(item: T): Unit =
-    throw new UnsupportedOperationException("writeItem method is not supported")
+  def setItem(item: T): Unit =
+    throw new NotImplementedError("setItem method is not implemented")
 
   /**
-    * write ith item
+    * set ith item
     * @param item the data item
     */
-  def writeItem(i: Int, item: T): Unit =
-    throw new UnsupportedOperationException("writeItem method is not supported")
+  def setItem(i: Int, item: T): Unit =
+    throw new NotImplementedError("setItem method is not implemented")
 
   /**
     * append data items from the iterator to the document
     * @param items iterator for the data item
     */
   def write(items: Iterator[T]): Unit =
-    throw new UnsupportedOperationException("write method is not supported")
+    throw new NotImplementedError("write method is not implemented")
 
   /**
     * append the file content with an opened input stream
     * @param inputStream the data source input stream
     */
   def write(inputStream: InputStream): Unit =
-    throw new UnsupportedOperationException("writeWithStream method is not supported")
+    throw new NotImplementedError("write method is not implemented")
 
   /**
     * convert document as an input stream
     * @return the input stream
     */
   def asInputStream(): InputStream =
-    throw new UnsupportedOperationException("asInputStream method is not supported")
+    throw new NotImplementedError("asInputStream method is not implemented")
 
   /**
     * convert document as a File
-    * @return
+    * @return the file
     */
-  def asFile(): File = throw new UnsupportedOperationException("asFile method is not supported")
+  def asFile(): File = throw new NotImplementedError("asFile method is not implemented")
 
   /**
     * physically remove current document


### PR DESCRIPTION
This PR modifies the `VirtualDocument`, rename some APIs and fix the `write` related APIs so that all write are semantically doing append.