### PR TITLE
Fix the betterproto version to 2.0.0b6

### DIFF
--- a/core/amber/requirements.txt
+++ b/core/amber/requirements.txt
@@ -10,7 +10,7 @@ pytest==7.4.0
 python-dateutil==2.8.1
 pytest-timeout
 protobuf==3.20.3
-betterproto~=2.0.0b3
+betterproto==2.0.0b6
 typing~=3.7.4.3
 pampy==0.3.0
 overrides


### PR DESCRIPTION
The reason of this fix is if the betterproto is upgraded to `2.0.0b7`, the console message's datetime would have issue, resulting into python udf's stuck.

This is only a temporary fix. The final fix should uniform the way python udf generate console messages. 