### PR TITLE
Enhance Download Functionality to Support All Data Types in Result Panel with Improved UI

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ResultExportService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ResultExportService.scala
@@ -197,8 +197,8 @@ class ResultExportService(opResultStorage: OpResultStorage, wId: UInteger) {
     // Convert the field to a byte array, regardless of its type
     val dataBytes: Array[Byte] = field match {
       case data: Array[Byte] => data
-      case data: String => data.getBytes(StandardCharsets.UTF_8)
-      case data => data.toString.getBytes(StandardCharsets.UTF_8)
+      case data: String      => data.getBytes(StandardCharsets.UTF_8)
+      case data              => data.toString.getBytes(StandardCharsets.UTF_8)
     }
 
     // Save the data file

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ResultExportService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ResultExportService.scala
@@ -1,6 +1,7 @@
 package edu.uci.ics.texera.web.service
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream}
+import java.nio.charset.StandardCharsets
 import java.util
 import java.util.concurrent.{Executors, ThreadPoolExecutor}
 import com.github.tototoshi.csv.CSVWriter
@@ -74,8 +75,8 @@ class ResultExportService(opResultStorage: OpResultStorage, wId: UInteger) {
         handleGoogleSheetRequest(cache, request, results, attributeNames)
       case "csv" =>
         handleCSVRequest(user, request, results, attributeNames)
-      case "binary" =>
-        handleBinaryRequest(user, request, results)
+      case "data" =>
+        handleDataRequest(user, request, results)
       case _ =>
         ResultExportResponse("error", s"Unknown export type: ${request.exportType}")
     }
@@ -176,7 +177,7 @@ class ResultExportService(opResultStorage: OpResultStorage, wId: UInteger) {
     targetSheet.getSpreadsheetId
   }
 
-  private def handleBinaryRequest(
+  private def handleDataRequest(
       user: User,
       request: ResultExportRequest,
       results: Iterable[Tuple]
@@ -191,47 +192,32 @@ class ResultExportService(opResultStorage: OpResultStorage, wId: UInteger) {
     }
 
     val selectedRow = results.toSeq(rowIndex)
-
     val field: Any = selectedRow.getField(columnIndex)
 
-    // Ensure the field is of type byte[]
-    val binaryData: Array[Byte] = field match {
+    // Convert the field to a byte array, regardless of its type
+    val dataBytes: Array[Byte] = field match {
       case data: Array[Byte] => data
-      case data: AnyRef
-          if data.getClass.isArray && data.getClass.getComponentType == classOf[Byte] =>
-        data.asInstanceOf[Array[Byte]]
-      case _ =>
-        return ResultExportResponse(
-          "error",
-          s"Expected binary data (Array[Byte]), but got: ${field.getClass}"
-        )
+      case data: String => data.getBytes(StandardCharsets.UTF_8)
+      case data => data.toString.getBytes(StandardCharsets.UTF_8)
     }
 
-    // Save the binary file (similar to how files are saved in the CSV handler)
-    binaryData match {
-      case data: Array[Byte] =>
-        val byteArray = data
-        val fileStream = new ByteArrayInputStream(byteArray)
+    // Save the data file
+    val fileStream = new ByteArrayInputStream(dataBytes)
 
-        // Save the binary file
-        request.datasetIds.foreach { did =>
-          val datasetPath = PathUtils.getDatasetPath(UInteger.valueOf(did))
-          val filePath = datasetPath.resolve(filename)
-          createNewDatasetVersionByAddingFiles(
-            UInteger.valueOf(did),
-            user,
-            Map(filePath -> fileStream)
-          )
-        }
-
-        ResultExportResponse(
-          "success",
-          s"Binary file $filename saved to Datasets ${request.datasetIds.mkString(",")}"
-        )
-
-      case _ =>
-        ResultExportResponse("error", s"Selected field is not binary data")
+    request.datasetIds.foreach { did =>
+      val datasetPath = PathUtils.getDatasetPath(UInteger.valueOf(did))
+      val filePath = datasetPath.resolve(filename)
+      createNewDatasetVersionByAddingFiles(
+        UInteger.valueOf(did),
+        user,
+        Map(filePath -> fileStream)
+      )
     }
+
+    ResultExportResponse(
+      "success",
+      s"Data file $filename saved to Datasets ${request.datasetIds.mkString(",")}"
+    )
   }
 
   /**

--- a/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.html
+++ b/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.html
@@ -1,6 +1,6 @@
 <div class="centered-container">
   <div
-    *ngIf="exportType === 'binary'"
+    *ngIf="exportType === 'data'"
     class="input-wrapper">
     <nz-form-item>
       <nz-form-label nzFor="filenameInput">Filename</nz-form-label>

--- a/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
+++ b/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
@@ -98,7 +98,9 @@
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let row of basicTable.data; let i = index" class="table-row-hover">
+      <tr
+        *ngFor="let row of basicTable.data; let i = index"
+        class="table-row-hover">
         <td
           *ngFor="let column of currentColumns; let columnIndex = index"
           class="table-cell"
@@ -111,7 +113,9 @@
             nzType="link"
             class="download-button"
             title="Download data">
-            <i nz-icon nzType="download"></i>
+            <i
+              nz-icon
+              nzType="cloud-download"></i>
           </button>
         </td>
       </tr>

--- a/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
+++ b/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
@@ -98,24 +98,21 @@
       </tr>
     </thead>
     <tbody>
-      <tr *ngFor="let row of basicTable.data; let i = index">
+      <tr *ngFor="let row of basicTable.data; let i = index" class="table-row-hover">
         <td
-          (click)="open(i, row)"
           *ngFor="let column of currentColumns; let columnIndex = index"
-          class="table-row"
+          class="table-cell"
           nzEllipsis
-          ngClass="data-size">
+          (click)="open(i, row)">
+          <span class="cell-content">{{ column.getCell(row) }}</span>
           <button
             (click)="downloadData(currentResult[i][column.columnDef], i, columnIndex, column.columnDef); $event.stopPropagation()"
             nz-button
-            nz-dropdown
-            class="borderless-button"
-            title="export data">
-            <i
-              nz-icon
-              nzType="cloud-download"></i>
+            nzType="link"
+            class="download-button"
+            title="Download data">
+            <i nz-icon nzType="download"></i>
           </button>
-          {{ column.getCell(row) }}
         </td>
       </tr>
     </tbody>

--- a/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
+++ b/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
@@ -106,12 +106,11 @@
           nzEllipsis
           ngClass="data-size">
           <button
-            *ngIf="isBinaryData(currentResult[i][column.columnDef])"
-            (click)="downloadBinaryData(currentResult[i][column.columnDef], i, columnIndex, column.columnDef); $event.stopPropagation()"
+            (click)="downloadData(currentResult[i][column.columnDef], i, columnIndex, column.columnDef); $event.stopPropagation()"
             nz-button
             nz-dropdown
             class="borderless-button"
-            title="export binary data">
+            title="export data">
             <i
               nz-icon
               nzType="cloud-download"></i>

--- a/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.scss
+++ b/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.scss
@@ -60,3 +60,39 @@ th.header-size {
     background-color: rgba(0, 0, 0, 0.05);
   }
 }
+
+.table-cell {
+  position: relative;
+  padding-right: 24px; // Make room for the download button
+}
+
+.cell-content {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.download-button {
+  position: absolute;
+  right: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  opacity: 0;
+  transition: opacity 0.2s ease-in-out;
+  padding: 4px 8px;
+  
+  i {
+    font-size: 14px;
+  }
+}
+
+.table-row-hover:hover {
+  .download-button {
+    opacity: 0.5;
+    
+    &:hover {
+      opacity: 1;
+    }
+  }
+}

--- a/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.scss
+++ b/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.scss
@@ -63,7 +63,7 @@ th.header-size {
 
 .table-cell {
   position: relative;
-  padding-right: 24px; // Make room for the download button
+  padding-right: 28px;
 }
 
 .cell-content {
@@ -80,17 +80,21 @@ th.header-size {
   transform: translateY(-50%);
   opacity: 0;
   transition: opacity 0.2s ease-in-out;
-  padding: 4px 8px;
-  
+  padding: 4px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+
   i {
-    font-size: 14px;
+    font-size: 16px; // Slightly larger to match the cloud icon
+    color: #1890ff; // Ant Design's primary blue color
   }
 }
 
 .table-row-hover:hover {
   .download-button {
-    opacity: 0.5;
-    
+    opacity: 0.7;
+
     &:hover {
       opacity: 1;
     }

--- a/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.ts
+++ b/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.ts
@@ -358,21 +358,14 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
     return trimAndFormatData(cellContent, TABLE_COLUMN_TEXT_LIMIT);
   }
 
-  isBinaryData(cellContent: any): boolean {
-    if (typeof cellContent === "string") {
-      return isBase64(cellContent) || isBinary(cellContent);
-    }
-    return false;
-  }
-
-  downloadBinaryData(binaryData: any, rowIndex: number, columnIndex: number, columnName: string): void {
+  downloadData(data: any, rowIndex: number, columnIndex: number, columnName: string): void {
     const realRowNumber = (this.currentPageIndex - 1) * this.pageSize + rowIndex;
     const defaultFileName = `${columnName}_${realRowNumber}`;
     const modal = this.modalService.create({
-      nzTitle: "Export Binary Data and Save to a Dataset",
+      nzTitle: "Export Data and Save to a Dataset",
       nzContent: ResultExportationComponent,
       nzData: {
-        exportType: "binary",
+        exportType: "data",
         workflowName: this.workflowActionService.getWorkflowMetadata.name,
         defaultFileName: defaultFileName,
         rowIndex: realRowNumber,


### PR DESCRIPTION
This PR builds upon the improvements made in PR #2855. Previously, the download button was limited to binary values in the result panel. However, users may also want to download other types of data, such as long strings, which were not supported in the previous implementation.

Key Improvements:
- Users can now download any value from the result panel, providing greater flexibility.
- This change removes the restriction of downloading only binary data.
- To maintain a clean and user-friendly interface, the download button is now hidden by default and will appear when the user hovers over a row. This prevents the UI from becoming cluttered with download buttons in every table cell.

https://github.com/user-attachments/assets/e060894e-bd65-4646-8b67-d85585b171d4


