### PR TITLE
Enhance Report Generation by AddingNotification During the Generation Process

### DIFF
--- a/core/gui/src/app/common/service/notification/notification.service.ts
+++ b/core/gui/src/app/common/service/notification/notification.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { NzMessageDataOptions, NzMessageService} from "ng-zorro-antd/message";
+import { NzMessageDataOptions, NzMessageService } from "ng-zorro-antd/message";
 import { NzNotificationService } from "ng-zorro-antd/notification";
 
 /**
@@ -11,7 +11,8 @@ import { NzNotificationService } from "ng-zorro-antd/notification";
 export class NotificationService {
   constructor(
     private message: NzMessageService,
-    private notification: NzNotificationService) {}
+    private notification: NzNotificationService
+  ) {}
 
   blank(title: string, content: string, options: NzMessageDataOptions = {}): void {
     this.notification.blank(title, content, options);

--- a/core/gui/src/app/common/service/notification/notification.service.ts
+++ b/core/gui/src/app/common/service/notification/notification.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from "@angular/core";
-import { NzMessageDataOptions, NzMessageService } from "ng-zorro-antd/message";
+import { NzMessageDataOptions, NzMessageService} from "ng-zorro-antd/message";
+import { NzNotificationService } from "ng-zorro-antd/notification";
 
 /**
  * NotificationService is an entry service for sending notifications
@@ -8,7 +9,27 @@ import { NzMessageDataOptions, NzMessageService } from "ng-zorro-antd/message";
   providedIn: "root",
 })
 export class NotificationService {
-  constructor(private message: NzMessageService) {}
+  constructor(
+    private message: NzMessageService,
+    private notification: NzNotificationService) {}
+
+  createReportNotification(): string {
+    const notificationId = this.notification.blank(
+      "报告生成中",
+      "报告正在生成，请稍候...",
+      { nzDuration: 0 } // 确保通知不会自动关闭
+    ).messageId; // 保存通知的ID，稍后可以用来关闭
+
+    return notificationId;
+  }
+
+  blank(title: string, content: string): void {
+    this.notification.blank(title, content, { nzDuration: 0 });
+  }
+
+  remove(id?: string): void {
+    this.notification.remove(id);
+  }
 
   success(message: string, options: NzMessageDataOptions = {}) {
     this.message.success(message, options);

--- a/core/gui/src/app/common/service/notification/notification.service.ts
+++ b/core/gui/src/app/common/service/notification/notification.service.ts
@@ -13,18 +13,8 @@ export class NotificationService {
     private message: NzMessageService,
     private notification: NzNotificationService) {}
 
-  createReportNotification(): string {
-    const notificationId = this.notification.blank(
-      "报告生成中",
-      "报告正在生成，请稍候...",
-      { nzDuration: 0 } // 确保通知不会自动关闭
-    ).messageId; // 保存通知的ID，稍后可以用来关闭
-
-    return notificationId;
-  }
-
-  blank(title: string, content: string): void {
-    this.notification.blank(title, content, { nzDuration: 0 });
+  blank(title: string, content: string, options: NzMessageDataOptions = {}): void {
+    this.notification.blank(title, content, options);
   }
 
   remove(id?: string): void {

--- a/core/gui/src/app/workspace/component/menu/menu.component.ts
+++ b/core/gui/src/app/workspace/component/menu/menu.component.ts
@@ -254,11 +254,7 @@ export class MenuComponent implements OnInit {
    */
   public onClickGenerateReport(): void {
     // Get notification and set nzDuration to 0 to prevent it from auto-closing
-    this.notificationService.blank(
-      "",
-      "The report is being generated...",
-      { nzDuration: 0 }
-    );
+    this.notificationService.blank("", "The report is being generated...", { nzDuration: 0 });
 
     const workflowName = this.currentWorkflowName;
     const WorkflowContent: WorkflowContent = this.workflowActionService.getWorkflowContent();
@@ -301,7 +297,6 @@ export class MenuComponent implements OnInit {
         },
       });
   }
-
 
   /**
    * This method checks whether the zoom ratio reaches minimum. If it is minimum, this method

--- a/core/gui/src/app/workspace/component/menu/menu.component.ts
+++ b/core/gui/src/app/workspace/component/menu/menu.component.ts
@@ -253,8 +253,11 @@ export class MenuComponent implements OnInit {
    * get the html to export all results.
    */
   public onClickGenerateReport(): void {
-    // Get notification
-    this.notificationService.info("The report is being generated...");
+    // Get notification and set nzDuration to 0 to prevent it from auto-closing
+    this.notificationService.blank(
+      "",
+      "The report is being generated...",
+    );
 
     const workflowName = this.currentWorkflowName;
     const WorkflowContent: WorkflowContent = this.workflowActionService.getWorkflowContent();
@@ -278,15 +281,26 @@ export class MenuComponent implements OnInit {
                 );
                 // Generate the final report as HTML after all results are retrieved
                 this.reportGenerationService.generateReportAsHtml(workflowSnapshotURL, sortedResults, workflowName);
+
+                // Close the notification after the report is generated
+                this.notificationService.remove();
+                this.notificationService.success("Report successfully generated.");
               },
               error: (error: unknown) => {
                 this.notificationService.error("Error in retrieving operator results: " + (error as Error).message);
+                // Close the notification on error
+                this.notificationService.remove();
               },
             });
         },
-        error: (e: unknown) => this.notificationService.error((e as Error).message),
+        error: (e: unknown) => {
+          this.notificationService.error((e as Error).message);
+          // Close the notification on error
+          this.notificationService.remove();
+        },
       });
   }
+
 
   /**
    * This method checks whether the zoom ratio reaches minimum. If it is minimum, this method

--- a/core/gui/src/app/workspace/component/menu/menu.component.ts
+++ b/core/gui/src/app/workspace/component/menu/menu.component.ts
@@ -257,6 +257,7 @@ export class MenuComponent implements OnInit {
     this.notificationService.blank(
       "",
       "The report is being generated...",
+      { nzDuration: 0 }
     );
 
     const workflowName = this.currentWorkflowName;


### PR DESCRIPTION
This PR enhances the report generation functionality by adding animation during the process. This PR is a continuation and enhancement of the previous PR:

Adding a button to generate a report for a workflow: https://github.com/Texera/texera/pull/2770
Enhancing Report Generation by adding Operator Results: https://github.com/Texera/texera/pull/2792
Enhancing Report Generation by Adding Operator Json and Comments Section : https://github.com/Texera/texera/pull/2807
Ai Flag: https://github.com/Texera/texera/pull/2818 and https://github.com/Texera/texera/pull/2808

Key Changes:

menu.component.ts: At the start, notification.blank is called to display a message, and notification.remove is used to remove it at the end. Upon successful generation, this.notificationService.success is invoked.

notification.service.ts: notification.blank and notification.remove have been added.

