### PR TITLE
Bound workspace panels

### DIFF
--- a/core/gui/src/app/workspace/component/left-panel/left-panel.component.html
+++ b/core/gui/src/app/workspace/component/left-panel/left-panel.component.html
@@ -1,6 +1,6 @@
 <div
   cdkDrag
-  cdkDragBoundary="body"
+  cdkDragBoundary="texera-workspace"
   id="left-container"
   class="box"
   nz-resizable

--- a/core/gui/src/app/workspace/component/left-panel/left-panel.component.scss
+++ b/core/gui/src/app/workspace/component/left-panel/left-panel.component.scss
@@ -6,7 +6,7 @@
 #left-container {
   position: fixed;
   top: 90px;
-  left: 15px;
+  left: 215px;
   z-index: 3;
   user-select: none;
   background: white;

--- a/core/gui/src/app/workspace/component/property-editor/property-editor.component.html
+++ b/core/gui/src/app/workspace/component/property-editor/property-editor.component.html
@@ -1,7 +1,7 @@
 <div
   [hidden]="!currentComponent"
   cdkDrag
-  cdkDragBoundary="body"
+  cdkDragBoundary="texera-workspace"
   id="right-container"
   nz-resizable
   [nzMinWidth]="260"

--- a/core/gui/src/app/workspace/component/result-panel/result-panel.component.html
+++ b/core/gui/src/app/workspace/component/result-panel/result-panel.component.html
@@ -1,7 +1,7 @@
 <div
   id="result-container"
   cdkDrag
-  cdkDragBoundary="body"
+  cdkDragBoundary="texera-workspace"
   nz-resizable
   [nzMinWidth]="300"
   [nzMinHeight]="250"

--- a/core/gui/src/app/workspace/component/result-panel/result-panel.component.scss
+++ b/core/gui/src/app/workspace/component/result-panel/result-panel.component.scss
@@ -9,7 +9,7 @@
 #result-container {
   position: fixed;
   top: calc(100vh - 300px);
-  left: 0;
+  left: 200px;
   user-select: none;
   background: white;
   border-radius: 5px;


### PR DESCRIPTION
## Purpose
After adding the workflow workspace under dashboard, the panels could move over the navbar. This PR seeks to disable that behavior and bound the draggable area to only the workspace part of the screen.

## Changes
Change the cdkDragBoundary from "body" to "texera-workspace" for result panel, left panel, and property editor.
Change the initial locations of result panel and left panel so they aren't on top of the navbar at initial load of workspace.
## Demo
![chrome_MUxfPgIIQP](https://github.com/user-attachments/assets/ab1ef090-ce2c-42f4-b354-19bf9c06baed)

