### PR TITLE
Fix ML Operator Schema Requirement Bug

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMLOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnMLOpDesc.scala
@@ -35,7 +35,6 @@ abstract class SklearnMLOpDesc extends PythonOperatorDescriptor {
 
   @JsonSchemaTitle("Text Attribute")
   @JsonPropertyDescription("Attribute in your dataset with text to vectorize.")
-  @JsonProperty(required = true)
   @JsonSchemaInject(
     strings = Array(
       new JsonSchemaString(


### PR DESCRIPTION
This pull request addresses a bug related to the schema requirements in the ML operator. The issue caused incorrect schema enforcement and has now been fixed. The change involves a minor adjustment in the code to ensure that the schema requirements are correctly applied, preventing static check errors.
