### PR TITLE
Add buttons for editing the name and description in the list item.

### DIFF
--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
@@ -5,26 +5,34 @@
     [routerLink]="entryLink"
     nz-row
     nzAlign="middle">
-
     <!-- Icon Column -->
-    <div nz-col nzSpan="1">
+    <div
+      nz-col
+      nzSpan="1">
       <div class="type-icon-div">
-        <i nz-icon [nzType]="iconType"></i>
+        <i
+          nz-icon
+          [nzType]="iconType"></i>
       </div>
     </div>
 
     <!-- ID Column -->
-    <div nz-col nzSpan="1">
+    <div
+      nz-col
+      nzSpan="1">
       <div class="resource-id">
         <em>#{{ entry.id }}</em>
       </div>
     </div>
 
-    <div nz-col nzSpan="10">
+    <div
+      nz-col
+      nzSpan="10">
       <div class="name-container">
         <!-- Edit Name Buttons -->
-        <div class="edit-button-group"
-             *ngIf="isPrivateSearch">
+        <div
+          class="edit-button-group"
+          *ngIf="isPrivateSearch">
           <button
             nz-button
             nzType="text"
@@ -32,12 +40,17 @@
             title="Rename"
             (click)="onEditName()"
             (click)="$event.stopPropagation()">
-            <i nz-icon nzTheme="outline" nzType="edit"></i>
+            <i
+              nz-icon
+              nzTheme="outline"
+              nzType="edit"></i>
           </button>
         </div>
 
         <!-- Name -->
-        <div class="resource-name truncate-single-line" *ngIf="!editingName">
+        <div
+          class="resource-name truncate-single-line"
+          *ngIf="!editingName">
           {{ entry.name }}
         </div>
         <input
@@ -48,14 +61,15 @@
           (blur)="confirmUpdateWorkflowCustomName(entry.name)"
           (keydown.enter)="confirmUpdateWorkflowCustomName(entry.name)"
           (click)="$event.stopPropagation()"
-          autofocus>
+          autofocus />
       </div>
 
       <!-- Description -->
       <div cladd="description-container">
         <!-- Edit Description Buttons -->
-        <div class="edit-button-group"
-             *ngIf="isPrivateSearch">
+        <div
+          class="edit-button-group"
+          *ngIf="isPrivateSearch">
           <button
             nz-button
             nzType="text"
@@ -63,10 +77,15 @@
             title="Edit Description"
             (click)="onEditDescription()"
             (click)="$event.stopPropagation()">
-            <i nz-icon nzTheme="outline" nzType="form"></i>
+            <i
+              nz-icon
+              nzTheme="outline"
+              nzType="form"></i>
           </button>
         </div>
-        <div class="resource-description truncate-single-line" *ngIf="!editingDescription">
+        <div
+          class="resource-description truncate-single-line"
+          *ngIf="!editingDescription">
           {{ entry.description ? entry.description : '' }}
         </div>
         <textarea

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
@@ -88,7 +88,7 @@
         <div class="resource-owner">
           <texera-user-avatar
             class="user-avatar"
-            [googleAvatar]=""
+            googleAvatar=""
             userColor="#1E90FF"
             [userName]="entry.ownerName || 'User'">
           </texera-user-avatar>

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
@@ -5,21 +5,82 @@
     [routerLink]="entryLink"
     nz-row
     nzAlign="middle">
-    <div
-      nz-col
-      nzSpan="1">
+
+    <!-- Icon Column -->
+    <div nz-col nzSpan="1">
       <div class="type-icon-div">
-        <i
-          nz-icon
-          [nzType]="iconType"></i>
+        <i nz-icon [nzType]="iconType"></i>
       </div>
     </div>
-    <div
-      nz-col
-      nzSpan="11">
-      <div class="resource-name truncate-single-line"><em>#{{ entry.id }}</em> {{ entry.name }}</div>
-      <div class="resource-description truncate-single-line">{{ entry.description || ""}}</div>
+
+    <!-- ID Column -->
+    <div nz-col nzSpan="1">
+      <div class="resource-id">
+        <em>#{{ entry.id }}</em>
+      </div>
     </div>
+
+    <div nz-col nzSpan="10">
+      <div class="name-container">
+        <!-- Edit Name Buttons -->
+        <div class="edit-button-group"
+             *ngIf="isPrivateSearch">
+          <button
+            nz-button
+            nzType="text"
+            class="edit-name-button"
+            title="Rename"
+            (click)="onEditName()"
+            (click)="$event.stopPropagation()">
+            <i nz-icon nzTheme="outline" nzType="edit"></i>
+          </button>
+        </div>
+
+        <!-- Name -->
+        <div class="resource-name truncate-single-line" *ngIf="!editingName">
+          {{ entry.name }}
+        </div>
+        <input
+          *ngIf="editingName"
+          #nameInput
+          class="resource-name-edit-input"
+          [(ngModel)]="entry.name"
+          (blur)="confirmUpdateWorkflowCustomName(entry.name)"
+          (keydown.enter)="confirmUpdateWorkflowCustomName(entry.name)"
+          (click)="$event.stopPropagation()"
+          autofocus>
+      </div>
+
+      <!-- Description -->
+      <div cladd="description-container">
+        <!-- Edit Description Buttons -->
+        <div class="edit-button-group"
+             *ngIf="isPrivateSearch">
+          <button
+            nz-button
+            nzType="text"
+            class="edit-description-button"
+            title="Edit Description"
+            (click)="onEditDescription()"
+            (click)="$event.stopPropagation()">
+            <i nz-icon nzTheme="outline" nzType="form"></i>
+          </button>
+        </div>
+        <div class="resource-description truncate-single-line" *ngIf="!editingDescription">
+          {{ entry.description ? entry.description : '' }}
+        </div>
+        <textarea
+          *ngIf="editingDescription"
+          #descriptionInput
+          class="resource-description-edit-textarea"
+          [(ngModel)]="entry.description"
+          (blur)="confirmUpdateWorkflowCustomDescription(entry.description)"
+          (keydown.enter)="confirmUpdateWorkflowCustomDescription(entry.description)"
+          (click)="$event.stopPropagation()"
+          autofocus></textarea>
+      </div>
+    </div>
+
     <div
       nz-col
       nzSpan="12">
@@ -27,7 +88,7 @@
         <div class="resource-owner">
           <texera-user-avatar
             class="user-avatar"
-            googleAvatar=""
+            [googleAvatar]=""
             userColor="#1E90FF"
             [userName]="entry.ownerName || 'User'">
           </texera-user-avatar>
@@ -45,6 +106,7 @@
       nz-button
       nzType="text"
       class="dropdown-item"
+      title="Share"
       (click)="onClickOpenShareAccess()">
       <i
         nz-icon
@@ -56,6 +118,7 @@
       nzType="text"
       *ngIf="entry.type==='workflow'"
       class="dropdown-item"
+      title="Copy"
       (click)="duplicated.emit()">
       <i
         nz-icon
@@ -67,6 +130,7 @@
       nzType="text"
       *ngIf="entry.type==='workflow'"
       class="dropdown-item"
+      title="Download"
       (click)="onClickDownload()">
       <i
         nz-icon
@@ -77,9 +141,10 @@
       nz-button
       nzType="text"
       class="dropdown-item"
+      title="Delete"
       (nzOnConfirm)="deleted.emit()"
       nz-popconfirm
-      nzPopconfirmTitle="Confirm to delete this workflow.">
+      nzPopconfirmTitle="Confirm to delete this item.">
       <i
         nz-icon
         nzTheme="outline"

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.scss
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.scss
@@ -121,7 +121,9 @@
   line-height: 1.5;
   max-height: 18px;
   overflow: hidden;
-  transition: border-color 0.3s, box-shadow 0.3s;
+  transition:
+    border-color 0.3s,
+    box-shadow 0.3s;
 }
 
 .name-container .description-container {

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.scss
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.scss
@@ -3,6 +3,14 @@
   width: 100%;
   background-color: white;
   position: relative;
+  cursor: pointer;
+
+  &:hover {
+    background-color: #f0f0f0;
+    .edit-button-group {
+      display: flex;
+    }
+  }
 }
 
 .truncate-single-line {
@@ -13,14 +21,30 @@
   text-overflow: ellipsis;
 }
 
-.resource-name {
+.resource-id {
   font-size: 17px;
   font-weight: 600;
+  margin-top: -5px;
+  margin-right: 25px;
+  margin-left: 5px;
+  text-align: right;
+  display: block;
 }
+
+.resource-name {
+  margin-left: 30px;
+  font-size: 17px;
+  font-weight: 600;
+  width: 85%;
+}
+
 .resource-description {
+  margin-left: 30px;
   font-size: 12px;
   font-weight: 300;
   color: grey;
+  width: 85%;
+  min-height: 18px;
 }
 
 .type-icon-div {
@@ -68,11 +92,66 @@
   }
 }
 
-.list-item-card:hover {
-  background-color: #f0f0f0;
-  cursor: pointer;
-}
-
 .list-item-card:hover .button-group {
   display: flex;
+}
+
+.resource-name-edit-input {
+  font-size: 17px;
+  font-weight: 600;
+  width: 85%;
+  padding: 0;
+  margin-bottom: 4px;
+  margin-left: 30px;
+  outline: none;
+  height: 23px;
+  border: 1px solid #d9d9d9;
+}
+
+.resource-description-edit-textarea {
+  font-size: 12px;
+  font-weight: 300;
+  width: 85%;
+  padding: 0;
+  margin-left: 30px;
+  border: 1px solid #d9d9d9;
+  outline: none;
+  resize: none;
+  height: 18px;
+  line-height: 1.5;
+  max-height: 18px;
+  overflow: hidden;
+  transition: border-color 0.3s, box-shadow 0.3s;
+}
+
+.name-container .description-container {
+  display: flex;
+  align-items: center;
+  position: relative;
+
+  &:hover {
+    .edit-button-group {
+      display: flex;
+    }
+  }
+}
+
+.edit-button-group {
+  display: none;
+  position: absolute;
+  left: 0;
+  align-items: center;
+
+  button {
+    margin-left: 0;
+    background-color: transparent;
+    font-size: 13px;
+    padding: 3px 4px;
+    height: 25px;
+    width: 25px;
+
+    &:hover {
+      background-color: #d9d9d9;
+    }
+  }
 }

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.ts
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.ts
@@ -1,9 +1,22 @@
-import { Component, EventEmitter, Input, Output, OnInit, OnChanges, SimpleChanges } from "@angular/core";
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+  ViewChild,
+  ElementRef,
+} from "@angular/core";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { NzModalService } from "ng-zorro-antd/modal";
 import { DashboardEntry } from "src/app/dashboard/type/dashboard-entry";
 import { ShareAccessComponent } from "../share-access/share-access.component";
-import { WorkflowPersistService } from "src/app/common/service/workflow-persist/workflow-persist.service";
+import {
+  WorkflowPersistService,
+  DEFAULT_WORKFLOW_NAME,
+} from "src/app/common/service/workflow-persist/workflow-persist.service";
 import { Workflow } from "src/app/common/type/workflow";
 import { FileSaverService } from "src/app/dashboard/service/user/file/file-saver.service";
 import { firstValueFrom } from "rxjs";
@@ -15,6 +28,11 @@ import { firstValueFrom } from "rxjs";
   styleUrls: ["./list-item.component.scss"],
 })
 export class ListItemComponent implements OnInit, OnChanges {
+  @ViewChild("nameInput") nameInput!: ElementRef
+  @ViewChild("descriptionInput") descriptionInput!: ElementRef;
+  editingName = false;
+  editingDescription = false;
+
   ROUTER_WORKFLOW_BASE_URL = "/dashboard/workspace";
   ROUTER_USER_PROJECT_BASE_URL = "/dashboard/user-project";
   ROUTER_DATASET_BASE_URL = "/dashboard/dataset";
@@ -30,13 +48,16 @@ export class ListItemComponent implements OnInit, OnChanges {
     }
     return this._entry;
   }
+
   set entry(value: DashboardEntry) {
     this._entry = value;
   }
+
   @Output() deleted = new EventEmitter<void>();
   @Output() duplicated = new EventEmitter<void>();
   @Output()
   refresh = new EventEmitter<void>();
+
   constructor(
     private modalService: NzModalService,
     private workflowPersistService: WorkflowPersistService,
@@ -99,6 +120,7 @@ export class ListItemComponent implements OnInit, OnChanges {
       });
     }
   }
+
   public onClickDownload(): void {
     if (this.entry.type === "workflow") {
       if (this.entry.id) {
@@ -120,6 +142,57 @@ export class ListItemComponent implements OnInit, OnChanges {
       }
     }
   }
+
+  onEditName(): void {
+    this.editingName = true;
+    setTimeout(() => {
+      if (this.nameInput) {
+        const inputElement = this.nameInput.nativeElement;
+        const valueLength = inputElement.value.length;
+        inputElement.focus();
+        inputElement.setSelectionRange(valueLength, valueLength);
+      }
+    }, 0);
+  }
+
+  onEditDescription(): void {
+    this.editingDescription = true;
+    setTimeout(() => {
+      if (this.descriptionInput) {
+        const textareaElement = this.descriptionInput.nativeElement;
+        const valueLength = textareaElement.value.length;
+        textareaElement.focus();
+        textareaElement.setSelectionRange(valueLength, valueLength);
+      }
+    }, 0);
+  }
+
+  public confirmUpdateWorkflowCustomName(name: string): void {
+    this.workflowPersistService
+      .updateWorkflowName(this.entry.id, name || DEFAULT_WORKFLOW_NAME)
+      .pipe(untilDestroyed(this))
+      .subscribe(() => {
+        this.entry.name = name || DEFAULT_WORKFLOW_NAME;
+      })
+      .add(() => {
+        this.editingName = false;
+      });
+  }
+
+  public confirmUpdateWorkflowCustomDescription(description: string | undefined): void {
+    const updatedDescription = description !== undefined ? description : "";
+
+    this.workflowPersistService
+      .updateWorkflowDescription(this.entry.id, updatedDescription)
+      .pipe(untilDestroyed(this))
+      .subscribe(() => {
+        this.entry.description = updatedDescription;
+      })
+      .add(() => {
+        this.editingDescription = false;
+      });
+  }
+
 
   formatTime(timestamp: number | undefined): string {
     if (timestamp === undefined) {

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.ts
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.ts
@@ -28,7 +28,7 @@ import { firstValueFrom } from "rxjs";
   styleUrls: ["./list-item.component.scss"],
 })
 export class ListItemComponent implements OnInit, OnChanges {
-  @ViewChild("nameInput") nameInput!: ElementRef
+  @ViewChild("nameInput") nameInput!: ElementRef;
   @ViewChild("descriptionInput") descriptionInput!: ElementRef;
   editingName = false;
   editingDescription = false;
@@ -192,7 +192,6 @@ export class ListItemComponent implements OnInit, OnChanges {
         this.editingDescription = false;
       });
   }
-
 
   formatTime(timestamp: number | undefined): string {
     if (timestamp === undefined) {


### PR DESCRIPTION
**Purpose:**
Add functionality to the list item that allows users to directly edit the name and description.

**Changes:**
1. Two buttons have been added to the list item, one for editing the name and the other for editing the description. The buttons will appear when the user hovers over the card.
2. The layout has been adjusted to separate the ID into one column and the name and description into another column.
3. The ID has been aligned to the right.

**Demo:**
old list item
![old](https://github.com/user-attachments/assets/66d7cd0c-e105-49ed-9f82-ab1d3a04235c)

old list item when hovers on it:
![old list item](https://github.com/user-attachments/assets/9d493433-be1f-46cb-833b-2bf56633814e)

new list item:
![new](https://github.com/user-attachments/assets/61ab5910-0012-4f1c-9e4a-16b8c1a1e3a7)


new list item hovers on it:
![new list item](https://github.com/user-attachments/assets/166673ea-2c27-42c3-9f91-7c78b4e95ea5)
