### PR TITLE
Pin numpy version to be <2.0

### DIFF
--- a/core/amber/requirements.txt
+++ b/core/amber/requirements.txt
@@ -1,5 +1,5 @@
 wheel
-numpy
+numpy<2.0
 pandas
 flake8
 black==24.3.0


### PR DESCRIPTION
numpy has released a major version 2.0. This breaks most of the C APIs that our dependencies are using. Per [official suggestion](https://numpy.org/devdocs/dev/depending_on_numpy.html#numpy-2-0-specific-advice), we pin numpy version to be smaller than 2.0 to avoid the API change, until dependencies adapt to this new major version of numpy.