### PR TITLE
Truncate row data bytes for better UI performance

### DIFF
--- a/core/gui/package.json
+++ b/core/gui/package.json
@@ -108,6 +108,7 @@
     "@types/papaparse": "5.3.5",
     "@types/quill": "2.0.9",
     "@types/uuid": "8.3.4",
+    "@types/validator": "^13.12.0",
     "@typescript-eslint/eslint-plugin": "7.0.2",
     "@typescript-eslint/parser": "7.0.2",
     "babel-plugin-dynamic-import-node": "^2.3.3",

--- a/core/gui/package.json
+++ b/core/gui/package.json
@@ -77,6 +77,7 @@
     "tinyqueue": "2.0.3",
     "tslib": "2.3.1",
     "uuid": "8.3.2",
+    "validator": "^13.12.0",
     "vscode": "npm:@codingame/monaco-vscode-api@~1.76.6",
     "vscode-ws-jsonrpc": "3.1.0",
     "y-monaco": "0.1.5",

--- a/core/gui/src/app/common/util/json.ts
+++ b/core/gui/src/app/common/util/json.ts
@@ -8,14 +8,28 @@
  * @param rowData original row data returns from execution
  */
 import { IndexableObject } from "../../workspace/types/result-table.interface";
+import validator from 'validator';
 import deepMap from "deep-map";
+
+function isBase64(str: string): boolean {
+  return validator.isBase64(str);
+}
+
+function isBinary(str: string): boolean {
+  const binaryRegex = /^[01]+$/;
+  return binaryRegex.test(str);
+}
 
 export function trimDisplayJsonData(rowData: IndexableObject, maxLen: number): Record<string, unknown> {
   return deepMap<Record<string, unknown>>(rowData, value => {
-    if (typeof value === "string" && value.length > maxLen) {
-      return value.substring(0, maxLen) + "...";
-    } else {
-      return value;
+    if (typeof value === "string") {
+      if ((isBase64(value) || isBinary(value))) {
+        return `bytes<${value.slice(0, 3)}...${value.slice(-3)}>`;
+      }
+      if (value.length > maxLen) {
+        return value.substring(0, maxLen) + "...";
+      }
     }
+    return value;
   });
 }

--- a/core/gui/src/app/common/util/json.ts
+++ b/core/gui/src/app/common/util/json.ts
@@ -8,7 +8,7 @@
  * @param rowData original row data returns from execution
  */
 import { IndexableObject } from "../../workspace/types/result-table.interface";
-import validator from 'validator';
+import validator from "validator";
 import deepMap from "deep-map";
 
 function isBase64(str: string): boolean {
@@ -23,7 +23,7 @@ function isBinary(str: string): boolean {
 export function trimDisplayJsonData(rowData: IndexableObject, maxLen: number): Record<string, unknown> {
   return deepMap<Record<string, unknown>>(rowData, value => {
     if (typeof value === "string") {
-      if ((isBase64(value) || isBinary(value))) {
+      if (isBase64(value) || isBinary(value)) {
         return `bytes<${value.slice(0, 3)}...${value.slice(-3)}>`;
       }
       if (value.length > maxLen) {

--- a/core/gui/yarn.lock
+++ b/core/gui/yarn.lock
@@ -12102,6 +12102,11 @@ validate-npm-package-name@^5.0.0:
   dependencies:
     builtins "^5.0.0"
 
+validator@^13.12.0:
+  version "13.12.0"
+  resolved "https://registry.yarnpkg.com/validator/-/validator-13.12.0.tgz#7d78e76ba85504da3fee4fd1922b385914d4b35f"
+  integrity sha512-c1Q0mCiPlgdTVVVIJIrBuxNicYE+t/7oKeI9MWLj3fh/uq2Pxh/3eeWbVZ4OcGW1TUf53At0njHw5SMdA3tmMg==
+
 vary@^1, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz#2299f02c6ded30d4a5961b0b9f74524a18f634fc"

--- a/core/gui/yarn.lock
+++ b/core/gui/yarn.lock
@@ -3260,6 +3260,11 @@
   resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
   integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
+"@types/validator@^13.12.0":
+  version "13.12.0"
+  resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.12.0.tgz#1fe4c3ae9de5cf5193ce64717c99ef2fa7d8756f"
+  integrity sha512-nH45Lk7oPIJ1RVOF6JgFI6Dy0QpHEzq4QecZhvguxYPDwT8c93prCMqAtiIttm39voZ+DDR+qkNnMpJmMBRqag==
+
 "@types/ws@^8.5.5":
   version "8.5.10"
   resolved "https://registry.yarnpkg.com/@types/ws/-/ws-8.5.10.tgz#4acfb517970853fa6574a3a6886791d04a396787"


### PR DESCRIPTION
This pull request introduces a feature to improve the user interface by truncating long byte strings (e.g., Base64 encoded data, binary strings) in row data. When detected, these strings are shortened to a more manageable format (e.g., bytes<000...abc>), improving the overall user experience. The change affects how row data is displayed, particularly for columns containing large binary data, ensuring that the UI remains responsive and clean.