### PR TITLE
Fix ConsoleMessage Datetime for betterproto 2.0.0b7

### DIFF
--- a/core/amber/requirements.txt
+++ b/core/amber/requirements.txt
@@ -26,3 +26,4 @@ bidict==0.22.0
 cached_property
 psutil
 transformers
+tzlocal

--- a/core/amber/src/main/python/core/runnables/data_processor.py
+++ b/core/amber/src/main/python/core/runnables/data_processor.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import traceback
-from datetime import datetime
+import datetime
 from threading import Event
 
 from loguru import logger
@@ -112,7 +112,7 @@ class DataProcessor(Runnable, Stoppable):
         self._context.console_message_manager.put_message(
             ConsoleMessage(
                 worker_id=self._context.worker_id,
-                timestamp=datetime.now(datetime.timezone.utc),
+                timestamp=datetime.datetime.now(datetime.timezone.utc),
                 msg_type=ConsoleMessageType.ERROR,
                 source=f"{module_name}:{func_name}:{line_number}",
                 title=title,

--- a/core/amber/src/main/python/core/runnables/data_processor.py
+++ b/core/amber/src/main/python/core/runnables/data_processor.py
@@ -112,7 +112,7 @@ class DataProcessor(Runnable, Stoppable):
         self._context.console_message_manager.put_message(
             ConsoleMessage(
                 worker_id=self._context.worker_id,
-                timestamp=datetime.now(),
+                timestamp=datetime.now(datetime.timezone.utc),
                 msg_type=ConsoleMessageType.ERROR,
                 source=f"{module_name}:{func_name}:{line_number}",
                 title=title,

--- a/core/amber/src/main/python/core/runnables/data_processor.py
+++ b/core/amber/src/main/python/core/runnables/data_processor.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import traceback
-import datetime
 from threading import Event
 
 from loguru import logger
@@ -11,6 +10,7 @@ from core.models import Tuple, ExceptionInfo
 from core.models.table import all_output_to_tuple
 from core.util import Stoppable
 from core.util.console_message.replace_print import replace_print
+from core.util.console_message.timestamp import current_time_in_local_timezone
 from core.util.runnable.runnable import Runnable
 from proto.edu.uci.ics.amber.engine.architecture.worker import (
     ConsoleMessage,
@@ -112,7 +112,7 @@ class DataProcessor(Runnable, Stoppable):
         self._context.console_message_manager.put_message(
             ConsoleMessage(
                 worker_id=self._context.worker_id,
-                timestamp=datetime.datetime.now(datetime.timezone.utc),
+                timestamp=current_time_in_local_timezone(),
                 msg_type=ConsoleMessageType.ERROR,
                 source=f"{module_name}:{func_name}:{line_number}",
                 title=title,

--- a/core/amber/src/main/python/core/runnables/main_loop.py
+++ b/core/amber/src/main/python/core/runnables/main_loop.py
@@ -335,7 +335,7 @@ class MainLoop(StoppableQueueBlockingRunnable):
                 PythonConsoleMessageV2(
                     ConsoleMessage(
                         worker_id=self.context.worker_id,
-                        timestamp=datetime.datetime.now(),
+                        timestamp=datetime.datetime.now(datetime.timezone.utc),
                         msg_type=ConsoleMessageType.DEBUGGER,
                         source="(Pdb)",
                         title=debug_event,

--- a/core/amber/src/main/python/core/runnables/main_loop.py
+++ b/core/amber/src/main/python/core/runnables/main_loop.py
@@ -23,6 +23,7 @@ from core.models.internal_queue import DataElement, ControlElement
 from core.runnables.data_processor import DataProcessor
 from core.util import StoppableQueueBlockingRunnable, get_one_of, set_one_of
 from core.util.customized_queue.queue_base import QueueElement
+from core.util.console_message.timestamp import current_time_in_local_timezone
 from proto.edu.uci.ics.amber.engine.architecture.worker import (
     ControlCommandV2,
     ConsoleMessageType,
@@ -335,7 +336,7 @@ class MainLoop(StoppableQueueBlockingRunnable):
                 PythonConsoleMessageV2(
                     ConsoleMessage(
                         worker_id=self.context.worker_id,
-                        timestamp=datetime.datetime.now(datetime.timezone.utc),
+                        timestamp=current_time_in_local_timezone(),
                         msg_type=ConsoleMessageType.DEBUGGER,
                         source="(Pdb)",
                         title=debug_event,

--- a/core/amber/src/main/python/core/runnables/main_loop.py
+++ b/core/amber/src/main/python/core/runnables/main_loop.py
@@ -1,4 +1,3 @@
-import datetime
 import threading
 import time
 import typing

--- a/core/amber/src/main/python/core/runnables/test_console_message.py
+++ b/core/amber/src/main/python/core/runnables/test_console_message.py
@@ -16,9 +16,7 @@ from proto.edu.uci.ics.amber.engine.architecture.worker import (
 )
 from core.util.console_message.timestamp import current_time_in_local_timezone
 
-'''
-This class covers test cases related to ConsoleMessage
-'''
+
 class TestConsoleMessage:
     @pytest.fixture
     def internal_queue(self):
@@ -57,7 +55,9 @@ class TestConsoleMessage:
         # below statements wrap the console message as the python control message
         command = set_one_of(ControlCommandV2, console_message)
         payload = set_one_of(ControlPayloadV2, ControlInvocationV2(1, command=command))
-        python_control_message = PythonControlMessage(tag=mock_controller, payload=payload)
+        python_control_message = PythonControlMessage(
+            tag=mock_controller, payload=payload
+        )
         # serialize the python control message to bytes
         python_control_message_bytes = bytes(python_control_message)
         # deserialize the control message from bytes

--- a/core/amber/src/main/python/core/runnables/test_console_message.py
+++ b/core/amber/src/main/python/core/runnables/test_console_message.py
@@ -1,6 +1,4 @@
 import pytest
-import datetime
-
 from core.models.internal_queue import InternalQueue
 from core.util.buffer.timed_buffer import TimedBuffer
 from core.util import set_one_of
@@ -19,7 +17,7 @@ from proto.edu.uci.ics.amber.engine.architecture.worker import (
 from core.util.console_message.timestamp import current_time_in_local_timezone
 
 '''
-This class covers test cases related to ConsoleMessage, including serialization and deserialization
+This class covers test cases related to ConsoleMessage
 '''
 class TestConsoleMessage:
     @pytest.fixture
@@ -36,7 +34,8 @@ class TestConsoleMessage:
             ConsoleMessage(
                 worker_id="0",
                 timestamp=current_time_in_local_timezone(),
-                # timestamp=datetime.datetime.now(), this will produce error if betterproto is set to 2.0.0b7
+                # this will produce error if betterproto is set to 2.0.0b7
+                # timestamp=datetime.datetime.now(),
                 msg_type=ConsoleMessageType.PRINT,
                 source="pytest",
                 title="Test Message",
@@ -55,14 +54,15 @@ class TestConsoleMessage:
         :param mock_controller: the mock actor id
         :param console_message: the test message
         '''
-        # below statements wrap the console message as the python control message,
-        #   which is the message that is actually being sent through the network when a console message is produced
+        # below statements wrap the console message as the python control message
         command = set_one_of(ControlCommandV2, console_message)
         payload = set_one_of(ControlPayloadV2, ControlInvocationV2(1, command=command))
         python_control_message = PythonControlMessage(tag=mock_controller, payload=payload)
         # serialize the python control message to bytes
         python_control_message_bytes = bytes(python_control_message)
         # deserialize the control message from bytes
-        parsed_python_control_message = PythonControlMessage().parse(python_control_message_bytes)
+        parsed_python_control_message = (
+            PythonControlMessage().parse(python_control_message_bytes)
+        )
         # deserialized one should equal to the original one
         assert python_control_message == parsed_python_control_message

--- a/core/amber/src/main/python/core/runnables/test_console_message.py
+++ b/core/amber/src/main/python/core/runnables/test_console_message.py
@@ -1,0 +1,68 @@
+import pytest
+import datetime
+
+from core.models.internal_queue import InternalQueue
+from core.util.buffer.timed_buffer import TimedBuffer
+from core.util import set_one_of
+from proto.edu.uci.ics.amber.engine.common import (
+    ActorVirtualIdentity,
+    ControlInvocationV2,
+    ControlPayloadV2,
+    PythonControlMessage
+)
+from proto.edu.uci.ics.amber.engine.architecture.worker import (
+    PythonConsoleMessageV2,
+    ConsoleMessage,
+    ConsoleMessageType,
+    ControlCommandV2,
+)
+from core.util.console_message.timestamp import current_time_in_local_timezone
+
+'''
+This class covers test cases related to ConsoleMessage, including serialization and deserialization
+'''
+class TestConsoleMessage:
+    @pytest.fixture
+    def internal_queue(self):
+        return InternalQueue()
+
+    @pytest.fixture
+    def timed_buffer(self):
+        return TimedBuffer()
+
+    @pytest.fixture
+    def console_message(self):
+        return PythonConsoleMessageV2(
+            ConsoleMessage(
+                worker_id="0",
+                timestamp=current_time_in_local_timezone(),
+                # timestamp=datetime.datetime.now(), this will produce error if betterproto is set to 2.0.0b7
+                msg_type=ConsoleMessageType.PRINT,
+                source="pytest",
+                title="Test Message",
+                message="Test Message",
+            )
+        )
+
+    @pytest.fixture
+    def mock_controller(self):
+        return ActorVirtualIdentity("CONTROLLER")
+
+    @pytest.mark.timeout(2)
+    def test_console_message_serialization(self, mock_controller, console_message):
+        '''
+        Test the serialization of the console message
+        :param mock_controller: the mock actor id
+        :param console_message: the test message
+        '''
+        # below statements wrap the console message as the python control message,
+        #   which is the message that is actually being sent through the network when a console message is produced
+        command = set_one_of(ControlCommandV2, console_message)
+        payload = set_one_of(ControlPayloadV2, ControlInvocationV2(1, command=command))
+        python_control_message = PythonControlMessage(tag=mock_controller, payload=payload)
+        # serialize the python control message to bytes
+        python_control_message_bytes = bytes(python_control_message)
+        # deserialize the control message from bytes
+        parsed_python_control_message = PythonControlMessage().parse(python_control_message_bytes)
+        # deserialized one should equal to the original one
+        assert python_control_message == parsed_python_control_message

--- a/core/amber/src/main/python/core/runnables/test_console_message.py
+++ b/core/amber/src/main/python/core/runnables/test_console_message.py
@@ -6,7 +6,7 @@ from proto.edu.uci.ics.amber.engine.common import (
     ActorVirtualIdentity,
     ControlInvocationV2,
     ControlPayloadV2,
-    PythonControlMessage
+    PythonControlMessage,
 )
 from proto.edu.uci.ics.amber.engine.architecture.worker import (
     PythonConsoleMessageV2,
@@ -47,11 +47,11 @@ class TestConsoleMessage:
 
     @pytest.mark.timeout(2)
     def test_console_message_serialization(self, mock_controller, console_message):
-        '''
+        """
         Test the serialization of the console message
         :param mock_controller: the mock actor id
         :param console_message: the test message
-        '''
+        """
         # below statements wrap the console message as the python control message
         command = set_one_of(ControlCommandV2, console_message)
         payload = set_one_of(ControlPayloadV2, ControlInvocationV2(1, command=command))
@@ -61,8 +61,8 @@ class TestConsoleMessage:
         # serialize the python control message to bytes
         python_control_message_bytes = bytes(python_control_message)
         # deserialize the control message from bytes
-        parsed_python_control_message = (
-            PythonControlMessage().parse(python_control_message_bytes)
+        parsed_python_control_message = PythonControlMessage().parse(
+            python_control_message_bytes
         )
         # deserialized one should equal to the original one
         assert python_control_message == parsed_python_control_message

--- a/core/amber/src/main/python/core/util/console_message/replace_print.py
+++ b/core/amber/src/main/python/core/util/console_message/replace_print.py
@@ -1,11 +1,10 @@
 import builtins
-import datetime
 import inspect
 from contextlib import redirect_stdout
 from io import StringIO
 
 from typing import ContextManager
-
+from core.util.console_message.timestamp import current_time_in_local_timezone
 from core.util.buffer.buffer_base import IBuffer
 from proto.edu.uci.ics.amber.engine.architecture.worker import (
     ConsoleMessage,
@@ -53,7 +52,7 @@ class replace_print(ContextManager):
                 complete_str = tmp_buf.getvalue()
                 console_message = ConsoleMessage(
                     worker_id=self.worker_id,
-                    timestamp=datetime.datetime.now(datetime.timezone.utc),
+                    timestamp=current_time_in_local_timezone(),
                     msg_type=ConsoleMessageType.PRINT,
                     source=(
                         f"{inspect.currentframe().f_back.f_globals['__name__']}"

--- a/core/amber/src/main/python/core/util/console_message/replace_print.py
+++ b/core/amber/src/main/python/core/util/console_message/replace_print.py
@@ -53,7 +53,7 @@ class replace_print(ContextManager):
                 complete_str = tmp_buf.getvalue()
                 console_message = ConsoleMessage(
                     worker_id=self.worker_id,
-                    timestamp=datetime.datetime.now(),
+                    timestamp=datetime.datetime.now(datetime.timezone.utc),
                     msg_type=ConsoleMessageType.PRINT,
                     source=(
                         f"{inspect.currentframe().f_back.f_globals['__name__']}"

--- a/core/amber/src/main/python/core/util/console_message/timestamp.py
+++ b/core/amber/src/main/python/core/util/console_message/timestamp.py
@@ -1,6 +1,7 @@
 import datetime
 import tzlocal
 
+
 def current_time_in_local_timezone():
     # Get the system's local timezone
     local_timezone = tzlocal.get_localzone()

--- a/core/amber/src/main/python/core/util/console_message/timestamp.py
+++ b/core/amber/src/main/python/core/util/console_message/timestamp.py
@@ -1,0 +1,11 @@
+import datetime
+import tzlocal
+
+def current_time_in_local_timezone():
+    # Get the system's local timezone
+    local_timezone = tzlocal.get_localzone()
+
+    # Get the current time in the local timezone
+    local_time = datetime.datetime.now(local_timezone)
+
+    return local_time


### PR DESCRIPTION
This PR fixes the error of python udf stuck when betterproto is at version `2.0.0b7`

This fix is compatible with betterproto `2.0.0b3` to `2.0.0b7`.

## The cause of the bug

When betterproto is at version `2.0.0b7`, timestamp requires the timezone information. Otherwise, there will be exceptions if `print` statements are in the python udf's code. 

Before the fix, here is the code snippet of creating `ConsoleMessage` in `pytexera`:
```python
ConsoleMessage(
                        worker_id=self.context.worker_id,
                        timestamp=datetime.datetime.now(),
                        msg_type=ConsoleMessageType.DEBUGGER,
                        source="(Pdb)",
                        title=debug_event,
                        message="",
                    )
```

## How the fix is done

By changing the `timestamp=datetime.datetime.now()` to `timestamp=datetime.datetime.now(datetime.timezone.utc)` in all occurrence of `ConsoleMessage` constructor, i.e. in `replace_print.py`, `data_processor.py` and `main_loop.py`. This problem got fixed.
 