### PR TITLE
Add wid to pod table and creation request

### DIFF
--- a/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
+++ b/core/workflow-pod-brain/src/main/scala/service/KubernetesClientService.scala
@@ -78,10 +78,10 @@ class KubernetesClientService(
    * @param uid        The uid which a new pod will be created for.
    * @return The newly created V1Pod object.
    */
-  def createPod(uid: Int): V1Pod = {
+  def createPod(uid: Int, wid: Int): V1Pod = {
     val uidString: String = String.valueOf(uid)
     val uidLabelSelector: String = s"userId=$uidString"
-    val pod: V1Pod = createUserPod(uid)
+    val pod: V1Pod = createUserPod(uid, wid)
 
     // Should be a list with a single pod
     try {
@@ -103,14 +103,14 @@ class KubernetesClientService(
    * @param uid        The uid which a pod pod will be created for.
    * @return The newly created V1Pod object.
    */
-  def createUserPod(uid: Int): V1Pod = {
+  def createUserPod(uid: Int, wid: Int): V1Pod = {
     val uidString: String = String.valueOf(uid)
     val pod: V1Pod = new V1Pod()
       .apiVersion("v1")
       .kind("Pod")
       .metadata(
         new V1ObjectMeta()
-          .name(s"user-pod-$uid")
+          .name(s"user-pod-$uid-wid-$wid")
           .namespace(poolNamespace)
           .labels(util.Map.of("userId", uidString, "workflow", "worker"))
       )
@@ -122,7 +122,7 @@ class KubernetesClientService(
               .image("ksdn117/web-socket-test")
               .ports(util.List.of(new V1ContainerPort().containerPort(8010))))
           )
-          .hostname(s"user-pod-$uid")
+          .hostname(s"user-pod-$uid-wid-$wid")
           .subdomain("workflow-pods")
           .overhead(null)
       )
@@ -134,8 +134,8 @@ class KubernetesClientService(
    *
    * @param uid   The pod owner's user id.
    */
-  def deletePod(uid: Int): Unit = {
-    coreApi.deleteNamespacedPod(s"user-pod-$uid", poolNamespace).execute()
+  def deletePod(uid: Int, wid: Int): Unit = {
+    coreApi.deleteNamespacedPod(s"user-pod-$uid-wid-$wid", poolNamespace).execute()
   }
 
   /**

--- a/core/workflow-pod-brain/src/main/scala/web/resources/WorkflowPodBrainResource.scala
+++ b/core/workflow-pod-brain/src/main/scala/web/resources/WorkflowPodBrainResource.scala
@@ -39,7 +39,7 @@ class WorkflowPodBrainResource {
   def createPod(
                  param: WorkflowPodCreationParams
                ): Pod = {
-    val newPod: V1Pod = new KubernetesClientService().createPod(param.uid.intValue())
+    val newPod: V1Pod = new KubernetesClientService().createPod(param.uid.intValue(), param.wid.intValue())
     val newSQLPod: Pod = new Pod()
 
     // Set uid, name, pod_uid, creation_time manually
@@ -48,6 +48,7 @@ class WorkflowPodBrainResource {
     newSQLPod.setName(newPod.getMetadata.getName)
     newSQLPod.setPodUid(newPod.getMetadata.getUid)
     newSQLPod.setCreationTime(Timestamp.from(newPod.getMetadata.getCreationTimestamp.toInstant))
+    newSQLPod.setPodId(param.wid)
 
     withTransaction(context) { ctx =>
       val podDao = new PodDao(ctx.configuration())
@@ -91,7 +92,7 @@ class WorkflowPodBrainResource {
   def terminatePod(
                     param: WorkflowPodTerminationParams
                   ): Response = {
-    new KubernetesClientService().deletePod(param.uid.intValue())
+    new KubernetesClientService().deletePod(param.uid.intValue(), param.wid.intValue())
     withTransaction(context) { ctx =>
       val podDao = new PodDao(ctx.configuration())
       val pods = podDao.fetchByUid(param.uid)


### PR DESCRIPTION
### Purpose
The purpose of the PR is to add the workflow id (wid) to the pod table in the texera_db, pod table and as part of the creation request whenever a new pod is created.

### Changes
The changes include adding a new parameter to creating the pod and deleting the pod. 
1) For creating the pod, wid is used to add to the pod_id of the pod table and also for the creation request by appending "wid-<wid>" to the name (i.e. user-pod-1 to user-pod-1-wid-1).
2) For deleting the pod, an appropriate wid is needed to specify which pod to delete since it is a primary key. As a result, wid is needed to determine that request.

### Demonstration
1) Pod Creation
<img width="828" alt="Screenshot 2024-08-29 at 3 33 39 PM" src="https://github.com/user-attachments/assets/3094b7b9-d2c3-43d7-8c1f-bb7efe9c7372">
2) Verify in pod table
<img width="1039" alt="Screenshot 2024-08-29 at 3 34 02 PM" src="https://github.com/user-attachments/assets/88a1ddec-a00c-492e-b510-300eb614494b">
3) Verify in minikube
<img width="988" alt="Screenshot 2024-08-29 at 3 34 22 PM" src="https://github.com/user-attachments/assets/217bec77-5e9d-4b16-972d-fec3692f6d2a">
