### PR TITLE
Fix education section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ The following is a workflow formulated using the Texera GUI in a Web browser, wh
 ## Education
 
 * [Data Science for All](https://ds4all.ics.uci.edu/) (an NSF-funded summer program to teach high-school students data science and AI/ML)
-* [ICS 80](https://canvas.eee.uci.edu/courses/63639/pages/syllabus) (a course in spring 2024 to teach 42 UCI undergraduates, mostly not from CS, data science and AI/ML)
+* [ICS 80](https://canvas.eee.uci.edu/courses/63639/pages/syllabus) (a Spring 2024 course at UCI, teaching 42 undergraduates, most of whom are not computer science majors, to learn data science and AI/ML)
 
 ## Videos
 * [dkNET Webinar "Texera: A Scalable Cloud Computing Platform for Sharing Data & Workflow-based Analysis" 04/26/2024](https://www.youtube.com/watch?v=B81iMFS5fPc)

--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ The following is a workflow formulated using the Texera GUI in a Web browser, wh
 
 ## Education
 
-* [Data Science for All](https://ds4all.ics.uci.edu/) (a course in spring 2024 to teach 42 UCI undergraduates, mostly not from CS, data science and AI/ML)
-* [ICS 80](https://canvas.eee.uci.edu/courses/63639/pages/syllabus) (an NSF-funded summer program to teach high-school students data science and AI/ML)
+* [Data Science for All](https://ds4all.ics.uci.edu/) (an NSF-funded summer program to teach high-school students data science and AI/ML)
+* [ICS 80](https://canvas.eee.uci.edu/courses/63639/pages/syllabus) (a course in spring 2024 to teach 42 UCI undergraduates, mostly not from CS, data science and AI/ML)
 
 ## Videos
 * [dkNET Webinar "Texera: A Scalable Cloud Computing Platform for Sharing Data & Workflow-based Analysis" 04/26/2024](https://www.youtube.com/watch?v=B81iMFS5fPc)


### PR DESCRIPTION
The description for courses in the education section was wrong. This PR fixes this error.