### PR TITLE
Introduce Vectorizer to ML models

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMLOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMLOpDesc.scala
@@ -1,8 +1,9 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonPropertyDescription}
+import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaInt, JsonSchemaString, JsonSchemaTitle}
 import edu.uci.ics.amber.engine.common.workflow.{InputPort, OutputPort, PortIdentity}
-import edu.uci.ics.texera.workflow.common.metadata.annotations.AutofillAttributeName
+import edu.uci.ics.texera.workflow.common.metadata.annotations.{AutofillAttributeName, CommonOpDescAnnotation, HideAnnotation}
 import edu.uci.ics.texera.workflow.common.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.texera.workflow.common.operators.PythonOperatorDescriptor
 import edu.uci.ics.texera.workflow.common.tuple.schema.{AttributeType, Schema}
@@ -12,10 +13,42 @@ abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
   @JsonIgnore
   var classification: Boolean = true
 
-  @JsonProperty(value = "Target Attribute", required = true)
-  @JsonPropertyDescription("attribute in your dataset corresponding to target")
+  @JsonSchemaTitle("Target Attribute")
+  @JsonPropertyDescription("Attribute in your dataset corresponding to target")
+  @JsonProperty(required = true)
   @AutofillAttributeName
   var target: String = _
+
+  @JsonSchemaTitle("Count Vectorizer")
+  @JsonPropertyDescription("Convert a collection of text documents to a matrix of token counts.")
+  @JsonProperty(defaultValue = "false")
+  var countVectorizer: Boolean = false
+
+  @JsonSchemaTitle("Text Attribute")
+  @JsonPropertyDescription("Attribute in your dataset with text to vectorize")
+  @JsonProperty(required = true)
+  @JsonSchemaInject(
+    strings = Array(
+      new JsonSchemaString(path = CommonOpDescAnnotation.autofill, value = CommonOpDescAnnotation.attributeName),
+      new JsonSchemaString(path = HideAnnotation.hideTarget, value = "countVectorizer"),
+      new JsonSchemaString(path = HideAnnotation.hideType, value = HideAnnotation.Type.equals),
+      new JsonSchemaString(path = HideAnnotation.hideExpectedValue, value = "false"),
+    ),
+    ints = Array(new JsonSchemaInt(path = CommonOpDescAnnotation.autofillAttributeOnPort, value = 0))
+  )
+  var text: String = _
+
+  @JsonSchemaTitle("Tfidf Transformer")
+  @JsonPropertyDescription("Transform a count matrix to a normalized tf or tf-idf representation.")
+  @JsonProperty(defaultValue = "false")
+  @JsonSchemaInject(
+    strings = Array(
+      new JsonSchemaString(path = HideAnnotation.hideTarget, value = "countVectorizer"),
+      new JsonSchemaString(path = HideAnnotation.hideType, value = HideAnnotation.Type.equals),
+      new JsonSchemaString(path = HideAnnotation.hideExpectedValue, value = "false")
+    )
+  )
+  val tfidfTransformer: Boolean = false
 
   @JsonIgnore
   def getImportStatements = ""
@@ -26,6 +59,8 @@ abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
   override def generatePythonCode(): String =
     s"""$getImportStatements
        |from sklearn.metrics import accuracy_score, f1_score, precision_score, recall_score, mean_absolute_error, r2_score
+       |from sklearn.pipeline import make_pipeline
+       |from sklearn.feature_extraction.text import CountVectorizer, TfidfTransformer
        |import numpy as np
        |from pytexera import *
        |class ProcessTableOperator(UDFTableOperator):
@@ -33,15 +68,14 @@ abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
        |    def process_table(self, table: Table, port: int) -> Iterator[Optional[TableLike]]:
        |        Y = table["$target"]
        |        X = table.drop("$target", axis=1)
+       |        X = ${if (countVectorizer) "X['"+text+"']" else "X"}
        |        if port == 0:
-       |            self.model = ${getImportStatements.split(" ").last}().fit(X, Y)
+       |            self.model = make_pipeline(${if (countVectorizer) "CountVectorizer()," else ""} ${if (tfidfTransformer) "TfidfTransformer()," else ""} ${getImportStatements.split(" ").last}()).fit(X, Y)
        |        else:
        |            predictions = self.model.predict(X)
        |            if ${if (classification) "True"
     else "False"}:
-       |                accuracy = accuracy_score(Y, predictions)
-       |                print("Overall Accuracy:", accuracy)
-       |
+       |                print("Overall Accuracy:", accuracy_score(Y, predictions))
        |                f1s = f1_score(Y, predictions, average=None)
        |                precisions = precision_score(Y, predictions, average=None)
        |                recalls = recall_score(Y, predictions, average=None)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMLOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMLOpDesc.scala
@@ -1,9 +1,18 @@
 package edu.uci.ics.texera.workflow.operators.sklearn
 
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonPropertyDescription}
-import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaInt, JsonSchemaString, JsonSchemaTitle}
+import com.kjetland.jackson.jsonSchema.annotations.{
+  JsonSchemaInject,
+  JsonSchemaInt,
+  JsonSchemaString,
+  JsonSchemaTitle
+}
 import edu.uci.ics.amber.engine.common.workflow.{InputPort, OutputPort, PortIdentity}
-import edu.uci.ics.texera.workflow.common.metadata.annotations.{AutofillAttributeName, CommonOpDescAnnotation, HideAnnotation}
+import edu.uci.ics.texera.workflow.common.metadata.annotations.{
+  AutofillAttributeName,
+  CommonOpDescAnnotation,
+  HideAnnotation
+}
 import edu.uci.ics.texera.workflow.common.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.texera.workflow.common.operators.PythonOperatorDescriptor
 import edu.uci.ics.texera.workflow.common.tuple.schema.{AttributeType, Schema}
@@ -14,7 +23,7 @@ abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
   var classification: Boolean = true
 
   @JsonSchemaTitle("Target Attribute")
-  @JsonPropertyDescription("Attribute in your dataset corresponding to target")
+  @JsonPropertyDescription("Attribute in your dataset corresponding to target.")
   @JsonProperty(required = true)
   @AutofillAttributeName
   var target: String = _
@@ -25,16 +34,21 @@ abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
   var countVectorizer: Boolean = false
 
   @JsonSchemaTitle("Text Attribute")
-  @JsonPropertyDescription("Attribute in your dataset with text to vectorize")
+  @JsonPropertyDescription("Attribute in your dataset with text to vectorize.")
   @JsonProperty(required = true)
   @JsonSchemaInject(
     strings = Array(
-      new JsonSchemaString(path = CommonOpDescAnnotation.autofill, value = CommonOpDescAnnotation.attributeName),
+      new JsonSchemaString(
+        path = CommonOpDescAnnotation.autofill,
+        value = CommonOpDescAnnotation.attributeName
+      ),
       new JsonSchemaString(path = HideAnnotation.hideTarget, value = "countVectorizer"),
       new JsonSchemaString(path = HideAnnotation.hideType, value = HideAnnotation.Type.equals),
-      new JsonSchemaString(path = HideAnnotation.hideExpectedValue, value = "false"),
+      new JsonSchemaString(path = HideAnnotation.hideExpectedValue, value = "false")
     ),
-    ints = Array(new JsonSchemaInt(path = CommonOpDescAnnotation.autofillAttributeOnPort, value = 0))
+    ints = Array(
+      new JsonSchemaInt(path = CommonOpDescAnnotation.autofillAttributeOnPort, value = 0)
+    )
   )
   var text: String = _
 
@@ -68,9 +82,12 @@ abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
        |    def process_table(self, table: Table, port: int) -> Iterator[Optional[TableLike]]:
        |        Y = table["$target"]
        |        X = table.drop("$target", axis=1)
-       |        X = ${if (countVectorizer) "X['"+text+"']" else "X"}
+       |        X = ${if (countVectorizer) "X['" + text + "']" else "X"}
        |        if port == 0:
-       |            self.model = make_pipeline(${if (countVectorizer) "CountVectorizer()," else ""} ${if (tfidfTransformer) "TfidfTransformer()," else ""} ${getImportStatements.split(" ").last}()).fit(X, Y)
+       |            self.model = make_pipeline(${if (countVectorizer) "CountVectorizer(),"
+    else ""} ${if (tfidfTransformer) "TfidfTransformer()," else ""} ${getImportStatements
+      .split(" ")
+      .last}()).fit(X, Y)
        |        else:
        |            predictions = self.model.predict(X)
        |            if ${if (classification) "True"

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
@@ -25,7 +25,7 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
        |        if port == 0:
        |            self.model = tuple_["$model"]
        |        else:
-       |            tuple_["$resultAttribute"] = str(self.model.predict(Table.from_tuple_likes([tuple_]))[0])
+       |            tuple_["$resultAttribute"] = str(self.model.predict(Table.from_tuple_likes([tuple_]).iloc[0, :])[0])
        |            yield tuple_""".stripMargin
 
   override def operatorInfo: OperatorInfo =


### PR DESCRIPTION
This PR introduces [CountVectorizer](https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.CountVectorizer.html#sklearn.feature_extraction.text.CountVectorizer) and [TfidfTransformer](https://scikit-learn.org/stable/modules/generated/sklearn.feature_extraction.text.TfidfTransformer.html) such that ML operators can take text feature as input and train the models.

<img width="400" alt="Screenshot 2024-05-20 at 13 54 16" src="https://github.com/Texera/texera/assets/11544314/485be74e-80af-457c-9d11-e28a6d80b6e9">
