### PR TITLE
Fix the issue displaying integer containing only 0 and 1

### DIFF
--- a/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.ts
+++ b/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.ts
@@ -346,7 +346,7 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
         if (row[col.columnKey] === null) {
           return "NULL"; // Explicitly show NULL for null values
         } else if (row[col.columnKey] !== undefined) {
-          return this.trimTableCell(row[col.columnKey].toString());
+          return this.trimTableCell(row[col.columnKey]);
         } else {
           return ""; // Keep empty string for undefined values
         }


### PR DESCRIPTION
This PR addresses an issue introduced in PR #2863, where non-string values (e.g., integers, longs) containing only 0 or 1 were incorrectly identified as binary data in the frontend and displayed as such. This fix ensures that non-string values are now correctly handled and displayed according to their actual type, preventing them from being mistakenly rendered as binary data.

[Before]

<img width="1034" alt="Screenshot 2024-09-24 at 11 30 12 AM" src="https://github.com/user-attachments/assets/f300334c-8df0-4d99-a65f-b05c50816b7e">

[After]
<img width="1032" alt="Screenshot 2024-09-24 at 11 30 40 AM" src="https://github.com/user-attachments/assets/dd34ec19-74ac-4b99-b05a-0730d2ea16e1">

