### PR TITLE
Fix dataset APIs not fetching files shared by others correctly

### DIFF
--- a/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -62,10 +62,14 @@ export class DatasetService {
   }
 
   public retrieveAccessibleDatasets(
-    includeVersions: boolean = false
+    includeVersions: boolean = false,
+    includeFileNodes: boolean = false
   ): Observable<{ datasets: DashboardDataset[]; fileNodes: DatasetFileNode[] }> {
     let params = new HttpParams();
     if (includeVersions) {
+      params = params.set("includeVersions", "true");
+    }
+    if (includeFileNodes) {
       params = params.set("includeFileNodes", "true");
     }
     return this.http.get<{ datasets: DashboardDataset[]; fileNodes: DatasetFileNode[] }>(

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
@@ -25,7 +25,7 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
 
   onClickOpenFileSelectionModal(): void {
     this.datasetService
-      .retrieveAccessibleDatasets(true)
+      .retrieveAccessibleDatasets(true, true)
       .pipe(untilDestroyed(this))
       .subscribe(response => {
         const fileNodes = response.fileNodes;


### PR DESCRIPTION
This PR fixes the issue that when a dataset is shared by other users, the ownerEmail is incorrect, which make the file not resolvable.

This PR also improves the `GET /datasets`'s expressiveness. It now has two flags:
1. `includeVersions`: if set as true, the versions of each dataset will be queried and returned by the backend.
2. `includeFileNodes`: if set as true, the versions and the file tree will be queried and returned

If both flags are set to be true, the return results are equivalent to just set `includeFileNodes` to be true