### PR TITLE
Enhance Report Generation by Adding Animation During the Generation Process

### DIFF
--- a/core/gui/src/app/workspace/component/menu/menu.component.html
+++ b/core/gui/src/app/workspace/component/menu/menu.component.html
@@ -10,7 +10,6 @@
     </a>
   </div>
   <div id="menu-content">
-
     <div
       class="report-generation-spinner"
       *ngIf="isReportGenerating">

--- a/core/gui/src/app/workspace/component/menu/menu.component.html
+++ b/core/gui/src/app/workspace/component/menu/menu.component.html
@@ -1,16 +1,5 @@
 <div id="menu-container">
   <div
-    class="report-generation-spinner"
-    *ngIf="isReportGenerating">
-    <div class="spinner-content">
-      <nz-spin
-        [nzSize]="'large'"
-        nzTip="Generating">
-      </nz-spin>
-    </div>
-  </div>
-
-  <div
     *ngIf="!userSystemEnabled"
     id="logo">
     <a href="{{userSystemEnabled?'/dashboard/workflow':'/'}}">
@@ -21,6 +10,18 @@
     </a>
   </div>
   <div id="menu-content">
+
+    <div
+      class="report-generation-spinner"
+      *ngIf="isReportGenerating">
+      <div class="spinner-content">
+        <nz-spin
+          [nzSize]="'large'"
+          nzTip="Generating">
+        </nz-spin>
+      </div>
+    </div>
+
     <div
       id="menu-user"
       *ngIf="userSystemEnabled">

--- a/core/gui/src/app/workspace/component/menu/menu.component.html
+++ b/core/gui/src/app/workspace/component/menu/menu.component.html
@@ -1,5 +1,16 @@
 <div id="menu-container">
   <div
+    class="report-generation-spinner"
+    *ngIf="isReportGenerating">
+    <div class="spinner-content">
+      <nz-spin
+        [nzSize]="'large'"
+        nzTip="Generating">
+      </nz-spin>
+    </div>
+  </div>
+
+  <div
     *ngIf="!userSystemEnabled"
     id="logo">
     <a href="{{userSystemEnabled?'/dashboard/workflow':'/'}}">

--- a/core/gui/src/app/workspace/component/menu/menu.component.scss
+++ b/core/gui/src/app/workspace/component/menu/menu.component.scss
@@ -106,3 +106,30 @@ texera-user-icon {
 texera-coeditor-user-icon {
   margin-left: -10px;
 }
+
+report-generation-spinner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(0, 0, 0, 0);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+}
+
+.spinner-content {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
+.ant-spin-text {
+  font-size: 18px;
+  color: #333;
+  margin-top: 10px;
+}

--- a/core/gui/src/app/workspace/component/menu/menu.component.scss
+++ b/core/gui/src/app/workspace/component/menu/menu.component.scss
@@ -109,8 +109,8 @@ texera-coeditor-user-icon {
 
 report-generation-spinner {
   position: fixed;
-  top: 0;
-  left: 0;
+  bottom: 0;
+  left: 50%;
   width: 100%;
   height: 100%;
   background-color: rgba(0, 0, 0, 0);

--- a/core/gui/src/app/workspace/component/menu/menu.component.ts
+++ b/core/gui/src/app/workspace/component/menu/menu.component.ts
@@ -254,7 +254,6 @@ export class MenuComponent implements OnInit {
    * get the html to export all results.
    */
   public onClickGenerateReport(): void {
-
     this.isReportGenerating = true;
 
     // Get notification

--- a/core/gui/src/app/workspace/component/menu/menu.component.ts
+++ b/core/gui/src/app/workspace/component/menu/menu.component.ts
@@ -53,6 +53,7 @@ import { ReportGenerationService } from "../../service/report-generation/report-
   styleUrls: ["menu.component.scss"],
 })
 export class MenuComponent implements OnInit {
+  public isReportGenerating = false;
   public executionState: ExecutionState; // set this to true when the workflow is started
   public ExecutionState = ExecutionState; // make Angular HTML access enum definition
   public isWorkflowValid: boolean = true; // this will check whether the workflow error or not
@@ -253,6 +254,9 @@ export class MenuComponent implements OnInit {
    * get the html to export all results.
    */
   public onClickGenerateReport(): void {
+
+    this.isReportGenerating = true;
+
     // Get notification
     this.notificationService.info("The report is being generated...");
 
@@ -278,13 +282,18 @@ export class MenuComponent implements OnInit {
                 );
                 // Generate the final report as HTML after all results are retrieved
                 this.reportGenerationService.generateReportAsHtml(workflowSnapshotURL, sortedResults, workflowName);
+                this.isReportGenerating = false;
               },
               error: (error: unknown) => {
                 this.notificationService.error("Error in retrieving operator results: " + (error as Error).message);
+                this.isReportGenerating = false;
               },
             });
         },
-        error: (e: unknown) => this.notificationService.error((e as Error).message),
+        error: (e: unknown) => {
+          this.notificationService.error((e as Error).message);
+          this.isReportGenerating = false;
+        },
       });
   }
 


### PR DESCRIPTION
This PR enhances the report generation functionality by adding animation during the process. This PR is a continuation and enhancement of the previous PR:

Adding a button to generate a report for a workflow: https://github.com/Texera/texera/pull/2770
Enhancing Report Generation by adding Operator Results: https://github.com/Texera/texera/pull/2792
Enhancing Report Generation by Adding Operator Json and Comments Section : https://github.com/Texera/texera/pull/2807
Ai Flag: https://github.com/Texera/texera/pull/2818 and https://github.com/Texera/texera/pull/2808

Key Changes:

1. menu.component.html

Added a div with class report-generation-spinner in the menu-content section.
Integrated a conditional *ngIf="isReportGenerating" to toggle the spinner visibility during report generation.
Included the nz-spin component from Ant Design with a “Generating” message for the spinner content.
SCSS Updates:

2. menu.component.scss

Defined new styles for the report-generation-spinner to ensure proper positioning and display behavior (fixed position, centered on the page).
Styled the spinner content, including text alignment and size adjustments for a clean UI.

3. menu.component.ts

Introduced a new boolean variable isReportGenerating in MenuComponent to control the spinner's state.
Updated the onClickGenerateReport method to set isReportGenerating = true when the report generation starts and reset it to false upon completion or error handling.
Enhanced error handling to ensure that the spinner is disabled when report generation fails.

Operation Process:
Click the button below to generate the report with detailed operator results and the workflow snapshot.
![image](https://github.com/user-attachments/assets/ea1c0fd4-3a96-4132-91c1-596219eea5ef)
![image](https://github.com/user-attachments/assets/f079c67b-cb8c-4438-9a15-cc4d2e5d7f25)
