### PR TITLE
Drop Java 8 support

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -55,7 +55,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        java-version: [ 8, 11 ]
+        java-version: [ 11 ]
     runs-on: ${{ matrix.os }}
     env:
       JAVA_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on:a
+on:
   push:
     branches:
       - 'ci-enable/**'

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -1,6 +1,6 @@
 name: build
 
-on:
+on:a
   push:
     branches:
       - 'ci-enable/**'


### PR DESCRIPTION
We decided to drop java 8 support since Oracle dropped java 8 support long time ago, and it's no longer LTS.