### PR TITLE
Modify the display method of Google login.

### DIFF
--- a/core/gui/src/app/dashboard/component/dashboard.component.html
+++ b/core/gui/src/app/dashboard/component/dashboard.component.html
@@ -137,15 +137,51 @@
       </li>
     </ul>
   </nz-sider>
-  <nz-layout>
-    <div
-      *ngIf="displayNavbar"
-      id="nav">
-      <texera-search-bar></texera-search-bar>
-      <texera-user-icon *ngIf="isLogin"></texera-user-icon>
-    </div>
-    <nz-content>
-      <router-outlet></router-outlet>
-    </nz-content>
-  </nz-layout>
+
+  <div class="page-container">
+    <ul
+      class="nav-links"
+      [ngClass]="{ 'hidden': isLogin }">
+      <li class="nav-item">
+        <a
+          class="nav-link"
+          href="https://github.com/Texera/texera/wiki/Getting-Started"
+          >Getting Started</a
+        >
+      </li>
+      <li class="nav-item">
+        <a
+          class="nav-link"
+          href="https://texera.github.io/blog/"
+          >Blogs</a
+        >
+      </li>
+      <li class="nav-item">
+        <iframe
+          style="margin-top: 2px"
+          src="https://ghbtns.com/github-btn.html?user=Texera&repo=texera&type=star&count=true"
+          frameborder="0"
+          scrolling="0"
+          width="90"
+          height="20"
+          title="GitHub"></iframe>
+      </li>
+      <li
+        class="nav-item"
+        id="googleButton"></li>
+    </ul>
+
+    <nz-layout>
+      <div
+        *ngIf="displayNavbar"
+        id="nav">
+        <texera-search-bar></texera-search-bar>
+        <texera-user-icon *ngIf="isLogin"></texera-user-icon>
+      </div>
+
+      <nz-content>
+        <router-outlet></router-outlet>
+      </nz-content>
+    </nz-layout>
+  </div>
 </nz-layout>

--- a/core/gui/src/app/dashboard/component/dashboard.component.scss
+++ b/core/gui/src/app/dashboard/component/dashboard.component.scss
@@ -58,3 +58,38 @@ button {
 nz-content {
   position: relative;
 }
+
+.page-container {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+}
+
+.nav-links {
+  list-style-type: none;
+  height: 70px;
+  padding: 10px;
+  margin: 0;
+  overflow: hidden;
+  background-color: #f8f9fa;
+  vertical-align: baseline;
+}
+
+.nav-item {
+  float: left;
+  padding: 14px;
+}
+
+.nav-link {
+  color: black;
+  font-weight: bold;
+}
+
+#googleButton {
+  float: right;
+  padding: 5px 0;
+}
+
+.hidden {
+  display: none;
+}

--- a/core/gui/src/app/dashboard/component/dashboard.component.ts
+++ b/core/gui/src/app/dashboard/component/dashboard.component.ts
@@ -51,26 +51,19 @@ export class DashboardComponent implements OnInit {
     this.isCollpased = false;
 
     if (!this.isLogin) {
-      if (!sessionStorage.getItem("homePageReloaded")) {
-        sessionStorage.setItem("homePageReloaded", "true");
-        window.location.reload();
-      } else {
-        sessionStorage.removeItem("homePageReloaded");
-
-        this.googleAuthService.googleAuthInit(document.getElementById("googleButton"));
-        this.googleAuthService.googleCredentialResponse
-          .pipe(mergeMap(res => this.userService.googleLogin(res.credential)))
-          .pipe(
-            catchError((e: unknown) => {
-              this.notificationService.error((e as Error).message, { nzDuration: 10 });
-              return throwError(() => e);
-            })
-          )
-          // eslint-disable-next-line rxjs-angular/prefer-takeuntil
-          .subscribe(() =>
-            this.router.navigateByUrl(this.route.snapshot.queryParams["returnUrl"] || "/dashboard/user/workflow")
-          );
-      }
+      this.googleAuthService.googleAuthInit(document.getElementById("googleButton"));
+      this.googleAuthService.googleCredentialResponse
+        .pipe(mergeMap(res => this.userService.googleLogin(res.credential)))
+        .pipe(
+          catchError((e: unknown) => {
+            this.notificationService.error((e as Error).message, { nzDuration: 10 });
+            return throwError(() => e);
+          })
+        )
+        // eslint-disable-next-line rxjs-angular/prefer-takeuntil
+        .subscribe(() =>
+          this.router.navigateByUrl(this.route.snapshot.queryParams["returnUrl"] || "/dashboard/user/workflow")
+        );
     }
     if (!document.cookie.includes("flarum_remember") && this.isLogin) {
       this.flarumService

--- a/core/gui/src/app/dashboard/component/dashboard.component.ts
+++ b/core/gui/src/app/dashboard/component/dashboard.component.ts
@@ -4,8 +4,12 @@ import { UserService } from "../../common/service/user/user.service";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { FlarumService } from "../service/user/flarum/flarum.service";
 import { HttpErrorResponse } from "@angular/common/http";
-import { Router } from "@angular/router";
+import { ActivatedRoute, Router } from "@angular/router";
 import { HubComponent } from "../../hub/component/hub.component";
+import { GoogleAuthService } from "../../common/service/user/google-auth.service";
+import { NotificationService } from "../../common/service/notification/notification.service";
+import { catchError, mergeMap } from "rxjs/operators";
+import { throwError } from "rxjs";
 
 @Component({
   selector: "texera-dashboard",
@@ -28,7 +32,10 @@ export class DashboardComponent implements OnInit {
     private userService: UserService,
     private router: Router,
     private flarumService: FlarumService,
-    private cdr: ChangeDetectorRef
+    private cdr: ChangeDetectorRef,
+    private route: ActivatedRoute,
+    private googleAuthService: GoogleAuthService,
+    private notificationService: NotificationService
   ) {
     this.userService
       .userChanged()
@@ -42,6 +49,29 @@ export class DashboardComponent implements OnInit {
 
   ngOnInit(): void {
     this.isCollpased = false;
+
+    if (!this.isLogin) {
+      if (!sessionStorage.getItem("homePageReloaded")) {
+        sessionStorage.setItem("homePageReloaded", "true");
+        window.location.reload();
+      } else {
+        sessionStorage.removeItem("homePageReloaded");
+
+        this.googleAuthService.googleAuthInit(document.getElementById("googleButton"));
+        this.googleAuthService.googleCredentialResponse
+          .pipe(mergeMap(res => this.userService.googleLogin(res.credential)))
+          .pipe(
+            catchError((e: unknown) => {
+              this.notificationService.error((e as Error).message, { nzDuration: 10 });
+              return throwError(() => e);
+            })
+          )
+          // eslint-disable-next-line rxjs-angular/prefer-takeuntil
+          .subscribe(() =>
+            this.router.navigateByUrl(this.route.snapshot.queryParams["returnUrl"] || "/dashboard/user/workflow")
+          );
+      }
+    }
     if (!document.cookie.includes("flarum_remember") && this.isLogin) {
       this.flarumService
         .auth()

--- a/core/gui/src/app/hub/component/home/home.component.html
+++ b/core/gui/src/app/hub/component/home/home.component.html
@@ -1,18 +1,3 @@
-<ul>
-  <li><a href="https://github.com/Texera/texera/wiki/Getting-Started">Getting Started</a></li>
-  <li><a href="https://texera.github.io/blog/">Blogs</a></li>
-  <li>
-    <iframe
-      style="margin-top: 2px"
-      src="https://ghbtns.com/github-btn.html?user=Texera&repo=texera&type=star&count=true"
-      frameborder="0"
-      scrolling="0"
-      width="90"
-      height="20"
-      title="GitHub"></iframe>
-  </li>
-  <li id="googleButton"></li>
-</ul>
 <div
   nz-row
   nzJustify="space-around"

--- a/core/gui/src/app/hub/component/home/home.component.scss
+++ b/core/gui/src/app/hub/component/home/home.component.scss
@@ -2,32 +2,8 @@
   text-align: center;
 }
 
-ul {
-  list-style-type: none;
-  height: 70px;
-  padding: 10px;
-  overflow: hidden;
-  background-color: #f8f9fa;
-  vertical-align: baseline;
-}
-
-li {
-  float: left;
-  padding: 14px;
-}
-
-li a {
-  color: black;
-  font-weight: bold;
-}
-
 #logo {
   height: 70px;
   padding: 0;
   margin-right: 14px;
-}
-
-#googleButton {
-  float: right;
-  padding: 5px 0;
 }

--- a/core/gui/src/app/hub/component/home/home.component.ts
+++ b/core/gui/src/app/hub/component/home/home.component.ts
@@ -1,12 +1,6 @@
 import { UntilDestroy } from "@ngneat/until-destroy";
 import { Component, OnInit } from "@angular/core";
 import { environment } from "../../../../environments/environment";
-import { UserService } from "../../../common/service/user/user.service";
-import { ActivatedRoute, Router } from "@angular/router";
-import { GoogleAuthService } from "../../../common/service/user/google-auth.service";
-import { NotificationService } from "../../../common/service/notification/notification.service";
-import { catchError, mergeMap } from "rxjs/operators";
-import { throwError } from "rxjs";
 
 @UntilDestroy()
 @Component({
@@ -14,37 +8,8 @@ import { throwError } from "rxjs";
   templateUrl: "./home.component.html",
   styleUrls: ["./home.component.scss"],
 })
-export class HomeComponent implements OnInit {
+export class HomeComponent {
   localLogin = environment.localLogin;
 
-  constructor(
-    private userService: UserService,
-    private route: ActivatedRoute,
-    private googleAuthService: GoogleAuthService,
-    private notificationService: NotificationService,
-    private router: Router
-  ) {}
-
-  ngOnInit(): void {
-    if (!sessionStorage.getItem("homePageReloaded")) {
-      sessionStorage.setItem("homePageReloaded", "true");
-      window.location.reload();
-    } else {
-      sessionStorage.removeItem("homePageReloaded");
-
-      this.googleAuthService.googleAuthInit(document.getElementById("googleButton"));
-      this.googleAuthService.googleCredentialResponse
-        .pipe(mergeMap(res => this.userService.googleLogin(res.credential)))
-        .pipe(
-          catchError((e: unknown) => {
-            this.notificationService.error((e as Error).message, { nzDuration: 10 });
-            return throwError(() => e);
-          })
-        )
-        // eslint-disable-next-line rxjs-angular/prefer-takeuntil
-        .subscribe(() =>
-          this.router.navigateByUrl(this.route.snapshot.queryParams["returnUrl"] || "/dashboard/user/workflow")
-        );
-    }
-  }
+  constructor() {}
 }


### PR DESCRIPTION
**Propose:**
Previously, the Google login button was only displayed on the home page, and the page would force a refresh when the user navigated to the home, resulting in a disjointed user experience. This PR updates the behavior to a smoother and more seamless version.

**Change:**
The top bar containing the Google login will always be present on the dashboard, but it will only be displayed when the user is not logged in.

**Demo:**
old:
https://github.com/user-attachments/assets/2a72475e-9519-4768-9f9a-458b25565129

new:
https://github.com/user-attachments/assets/c7ddc9de-c889-4cbb-b5c7-6b5116f617cf