### PR TITLE
Remove the discarding uncommitted dataset data check when the TexeraWebApplication is launching

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWebApplication.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWebApplication.scala
@@ -122,8 +122,9 @@ object TexeraWebApplication {
 
     val clusterMode = argMap.get(Symbol("cluster")).asInstanceOf[Option[Boolean]].getOrElse(false)
 
-    // Do the uncommitted changes cleanup of datasets
-    discardUncommittedChangesOfAllDatasets()
+    // TODO: figure out a safety way of calling discardUncommittedChangesOfAllDatasets
+    // Currently in kubernetes, multiple pods calling this function can result into thread competition
+    // discardUncommittedChangesOfAllDatasets()
 
     // start actor system master node
     AmberRuntime.startActorMaster(clusterMode)


### PR DESCRIPTION
This PR removes the call of `discardUncommittedChangesOfAllDatasets`

This function call can result into thread competition in some deployment setting, e.g. Kubernetes.