### PR TITLE
Hello World DropWizard Docker Image Modification

### DIFF
--- a/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
+++ b/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
@@ -100,7 +100,7 @@ class KubernetesClientService(
           .spec(
             new V1PodSpec().containers(util.List.of(new V1Container()
             .name("worker")
-            .image("kelvinyz/python-watcher:latest")
+            .image("pureblank/dropwizard-example:latest")
             .ports(util.List.of(new V1ContainerPort().containerPort(8080)))))
           )
         )


### PR DESCRIPTION
### Pull Request Summary
* Currently, the Kubernetes Pod is running on a docker image that does not have a way to test if the application is running reliably and correctly. 
* The change is to change the corresponding image to one that we can test to ensure the application is running on the pod

#### Test
* After getting the Kubernetes cluster setup:
1) kubectl port-forward pod/<POD-NAME> 8080:8080
2) Go the url of the application the pod is running:
Ex: http://localhost:8080/hello-world
 
<img width="1710" alt="Screenshot 2024-07-30 at 9 57 06 PM" src="https://github.com/user-attachments/assets/2c8ec4e3-4926-428c-a3b5-a1189f617654">

#### Testing with Postman gives the same result
<img width="1213" alt="Screenshot 2024-07-30 at 9 57 41 PM" src="https://github.com/user-attachments/assets/f9d5487b-55fb-416f-9db3-0bf95ece5702">

#### Additional test that returns the current date
<img width="852" alt="Screenshot 2024-07-30 at 9 58 33 PM" src="https://github.com/user-attachments/assets/a98f44d0-c0ff-49d2-bb2f-4f52bd5be4f1">
