### PR TITLE
Remove userId from WorkflowContext

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/storage/DatasetFileDocument.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/storage/DatasetFileDocument.scala
@@ -7,7 +7,7 @@ import java.io.{File, InputStream, FileOutputStream}
 import java.net.URI
 import java.nio.file.{Files, Path}
 
-class DatasetFileDocument(uid: UInteger, fileFullPath: Path) extends VirtualDocument[Nothing] {
+class DatasetFileDocument(fileFullPath: Path) extends VirtualDocument[Nothing] {
 
   private val (_, dataset, datasetVersion, fileRelativePath) =
     DatasetResource.resolveFilePath(fileFullPath)
@@ -20,7 +20,7 @@ class DatasetFileDocument(uid: UInteger, fileFullPath: Path) extends VirtualDocu
     )
 
   override def asInputStream(): InputStream =
-    DatasetResource.getDatasetFile(dataset.getDid, datasetVersion.getDvid, uid, fileRelativePath)
+    DatasetResource.getDatasetFile(dataset.getDid, datasetVersion.getDvid, fileRelativePath)
 
   override def asFile(): File = {
     tempFile match {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/storage/DatasetFileDocument.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/storage/DatasetFileDocument.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.amber.engine.common.storage
 
 import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetResource
-import org.jooq.types.UInteger
 
 import java.io.{File, InputStream, FileOutputStream}
 import java.net.URI

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/SchemaPropagationResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/SchemaPropagationResource.scala
@@ -31,7 +31,6 @@ class SchemaPropagationResource extends LazyLogging {
     val logicalPlanPojo = Utils.objectMapper.readValue(workflowStr, classOf[LogicalPlanPojo])
 
     val context = new WorkflowContext(
-      userId = Option(sessionUser.getUser.getUid),
       workflowId = WorkflowIdentity(wid.toString.toLong)
     )
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -103,7 +103,6 @@ class WorkflowWebsocketResource extends LazyLogging {
             new ExecutionStateStore()
           }
           val workflowContext = new WorkflowContext(
-            uidOpt,
             sessionState.getCurrentWorkflowState.get.workflowId
           )
           try {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
@@ -273,7 +273,6 @@ object DatasetResource {
   def getDatasetFile(
       did: UInteger,
       dvid: UInteger,
-      uid: UInteger,
       fileRelativePath: java.nio.file.Path
   ): InputStream = {
     val versionHash = getDatasetVersionByID(context, dvid).getVersionHash

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -140,10 +140,8 @@ class WorkflowService(
     )
   }
 
-  private[this] def createWorkflowContext(
-      uidOpt: Option[UInteger]
-  ): WorkflowContext = {
-    new WorkflowContext(uidOpt, workflowId)
+  private[this] def createWorkflowContext(): WorkflowContext = {
+    new WorkflowContext(workflowId)
   }
 
   def initExecutionService(req: WorkflowExecuteRequest, uidOpt: Option[UInteger]): Unit = {
@@ -151,12 +149,12 @@ class WorkflowService(
       //unsubscribe all
       executionService.getValue.unsubscribeAll()
     }
-    val workflowContext: WorkflowContext = createWorkflowContext(uidOpt)
+    val workflowContext: WorkflowContext = createWorkflowContext()
     var controllerConf = ControllerConfig.default
 
     workflowContext.executionId = ExecutionsMetadataPersistService.insertNewExecution(
       workflowContext.workflowId,
-      workflowContext.userId,
+      uidOpt,
       req.executionName,
       convertToJson(req.engineVersion)
     )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/WorkflowContext.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/WorkflowContext.scala
@@ -11,7 +11,6 @@ object WorkflowContext {
   val DEFAULT_WORKFLOW_ID: WorkflowIdentity = WorkflowIdentity(1L)
 }
 class WorkflowContext(
-    var userId: Option[UInteger] = None,
     var workflowId: WorkflowIdentity = DEFAULT_WORKFLOW_ID,
     var executionId: ExecutionIdentity = DEFAULT_EXECUTION_ID
 )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/WorkflowContext.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/WorkflowContext.scala
@@ -4,7 +4,6 @@ import edu.uci.ics.texera.workflow.common.WorkflowContext.{
   DEFAULT_EXECUTION_ID,
   DEFAULT_WORKFLOW_ID
 }
-import org.jooq.types.UInteger
 
 object WorkflowContext {
   val DEFAULT_EXECUTION_ID: ExecutionIdentity = ExecutionIdentity(1L)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/download/BulkDownloaderOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/download/BulkDownloaderOpDesc.scala
@@ -33,7 +33,6 @@ class BulkDownloaderOpDesc extends LogicalOp {
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity
   ): PhysicalOp = {
-    assert(getContext.userId.isDefined)
     PhysicalOp
       .oneToOnePhysicalOp(
         workflowId,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/ScanSourceOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/ScanSourceOpDesc.scala
@@ -3,6 +3,7 @@ package edu.uci.ics.texera.workflow.operators.source.scan
 import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonPropertyDescription}
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
+import edu.uci.ics.amber.engine.common.AmberConfig
 import edu.uci.ics.amber.engine.common.storage.DatasetFileDocument
 import edu.uci.ics.amber.engine.common.workflow.OutputPort
 import edu.uci.ics.texera.workflow.common.WorkflowContext
@@ -64,9 +65,9 @@ abstract class ScanSourceOpDesc extends SourceOperatorDescriptor {
       throw new RuntimeException("no input file name")
     }
 
-    if (getContext.userId.isDefined) {
+    if (AmberConfig.isUserSystemEnabled) {
       // if user system is defined, a datasetFileDesc will be initialized, which is the handle of reading file from the dataset
-      datasetFile = Some(new DatasetFileDocument(getContext.userId.get, Paths.get(fileName.get)))
+      datasetFile = Some(new DatasetFileDocument(Paths.get(fileName.get)))
     } else {
       // otherwise, the fileName will be inputted by user, which is the filePath.
       filePath = fileName
@@ -89,7 +90,7 @@ abstract class ScanSourceOpDesc extends SourceOperatorDescriptor {
   // resolve the file path based on whether the user system is enabled
   // it will check for the presence of the given filePath/Desc
   def determineFilePathOrDatasetFile(): (String, DatasetFileDocument) = {
-    if (getContext.userId.isDefined) {
+    if (AmberConfig.isUserSystemEnabled) {
       val file = datasetFile.getOrElse(
         throw new RuntimeException("Dataset file descriptor is not provided.")
       )

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/download/BulkDownloaderOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/download/BulkDownloaderOpExecSpec.scala
@@ -7,7 +7,6 @@ import edu.uci.ics.texera.workflow.common.WorkflowContext.{
 }
 import edu.uci.ics.texera.workflow.common.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.tuple.schema.{Attribute, AttributeType, Schema}
-import org.jooq.types.UInteger
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 class BulkDownloaderOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
@@ -37,7 +36,7 @@ class BulkDownloaderOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   var opExec: BulkDownloaderOpExec = _
   before {
     opExec = new BulkDownloaderOpExec(
-      new WorkflowContext(Some(UInteger.valueOf(1)), DEFAULT_WORKFLOW_ID, DEFAULT_EXECUTION_ID),
+      new WorkflowContext(DEFAULT_WORKFLOW_ID, DEFAULT_EXECUTION_ID),
       urlAttribute = "url"
     )
   }


### PR DESCRIPTION
This PR removes `userId` from `WorkflowContext`.

## Purpose of the removal

`userId` requires the WorkflowContext to have the session info. This is not clean as some components like WorkflowCompiler should not have dependencies with user session.

## Usages of userId

There are only few usages related to `WorkflowContext.userId`. Most of these usages are redundant.

As userId was used for resolving user files, which is replaced by dataset now. It does not depend on or cause dependency of session.