### PR TITLE
Fix blinking issue in result panel during the execution

### DIFF
--- a/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.ts
+++ b/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.ts
@@ -80,13 +80,6 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
         }
         const opUpdate = update[this.operatorId];
         if (!opUpdate || !isWebPaginationUpdate(opUpdate)) {
-          // clear result panel if currently display results
-          if (this.totalNumTuples > 0) {
-            this.totalNumTuples = 0;
-            this.currentPageIndex = 1;
-            this.currentColumns = undefined;
-            this.currentResult = [];
-          }
           return;
         }
         let columnCount = this.currentColumns?.length;


### PR DESCRIPTION
Since the backend sends "delta" updates of the results, there is a chance that nothing has changed between the two result updates. Thus, the backend may send an empty update to the frontend. This PR removes the logic that clears all results when an empty WebResultUpdate event is received, ensuring the user can see the results during execution.







