### PR TITLE
Fix result penal glitches on the initial view

### DIFF
--- a/core/gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.scss
+++ b/core/gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.scss
@@ -86,7 +86,7 @@
 }
 
 .console-input-container {
-  position: fixed;
+  position: absolute;
   bottom: 22px;
   left: 139px;
 }

--- a/core/gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.scss
+++ b/core/gui/src/app/workspace/component/result-panel/console-frame/console-frame.component.scss
@@ -9,7 +9,7 @@
 }
 
 .console-list-container {
-  position: fixed;
+  position: absolute;
   height: calc(100% - 140px);
   width: calc(100% - 160px);
   border: 1px solid #e8e8e8;

--- a/core/gui/src/app/workspace/component/visualization-panel-content/visualization-frame-content.component.scss
+++ b/core/gui/src/app/workspace/component/visualization-panel-content/visualization-frame-content.component.scss
@@ -1,5 +1,5 @@
 #html-content {
-  position: fixed;
+  position: absolute;
   width: calc(100% - 115px);
   height: calc(100% - 40px);
   border: none;


### PR DESCRIPTION
## Issue Overview
This PR resolves an issue where, when local storage is empty, running a workflow causes the visualization and console to overflow beyond the boundaries of the result panel.
issue: #2784
<img width="1231" alt="截屏2024-08-16 上午11 55 34" src="https://github.com/user-attachments/assets/d3797646-5fb8-4a62-93ef-cd32245db3d8">
<img width="1609" alt="截屏2024-08-16 上午11 58 07" src="https://github.com/user-attachments/assets/40548ede-9a80-4ea2-9de8-c1c42ff4b2ea">
## Fix Explanation
This adjustment ensures that these elements are now positioned relative to their nearest positioned ancestor, which is the result panel in this case, rather than the entire browser window.