### PR TITLE
Fix Python Source Operator with Mutiple Output

### DIFF
--- a/core/amber/src/main/python/core/runnables/data_processor.py
+++ b/core/amber/src/main/python/core/runnables/data_processor.py
@@ -110,6 +110,7 @@ class DataProcessor(Runnable, Stoppable):
                     output_tuple.finalize(
                         self._context.output_manager.get_port().get_schema()
                     )
+                self._switch_context()
                 self._context.tuple_processing_manager.current_output_tuple = (
                     output_tuple
                 )


### PR DESCRIPTION
Fix the bug where the Python Source Operator only produces the last tuple when there are multiple outputs.