### PR TITLE
Upgrade the `ng build` command in deploy-daemon.sh

### DIFF
--- a/core/scripts/deploy-daemon.sh
+++ b/core/scripts/deploy-daemon.sh
@@ -22,7 +22,7 @@ then
   echo
 
   echo "${green}Compiling GUI...${reset}"
-  cd ../gui && yarn install && ng build --prod  --deploy-url=/ --base-href=/
+  cd ../gui && yarn install && ng build --configuration production --deploy-url=/ --base-href=/
   echo "${green}GUI compiled.${reset}"
   echo
   cd ..


### PR DESCRIPTION
This PR updates the `ng build` command in `deploy-daemon.sh`.

Before the change, the command is:
`ng build --prod  --deploy-url=/ --base-href=/`

However, `--prod` is deprecated in angular 14 according to https://github.com/angular/angular-cli/blob/main/CHANGELOG.md#breaking-changes-2
<img width="1072" alt="Screenshot 2024-09-19 at 10 02 56 PM" src="https://github.com/user-attachments/assets/03e5052e-d29a-4aeb-9d0c-71239795baef">

And our angular version is angular 16.

So I updated it to make it align with current angular: `ng build --configuration production  --deploy-url=/ --base-href=/`
