### PR TITLE
Fix Python Console GUI

### DIFF
--- a/core/gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.html
+++ b/core/gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.html
@@ -108,7 +108,6 @@
             </nz-tag>
           </div>
           <div
-            style="display: flex"
             nzcol
             nz-span="12">
             <nz-tag
@@ -166,7 +165,7 @@
   <input
     type="text"
     nz-input
-    style="width: calc(100% - 130px)"
+    style="width: calc(100% - 160px)"
     [(ngModel)]="command"
     (keyup.enter)="submitDebugCommand()" />
 </nz-input-group>

--- a/core/gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.scss
+++ b/core/gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.scss
@@ -10,9 +10,8 @@
 
 .console-list-container {
   position: fixed;
-  height: calc(100% - 130px);
-  min-height: 20px;
-  width: calc(100% - 130px);
+  height: calc(100% - 140px);
+  width: calc(100% - 160px);
   border: 1px solid #e8e8e8;
   border-radius: 2px;
   overflow: auto;
@@ -88,6 +87,6 @@
 
 .console-input-container {
   position: fixed;
-  bottom: 20px;
-  left: 125px;
+  bottom: 22px;
+  left: 139px;
 }

--- a/core/gui/src/app/workspace/component/result-panel/result-panel.component.html
+++ b/core/gui/src/app/workspace/component/result-panel/result-panel.component.html
@@ -1,5 +1,4 @@
 <div
-  class="texera-workspace-result-panel-body"
   id="result-container"
   cdkDrag
   cdkDragBoundary="body"
@@ -45,11 +44,12 @@
         nzType="border"></span>
     </li>
   </ul>
-  <div id="content">
+  <div
+    id="content"
+    *ngIf="width">
     <h4
       id="title"
-      cdkDragHandle
-      *ngIf="width">
+      cdkDragHandle>
       Result Panel: {{operatorTitle}}
     </h4>
     <nz-tabset

--- a/core/gui/src/app/workspace/component/result-panel/result-panel.component.scss
+++ b/core/gui/src/app/workspace/component/result-panel/result-panel.component.scss
@@ -12,9 +12,6 @@
   left: 0;
   user-select: none;
   background: white;
-}
-
-.texera-workspace-result-panel-body {
   border-radius: 5px;
   box-shadow:
     0 3px 1px -2px #0003,

--- a/core/gui/src/app/workspace/component/result-panel/result-panel.component.spec.ts
+++ b/core/gui/src/app/workspace/component/result-panel/result-panel.component.spec.ts
@@ -55,7 +55,7 @@ describe("ResultPanelComponent", () => {
       state: ExecutionState.Completed,
     });
     fixture.detectChanges();
-    const resultPanelDiv = fixture.debugElement.query(By.css(".texera-workspace-result-panel-body"));
+    const resultPanelDiv = fixture.debugElement.query(By.css("#result-container"));
     const resultPanelHtmlElement: HTMLElement = resultPanelDiv.nativeElement;
     expect(resultPanelHtmlElement).toBeTruthy();
   });


### PR DESCRIPTION
This PR fixes the following issues in Python Console GUI:
1. The console buttons still display after minimized.
2. The console box overflows.

| Before the fix| After the fix|
| ------------- | ------------- |
|![image](https://github.com/Texera/texera/assets/11544314/d1c2c085-3903-4a69-96b2-e856813b92d8)|![image](https://github.com/Texera/texera/assets/11544314/161d9456-986f-4598-98ff-afef9fe787d1)
|![image](https://github.com/Texera/texera/assets/11544314/823bc152-25ae-45a1-958c-aa3771eb9bc9)|![image](https://github.com/Texera/texera/assets/11544314/650ef3eb-7b6f-4b81-a9a2-6d1ab146b3cd)

