### PR TITLE
Add Email Notification Logic

### DIFF
--- a/core/gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.spec.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.spec.ts
@@ -3,6 +3,10 @@ import { OperatorMetadataService } from "src/app/workspace/service/operator-meta
 import { StubOperatorMetadataService } from "src/app/workspace/service/operator-metadata/stub-operator-metadata.service";
 
 import { ContextMenuComponent } from "./context-menu.component";
+import { GmailService } from "src/app/common/service/gmail/gmail.service";
+import { ExecuteWorkflowService } from "src/app/workspace/service/execute-workflow/execute-workflow.service";
+import { OperatorMenuService } from "src/app/workspace/service/operator-menu/operator-menu.service";
+import { HttpClientModule } from "@angular/common/http";
 
 describe("ContextMenuComponent", () => {
   let component: ContextMenuComponent;
@@ -12,6 +16,7 @@ describe("ContextMenuComponent", () => {
     await TestBed.configureTestingModule({
       declarations: [ContextMenuComponent],
       providers: [{ provide: OperatorMetadataService, useClass: StubOperatorMetadataService }],
+      imports: [HttpClientModule],
     }).compileComponents();
   });
 

--- a/core/gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.spec.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.spec.ts
@@ -3,9 +3,6 @@ import { OperatorMetadataService } from "src/app/workspace/service/operator-meta
 import { StubOperatorMetadataService } from "src/app/workspace/service/operator-metadata/stub-operator-metadata.service";
 
 import { ContextMenuComponent } from "./context-menu.component";
-import { GmailService } from "src/app/common/service/gmail/gmail.service";
-import { ExecuteWorkflowService } from "src/app/workspace/service/execute-workflow/execute-workflow.service";
-import { OperatorMenuService } from "src/app/workspace/service/operator-menu/operator-menu.service";
 import { HttpClientModule } from "@angular/common/http";
 
 describe("ContextMenuComponent", () => {

--- a/core/gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@angular/core";
+import { Injectable, Inject } from "@angular/core";
 import { from, Observable, Subject } from "rxjs";
 import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";
 import { WorkflowGraphReadonly } from "../workflow-graph/model/workflow-graph";
@@ -29,6 +29,7 @@ import { intersection } from "../../../common/util/set";
 import { Workflow, WorkflowContent, WorkflowSettings } from "../../../common/type/workflow";
 import { UserService } from "src/app/common/service/user/user.service";
 import { GmailService } from "src/app/common/service/gmail/gmail.service";
+import { DOCUMENT } from "@angular/common";
 
 // TODO: change this declaration
 export const FORM_DEBOUNCE_TIME_MS = 150;
@@ -78,7 +79,8 @@ export class ExecuteWorkflowService {
     private workflowStatusService: WorkflowStatusService,
     private notificationService: NotificationService,
     private userService: UserService,
-    private gmailService: GmailService
+    private gmailService: GmailService,
+    @Inject(DOCUMENT) private document: Document
   ) {
     workflowWebsocketService.websocketEvent().subscribe(event => {
       switch (event.type) {
@@ -302,55 +304,14 @@ export class ExecuteWorkflowService {
       return;
     }
     this.updateWorkflowActionLock(stateInfo);
-    if (
-      stateInfo.state === ExecutionState.Completed ||
-      stateInfo.state === ExecutionState.Failed ||
-      stateInfo.state === ExecutionState.Killed ||
-      stateInfo.state === ExecutionState.Paused
-    ) {
-      // Check if current user is defined
-      const currentUser = this.userService.getCurrentUser();
-      if (currentUser) {
-        const userEmail = currentUser.email;
-        const workflowId = this.workflowActionService.getWorkflow().wid;
-        const workflowName = this.workflowActionService.getWorkflow().name;
-        const state = stateInfo.state;
-        const timestamp =
-          new Date().toLocaleString("en-US", {
-            timeZone: "UTC",
-            year: "numeric",
-            month: "long",
-            day: "numeric",
-            hour: "numeric",
-            minute: "numeric",
-            second: "numeric",
-            hour12: true,
-          }) + " (UTC)";
-        const dashboardUrl = `https://texera.ics.uci.edu/dashboard/workspace/${workflowId}`;
+    const isTransitionFromRunningToNonRunning =
+      this.currentState.state === ExecutionState.Running &&
+      [ExecutionState.Completed, ExecutionState.Failed, ExecutionState.Killed, ExecutionState.Paused].includes(
+        stateInfo.state
+      );
 
-        // Construct email subject and content
-        const subject = `Workflow ${workflowName} (${workflowId}) Status: ${state}`;
-        const content = `
-          Hello,
-  
-          The workflow with the following details has changed its state:
-  
-          - Workflow ID: ${workflowId}
-          - Workflow Name: ${workflowName}
-          - State: ${state}
-          - Timestamp: ${timestamp}
-  
-          You can view more details by visiting: ${dashboardUrl}
-  
-          Regards,
-          Texera Team
-        `;
-
-        // Send the email
-        this.gmailService.sendEmail(subject, content, userEmail);
-      } else {
-        console.log("Current user is undefined. Cannot send email.");
-      }
+    if (isTransitionFromRunningToNonRunning) {
+      this.sendWorkflowStatusEmail(stateInfo);
     }
     const previousState = this.currentState;
     // update current state
@@ -384,6 +345,58 @@ export class ExecuteWorkflowService {
       default:
         return exhaustiveGuard(stateInfo);
     }
+  }
+
+  /**
+   * Sends an email notification about the change in workflow state.
+   * This method constructs the email content with details such as the workflow ID, name,
+   * new state, and a timestamp, then sends it to the user's email address.
+   * The email is sent only if the current user is defined.
+   *
+   * @param stateInfo - The new execution state information containing the updated state of the workflow.
+   */
+  private sendWorkflowStatusEmail(stateInfo: ExecutionStateInfo): void {
+    const currentUser = this.userService.getCurrentUser();
+    if (!currentUser) {
+      console.log("Current user is undefined. Cannot send email.");
+      return;
+    }
+
+    const userEmail = currentUser.email;
+    const workflow = this.workflowActionService.getWorkflow();
+    const timestamp =
+      new Date().toLocaleString("en-US", {
+        timeZone: "UTC",
+        year: "numeric",
+        month: "long",
+        day: "numeric",
+        hour: "numeric",
+        minute: "numeric",
+        second: "numeric",
+        hour12: true,
+      }) + " (UTC)";
+
+    const baseUrl = this.document.location.origin;
+    const dashboardUrl = `${baseUrl}/dashboard/workspace/${workflow.wid}`;
+
+    const subject = `Workflow ${workflow.name} (${workflow.wid}) Status: ${stateInfo.state}`;
+    const content = `
+        Hello,
+    
+        The workflow with the following details has changed its state:
+    
+        - Workflow ID: ${workflow.wid}
+        - Workflow Name: ${workflow.name}
+        - State: ${stateInfo.state}
+        - Timestamp: ${timestamp}
+    
+        You can view more details by visiting: ${dashboardUrl}
+    
+        Regards,
+        Texera Team
+      `;
+
+    this.gmailService.sendEmail(subject, content, userEmail);
   }
 
   /**

--- a/core/gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -27,7 +27,6 @@ import { WorkflowStatusService } from "../workflow-status/workflow-status.servic
 import { isDefined } from "../../../common/util/predicate";
 import { intersection } from "../../../common/util/set";
 import { Workflow, WorkflowContent, WorkflowSettings } from "../../../common/type/workflow";
-import { UserService } from "src/app/common/service/user/user.service";
 import { GmailService } from "src/app/common/service/gmail/gmail.service";
 import { DOCUMENT } from "@angular/common";
 
@@ -78,7 +77,6 @@ export class ExecuteWorkflowService {
     private workflowWebsocketService: WorkflowWebsocketService,
     private workflowStatusService: WorkflowStatusService,
     private notificationService: NotificationService,
-    private userService: UserService,
     private gmailService: GmailService,
     @Inject(DOCUMENT) private document: Document
   ) {
@@ -356,13 +354,6 @@ export class ExecuteWorkflowService {
    * @param stateInfo - The new execution state information containing the updated state of the workflow.
    */
   private sendWorkflowStatusEmail(stateInfo: ExecutionStateInfo): void {
-    const currentUser = this.userService.getCurrentUser();
-    if (!currentUser) {
-      console.log("Current user is undefined. Cannot send email.");
-      return;
-    }
-
-    const userEmail = currentUser.email;
     const workflow = this.workflowActionService.getWorkflow();
     const timestamp =
       new Date().toLocaleString("en-US", {
@@ -396,7 +387,7 @@ export class ExecuteWorkflowService {
         Texera Team
       `;
 
-    this.gmailService.sendEmail(subject, content, userEmail);
+    this.gmailService.sendEmail(subject, content);
   }
 
   /**

--- a/core/gui/src/app/workspace/service/operator-menu/operator-menu.service.spec.ts
+++ b/core/gui/src/app/workspace/service/operator-menu/operator-menu.service.spec.ts
@@ -3,6 +3,7 @@ import { OperatorMetadataService } from "../operator-metadata/operator-metadata.
 import { StubOperatorMetadataService } from "../operator-metadata/stub-operator-metadata.service";
 
 import { OperatorMenuService } from "./operator-menu.service";
+import { HttpClientModule } from "@angular/common/http";
 
 describe("OperatorMenuService", () => {
   let service: OperatorMenuService;
@@ -10,6 +11,7 @@ describe("OperatorMenuService", () => {
   beforeEach(() => {
     TestBed.configureTestingModule({
       providers: [{ provide: OperatorMetadataService, useClass: StubOperatorMetadataService }],
+      imports: [HttpClientModule],
     });
     service = TestBed.inject(OperatorMenuService);
   });

--- a/core/gui/src/app/workspace/service/workflow-status/operator-reuse-cache-status.service.spec.ts
+++ b/core/gui/src/app/workspace/service/workflow-status/operator-reuse-cache-status.service.spec.ts
@@ -3,6 +3,7 @@ import { OperatorMetadataService } from "../operator-metadata/operator-metadata.
 import { StubOperatorMetadataService } from "../operator-metadata/stub-operator-metadata.service";
 
 import { OperatorReuseCacheStatusService } from "./operator-reuse-cache-status.service";
+import { HttpClientModule } from "@angular/common/http";
 
 describe("OperatorCacheStatusService", () => {
   let service: OperatorReuseCacheStatusService;
@@ -15,6 +16,7 @@ describe("OperatorCacheStatusService", () => {
           useClass: StubOperatorMetadataService,
         },
       ],
+      imports: [HttpClientModule],
     });
     service = TestBed.inject(OperatorReuseCacheStatusService);
   });


### PR DESCRIPTION
This PR introduces functionality to send an email notification whenever a workflow transitions from a running state to a non-running state (e.g., `Completed`, `Failed`, `Killed`, or `Paused`). This feature was requested by the bioinformatics team at Cornell University to facilitate their long-running workflows. They wanted to be notified once the execution of their workflow is finished.

### Implementation Details

A new `sendWorkflowStatusEmail` method has been added to handle the construction of the email notification, which includes details such as the workflow ID, name, state, timestamp, and a link to the dashboard. This method is triggered on the frontend whenever it detects a status change from the backend.

### Setup
To enable this functionality, update the following parameters in the core/amber/src/main/resources/application.conf file:
1. Set `user-sys.enabled` to true.
2. Set `user-sys.google.clientId` to your Google API client ID.
3. Set `user-sys.google.smtp.gmail` to your Gmail ID (ensure that IMAP is enabled for this account).
4. Set `user-sys.google.smtp.password` to your Gmail password.


https://github.com/user-attachments/assets/dd72af90-b8a8-45ef-9bcc-1ba628e55e9a

