### PR TITLE
Reduce the Information Fetching of the File Selection Window of Scan Operators

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/aggregate/AggregateOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/aggregate/AggregateOpDesc.scala
@@ -31,9 +31,9 @@ class AggregateOpDesc extends LogicalOp {
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity
   ): PhysicalPlan = {
-    if (aggregations.isEmpty) {
-      throw new UnsupportedOperationException("Aggregation Functions Cannot be Empty")
-    }
+//    if (aggregations.isEmpty) {
+//      throw new UnsupportedOperationException("Aggregation Functions Cannot be Empty")
+//    }
 
     // TODO: this is supposed to be blocking but due to limitations of materialization naming on the logical operator
     // we are keeping it not annotated as blocking.

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/aggregate/AggregateOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/aggregate/AggregateOpDesc.scala
@@ -31,9 +31,9 @@ class AggregateOpDesc extends LogicalOp {
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity
   ): PhysicalPlan = {
-//    if (aggregations.isEmpty) {
-//      throw new UnsupportedOperationException("Aggregation Functions Cannot be Empty")
-//    }
+    if (aggregations.isEmpty) {
+      throw new UnsupportedOperationException("Aggregation Functions Cannot be Empty")
+    }
 
     // TODO: this is supposed to be blocking but due to limitations of materialization naming on the logical operator
     // we are keeping it not annotated as blocking.

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -18,6 +18,10 @@
         <div class="dataset-option">
           <div class="dataset-id-container">{{ dataset.dataset.did }}</div>
           <span class="dataset-name">{{ dataset.dataset.name }}</span>
+          <span class="dataset-owner" *ngIf="dataset.isOwner">OWNER</span>
+          <span class="dataset-access-privilege" *ngIf="!dataset.isOwner">
+            {{ dataset.accessPrivilege }}
+          </span>
         </div>
       </nz-option>
     </nz-select>

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -8,7 +8,17 @@
       (ngModelChange)="onDatasetChange()"
       class="select-dataset"
     >
-      <nz-option *ngFor="let dataset of datasets" [nzValue]="dataset" [nzLabel]="dataset.dataset.name"></nz-option>
+      <nz-option
+        *ngFor="let dataset of datasets"
+        [nzValue]="dataset"
+        [nzLabel]="dataset.dataset.name"
+        [nzCustomContent]="true"
+      >
+        <div class="dataset-option">
+          <div class="dataset-id-container">{{ dataset.dataset.did }}</div>
+          <span>{{ dataset.dataset.name }}</span>
+        </div>
+      </nz-option>
     </nz-select>
 
     <nz-select
@@ -20,7 +30,14 @@
       (ngModelChange)="onVersionChange()"
       class="select-version"
     >
-      <nz-option *ngFor="let version of datasetVersions" [nzValue]="version" [nzLabel]="version.name"></nz-option>
+      <nz-option
+        *ngFor="let version of datasetVersions"
+        [nzValue]="version"
+        [nzLabel]="version.name"
+        [nzCustomContent]="true"
+      >
+        {{ version.name }}
+      </nz-option>
     </nz-select>
   </div>
 

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -1,29 +1,34 @@
 <div class="container">
-  <nz-select
-    nzShowSearch
-    nzAllowClear
-    nzPlaceHolder="Select dataset"
-    [(ngModel)]="selectedDataset"
-    (ngModelChange)="onDatasetChange()"
-  >
-    <nz-option *ngFor="let dataset of datasets" [nzValue]="dataset" [nzLabel]="dataset.dataset.name"></nz-option>
-  </nz-select>
+  <div class="selection-row">
+    <nz-select
+      nzShowSearch
+      nzAllowClear
+      nzPlaceHolder="Select dataset"
+      [(ngModel)]="selectedDataset"
+      (ngModelChange)="onDatasetChange()"
+      class="select-dataset"
+    >
+      <nz-option *ngFor="let dataset of datasets" [nzValue]="dataset" [nzLabel]="dataset.dataset.name"></nz-option>
+    </nz-select>
 
-  <nz-select
-    nzShowSearch
-    nzAllowClear
-    nzPlaceHolder="Select version"
-    [(ngModel)]="selectedVersion"
-    (ngModelChange)="onVersionChange()"
-    [nzDisabled]="!selectedDataset"
-  >
-    <nz-option *ngFor="let version of datasetVersions" [nzValue]="version" [nzLabel]="version.name"></nz-option>
-  </nz-select>
+    <nz-select
+      *ngIf="selectedDataset"
+      nzShowSearch
+      nzAllowClear
+      nzPlaceHolder="Select version"
+      [(ngModel)]="selectedVersion"
+      (ngModelChange)="onVersionChange()"
+      class="select-version"
+    >
+      <nz-option *ngFor="let version of datasetVersions" [nzValue]="version" [nzLabel]="version.name"></nz-option>
+    </nz-select>
+  </div>
 
   <texera-user-dataset-version-filetree
     *ngIf="suggestedFileTreeNodes.length > 0"
     [isExpandAllAfterViewInit]="true"
     [fileTreeNodes]="suggestedFileTreeNodes"
     (selectedTreeNode)="onFileTreeNodeSelected($event)"
+    class="texera-user-dataset-version-filetree"
   ></texera-user-dataset-version-filetree>
 </div>

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="container">
   <nz-select
     nzShowSearch
     nzAllowClear
@@ -21,11 +21,11 @@
   </nz-select>
 
   <button nz-button (click)="showFiles()" [disabled]="!selectedVersion">Show Files</button>
-</div>
 
-<texera-user-dataset-version-filetree
-  *ngIf="suggestedFileTreeNodes.length > 0"
-  [isExpandAllAfterViewInit]="true"
-  [fileTreeNodes]="suggestedFileTreeNodes"
-  (selectedTreeNode)="onFileTreeNodeSelected($event)"
-></texera-user-dataset-version-filetree>
+  <texera-user-dataset-version-filetree
+    *ngIf="suggestedFileTreeNodes.length > 0"
+    [isExpandAllAfterViewInit]="true"
+    [fileTreeNodes]="suggestedFileTreeNodes"
+    (selectedTreeNode)="onFileTreeNodeSelected($event)"
+  ></texera-user-dataset-version-filetree>
+</div>

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -7,19 +7,23 @@
       [(ngModel)]="selectedDataset"
       (ngModelChange)="onDatasetChange()"
       [ngStyle]="{'width': isDatasetSelected ? '60%' : '100%'}"
-      class="select-dataset"
-    >
+      class="select-dataset">
       <nz-option
         *ngFor="let dataset of datasets"
         [nzValue]="dataset"
         [nzLabel]="dataset.dataset.name"
-        [nzCustomContent]="true"
-      >
+        [nzCustomContent]="true">
         <div class="dataset-option">
           <div class="dataset-id-container">{{ dataset.dataset.did }}</div>
           <span class="dataset-name">{{ dataset.dataset.name }}</span>
-          <span class="dataset-owner" *ngIf="dataset.isOwner">OWNER</span>
-          <span class="dataset-access-privilege" *ngIf="!dataset.isOwner">
+          <span
+            class="dataset-owner"
+            *ngIf="dataset.isOwner"
+            >OWNER</span
+          >
+          <span
+            class="dataset-access-privilege"
+            *ngIf="!dataset.isOwner">
             {{ dataset.accessPrivilege }}
           </span>
         </div>
@@ -33,13 +37,11 @@
       nzPlaceHolder="Select version"
       [(ngModel)]="selectedVersion"
       (ngModelChange)="onVersionChange()"
-      class="select-version"
-    >
+      class="select-version">
       <nz-option
         *ngFor="let version of datasetVersions"
         [nzValue]="version"
-        [nzLabel]="version.name"
-      >
+        [nzLabel]="version.name">
       </nz-option>
     </nz-select>
   </div>
@@ -49,6 +51,5 @@
     [isExpandAllAfterViewInit]="true"
     [fileTreeNodes]="suggestedFileTreeNodes"
     (selectedTreeNode)="onFileTreeNodeSelected($event)"
-    class="texera-user-dataset-version-filetree"
-  ></texera-user-dataset-version-filetree>
+    class="texera-user-dataset-version-filetree"></texera-user-dataset-version-filetree>
 </div>

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -14,7 +14,7 @@
         [nzCustomContent]="true">
         <div class="dataset-option">
           <div class="dataset-id-container">{{ dataset.dataset.did }}</div>
-          <span>{{ dataset.dataset.name }}</span>
+          <span class="dataset-name">{{ dataset.dataset.name }}</span>
         </div>
       </nz-option>
     </nz-select>
@@ -30,9 +30,7 @@
       <nz-option
         *ngFor="let version of datasetVersions"
         [nzValue]="version"
-        [nzLabel]="version.name"
-        [nzCustomContent]="true">
-        {{ version.name }}
+        [nzLabel]="version.name">
       </nz-option>
     </nz-select>
   </div>

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -6,12 +6,15 @@
       nzPlaceHolder="Select dataset"
       [(ngModel)]="selectedDataset"
       (ngModelChange)="onDatasetChange()"
-      class="select-dataset">
+      [ngStyle]="{'width': isDatasetSelected ? '60%' : '100%'}"
+      class="select-dataset"
+    >
       <nz-option
         *ngFor="let dataset of datasets"
         [nzValue]="dataset"
         [nzLabel]="dataset.dataset.name"
-        [nzCustomContent]="true">
+        [nzCustomContent]="true"
+      >
         <div class="dataset-option">
           <div class="dataset-id-container">{{ dataset.dataset.did }}</div>
           <span class="dataset-name">{{ dataset.dataset.name }}</span>
@@ -26,11 +29,13 @@
       nzPlaceHolder="Select version"
       [(ngModel)]="selectedVersion"
       (ngModelChange)="onVersionChange()"
-      class="select-version">
+      class="select-version"
+    >
       <nz-option
         *ngFor="let version of datasetVersions"
         [nzValue]="version"
-        [nzLabel]="version.name">
+        [nzLabel]="version.name"
+      >
       </nz-option>
     </nz-select>
   </div>
@@ -40,5 +45,6 @@
     [isExpandAllAfterViewInit]="true"
     [fileTreeNodes]="suggestedFileTreeNodes"
     (selectedTreeNode)="onFileTreeNodeSelected($event)"
-    class="texera-user-dataset-version-filetree"></texera-user-dataset-version-filetree>
+    class="texera-user-dataset-version-filetree"
+  ></texera-user-dataset-version-filetree>
 </div>

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -6,14 +6,12 @@
       nzPlaceHolder="Select dataset"
       [(ngModel)]="selectedDataset"
       (ngModelChange)="onDatasetChange()"
-      class="select-dataset"
-    >
+      class="select-dataset">
       <nz-option
         *ngFor="let dataset of datasets"
         [nzValue]="dataset"
         [nzLabel]="dataset.dataset.name"
-        [nzCustomContent]="true"
-      >
+        [nzCustomContent]="true">
         <div class="dataset-option">
           <div class="dataset-id-container">{{ dataset.dataset.did }}</div>
           <span>{{ dataset.dataset.name }}</span>
@@ -28,14 +26,12 @@
       nzPlaceHolder="Select version"
       [(ngModel)]="selectedVersion"
       (ngModelChange)="onVersionChange()"
-      class="select-version"
-    >
+      class="select-version">
       <nz-option
         *ngFor="let version of datasetVersions"
         [nzValue]="version"
         [nzLabel]="version.name"
-        [nzCustomContent]="true"
-      >
+        [nzCustomContent]="true">
         {{ version.name }}
       </nz-option>
     </nz-select>
@@ -46,6 +42,5 @@
     [isExpandAllAfterViewInit]="true"
     [fileTreeNodes]="suggestedFileTreeNodes"
     (selectedTreeNode)="onFileTreeNodeSelected($event)"
-    class="texera-user-dataset-version-filetree"
-  ></texera-user-dataset-version-filetree>
+    class="texera-user-dataset-version-filetree"></texera-user-dataset-version-filetree>
 </div>

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -1,15 +1,3 @@
-<!-- <input
-  nz-input
-  placeholder="Search for files from datasets..."
-  [(ngModel)]="filterText"
-  (ngModelChange)="filterFileTreeNodes()" />
-
-<texera-user-dataset-version-filetree
-  [isExpandAllAfterViewInit]="true"
-  [fileTreeNodes]="suggestedFileTreeNodes"
-  (selectedTreeNode)="onFileTreeNodeSelected($event)">
-</texera-user-dataset-version-filetree> -->
-
 <div>
   <nz-select
     nzShowSearch
@@ -29,7 +17,7 @@
     (ngModelChange)="onVersionChange()"
     [nzDisabled]="!selectedDataset"
   >
-    <nz-option *ngFor="let version of selectedDataset?.versions" [nzValue]="version.datasetVersion" [nzLabel]="version.datasetVersion.name"></nz-option>
+    <nz-option *ngFor="let version of datasetVersions" [nzValue]="version" [nzLabel]="version.name"></nz-option>
   </nz-select>
 
   <button nz-button (click)="showFiles()" [disabled]="!selectedVersion">Show Files</button>

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -20,8 +20,6 @@
     <nz-option *ngFor="let version of datasetVersions" [nzValue]="version" [nzLabel]="version.name"></nz-option>
   </nz-select>
 
-  <button nz-button (click)="showFiles()" [disabled]="!selectedVersion">Show Files</button>
-
   <texera-user-dataset-version-filetree
     *ngIf="suggestedFileTreeNodes.length > 0"
     [isExpandAllAfterViewInit]="true"

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -1,4 +1,4 @@
-<input
+<!-- <input
   nz-input
   placeholder="Search for files from datasets..."
   [(ngModel)]="filterText"
@@ -8,4 +8,36 @@
   [isExpandAllAfterViewInit]="true"
   [fileTreeNodes]="suggestedFileTreeNodes"
   (selectedTreeNode)="onFileTreeNodeSelected($event)">
-</texera-user-dataset-version-filetree>
+</texera-user-dataset-version-filetree> -->
+
+<div>
+  <nz-select
+    nzShowSearch
+    nzAllowClear
+    nzPlaceHolder="Select dataset"
+    [(ngModel)]="selectedDataset"
+    (ngModelChange)="onDatasetChange()"
+  >
+    <nz-option *ngFor="let dataset of datasets" [nzValue]="dataset" [nzLabel]="dataset.dataset.name"></nz-option>
+  </nz-select>
+
+  <nz-select
+    nzShowSearch
+    nzAllowClear
+    nzPlaceHolder="Select version"
+    [(ngModel)]="selectedVersion"
+    (ngModelChange)="onVersionChange()"
+    [nzDisabled]="!selectedDataset"
+  >
+    <nz-option *ngFor="let version of selectedDataset?.versions" [nzValue]="version.datasetVersion" [nzLabel]="version.datasetVersion.name"></nz-option>
+  </nz-select>
+
+  <button nz-button (click)="showFiles()" [disabled]="!selectedVersion">Show Files</button>
+</div>
+
+<texera-user-dataset-version-filetree
+  *ngIf="suggestedFileTreeNodes.length > 0"
+  [isExpandAllAfterViewInit]="true"
+  [fileTreeNodes]="suggestedFileTreeNodes"
+  (selectedTreeNode)="onFileTreeNodeSelected($event)"
+></texera-user-dataset-version-filetree>

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
@@ -20,10 +20,12 @@
 
 .select-dataset {
   flex: 0 0 60%;
+  max-width: 60%;
 }
 
 .select-version {
   flex: 1;
+  min-width: 0; 
 }
 
 .texera-user-dataset-version-filetree {
@@ -38,16 +40,24 @@
   text-overflow: ellipsis;
 }
 
+.dataset-name {
+  display: inline-block;
+  max-width: calc(100% - 28px); /* Subtract the space occupied by the id container and margin */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .dataset-id-container {
   background-color: grey;
   color: white;
-  width: 25px;
-  height: 25px;
+  width: 23px;
+  height: 23px;
   border-radius: 50%;
   display: flex;
   justify-content: center;
   align-items: center;
-  font-size: 14px;
+  font-size: 12px;
   margin-right: 5px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   overflow: hidden;

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
@@ -53,18 +53,6 @@
   overflow: hidden;
 }
 
-::ng-deep .ant-select-dropdown {
-  max-height: 400px; /* 增加下拉菜单的最大高度 */
-}
 
-::ng-deep .ant-select-item-option-content {
-  display: flex;
-  align-items: center;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
 
-::ng-deep .ant-select-item-option {
-  height: auto; /* 确保每个选项的高度是自适应的 */
-}
+

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
@@ -41,8 +41,8 @@
 .dataset-id-container {
   background-color: grey;
   color: white;
-  width: 35px;
-  height: 35px;
+  width: 25px;
+  height: 25px;
   border-radius: 50%;
   display: flex;
   justify-content: center;

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
@@ -19,13 +19,52 @@
 }
 
 .select-dataset {
-  flex: 0 0 60%; 
+  flex: 0 0 60%;
 }
 
 .select-version {
-  flex: 1; 
+  flex: 1;
 }
 
 .texera-user-dataset-version-filetree {
   margin-top: 16px;
+}
+
+.dataset-option {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.dataset-id-container {
+  background-color: grey;
+  color: white;
+  width: 35px;
+  height: 35px;
+  border-radius: 50%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 14px;
+  margin-right: 5px;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+::ng-deep .ant-select-dropdown {
+  max-height: 400px; /* 增加下拉菜单的最大高度 */
+}
+
+::ng-deep .ant-select-item-option-content {
+  display: flex;
+  align-items: center;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+::ng-deep .ant-select-item-option {
+  height: auto; /* 确保每个选项的高度是自适应的 */
 }

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
@@ -19,8 +19,7 @@
 }
 
 .select-dataset {
-  flex: 0 0 60%;
-  max-width: 60%;
+  transition: width 0.3s; /* Add animation effect */
 }
 
 .select-version {

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
@@ -41,7 +41,7 @@
 
 .dataset-name {
   display: inline-block;
-  max-width: calc(100% - 28px); /* Subtract the space occupied by the id container and margin */
+  max-width: calc(100% - 100px); /* Adjust to fit other elements */
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -61,3 +61,11 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   overflow: hidden;
 }
+
+.dataset-owner, .dataset-access-privilege {
+  margin-left: 10px;
+  font-size: 12px;
+  color: grey;
+}
+
+

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
@@ -24,7 +24,7 @@
 
 .select-version {
   flex: 1;
-  min-width: 0; 
+  min-width: 0;
 }
 
 .texera-user-dataset-version-filetree {
@@ -62,10 +62,9 @@
   overflow: hidden;
 }
 
-.dataset-owner, .dataset-access-privilege {
+.dataset-owner,
+.dataset-access-privilege {
   margin-left: 10px;
   font-size: 12px;
   color: grey;
 }
-
-

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
@@ -1,24 +1,31 @@
 :host {
-    display: block;
-    padding: 16px;
-  }
-  
-  .container {
-    display: flex;
-    flex-direction: column;
-    gap: 16px;
-  }
-  
-  .nz-select {
-    width: 100%;
-  }
-  
-  button {
-    align-self: flex-start;
-    margin-top: 8px;
-  }
-  
-  .texera-user-dataset-version-filetree {
-    margin-top: 16px;
-  }
-  
+  display: block;
+  padding: 16px;
+}
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.selection-row {
+  display: flex;
+  gap: 16px;
+}
+
+.nz-select {
+  width: 100%;
+}
+
+.select-dataset {
+  flex: 0 0 60%; 
+}
+
+.select-version {
+  flex: 1; 
+}
+
+.texera-user-dataset-version-filetree {
+  margin-top: 16px;
+}

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
@@ -1,0 +1,24 @@
+:host {
+    display: block;
+    padding: 16px;
+  }
+  
+  .container {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  
+  .nz-select {
+    width: 100%;
+  }
+  
+  button {
+    align-self: flex-start;
+    margin-top: 8px;
+  }
+  
+  .texera-user-dataset-version-filetree {
+    margin-top: 16px;
+  }
+  

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.scss
@@ -52,7 +52,3 @@
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   overflow: hidden;
 }
-
-
-
-

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -13,7 +13,7 @@ import { DatasetService } from "../../../dashboard/service/user/dataset/dataset.
   styleUrls: ["file-selection.component.scss"],
 })
 export class FileSelectionComponent implements OnInit {
-  readonly datasets: ReadonlyArray<DashboardDataset> = inject(NZ_MODAL_DATA).datasets; // 获取传递的数据集信息
+  readonly datasets: ReadonlyArray<DashboardDataset> = inject(NZ_MODAL_DATA).datasets;
   selectedDataset?: DashboardDataset;
   selectedVersion?: DatasetVersion;
   datasetVersions?: DatasetVersion[];

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -30,15 +30,17 @@ export class FileSelectionComponent implements OnInit {
     if (this.selectedDataset && this.selectedDataset.dataset.did !== undefined) {
       this.datasetService.retrieveDatasetVersionList(this.selectedDataset.dataset.did).subscribe((versions) => {
         this.datasetVersions = versions;
+        // set default version to the latest version
+        if (this.datasetVersions && this.datasetVersions.length > 0) {
+          this.selectedVersion = this.datasetVersions[0];
+          this.onVersionChange(); 
+        }
       });
     }
   }
 
   onVersionChange() {
     this.suggestedFileTreeNodes = [];
-  }
-
-  showFiles() {
     if (this.selectedDataset && this.selectedDataset.dataset.did !== undefined && this.selectedVersion && this.selectedVersion.dvid !== undefined) {
       this.datasetService
         .retrieveDatasetVersionFileTree(this.selectedDataset.dataset.did, this.selectedVersion.dvid)
@@ -54,4 +56,3 @@ export class FileSelectionComponent implements OnInit {
     this.modalRef.close(node);
   }
 }
-

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -21,8 +21,7 @@ export class FileSelectionComponent implements OnInit {
 
   constructor(private modalRef: NzModalRef, private datasetService: DatasetService) {}
 
-  ngOnInit() {
-  }
+  ngOnInit() {}
 
   onDatasetChange() {
     this.selectedVersion = undefined;

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -18,22 +18,19 @@ export class FileSelectionComponent {
   selectedVersion?: DatasetVersion;
   datasetVersions?: DatasetVersion[];
   suggestedFileTreeNodes: DatasetFileNode[] = [];
+  isDatasetSelected: boolean = false;
 
-  constructor(
-    private modalRef: NzModalRef,
-    private datasetService: DatasetService
-  ) {}
+  constructor(private modalRef: NzModalRef, private datasetService: DatasetService) {}
 
   onDatasetChange() {
     this.selectedVersion = undefined;
     this.suggestedFileTreeNodes = [];
+    this.isDatasetSelected = !!this.selectedDataset;
     if (this.selectedDataset && this.selectedDataset.dataset.did !== undefined) {
-      this.datasetService
-        .retrieveDatasetVersionList(this.selectedDataset.dataset.did)
+      this.datasetService.retrieveDatasetVersionList(this.selectedDataset.dataset.did)
         .pipe(untilDestroyed(this))
-        .subscribe(versions => {
+        .subscribe((versions) => {
           this.datasetVersions = versions;
-          // set default version to the latest version
           if (this.datasetVersions && this.datasetVersions.length > 0) {
             this.selectedVersion = this.datasetVersions[0];
             this.onVersionChange();
@@ -44,14 +41,8 @@ export class FileSelectionComponent {
 
   onVersionChange() {
     this.suggestedFileTreeNodes = [];
-    if (
-      this.selectedDataset &&
-      this.selectedDataset.dataset.did !== undefined &&
-      this.selectedVersion &&
-      this.selectedVersion.dvid !== undefined
-    ) {
-      this.datasetService
-        .retrieveDatasetVersionFileTree(this.selectedDataset.dataset.did, this.selectedVersion.dvid)
+    if (this.selectedDataset && this.selectedDataset.dataset.did !== undefined && this.selectedVersion && this.selectedVersion.dvid !== undefined) {
+      this.datasetService.retrieveDatasetVersionFileTree(this.selectedDataset.dataset.did, this.selectedVersion.dvid)
         .pipe(untilDestroyed(this))
         .subscribe(fileNodes => {
           this.suggestedFileTreeNodes = fileNodes;

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -20,16 +20,20 @@ export class FileSelectionComponent {
   suggestedFileTreeNodes: DatasetFileNode[] = [];
   isDatasetSelected: boolean = false;
 
-  constructor(private modalRef: NzModalRef, private datasetService: DatasetService) {}
+  constructor(
+    private modalRef: NzModalRef,
+    private datasetService: DatasetService
+  ) {}
 
   onDatasetChange() {
     this.selectedVersion = undefined;
     this.suggestedFileTreeNodes = [];
     this.isDatasetSelected = !!this.selectedDataset;
     if (this.selectedDataset && this.selectedDataset.dataset.did !== undefined) {
-      this.datasetService.retrieveDatasetVersionList(this.selectedDataset.dataset.did)
+      this.datasetService
+        .retrieveDatasetVersionList(this.selectedDataset.dataset.did)
         .pipe(untilDestroyed(this))
-        .subscribe((versions) => {
+        .subscribe(versions => {
           this.datasetVersions = versions;
           if (this.datasetVersions && this.datasetVersions.length > 0) {
             this.selectedVersion = this.datasetVersions[0];
@@ -41,8 +45,14 @@ export class FileSelectionComponent {
 
   onVersionChange() {
     this.suggestedFileTreeNodes = [];
-    if (this.selectedDataset && this.selectedDataset.dataset.did !== undefined && this.selectedVersion && this.selectedVersion.dvid !== undefined) {
-      this.datasetService.retrieveDatasetVersionFileTree(this.selectedDataset.dataset.did, this.selectedVersion.dvid)
+    if (
+      this.selectedDataset &&
+      this.selectedDataset.dataset.did !== undefined &&
+      this.selectedVersion &&
+      this.selectedVersion.dvid !== undefined
+    ) {
+      this.datasetService
+        .retrieveDatasetVersionFileTree(this.selectedDataset.dataset.did, this.selectedVersion.dvid)
         .pipe(untilDestroyed(this))
         .subscribe(fileNodes => {
           this.suggestedFileTreeNodes = fileNodes;

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -1,66 +1,7 @@
-// import { Component, inject } from "@angular/core";
-// import { NZ_MODAL_DATA, NzModalRef } from "ng-zorro-antd/modal";
-// import { UntilDestroy } from "@ngneat/until-destroy";
-// import { DatasetFileNode } from "../../../common/type/datasetVersionFileTree";
-
-// @UntilDestroy()
-// @Component({
-//   selector: "texera-file-selection-model",
-//   templateUrl: "file-selection.component.html",
-//   styleUrls: ["file-selection.component.scss"],
-// })
-// export class FileSelectionComponent {
-//   readonly datasetRootFileNodes: ReadonlyArray<DatasetFileNode> = inject(NZ_MODAL_DATA).datasetRootFileNodes;
-//   suggestedFileTreeNodes: DatasetFileNode[] = [...this.datasetRootFileNodes];
-//   filterText: string = "";
-
-//   constructor(private modalRef: NzModalRef) {}
-
-//   filterFileTreeNodes() {
-//     const filterText = this.filterText.trim().toLowerCase();
-
-//     if (!filterText) {
-//       this.suggestedFileTreeNodes = [...this.datasetRootFileNodes];
-//     } else {
-//       const filterNodes = (node: DatasetFileNode): DatasetFileNode | null => {
-//         // For 'file' type nodes, check if the node's name matches the filter text.
-//         // Directories are not filtered out by name, but their children are filtered recursively.
-//         if (node.type === "file" && !node.name.toLowerCase().includes(filterText)) {
-//           return null; // Exclude files that don't match the filter.
-//         }
-
-//         // If the node is a directory, recurse into its children, if any.
-//         if (node.type === "directory" && node.children) {
-//           const filteredChildren = node.children.map(filterNodes).filter(child => child !== null) as DatasetFileNode[];
-
-//           if (filteredChildren.length > 0) {
-//             // If any children match, return the current directory node with filtered children.
-//             return { ...node, children: filteredChildren };
-//           } else {
-//             // If no children match, exclude the directory node.
-//             return null;
-//           }
-//         }
-
-//         // Return the node if it's a file that matches or a directory with matching descendants.
-//         return node;
-//       };
-
-//       this.suggestedFileTreeNodes = this.datasetRootFileNodes
-//         .map(filterNodes)
-//         .filter(node => node !== null) as DatasetFileNode[];
-//     }
-//   }
-
-//   onFileTreeNodeSelected(node: DatasetFileNode) {
-//     this.modalRef.close(node);
-//   }
-// }
-
 import { Component, inject, OnInit } from "@angular/core";
 import { NZ_MODAL_DATA, NzModalRef } from "ng-zorro-antd/modal";
 import { UntilDestroy } from "@ngneat/until-destroy";
-import { DatasetFileNode} from "../../../common/type/datasetVersionFileTree";
+import { DatasetFileNode } from "../../../common/type/datasetVersionFileTree";
 import { DatasetVersion } from "../../../common/type/dataset";
 import { DashboardDataset } from "../../../dashboard/type/dashboard-dataset.interface";
 import { DatasetService } from "../../../dashboard/service/user/dataset/dataset.service";
@@ -75,6 +16,7 @@ export class FileSelectionComponent implements OnInit {
   readonly datasets: ReadonlyArray<DashboardDataset> = inject(NZ_MODAL_DATA).datasets; // 获取传递的数据集信息
   selectedDataset?: DashboardDataset;
   selectedVersion?: DatasetVersion;
+  datasetVersions?: DatasetVersion[];
   suggestedFileTreeNodes: DatasetFileNode[] = [];
   filterText: string = "";
 
@@ -86,6 +28,11 @@ export class FileSelectionComponent implements OnInit {
   onDatasetChange() {
     this.selectedVersion = undefined;
     this.suggestedFileTreeNodes = [];
+    if (this.selectedDataset && this.selectedDataset.dataset.did !== undefined) {
+      this.datasetService.retrieveDatasetVersionList(this.selectedDataset.dataset.did).subscribe((versions) => {
+        this.datasetVersions = versions;
+      });
+    }
   }
 
   onVersionChange() {

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -1,7 +1,69 @@
-import { Component, inject } from "@angular/core";
+// import { Component, inject } from "@angular/core";
+// import { NZ_MODAL_DATA, NzModalRef } from "ng-zorro-antd/modal";
+// import { UntilDestroy } from "@ngneat/until-destroy";
+// import { DatasetFileNode } from "../../../common/type/datasetVersionFileTree";
+
+// @UntilDestroy()
+// @Component({
+//   selector: "texera-file-selection-model",
+//   templateUrl: "file-selection.component.html",
+//   styleUrls: ["file-selection.component.scss"],
+// })
+// export class FileSelectionComponent {
+//   readonly datasetRootFileNodes: ReadonlyArray<DatasetFileNode> = inject(NZ_MODAL_DATA).datasetRootFileNodes;
+//   suggestedFileTreeNodes: DatasetFileNode[] = [...this.datasetRootFileNodes];
+//   filterText: string = "";
+
+//   constructor(private modalRef: NzModalRef) {}
+
+//   filterFileTreeNodes() {
+//     const filterText = this.filterText.trim().toLowerCase();
+
+//     if (!filterText) {
+//       this.suggestedFileTreeNodes = [...this.datasetRootFileNodes];
+//     } else {
+//       const filterNodes = (node: DatasetFileNode): DatasetFileNode | null => {
+//         // For 'file' type nodes, check if the node's name matches the filter text.
+//         // Directories are not filtered out by name, but their children are filtered recursively.
+//         if (node.type === "file" && !node.name.toLowerCase().includes(filterText)) {
+//           return null; // Exclude files that don't match the filter.
+//         }
+
+//         // If the node is a directory, recurse into its children, if any.
+//         if (node.type === "directory" && node.children) {
+//           const filteredChildren = node.children.map(filterNodes).filter(child => child !== null) as DatasetFileNode[];
+
+//           if (filteredChildren.length > 0) {
+//             // If any children match, return the current directory node with filtered children.
+//             return { ...node, children: filteredChildren };
+//           } else {
+//             // If no children match, exclude the directory node.
+//             return null;
+//           }
+//         }
+
+//         // Return the node if it's a file that matches or a directory with matching descendants.
+//         return node;
+//       };
+
+//       this.suggestedFileTreeNodes = this.datasetRootFileNodes
+//         .map(filterNodes)
+//         .filter(node => node !== null) as DatasetFileNode[];
+//     }
+//   }
+
+//   onFileTreeNodeSelected(node: DatasetFileNode) {
+//     this.modalRef.close(node);
+//   }
+// }
+
+import { Component, inject, OnInit } from "@angular/core";
 import { NZ_MODAL_DATA, NzModalRef } from "ng-zorro-antd/modal";
 import { UntilDestroy } from "@ngneat/until-destroy";
-import { DatasetFileNode } from "../../../common/type/datasetVersionFileTree";
+import { DatasetFileNode} from "../../../common/type/datasetVersionFileTree";
+import { DatasetVersion } from "../../../common/type/dataset";
+import { DashboardDataset } from "../../../dashboard/type/dashboard-dataset.interface";
+import { DatasetService } from "../../../dashboard/service/user/dataset/dataset.service";
 
 @UntilDestroy()
 @Component({
@@ -9,46 +71,36 @@ import { DatasetFileNode } from "../../../common/type/datasetVersionFileTree";
   templateUrl: "file-selection.component.html",
   styleUrls: ["file-selection.component.scss"],
 })
-export class FileSelectionComponent {
-  readonly datasetRootFileNodes: ReadonlyArray<DatasetFileNode> = inject(NZ_MODAL_DATA).datasetRootFileNodes;
-  suggestedFileTreeNodes: DatasetFileNode[] = [...this.datasetRootFileNodes];
+export class FileSelectionComponent implements OnInit {
+  readonly datasets: ReadonlyArray<DashboardDataset> = inject(NZ_MODAL_DATA).datasets; // 获取传递的数据集信息
+  selectedDataset?: DashboardDataset;
+  selectedVersion?: DatasetVersion;
+  suggestedFileTreeNodes: DatasetFileNode[] = [];
   filterText: string = "";
 
-  constructor(private modalRef: NzModalRef) {}
+  constructor(private modalRef: NzModalRef, private datasetService: DatasetService) {}
 
-  filterFileTreeNodes() {
-    const filterText = this.filterText.trim().toLowerCase();
+  ngOnInit() {
+  }
 
-    if (!filterText) {
-      this.suggestedFileTreeNodes = [...this.datasetRootFileNodes];
-    } else {
-      const filterNodes = (node: DatasetFileNode): DatasetFileNode | null => {
-        // For 'file' type nodes, check if the node's name matches the filter text.
-        // Directories are not filtered out by name, but their children are filtered recursively.
-        if (node.type === "file" && !node.name.toLowerCase().includes(filterText)) {
-          return null; // Exclude files that don't match the filter.
-        }
+  onDatasetChange() {
+    this.selectedVersion = undefined;
+    this.suggestedFileTreeNodes = [];
+  }
 
-        // If the node is a directory, recurse into its children, if any.
-        if (node.type === "directory" && node.children) {
-          const filteredChildren = node.children.map(filterNodes).filter(child => child !== null) as DatasetFileNode[];
+  onVersionChange() {
+    this.suggestedFileTreeNodes = [];
+  }
 
-          if (filteredChildren.length > 0) {
-            // If any children match, return the current directory node with filtered children.
-            return { ...node, children: filteredChildren };
-          } else {
-            // If no children match, exclude the directory node.
-            return null;
-          }
-        }
-
-        // Return the node if it's a file that matches or a directory with matching descendants.
-        return node;
-      };
-
-      this.suggestedFileTreeNodes = this.datasetRootFileNodes
-        .map(filterNodes)
-        .filter(node => node !== null) as DatasetFileNode[];
+  showFiles() {
+    if (this.selectedDataset && this.selectedDataset.dataset.did !== undefined && this.selectedVersion && this.selectedVersion.dvid !== undefined) {
+      this.datasetService
+        .retrieveDatasetVersionFileTree(this.selectedDataset.dataset.did, this.selectedVersion.dvid)
+        .subscribe(fileNodes => {
+          this.suggestedFileTreeNodes = fileNodes;
+          console.log("+++++")
+          console.log(this.suggestedFileTreeNodes)
+        });
     }
   }
 
@@ -56,3 +108,4 @@ export class FileSelectionComponent {
     this.modalRef.close(node);
   }
 }
+

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -19,7 +19,10 @@ export class FileSelectionComponent implements OnInit {
   datasetVersions?: DatasetVersion[];
   suggestedFileTreeNodes: DatasetFileNode[] = [];
 
-  constructor(private modalRef: NzModalRef, private datasetService: DatasetService) {}
+  constructor(
+    private modalRef: NzModalRef,
+    private datasetService: DatasetService
+  ) {}
 
   ngOnInit() {}
 
@@ -27,12 +30,12 @@ export class FileSelectionComponent implements OnInit {
     this.selectedVersion = undefined;
     this.suggestedFileTreeNodes = [];
     if (this.selectedDataset && this.selectedDataset.dataset.did !== undefined) {
-      this.datasetService.retrieveDatasetVersionList(this.selectedDataset.dataset.did).subscribe((versions) => {
+      this.datasetService.retrieveDatasetVersionList(this.selectedDataset.dataset.did).subscribe(versions => {
         this.datasetVersions = versions;
         // set default version to the latest version
         if (this.datasetVersions && this.datasetVersions.length > 0) {
           this.selectedVersion = this.datasetVersions[0];
-          this.onVersionChange(); 
+          this.onVersionChange();
         }
       });
     }
@@ -40,7 +43,12 @@ export class FileSelectionComponent implements OnInit {
 
   onVersionChange() {
     this.suggestedFileTreeNodes = [];
-    if (this.selectedDataset && this.selectedDataset.dataset.did !== undefined && this.selectedVersion && this.selectedVersion.dvid !== undefined) {
+    if (
+      this.selectedDataset &&
+      this.selectedDataset.dataset.did !== undefined &&
+      this.selectedVersion &&
+      this.selectedVersion.dvid !== undefined
+    ) {
       this.datasetService
         .retrieveDatasetVersionFileTree(this.selectedDataset.dataset.did, this.selectedVersion.dvid)
         .subscribe(fileNodes => {

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -45,8 +45,6 @@ export class FileSelectionComponent implements OnInit {
         .retrieveDatasetVersionFileTree(this.selectedDataset.dataset.did, this.selectedVersion.dvid)
         .subscribe(fileNodes => {
           this.suggestedFileTreeNodes = fileNodes;
-          console.log("+++++")
-          console.log(this.suggestedFileTreeNodes)
         });
     }
   }

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -18,7 +18,6 @@ export class FileSelectionComponent implements OnInit {
   selectedVersion?: DatasetVersion;
   datasetVersions?: DatasetVersion[];
   suggestedFileTreeNodes: DatasetFileNode[] = [];
-  filterText: string = "";
 
   constructor(private modalRef: NzModalRef, private datasetService: DatasetService) {}
 

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
@@ -28,15 +28,13 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
       .retrieveAccessibleDatasets()
       .pipe(untilDestroyed(this))
       .subscribe(response => {
-        // const fileNodes = response.fileNodes;
-        const datasets = response.datasets; // 获取数据集信息
+        const datasets = response.datasets; 
         const modal = this.modalService.create({
           nzTitle: "Please select one file from datasets",
           nzContent: FileSelectionComponent,
           nzFooter: null,
           nzData: {
-            // datasetRootFileNodes: fileNodes,
-            datasets: datasets, // 传递数据集信息
+            datasets: datasets, 
           },
         });
         // Handle the selection from the modal

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
@@ -25,7 +25,7 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
 
   onClickOpenFileSelectionModal(): void {
     this.datasetService
-      .retrieveAccessibleDatasets(true)
+      .retrieveAccessibleDatasets()
       .pipe(untilDestroyed(this))
       .subscribe(response => {
         // const fileNodes = response.fileNodes;

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
@@ -28,13 +28,15 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
       .retrieveAccessibleDatasets(true)
       .pipe(untilDestroyed(this))
       .subscribe(response => {
-        const fileNodes = response.fileNodes;
+        // const fileNodes = response.fileNodes;
+        const datasets = response.datasets; // 获取数据集信息
         const modal = this.modalService.create({
           nzTitle: "Please select one file from datasets",
           nzContent: FileSelectionComponent,
           nzFooter: null,
           nzData: {
-            datasetRootFileNodes: fileNodes,
+            // datasetRootFileNodes: fileNodes,
+            datasets: datasets, // 传递数据集信息
           },
         });
         // Handle the selection from the modal

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
@@ -28,13 +28,13 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
       .retrieveAccessibleDatasets()
       .pipe(untilDestroyed(this))
       .subscribe(response => {
-        const datasets = response.datasets; 
+        const datasets = response.datasets;
         const modal = this.modalService.create({
           nzTitle: "Please select one file from datasets",
           nzContent: FileSelectionComponent,
           nzFooter: null,
           nzData: {
-            datasets: datasets, 
+            datasets: datasets,
           },
         });
         // Handle the selection from the modal


### PR DESCRIPTION
## Summary:
This PR introduces a new file-selection component for dynamically selecting datasets and their versions, and subsequently displaying files belonging to the selected version.

## Purpose:
The main goal of this PR is to optimize resource usage. Instead of initially fetching all file nodes for all versions of all datasets, we first retrieve all datasets. Based on the user's selection, we then fetch the corresponding versions of the selected dataset. Finally, upon selecting a version, we fetch and display the file nodes for that specific version.

## Dynamic Fetching:
Fetch all datasets initially.
Fetch versions of the selected dataset upon dataset selection.
Fetch file nodes of the selected version upon version selection.

## UI Enhancements:
Each dataset option displays its dataset ID and owner status.
Upon selecting a dataset, the default version is set to the latest version, users can change the version if needed.
Files are automatically displayed once a version is selected.

<img width="529" alt="截屏2024-07-29 上午10 01 03" src="https://github.com/user-attachments/assets/3ac309d5-4370-46dc-9849-d27b5b655b3d">
