### PR TITLE
Implement Websocket Proxy and Namespaces

### DIFF
--- a/core/workflow-pod-brain/build.sbt
+++ b/core/workflow-pod-brain/build.sbt
@@ -31,3 +31,9 @@ libraryDependencies += "com.typesafe" % "config" % "1.4.1"
 
 // https://mvnrepository.com/artifact/mysql/mysql-connector-java
 libraryDependencies += "mysql" % "mysql-connector-java" % "8.0.33"
+
+// Scala https library
+libraryDependencies += "com.softwaremill.sttp.client4" %% "core" % "4.0.0-M6"
+
+// Scala JSON library
+libraryDependencies += "com.lihaoyi" %% "upickle" % "3.1.0"

--- a/core/workflow-pod-brain/build.sbt
+++ b/core/workflow-pod-brain/build.sbt
@@ -13,7 +13,6 @@ val dropwizardVersion = "4.0.7"
 // https://mvnrepository.com/artifact/io.dropwizard/dropwizard-core
 val dropwizardDependencies = Seq(
   "io.dropwizard" % "dropwizard-core" % dropwizardVersion,
-
 )
 
 
@@ -37,3 +36,11 @@ libraryDependencies += "com.softwaremill.sttp.client4" %% "core" % "4.0.0-M6"
 
 // Scala JSON library
 libraryDependencies += "com.lihaoyi" %% "upickle" % "3.1.0"
+
+// Websockets
+
+// Dependency used in main Texera codebase is outdated for dropwizard version 4.0.7
+//libraryDependencies += "com.liveperson" % "dropwizard-websockets" % "1.3.14"
+
+// Newer websocket bundle that works with dropwizard version >= 4.0.0
+libraryDependencies += "be.tomcools" % "dropwizard-websocket-jsr356-bundle" % "4.0.0"

--- a/core/workflow-pod-brain/scripts/workflow_pods_namespaces.yaml
+++ b/core/workflow-pod-brain/scripts/workflow_pods_namespaces.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: wf-pod-brain
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: wf-pod-pool

--- a/core/workflow-pod-brain/scripts/workflow_pods_service.yaml
+++ b/core/workflow-pod-brain/scripts/workflow_pods_service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: workflow-pods
-  namespace: default
+  namespace: wf-pod-pool
 spec:
   clusterIP: None
   selector:

--- a/core/workflow-pod-brain/src/main/resources/application.conf
+++ b/core/workflow-pod-brain/src/main/resources/application.conf
@@ -1,8 +1,9 @@
 kubernetes {
     kube-config-path = "~/.kube/config" # kube config path, used as the credentials to connect to Kubernetes cluster
-    namespace = "" # the name of the namespace
+    namespace = "default" # the default namespace kubernetes resources go in
+    brain-namespace = "wf-pod-brain" # the name of the workflow pod brain application namespace
+    pool-namespace = "wf-pod-pool" # the name of the workflow pod pool namespace
     workflow-pod-brain-deployment-name = "workflow-pod-brain" # deployment name of the workflow pod brain application
-    workflow-pod-pool-deployment-name = "workflow-pod-pool" # deployment name of the workflow pods
 }
 
 jdbc {

--- a/core/workflow-pod-brain/src/main/scala/WorkflowPodBrainApplication.scala
+++ b/core/workflow-pod-brain/src/main/scala/WorkflowPodBrainApplication.scala
@@ -1,16 +1,24 @@
+import be.tomcools.dropwizard.websocket.WebsocketBundle
 import config.ApplicationConf
 import io.dropwizard.core.{Application, Configuration}
 import io.dropwizard.core.setup.{Bootstrap, Environment}
-import web.resources.{HelloWorldResource, WorkflowPodBrainResource}
-
-import service.KubernetesClientService
+import web.resources.{HelloWorldResource, WebsocketProxyEndpoint, WorkflowPodBrainResource}
 
 class WorkflowPodBrainApplication extends Application[Configuration] {
-  override def initialize(bootstrap: Bootstrap[Configuration]): Unit = {}
+  var websocket = new WebsocketBundle[Configuration]
+
+  override def initialize(bootstrap: Bootstrap[Configuration]): Unit = {
+    // Add WebsocketBundle to dropwizard
+    bootstrap.addBundle(websocket)
+  }
 
   override def run(configuration: Configuration, environment: Environment): Unit = {
     val appConfig = ApplicationConf.appConfig
 
+    // Add any websocket endpoint here
+    websocket.addEndpoint(classOf[WebsocketProxyEndpoint])
+
+    // Register http resources
     environment.jersey().register(new HelloWorldResource)
     environment.jersey().register(new WorkflowPodBrainResource)
 

--- a/core/workflow-pod-brain/src/main/scala/WorkflowPodBrainApplication.scala
+++ b/core/workflow-pod-brain/src/main/scala/WorkflowPodBrainApplication.scala
@@ -15,18 +15,6 @@ class WorkflowPodBrainApplication extends Application[Configuration] {
     environment.jersey().register(new WorkflowPodBrainResource)
 
     println(s"Kube Config Path: ${appConfig.kubernetes.kubeConfigPath}")
-    println(s"Namespace: ${appConfig.kubernetes.namespace}")
-    println(s"Workflow Pod Brain Deployment Name: ${appConfig.kubernetes.workflowPodBrainDeploymentName}")
-    println(s"Workflow Pod Pool Deployment Name: ${appConfig.kubernetes.workflowPodPoolDeploymentName}")
-
-//    // Check if service functions work
-//    val pods = new KubernetesClientService().getPodsList()
-//    pods.foreach(pod => println(pod.getMetadata.getName))
-//
-//    val newPod = new KubernetesClientService().createPod("1")
-//    println(newPod.getMetadata.getUid)
-//    println(newPod.getMetadata.getName)
-//    println(newPod.getMetadata.getAnnotations)
   }
 }
 

--- a/core/workflow-pod-brain/src/main/scala/config/ApplicationConf.scala
+++ b/core/workflow-pod-brain/src/main/scala/config/ApplicationConf.scala
@@ -5,8 +5,9 @@ import com.typesafe.config.{Config, ConfigFactory}
 case class KubernetesConfig(
                              kubeConfigPath: String,
                              namespace: String,
-                             workflowPodBrainDeploymentName: String,
-                             workflowPodPoolDeploymentName: String
+                             workflowPodBrainNamespace: String,
+                             workflowPodPoolNamespace: String,
+                             workflowPodBrainDeploymentName: String
                            )
 
 case class MysqlConfig(
@@ -27,8 +28,9 @@ object ApplicationConf {
     kubernetes = KubernetesConfig(
       kubeConfigPath = expandPath(config.getString("kubernetes.kube-config-path")),
       namespace = config.getString("kubernetes.namespace"),
-      workflowPodBrainDeploymentName = config.getString("kubernetes.workflow-pod-brain-deployment-name"),
-      workflowPodPoolDeploymentName = config.getString("kubernetes.workflow-pod-pool-deployment-name")
+      workflowPodBrainNamespace = config.getString("kubernetes.brain-namespace"),
+      workflowPodPoolNamespace = config.getString("kubernetes.pool-namespace"),
+      workflowPodBrainDeploymentName = config.getString("kubernetes.workflow-pod-brain-deployment-name")
     ),
     mysqlConfig = MysqlConfig(
       url = config.getString("jdbc.url"),

--- a/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
+++ b/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
@@ -9,6 +9,10 @@ import service.KubernetesClientConfig.kubernetesConfig
 
 import java.util
 import scala.jdk.CollectionConverters.CollectionHasAsScala
+import sttp.client4.quick.{RichRequest, quickRequest}
+import sttp.client4.{Response, UriContext}
+import sttp.model.Uri
+import sttp.model.Uri.QuerySegment.Value
 
 object KubernetesClientConfig {
 
@@ -134,7 +138,23 @@ class KubernetesClientService(
    * @param workflow   The JSON representation of a texera workflow.
    * @return The response object produced by the worker pod.
    */
-  def sendWorkflow(uid: String, workflow: String): Map[String, String] = ???
+  def sendWorkflow(uid: String, workflow: String): Map[String, ujson.Value] = {
+    // Build and send request
+//    val podUri: Uri = uri"http://user-pod-$uid.workflow-pods.default.svc.cluster.local:8080/hello-world"
+    val podUri: Uri = uri"http://localhost:8080/hello-world"
+    val response = quickRequest.get(podUri).send()
+//    val workflowJSON = ujson.Obj(
+//      "uid" -> uid,
+//      "workflow" -> workflow
+//    )
+//    val response: Response[String] = quickRequest
+//      .post(podUri)
+//      .header("Content-Type", "application/json")
+//      .body(ujson.write(workflowJSON))
+//      .send()
+
+    ujson.read(response.body).obj.toMap
+  }
 
   /**
    * Find and replace pod in case of pod failure.

--- a/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
+++ b/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
@@ -139,31 +139,6 @@ class KubernetesClientService(
   }
 
   /**
-   * Sends given workflow to specified user's pod and gets workflow response.
-   *
-   * @param uid        The user id who the workflow belongs to.
-   * @param workflow   The JSON representation of a texera workflow.
-   * @return The response object produced by the worker pod.
-   */
-  def sendWorkflow(uid: String, workflow: String): Map[String, ujson.Value] = {
-    // Build and send request
-//    val podUri: Uri = uri"http://user-pod-$uid.workflow-pods.default.svc.cluster.local:8080/hello-world"
-    val podUri: Uri = uri"http://localhost:8080/hello-world"
-    val response = quickRequest.get(podUri).send()
-//    val workflowJSON = ujson.Obj(
-//      "uid" -> uid,
-//      "workflow" -> workflow
-//    )
-//    val response: Response[String] = quickRequest
-//      .post(podUri)
-//      .header("Content-Type", "application/json")
-//      .body(ujson.write(workflowJSON))
-//      .send()
-
-    ujson.read(response.body).obj.toMap
-  }
-
-  /**
    * Find and replace pod in case of pod failure.
    *
    * @param uid        The uid which a new pod will be created for.

--- a/core/workflow-pod-brain/src/main/scala/web/resources/SharedState.scala
+++ b/core/workflow-pod-brain/src/main/scala/web/resources/SharedState.scala
@@ -1,0 +1,9 @@
+package web.resources
+
+import jakarta.websocket.Session
+
+class SharedState {
+  // Using Option to safely handle the absence of a session
+  @volatile var clientSession: Option[Session] = None
+  @volatile var podSession: Option[Session] = None
+}

--- a/core/workflow-pod-brain/src/main/scala/web/resources/WebsocketPodClient.scala
+++ b/core/workflow-pod-brain/src/main/scala/web/resources/WebsocketPodClient.scala
@@ -1,0 +1,29 @@
+package web.resources
+
+import jakarta.websocket._
+
+class WebsocketPodClient(sharedState: SharedState) extends Endpoint {
+
+  def onOpen(session: Session, config: EndpointConfig): Unit = {
+    sharedState.podSession = Some(session)
+
+    // Forward messages from the Pod to the user
+    session.addMessageHandler(new MessageHandler.Whole[String] {
+      override def onMessage(message: String): Unit = {
+        sharedState.clientSession.foreach { clientSession =>
+          if (clientSession.isOpen) {
+            clientSession.getBasicRemote.sendText(message)
+          }
+        }
+      }
+    })
+  }
+
+  override def onError(session: Session, thr: Throwable): Unit = {
+    thr.printStackTrace()
+  }
+
+  override def onClose(session: Session, closeReason: CloseReason): Unit = {
+    println(s"Pod connection closed: ${closeReason.getReasonPhrase}")
+  }
+}

--- a/core/workflow-pod-brain/src/main/scala/web/resources/WebsocketProxyEndpoint.scala
+++ b/core/workflow-pod-brain/src/main/scala/web/resources/WebsocketProxyEndpoint.scala
@@ -1,0 +1,48 @@
+package web.resources
+
+import java.net.URI
+import jakarta.websocket.{ClientEndpointConfig, ContainerProvider, OnClose, OnMessage, OnOpen, Session}
+import jakarta.websocket.server.ServerEndpoint
+
+@ServerEndpoint(value = "/ws-proxy")
+class WebsocketProxyEndpoint {
+
+  val sharedState: SharedState = new SharedState()
+
+  @OnOpen
+  def onOpen(session: Session): Unit = {
+    // Create a new SharedState instance for each connection
+    sharedState.clientSession = Some(session)
+
+    // Connect to the target WebSocket server (the Kubernetes Pod)
+    try {
+//      val targetUri = new URI("ws://user-pod-1.workflow-pods.default.svc.cluster.local:8010")
+      val targetUri = new URI("ws://localhost:8010")
+
+      // Use jarkata websockets to connect to User Pod
+      val client = ContainerProvider.getWebSocketContainer
+      val endpointInstance = new WebsocketPodClient(sharedState)
+      val clientConfig = ClientEndpointConfig.Builder.create().build()
+      client.connectToServer(endpointInstance, clientConfig, targetUri)
+    } catch {
+      case e: Exception => e.printStackTrace()
+    }
+  }
+
+  @OnMessage
+  def onMessage(message: String): Unit = {
+    // Forward the message from the user to the Pod
+    sharedState.podSession.foreach { podSession =>
+      if (podSession.isOpen) {
+        podSession.getBasicRemote.sendText(message)
+      }
+    }
+  }
+
+  @OnClose
+  def onClose(): Unit = {
+    // Close the connection to the Pod when the user disconnects
+    sharedState.podSession.foreach(_.close())
+    sharedState.clientSession.foreach(_.close())
+  }
+}

--- a/core/workflow-pod-brain/src/main/scala/web/resources/WorkflowPodBrainResource.scala
+++ b/core/workflow-pod-brain/src/main/scala/web/resources/WorkflowPodBrainResource.scala
@@ -9,7 +9,7 @@ import service.KubernetesClientService
 import web.Utils.withTransaction
 import web.model.SqlServer
 import web.model.jooq.generated.tables.daos.PodDao
-import web.resources.WorkflowPodBrainResource.{WorkflowPodCreationParams, WorkflowPodTerminationParams, context}
+import web.resources.WorkflowPodBrainResource.{WorkflowPodCreationParams, WorkflowPodTerminationParams, WorkflowPodRunParams, context}
 import web.model.jooq.generated.tables.pojos.Pod
 
 import java.sql.Timestamp
@@ -113,8 +113,9 @@ class WorkflowPodBrainResource {
   @Path("/{uid}/run-workflow")
   def runWorkflow(
                     @PathParam("uid") uid: String,
-                    param: WorkflowPodTerminationParams
+                    param: WorkflowPodRunParams
                   ): Response = {
-    Response.ok(s"Endpoints successfully reached by uid: $uid").build()
+    val responseBody = ujson.write(new KubernetesClientService().sendWorkflow(uid, param.workflow))
+    Response.ok(responseBody, MediaType.APPLICATION_JSON).build()
   }
 }

--- a/core/workflow-pod-brain/src/main/scala/web/resources/WorkflowPodBrainResource.scala
+++ b/core/workflow-pod-brain/src/main/scala/web/resources/WorkflowPodBrainResource.scala
@@ -100,22 +100,4 @@ class WorkflowPodBrainResource {
       Response.ok(s"Successfully terminated deployment and pod of uid ${param.uid}").build()
     }
   }
-
-
-  /**
-   * Run given workflow in request body.
-   * @param param the parameters
-   * @return workflow result
-   */
-  @POST
-  @Consumes(Array(MediaType.APPLICATION_JSON))
-  @Produces(Array(MediaType.APPLICATION_JSON))
-  @Path("/{uid}/run-workflow")
-  def runWorkflow(
-                    @PathParam("uid") uid: String,
-                    param: WorkflowPodRunParams
-                  ): Response = {
-    val responseBody = ujson.write(new KubernetesClientService().sendWorkflow(uid, param.workflow))
-    Response.ok(responseBody, MediaType.APPLICATION_JSON).build()
-  }
 }


### PR DESCRIPTION
## Purpose of PR

This PR implements a simple implementation of a Websocket proxy, allowing us to use the `WorkflowPodBrainApplication` as a proxy, directing user connections and requests from the brain application to a pod of our choosing and returning the response without the user needing to directly talk to the pod. In addition, two namespaces (one for the brain pods and one for the user pods) are added and integrated in the application configurations.

## Changes

`KubernetesClientService.scala`: 
- Refactored methods to integrate addition of multiple namespaces
- Deleted `sendWorkflow` resource due to pivot in direction
- Refactor some functions to take advantage of Kubernetes API request builders
- Change pod image to a websocket server image and port from 8080 to 8010 (due to image's websocket server setup)

`WorkflowPodBrainResource.scala`: 
- Deleted `runWorkflow` resource due to pivot in direction

`workflow_pods_service.yaml`, `workflow_pods_namespace.yaml`, `application.conf`, `ApplicationConf.scala`:
- Refactor to implement namespaces

`WebsocketProxyEndpoint`, `WebsocketPodClient`, `SharedState`:
- Implement Websocket proxy server and client endpoints 

`WorkflowPodBrainApplication`:
- Integrate Websocket bundle into dropwizard server
- Add websocket proxy server endpoint resource

`build.sbt`:
- Added sttp and upickle dependencies to handle http requests with Scala native libraries
- Added updated dropwizard websocket bundle compatible with dropwizard versions >= 4.0.0

## Testing

Create a pod with a uid of 1 with the following endpoint:
```
http://localhost:8888/workflowpod/create
```

Port forward the pod with the following command:
```
kubectl port-forward -n wf-pod-pool pod/user-pod-1 8010:8010
```

Now use either postman with a websocket connection type or wscat to access the websocket proxy endpoint:
```
ws://localhost:8888/ws-proxy
```

Once connected, you can freely send text messages to the pod. Each message sent will be returned to the user prefixed by "Server received from client:" to indicate a response from the pod. If you would like to view the logs of the pod, use the following command:
```
kubectl logs -n wf-pod-pool pod/user-pod-1 -f
```