### PR TITLE
Add file selection button

### DIFF
--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.html
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.html
@@ -1,32 +1,22 @@
-<!-- <input
-  nz-input
-  [readOnly]="isFileSelectionEnabled"
-  required
-  [formControl]="formControl"
-  [formlyAttributes]="field"
-  (click)="isFileSelectionEnabled && onClickOpenFileSelectionModal()" />
+<div class="input-autocomplete-container">
+  <input
+    *ngIf="selectedFilePath"
+    nz-input
+    [readOnly]="isFileSelectionEnabled"
+    required
+    [formControl]="formControl"
+    [formlyAttributes]="field" />
+  <button
+    nz-button
+    nzType="primary"
+    nzSize="small"
+    (click)="isFileSelectionEnabled && onClickOpenFileSelectionModal()">
+    {{ selectedFilePath ? 'Reselect File' : 'Select File' }}
+  </button>
+</div>
 <div
   class="alert alert-danger"
   role="alert"
   *ngIf="props.showError && formControl.errors">
   <formly-validation-message [field]="field"></formly-validation-message>
-</div> -->
-
-<div class="input-autocomplete-container">
-  <input *ngIf="selectedFilePath"
-    nz-input
-    [readOnly]="isFileSelectionEnabled"
-    required
-    [formControl]="formControl"
-    [formlyAttributes]="field"
-  />
-<button nz-button nzType="primary" nzSize="small" (click)="isFileSelectionEnabled && onClickOpenFileSelectionModal()">
-  {{ selectedFilePath ? 'Reselect File' : 'Select File' }}
-</button>  
-</div>
-<div
-class="alert alert-danger"
-role="alert"
-*ngIf="props.showError && formControl.errors">
-<formly-validation-message [field]="field"></formly-validation-message>
 </div>

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.html
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.html
@@ -21,7 +21,7 @@
     [formlyAttributes]="field"
   />
 <button nz-button nzType="primary" nzSize="small" (click)="isFileSelectionEnabled && onClickOpenFileSelectionModal()">
-  Select File
+  {{ selectedFilePath ? 'Reselect File' : 'Select File' }}
 </button>  
 </div>
 <div

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.html
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.html
@@ -8,7 +8,7 @@
     [formlyAttributes]="field" />
   <button
     nz-button
-    nzType="primary"
+    class="file-select-button"
     nzSize="small"
     (click)="isFileSelectionEnabled && onClickOpenFileSelectionModal()">
     {{ selectedFilePath ? 'Reselect File' : 'Select File' }}

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.html
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.html
@@ -1,4 +1,4 @@
-<input
+<!-- <input
   nz-input
   [readOnly]="isFileSelectionEnabled"
   required
@@ -10,4 +10,23 @@
   role="alert"
   *ngIf="props.showError && formControl.errors">
   <formly-validation-message [field]="field"></formly-validation-message>
+</div> -->
+
+<div class="input-autocomplete-container">
+  <input
+    nz-input
+    [readOnly]="isFileSelectionEnabled"
+    required
+    [formControl]="formControl"
+    [formlyAttributes]="field"
+  />
+<button nz-button nzType="primary" nzSize="small" (click)="isFileSelectionEnabled && onClickOpenFileSelectionModal()">
+  Select File
+</button>  
+</div>
+<div
+class="alert alert-danger"
+role="alert"
+*ngIf="props.showError && formControl.errors">
+<formly-validation-message [field]="field"></formly-validation-message>
 </div>

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.html
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.html
@@ -13,7 +13,7 @@
 </div> -->
 
 <div class="input-autocomplete-container">
-  <input
+  <input *ngIf="selectedFilePath"
     nz-input
     [readOnly]="isFileSelectionEnabled"
     required

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.scss
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.scss
@@ -1,3 +1,17 @@
 mat-form-field {
   width: 100%;
 }
+.input-autocomplete-container {
+  display: flex;
+  align-items: center; 
+  width: 100%; 
+
+  input {
+    flex: 1; 
+    margin-right: 10px; 
+  }
+
+  button {
+    white-space: nowrap; 
+  }
+}

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.scss
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.scss
@@ -16,16 +16,16 @@ mat-form-field {
   }
 
   .file-select-button {
-    border: 2px solid #1890ff; 
-    color: #1890ff; 
+    border: 2px solid #1890ff;
+    color: #1890ff;
 
     &:hover {
-      background-color: #e6f7ff;  
+      background-color: #e6f7ff;
       border-color: #1890ff;
     }
 
     &:focus {
-      box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.2); 
+      box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.2);
     }
   }
 }

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.scss
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.scss
@@ -14,4 +14,18 @@ mat-form-field {
   button {
     white-space: nowrap;
   }
+
+  .file-select-button {
+    border: 2px solid #1890ff; 
+    color: #1890ff; 
+
+    &:hover {
+      background-color: #e6f7ff;  
+      border-color: #1890ff;
+    }
+
+    &:focus {
+      box-shadow: 0 0 0 2px rgba(24, 144, 255, 0.2); 
+    }
+  }
 }

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.scss
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.scss
@@ -3,15 +3,15 @@ mat-form-field {
 }
 .input-autocomplete-container {
   display: flex;
-  align-items: center; 
-  width: 100%; 
+  align-items: center;
+  width: 100%;
 
   input {
-    flex: 1; 
-    margin-right: 10px; 
+    flex: 1;
+    margin-right: 10px;
   }
 
   button {
-    white-space: nowrap; 
+    white-space: nowrap;
   }
 }

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
@@ -49,4 +49,8 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
   get isFileSelectionEnabled(): boolean {
     return environment.userSystemEnabled;
   }
+
+  get selectedFilePath(): string | null {
+    return this.formControl.value; 
+  }
 }

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
@@ -51,6 +51,6 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
   }
 
   get selectedFilePath(): string | null {
-    return this.formControl.value; 
+    return this.formControl.value;
   }
 }


### PR DESCRIPTION
Added a "Select File" button, allowing users to choose a file from a dataset. The button label changes to "Reselect File" after a file is selected, and the selected file path is displayed in a read-only input box. 
<img width="309" alt="截屏2024-09-18 下午12 47 35" src="https://github.com/user-attachments/assets/923f4945-0452-476f-a11a-4429ad98786f">
<img width="308" alt="截屏2024-09-18 下午12 47 47" src="https://github.com/user-attachments/assets/36838545-1791-4604-9db5-52566f03fc07">

