### PR TITLE
Implement Basic Workflow Pod Lifecycle API

### DIFF
--- a/core/workflow-pod-brain/src/main/scala/WorkflowPodBrainApplication.scala
+++ b/core/workflow-pod-brain/src/main/scala/WorkflowPodBrainApplication.scala
@@ -23,7 +23,7 @@ class WorkflowPodBrainApplication extends Application[Configuration] {
 //    val pods = new KubernetesClientService().getPodsList()
 //    pods.foreach(pod => println(pod.getMetadata.getName))
 //
-//    val newPod = new KubernetesClientService().createPod(1)
+//    val newPod = new KubernetesClientService().createPod("1")
 //    println(newPod.getMetadata.getUid)
 //    println(newPod.getMetadata.getName)
 //    println(newPod.getMetadata.getAnnotations)

--- a/core/workflow-pod-brain/src/main/scala/WorkflowPodBrainApplication.scala
+++ b/core/workflow-pod-brain/src/main/scala/WorkflowPodBrainApplication.scala
@@ -3,6 +3,8 @@ import io.dropwizard.core.{Application, Configuration}
 import io.dropwizard.core.setup.{Bootstrap, Environment}
 import web.resources.{HelloWorldResource, WorkflowPodBrainResource}
 
+import service.KubernetesClientService
+
 class WorkflowPodBrainApplication extends Application[Configuration] {
   override def initialize(bootstrap: Bootstrap[Configuration]): Unit = {}
 
@@ -16,6 +18,15 @@ class WorkflowPodBrainApplication extends Application[Configuration] {
     println(s"Namespace: ${appConfig.kubernetes.namespace}")
     println(s"Workflow Pod Brain Deployment Name: ${appConfig.kubernetes.workflowPodBrainDeploymentName}")
     println(s"Workflow Pod Pool Deployment Name: ${appConfig.kubernetes.workflowPodPoolDeploymentName}")
+
+//    // Check if service functions work
+//    val pods = new KubernetesClientService().getPodsList()
+//    pods.foreach(pod => println(pod.getMetadata.getName))
+//
+//    val newPod = new KubernetesClientService().createPod(1)
+//    println(newPod.getMetadata.getUid)
+//    println(newPod.getMetadata.getName)
+//    println(newPod.getMetadata.getAnnotations)
   }
 }
 

--- a/core/workflow-pod-brain/src/main/scala/config/ApplicationConf.scala
+++ b/core/workflow-pod-brain/src/main/scala/config/ApplicationConf.scala
@@ -25,7 +25,7 @@ object ApplicationConf {
 
   val appConfig: AppConfig = AppConfig(
     kubernetes = KubernetesConfig(
-      kubeConfigPath = config.getString("kubernetes.kube-config-path"),
+      kubeConfigPath = expandPath(config.getString("kubernetes.kube-config-path")),
       namespace = config.getString("kubernetes.namespace"),
       workflowPodBrainDeploymentName = config.getString("kubernetes.workflow-pod-brain-deployment-name"),
       workflowPodPoolDeploymentName = config.getString("kubernetes.workflow-pod-pool-deployment-name")
@@ -36,4 +36,12 @@ object ApplicationConf {
       password = config.getString("jdbc.password")
     )
   )
+
+  private def expandPath(path: String): String = {
+    if (path.startsWith("~")) {
+      System.getProperty("user.home") + path.substring(1)
+    } else {
+      path
+    }
+  }
 }

--- a/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
+++ b/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
@@ -102,7 +102,15 @@ class KubernetesClientService(
     appsApi.createNamespacedDeployment(namespace, deployment).execute()
 
     // Should be a list with a single pod
-    getPodsList(uid).last
+    try {
+      getPodsList(uid).last
+    }
+    catch {
+      case e: java.util.NoSuchElementException =>
+        Thread.sleep(1000)
+        getPodsList(uid).last
+    }
+
   }
 
   /**

--- a/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
+++ b/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
@@ -73,7 +73,8 @@ class KubernetesClientService(
    * @param uid        The uid which a new pod will be created for.
    * @return The newly created V1Pod object.
    */
-  def createPod(uid: String): V1Pod = {
+  def createPod(uid: Int): V1Pod = {
+    val uidString: String = String.valueOf(uid)
     val deployment: V1Deployment = new V1Deployment()
       .apiVersion("apps/v1")
       .kind("Deployment")
@@ -81,15 +82,15 @@ class KubernetesClientService(
         new V1ObjectMeta()
         .name(s"user-deployment-$uid")
         .namespace(namespace)
-        .labels(util.Map.of("userId", uid))
+        .labels(util.Map.of("userId", uidString))
       )
       .spec(
         new V1DeploymentSpec()
         .replicas(1)
-        .selector(new V1LabelSelector().matchLabels(util.Map.of("userId", uid)))
+        .selector(new V1LabelSelector().matchLabels(util.Map.of("userId", uidString)))
         .template(
           new V1PodTemplateSpec()
-          .metadata(new V1ObjectMeta().labels(util.Map.of("userId", uid))
+          .metadata(new V1ObjectMeta().labels(util.Map.of("userId", uidString))
           )
           .spec(
             new V1PodSpec().containers(util.List.of(new V1Container()
@@ -103,12 +104,12 @@ class KubernetesClientService(
 
     // Should be a list with a single pod
     try {
-      getPodsList(uid).last
+      getPodsList(uidString).last
     }
     catch {
       case e: java.util.NoSuchElementException =>
         Thread.sleep(1000)
-        getPodsList(uid).last
+        getPodsList(uidString).last
     }
 
   }

--- a/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
+++ b/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
@@ -29,7 +29,12 @@ class KubernetesClientService(
                                val namespace: String = kubernetesConfig.namespace,
                                val deploymentName: String = kubernetesConfig.workflowPodPoolDeploymentName) {
 
+  // Kubernetes Api Clients are collections of different K8s objects and functions
+  // which provide programmatic access to K8s resources.
+
+  // Contains objects and resources that are core building blocks of a K8s cluster, such as pods and services.
   private val coreApi: CoreV1Api = KubernetesClientConfig.createKubernetesCoreClient()
+  // Contains a set of higher level application-focused resources such as Deployments and StatefulSets.
   private val appsApi: AppsV1Api = KubernetesClientConfig.createKubernetesAppsClient()
 
   /**

--- a/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
+++ b/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
@@ -2,18 +2,26 @@ package service
 
 import config.ApplicationConf.appConfig
 import io.kubernetes.client.openapi.{ApiClient, Configuration}
-import io.kubernetes.client.openapi.apis.CoreV1Api
-import io.kubernetes.client.openapi.models.{V1Pod, V1PodList}
+import io.kubernetes.client.openapi.apis.{AppsV1Api, CoreV1Api}
+import io.kubernetes.client.openapi.models.{V1Deployment, V1DeploymentSpec, V1ObjectMeta, V1Pod, V1PodList}
 import io.kubernetes.client.util.Config
 import service.KubernetesClientConfig.kubernetesConfig
+
+import java.util
+import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 object KubernetesClientConfig {
 
   val kubernetesConfig = appConfig.kubernetes
-  def createKubernetesClient(): CoreV1Api = {
+  def createKubernetesCoreClient(): CoreV1Api = {
     val client: ApiClient = Config.fromConfig(kubernetesConfig.kubeConfigPath)
     Configuration.setDefaultApiClient(client)
     new CoreV1Api(client)
+  }
+  def createKubernetesAppsClient(): AppsV1Api = {
+    val client: ApiClient = Config.fromConfig(kubernetesConfig.kubeConfigPath)
+    Configuration.setDefaultApiClient(client)
+    new AppsV1Api(client)
   }
 }
 
@@ -21,14 +29,19 @@ class KubernetesClientService(
                                val namespace: String = kubernetesConfig.namespace,
                                val deploymentName: String = kubernetesConfig.workflowPodPoolDeploymentName) {
 
-  private val api: CoreV1Api = KubernetesClientConfig.createKubernetesClient()
+  private val coreApi: CoreV1Api = KubernetesClientConfig.createKubernetesCoreClient()
+  private val appsApi: AppsV1Api = KubernetesClientConfig.createKubernetesAppsClient()
 
   /**
     * Retrieves the list of pods for a given deployment in the specified namespace.
     *
     * @return A list of V1Pod objects representing the pods in the deployment.
     */
-  def getPodsList(): List[V1Pod] = ???
+  def getPodsList(): List[V1Pod] = {
+    // TODO: Get only pods from workflow-pod-pool and not all pods from defined namespace
+    val request = coreApi.listNamespacedPod(namespace)
+    request.execute().getItems.asScala.toList
+  }
 
   /**
     * Creates a new pod under the specified deployment.
@@ -37,6 +50,78 @@ class KubernetesClientService(
     * @return The newly created V1Pod object.
     */
   def createPod(podSpec: V1Pod): V1Pod = ???
+
+  /**
+   * Creates a new pod under the specified deployment.
+   *
+   * @param uid        The uid which a new pod will be created for.
+   * @return The newly created V1Pod object.
+   */
+  def createPod(uid: Int): V1Pod = {
+    val deployment: V1Deployment = appsApi.readNamespacedDeployment(
+      kubernetesConfig.workflowPodPoolDeploymentName,
+      namespace
+    ).execute()
+    val spec: V1DeploymentSpec = deployment.getSpec
+
+    val currReplicas: Int = spec.getReplicas
+    val newReplicas: Int = currReplicas + 1
+    spec.setReplicas(newReplicas)
+
+    appsApi.replaceNamespacedDeployment(
+      kubernetesConfig.workflowPodPoolDeploymentName,
+      namespace,
+      deployment
+    ).execute()
+    println(s"Set ${kubernetesConfig.workflowPodPoolDeploymentName} replica number from $currReplicas to $newReplicas")
+
+    // Get and return the newly created pod.
+    pollForNewPod(uid)
+  }
+
+  /**
+   * Find and return the latest created pod.
+   *
+   * @param uid        The uid which a new pod will be created for.
+   * @return A newly created pod with user id attached as an annotation.
+   */
+  private def pollForNewPod(uid: Int): V1Pod = {
+    var returnPod: V1Pod = null
+    var podFound: Boolean = false
+
+    // Loop through list of all pods in deployment to find pods without an owner (i.e. no "uid" annotation).
+    // After finding owner-less pod, create "uid" annotation and set to uid parameter. Then, save the modified pod,
+    // exit the loop, and return the modified pod.
+    while (!podFound) {
+      val podList = getPodsList()
+      podList.foreach(pod => {
+        val metadata: V1ObjectMeta = pod.getMetadata
+        val annotations: java.util.Map[String, String] =
+          if (metadata.getAnnotations == null) new util.HashMap[String, String]() else metadata.getAnnotations
+
+        if (!podFound && pod.getStatus.getPhase == "Running" && !annotations.containsKey("uid")) {
+          annotations.put("uid", String.valueOf(uid))
+          metadata.setAnnotations(annotations)
+          pod.setMetadata(metadata)
+
+          // Possible error code 409 here.
+          // Happens due to pod changing state after retrieving the initial podList,
+          // leading to a mismatch between the cluster's current pod and the server's current pod object.
+          // Current Solution => only consider pods which are in the "Running" state.
+          // Could also add exception handling to retry in case of error.
+          coreApi.replaceNamespacedPod(pod.getMetadata.getName, namespace, pod).execute()
+
+          returnPod = pod
+          podFound = true
+        }
+      })
+
+      if (!podFound) {
+        Thread.sleep(500)
+      }
+    }
+    returnPod
+  }
 
   /**
     * Deletes an existing pod in the specified namespace.

--- a/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
+++ b/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
@@ -106,6 +106,22 @@ class KubernetesClientService(
   }
 
   /**
+    * Deletes an existing pod with the specified pod name.
+    *
+    * @param podName   The name of the pod to be deleted.
+    */
+  def deletePod(podName: String): Unit = ???
+
+  /**
+   * Deletes an existing deployment belonging to the specific user id.
+   *
+   * @param uid   The deployment owner's user id.
+   */
+  def deleteDeployment(uid: Int): Unit = {
+    appsApi.deleteNamespacedDeployment(s"user-deployment-$uid", namespace).execute()
+  }
+
+  /**
    * Find and return the latest created pod.
    *
    * @param uid        The uid which a new pod will be created for.
@@ -147,14 +163,5 @@ class KubernetesClientService(
       }
     }
     returnPod
-  }
-
-  /**
-    * Deletes an existing pod with the specified pod name.
-    *
-    * @param podName   The name of the pod to be deleted.
-    */
-  def deletePod(podName: String): Unit = {
-
   }
 }

--- a/core/workflow-pod-brain/src/main/scala/web/resources/WorkflowPodBrainResource.scala
+++ b/core/workflow-pod-brain/src/main/scala/web/resources/WorkflowPodBrainResource.scala
@@ -92,7 +92,8 @@ class WorkflowPodBrainResource {
     withTransaction(context) { ctx =>
       val podDao = new PodDao(ctx.configuration())
       val pods = podDao.fetchByUid(param.uid)
-      podDao.delete(pods)
+      pods.forEach(pod => pod.setTerminateTime(new Timestamp(System.currentTimeMillis())))
+      podDao.update(pods)
       Response.ok(s"Successfully terminated deployment and pod of uid ${param.uid}").build()
     }
   }

--- a/core/workflow-pod-brain/src/main/scala/web/resources/WorkflowPodBrainResource.scala
+++ b/core/workflow-pod-brain/src/main/scala/web/resources/WorkflowPodBrainResource.scala
@@ -37,7 +37,7 @@ class WorkflowPodBrainResource {
   def createPod(
                  param: WorkflowPodCreationParams
                ): Pod = {
-    val newPod: V1Pod = new KubernetesClientService().createPod(param.uid.toString)
+    val newPod: V1Pod = new KubernetesClientService().createPod(param.uid.intValue())
     val newSQLPod: Pod = new Pod()
 
     // Set uid, name, pod_uid, creation_time manually

--- a/core/workflow-pod-brain/src/main/scala/web/resources/WorkflowPodBrainResource.scala
+++ b/core/workflow-pod-brain/src/main/scala/web/resources/WorkflowPodBrainResource.scala
@@ -1,14 +1,18 @@
 package web.resources
 
 import jakarta.ws.rs.core.{MediaType, Response}
-import jakarta.ws.rs.{Consumes, GET, POST, Path, Produces}
+import jakarta.ws.rs.{Consumes, GET, POST, Path, Produces, QueryParam}
 import org.jooq.DSLContext
 import org.jooq.types.UInteger
+import service.KubernetesClientService
 import web.Utils.withTransaction
 import web.model.SqlServer
 import web.model.jooq.generated.tables.daos.PodDao
 import web.resources.WorkflowPodBrainResource.{WorkflowPodCreationParams, WorkflowPodTerminationParams, context}
 import web.model.jooq.generated.tables.pojos.Pod
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
 object WorkflowPodBrainResource {
 
   private lazy val context: DSLContext = SqlServer.createDSLContext()
@@ -31,15 +35,7 @@ class WorkflowPodBrainResource {
   @Path("/create")
   def createPod(
                  param: WorkflowPodCreationParams
-               ): Pod = {
-    // example codes of using withTransaction to make your queries consistent
-    // and to use jooq
-    withTransaction(context) { ctx =>
-      val podDao = new PodDao(ctx.configuration())
-      println(param)
-      podDao.fetchOneByPodId(UInteger.valueOf(1))
-    }
-  }
+               ): Pod = ???
 
 
   /**
@@ -48,7 +44,14 @@ class WorkflowPodBrainResource {
     */
   @GET
   @Path("")
-  def listPods(): List[Pod] = ???
+  @Produces(Array(MediaType.APPLICATION_JSON))
+  def listPods(@QueryParam("uid") uid: UInteger): java.util.List[Pod] = {
+    withTransaction(context) { ctx =>
+      val podDao = new PodDao(ctx.configuration())
+      val pods = podDao.fetchByUid(uid)
+      pods
+    }
+  }
 
 
   /**

--- a/core/workflow-pod-brain/src/main/scala/web/resources/WorkflowPodBrainResource.scala
+++ b/core/workflow-pod-brain/src/main/scala/web/resources/WorkflowPodBrainResource.scala
@@ -38,7 +38,7 @@ class WorkflowPodBrainResource {
   def createPod(
                  param: WorkflowPodCreationParams
                ): Pod = {
-    val newPod: V1Pod = new KubernetesClientService().createPod(param.uid.intValue())
+    val newPod: V1Pod = new KubernetesClientService().createPod(param.uid.toString)
     val newSQLPod: Pod = new Pod()
 
     // Set uid, name, pod_uid, creation_time manually


### PR DESCRIPTION
This PR implements the `createPod`, `listPods`, and `terminatePod` API endpoints, as well as related service functions. Together, they allow control over the lifecycle of a Kubernetes pod and all pods are saved in the `texera_db` database under the `pod` table. 

### Architecture
The overall architecture is different from the original design shown below as a singular deployment containing all user pods does not allow for the freedom to decide which pod is deleted without significant added complexity. Instead of a singular deployment, each user gets their own deployment, from which a pod the user can use is spawned from.
![architecture](https://github.com/user-attachments/assets/42232521-316f-4e2b-981c-7e9e369501aa)

