### PR TITLE
Fix Python Source Operator

### DIFF
--- a/core/amber/src/main/python/core/architecture/packaging/input_manager.py
+++ b/core/amber/src/main/python/core/architecture/packaging/input_manager.py
@@ -89,7 +89,7 @@ class InputManager:
     ) -> Iterator[Union[Tuple, InternalMarker]]:
         # special case used to yield for source op
         if from_ == InputManager.SOURCE_STARTER:
-            yield EndOfInputChannel()
+            yield EndOfInputPort()
             yield EndOfOutputPorts()
             return
 


### PR DESCRIPTION
Fix the bug in the Python source operator, caused by a typo in PR #2802.