### PR TITLE
Make Dashboard Menu expanded By Default

### DIFF
--- a/core/gui/src/app/dashboard/user/component/dashboard.component.html
+++ b/core/gui/src/app/dashboard/user/component/dashboard.component.html
@@ -9,7 +9,6 @@
 <nz-layout class="layout">
   <nz-sider
     nzCollapsible
-    nzCollapsed="true"
     [nzCollapsedWidth]="45"
     nzTheme="light">
     <ul


### PR DESCRIPTION
Revert the change we made on #2545 since it's hard for users to recognize the meaning of each icon. 

<img width="215" alt="Screenshot 2024-07-11 at 15 02 25" src="https://github.com/user-attachments/assets/dab28196-6d82-4488-b81f-1d85b345d04e">
