### PR TITLE
Fix correct path handling in Dataset API for cross-platform compatibility

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
@@ -175,7 +175,7 @@ object DatasetResource {
   def resolveFilePath(
       filePath: java.nio.file.Path
   ): (Dataset, DatasetVersion, java.nio.file.Path) = {
-    val pathSegments = filePath.toString.stripPrefix("/").split("/")
+    val pathSegments = filePath.toString.stripPrefix("/").stripPrefix("\\").split("[/\\\\]")
 
     if (pathSegments.length < 4) {
       throw new BadRequestException(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
@@ -178,7 +178,6 @@ object DatasetResource {
 
     val pathSegments = (0 until filePath.getNameCount).map(filePath.getName(_).toString).toArray
 
-
     if (pathSegments.length < 4) {
       throw new BadRequestException(
         "Invalid file path format. Expected format: /ownerEmail/datasetName/versionName/fileRelativePath"

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
@@ -175,7 +175,9 @@ object DatasetResource {
   def resolveFilePath(
       filePath: java.nio.file.Path
   ): (Dataset, DatasetVersion, java.nio.file.Path) = {
-    val pathSegments = filePath.toString.stripPrefix("/").stripPrefix("\\").split("[/\\\\]")
+
+    val pathSegments = (0 until filePath.getNameCount).map(filePath.getName(_).toString).toArray
+
 
     if (pathSegments.length < 4) {
       throw new BadRequestException(


### PR DESCRIPTION
This PR fixes the path handling in the Dataset API to ensure it works correctly on both Windows and Unix-like systems.

The previous implementation of the path handling logic did not correctly account for Windows-style paths with backslashes (`\`).   The new implementation ensures that paths are correctly handled regardless of the operating system.

![loading page](https://github.com/user-attachments/assets/851e0bbe-da82-4929-a0a1-e035e5d880d9)
