### PR TITLE
Improve row data UI show more information

### DIFF
--- a/core/gui/src/app/common/util/json.ts
+++ b/core/gui/src/app/common/util/json.ts
@@ -25,8 +25,15 @@ export function trimDisplayJsonData(rowData: IndexableObject, maxLen: number): R
     if (typeof value === "string") {
       if (isBase64(value) || isBinary(value)) {
         const length = value.length;
+        // If length is less than 13, show the entire string.
+        if (length < 13) {
+          return `bytes'${value}' (length: ${length})`;
+        }
+        // Otherwise, show the leading and trailing bytes with ellipsis in between.
         const leadingBytes = value.slice(0, 10);
+        // If the length of the value is less than 10, leadingBytes will take the entire string.
         const trailingBytes = value.slice(-3);
+        // If the length of the value is less than 3, trailingBytes will take the entire string.
         return `bytes'${leadingBytes}...${trailingBytes}' (length: ${length})`;
       }
       if (value.length > maxLen) {

--- a/core/gui/src/app/common/util/json.ts
+++ b/core/gui/src/app/common/util/json.ts
@@ -24,7 +24,10 @@ export function trimDisplayJsonData(rowData: IndexableObject, maxLen: number): R
   return deepMap<Record<string, unknown>>(rowData, value => {
     if (typeof value === "string") {
       if (isBase64(value) || isBinary(value)) {
-        return `bytes<${value.slice(0, 3)}...${value.slice(-3)}>`;
+        const length = value.length;
+        const leadingBytes = value.slice(0, 10);
+        const trailingBytes = value.slice(-3);
+        return `bytes'${leadingBytes}...${trailingBytes}' (length: ${length})`;
       }
       if (value.length > maxLen) {
         return value.substring(0, maxLen) + "...";


### PR DESCRIPTION
This PR enhances the display of long binary or Base64 encoded strings in row data by transforming them into a more user-friendly format. The new format includes the first 10 characters, the last 3 characters, and the total length of the string. This update helps improve the readability of the data in the UI.
issue: #2787
![截屏2024-08-15 下午3 41 05](https://github.com/user-attachments/assets/ae991e75-11b8-463c-bdae-532585872913)

