### PR TITLE
Fix frontend code editor language detection

### DIFF
--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -68,10 +68,9 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
     const currentOperatorId = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()[0];
     const operatorType = this.workflowActionService.getTexeraGraph().getOperator(currentOperatorId).operatorType;
 
-    console.log(operatorType);
     if (operatorType === "RUDFSource" || operatorType === "RUDF") {
       this.changeLanguage("r");
-    } else if (operatorType === "PythonUDFV2" || operatorType === "PythonUDFSourceV2") {
+    } else if (operatorType === "PythonUDFV2" || operatorType === "PythonUDFSourceV2" || operatorType === "DualInputPortsPythonUDFV2") {
       this.changeLanguage("python");
     } else {
       this.changeLanguage("java");

--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -70,7 +70,11 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
 
     if (operatorType === "RUDFSource" || operatorType === "RUDF") {
       this.changeLanguage("r");
-    } else if (operatorType === "PythonUDFV2" || operatorType === "PythonUDFSourceV2" || operatorType === "DualInputPortsPythonUDFV2") {
+    } else if (
+      operatorType === "PythonUDFV2" ||
+      operatorType === "PythonUDFSourceV2" ||
+      operatorType === "DualInputPortsPythonUDFV2"
+    ) {
       this.changeLanguage("python");
     } else {
       this.changeLanguage("java");


### PR DESCRIPTION
This PR fixes language detection for the frontend UDF editors. The language of the editor is determined based on the operator types and it is missing `DualInputPortsPythonUDFV2`.