### PR TITLE
Fix result of workflow with visualization operators is always blank when mongodb is on

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
@@ -252,22 +252,27 @@ class ExecutionResultService(
                 val sinkMgr = sinkOperators(opId).getStorage
                 if (oldState.resultInfo.isEmpty) {
                   val fields = sinkMgr.getAllFields()
-                  tableFields.update(
-                    opId.id,
-                    Map(
-                      "numericFields" -> fields(0),
-                      "catFields" -> fields(1),
-                      "dateFields" -> fields(2)
+                  if (fields.length >= 3) {
+                    tableFields.update(
+                      opId.id,
+                      Map(
+                        "numericFields" -> fields(0),
+                        "catFields" -> fields(1),
+                        "dateFields" -> fields(2)
+                      )
                     )
-                  )
+                  }
                 }
-                val tableCatStats = sinkMgr.getCatColStats(tableFields(opId.id)("catFields"))
-                val tableDateStats = sinkMgr.getDateColStats(tableFields(opId.id)("dateFields"))
-                val tableNumericStats =
-                  sinkMgr.getNumericColStats(tableFields(opId.id)("numericFields"))
-                val allStats = tableNumericStats ++ tableCatStats ++ tableDateStats
-                if (tableNumericStats.nonEmpty || tableCatStats.nonEmpty || tableDateStats.nonEmpty)
-                  allTableStats(opId.id) = allStats
+                if (tableFields.contains(opId.id) && tableFields(opId.id).contains("catFields") &&
+                  tableFields(opId.id).contains("dateFields") && tableFields(opId.id).contains("numericFields")) {
+                  val tableCatStats = sinkMgr.getCatColStats(tableFields(opId.id)("catFields"))
+                  val tableDateStats = sinkMgr.getDateColStats(tableFields(opId.id)("dateFields"))
+                  val tableNumericStats = sinkMgr.getNumericColStats(tableFields(opId.id)("numericFields"))
+                  val allStats = tableNumericStats ++ tableCatStats ++ tableDateStats
+                  if (tableNumericStats.nonEmpty || tableCatStats.nonEmpty || tableDateStats.nonEmpty) {
+                    allTableStats(opId.id) = allStats
+                  }
+                }
               }
           }
         Iterable(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
@@ -258,7 +258,7 @@ class ExecutionResultService(
                     // 2. catFields: An array of categorical field names
                     // 3. dateFields: An array of date field names
                     val NumericFieldsArray = "numericFields"
-                    val CategoricalFieldsArray = "categoricalFields"
+                    val CategoricalFieldsArray = "catFields"
                     val DateFieldsArray = "dateFields"
 
                     // Update tableFields with extracted fields

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
@@ -253,12 +253,21 @@ class ExecutionResultService(
                 if (oldState.resultInfo.isEmpty) {
                   val fields = sinkMgr.getAllFields()
                   if (fields.length >= 3) {
+                    // The fields array for MongoDB operators should contain three arrays:
+                    // 1. numericFields: An array of numeric field names
+                    // 2. catFields: An array of categorical field names
+                    // 3. dateFields: An array of date field names
+                    val NumericFieldsArray = "numericFields"
+                    val CategoricalFieldsArray = "categoricalFields"
+                    val DateFieldsArray = "dateFields"
+
+                    // Update tableFields with extracted fields
                     tableFields.update(
                       opId.id,
                       Map(
-                        "numericFields" -> fields(0),
-                        "catFields" -> fields(1),
-                        "dateFields" -> fields(2)
+                        NumericFieldsArray -> fields(0),
+                        CategoricalFieldsArray -> fields(1),
+                        DateFieldsArray -> fields(2)
                       )
                     )
                   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
@@ -263,13 +263,19 @@ class ExecutionResultService(
                     )
                   }
                 }
-                if (tableFields.contains(opId.id) && tableFields(opId.id).contains("catFields") &&
-                  tableFields(opId.id).contains("dateFields") && tableFields(opId.id).contains("numericFields")) {
+                if (
+                  tableFields.contains(opId.id) && tableFields(opId.id).contains("catFields") &&
+                  tableFields(opId.id).contains("dateFields") && tableFields(opId.id)
+                    .contains("numericFields")
+                ) {
                   val tableCatStats = sinkMgr.getCatColStats(tableFields(opId.id)("catFields"))
                   val tableDateStats = sinkMgr.getDateColStats(tableFields(opId.id)("dateFields"))
-                  val tableNumericStats = sinkMgr.getNumericColStats(tableFields(opId.id)("numericFields"))
+                  val tableNumericStats =
+                    sinkMgr.getNumericColStats(tableFields(opId.id)("numericFields"))
                   val allStats = tableNumericStats ++ tableCatStats ++ tableDateStats
-                  if (tableNumericStats.nonEmpty || tableCatStats.nonEmpty || tableDateStats.nonEmpty) {
+                  if (
+                    tableNumericStats.nonEmpty || tableCatStats.nonEmpty || tableDateStats.nonEmpty
+                  ) {
                     allTableStats(opId.id) = allStats
                   }
                 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
@@ -257,17 +257,17 @@ class ExecutionResultService(
                     // 1. numericFields: An array of numeric field names
                     // 2. catFields: An array of categorical field names
                     // 3. dateFields: An array of date field names
-                    val NumericFieldsArray = "numericFields"
-                    val CategoricalFieldsArray = "catFields"
-                    val DateFieldsArray = "dateFields"
+                    val NumericFieldsNamesArray = "numericFields"
+                    val CategoricalFieldsNamesArray = "catFields"
+                    val DateFieldsNamesArray = "dateFields"
 
                     // Update tableFields with extracted fields
                     tableFields.update(
                       opId.id,
                       Map(
-                        NumericFieldsArray -> fields(0),
-                        CategoricalFieldsArray -> fields(1),
-                        DateFieldsArray -> fields(2)
+                        NumericFieldsNamesArray -> fields(0),
+                        CategoricalFieldsNamesArray -> fields(1),
+                        DateFieldsNamesArray -> fields(2)
                       )
                     )
                   }


### PR DESCRIPTION
Issue number: #2729 

---
Cause: 
the sink manager type for visualizer operators is still "edu.uci.ics.texera.workflow.operators.sink.storage.MemoryStorage" even if the mode is set to mongodb. This results in the inability to access sinkMgr.getAllFields() as expected for MongoDB storage.

---
Fix:
Ensure that the "fields" array obtained from "val fields = sinkMgr.getAllFields()" is not empty. If fields is not empty, this indicates that the MongoDB storage is correctly accessed and contains valid data. Here is the implemented fix:

Check if fields is not empty:
Only proceed with updating tableFields if fields is not empty and has the required length of at least 3.

Update tableFields:
If fields meets the criteria, update tableFields with the relevant field mappings.

Compute statistics:
Ensure tableFields contains the necessary fields before computing statistics for categorical, date, and numeric fields.