### PR TITLE
Remove default option for sort of Admin page

### DIFF
--- a/core/gui/src/app/dashboard/component/admin/execution/admin-execution.component.html
+++ b/core/gui/src/app/dashboard/component/admin/execution/admin-execution.component.html
@@ -15,16 +15,19 @@
     <tr>
       <th
         [nzSortFn]="sortByWorkflowName"
+        [nzSortDirections]="['ascend', 'descend']"
         nzWidth="16%">
         Workflow (ID)
       </th>
       <th
         [nzSortFn]="sortByExecutionName"
+        [nzSortDirections]="['ascend', 'descend']"
         nzWidth="16%">
         Execution Name (ID)
       </th>
       <th
         [nzSortFn]="sortByInitiator"
+        [nzSortDirections]="['ascend', 'descend']"
         nzWidth="12%">
         Initiator
       </th>
@@ -46,6 +49,7 @@
       <th nzWidth="10%">Time Used (hh:mm:ss)</th>
       <th
         [nzSortFn]="sortByCompletedTime"
+        [nzSortDirections]="['ascend', 'descend']"
         nzWidth="15%">
         End Time
       </th>

--- a/core/gui/src/app/dashboard/component/admin/user/admin-user.component.html
+++ b/core/gui/src/app/dashboard/component/admin/user/admin-user.component.html
@@ -13,8 +13,11 @@
   <thead>
     <tr>
       <th>Avatar</th>
-      <th [nzSortFn]="sortByID"
-      [nzSortDirections]="['ascend', 'descend']">ID</th>
+      <th
+        [nzSortFn]="sortByID"
+        [nzSortDirections]="['ascend', 'descend']">
+        ID
+      </th>
       <th
         [nzSortFn]="sortByName"
         [nzSortDirections]="['ascend', 'descend']"

--- a/core/gui/src/app/dashboard/component/admin/user/admin-user.component.html
+++ b/core/gui/src/app/dashboard/component/admin/user/admin-user.component.html
@@ -13,9 +13,11 @@
   <thead>
     <tr>
       <th>Avatar</th>
-      <th [nzSortFn]="sortByID">ID</th>
+      <th [nzSortFn]="sortByID"
+      [nzSortDirections]="['ascend', 'descend']">ID</th>
       <th
         [nzSortFn]="sortByName"
+        [nzSortDirections]="['ascend', 'descend']"
         nzCustomFilter>
         Name
         <nz-filter-trigger
@@ -29,6 +31,7 @@
       </th>
       <th
         [nzSortFn]="sortByEmail"
+        [nzSortDirections]="['ascend', 'descend']"
         nzCustomFilter>
         Email
         <nz-filter-trigger
@@ -43,6 +46,7 @@
       <th>Action</th>
       <th
         [nzFilterFn]="filterByRole"
+        [nzSortDirections]="['ascend', 'descend']"
         [nzFilters]="[
       { text: 'INACTIVE', value: 'INACTIVE' },
       { text: 'REGULAR', value: 'REGULAR'},


### PR DESCRIPTION
## PR Description
Now, for the Admin Users and Execution Pages, the sorting order toggles between ascending and descending without a default state, providing a more intuitive user experience.

