### PR TITLE
Add owner detail page and refactor detail page

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/hub/workflow/HubWorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/hub/workflow/HubWorkflowResource.scala
@@ -92,4 +92,16 @@ class HubWorkflowResource {
       throw new ForbiddenException("No sufficient access privilege.")
     }
   }
+
+  @GET
+  @Path("/workflow_description")
+  def getWorkflowDescription(@QueryParam("wid") wid: UInteger): String = {
+    context
+      .select(
+        WORKFLOW.DESCRIPTION
+      )
+      .from(WORKFLOW)
+      .where(WORKFLOW.WID.eq(wid))
+      .fetchOneInto(classOf[String])
+  }
 }

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
@@ -123,6 +123,15 @@
     *ngIf="isPrivateSearch"
     class="button-group">
     <button
+      *ngIf="entry.type==='workflow'"
+      nz-button
+      nzType="text"
+      class="dropdown-item"
+      title="Detail"
+      (click)="openDetailModal(this.entry.id)">
+      <i nz-icon nzTheme="outline" nzType="eye"></i>
+    </button>
+    <button
       nz-button
       nzType="text"
       class="dropdown-item"

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
@@ -129,7 +129,10 @@
       class="dropdown-item"
       title="Detail"
       (click)="openDetailModal(this.entry.id)">
-      <i nz-icon nzTheme="outline" nzType="eye"></i>
+      <i
+        nz-icon
+        nzTheme="outline"
+        nzType="eye"></i>
     </button>
     <button
       nz-button

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.ts
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.ts
@@ -21,6 +21,7 @@ import { Workflow } from "src/app/common/type/workflow";
 import { FileSaverService } from "src/app/dashboard/service/user/file/file-saver.service";
 import { firstValueFrom } from "rxjs";
 import { SearchService } from "../../../service/user/search.service";
+import { HubWorkflowDetailComponent } from "../../../../hub/component/workflow/detail/hub-workflow-detail.component";
 
 @UntilDestroy()
 @Component({
@@ -66,7 +67,8 @@ export class ListItemComponent implements OnInit, OnChanges {
     private searchService: SearchService,
     private modalService: NzModalService,
     private workflowPersistService: WorkflowPersistService,
-    private fileSaverService: FileSaverService
+    private fileSaverService: FileSaverService,
+    private modal: NzModalService
   ) {}
 
   initializeEntry() {
@@ -235,6 +237,26 @@ export class ListItemComponent implements OnInit, OnChanges {
       return `${weeksAgo} weeks ago`;
     } else {
       return new Date(timestamp).toLocaleDateString();
+    }
+  }
+
+  openDetailModal(wid: number | undefined): void {
+    const modalRef = this.modal.create({
+      nzTitle: "Workflow Detail",
+      nzContent: HubWorkflowDetailComponent,
+      nzFooter: null,
+      nzStyle: { width: "60%" },
+      nzBodyStyle: { maxHeight: "70vh", overflow: "auto" },
+    });
+
+    const instance = modalRef.componentInstance;
+    if (instance) {
+      if (wid !== undefined) {
+        instance.wid = wid;
+      } else {
+        console.warn("wid is undefined, default handling can be added here");
+        instance.wid = 0;
+      }
     }
   }
 }

--- a/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.html
+++ b/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.html
@@ -11,7 +11,7 @@
     </div>
     <div>
       <h2>Created By</h2>
-      <p>{{ ownerUser.name }}</p>
+      <p>{{ ownerName }}</p>
     </div>
   </div>
   <h2>Preview</h2>

--- a/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.html
+++ b/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.html
@@ -1,3 +1,16 @@
+<button
+  *ngIf="isHub"
+  nz-button
+  nzType="text"
+  nzSize="large"
+  class="go-back-button"
+  (click)="goBack()">
+    <span
+      nz-icon
+      nzType="arrow-left"
+      nzTheme="outline"></span>
+</button>
+
 <div class="container prevent-select">
   <h1>Workflow Detail Page</h1>
   <div class="workflow-info">
@@ -14,6 +27,11 @@
       <p>{{ ownerName }}</p>
     </div>
   </div>
+  <div class="workflow-description">
+    <h2>Description</h2>
+    <p>{{workflowDescription}}</p>
+  </div>
+
   <h2>Preview</h2>
   <div class="preview-containers">
     <texera-workflow-editor></texera-workflow-editor>

--- a/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.html
+++ b/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.html
@@ -5,10 +5,10 @@
   nzSize="large"
   class="go-back-button"
   (click)="goBack()">
-    <span
-      nz-icon
-      nzType="arrow-left"
-      nzTheme="outline"></span>
+  <span
+    nz-icon
+    nzType="arrow-left"
+    nzTheme="outline"></span>
 </button>
 
 <div class="container prevent-select">

--- a/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.scss
+++ b/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.scss
@@ -60,3 +60,15 @@ texera-mini-map {
 .prevent-select {
   user-select: none;
 }
+
+.workflow-description {
+  padding: 10px;
+  background-color: #e9e9e9;
+  margin-top: 20px;
+}
+
+.go-back-button {
+  position: absolute;
+  left: 20px;
+  top: 20px;
+}

--- a/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.ts
+++ b/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.ts
@@ -26,6 +26,7 @@ import { of } from "rxjs";
 import { isDefined } from "../../../../common/util/predicate";
 import { HubWorkflowService } from "../../../service/workflow/hub-workflow.service";
 import { User } from "src/app/common/type/user";
+import { Location } from "@angular/common";
 
 @UntilDestroy()
 @Component({
@@ -33,9 +34,11 @@ import { User } from "src/app/common/type/user";
   templateUrl: "hub-workflow-detail.component.html",
   styleUrls: ["hub-workflow-detail.component.scss"],
 })
-export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy {
+export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy, OnInit {
+  isHub: boolean = true;
   workflowName: string = "";
   ownerName: string = "";
+  workflowDescription: string = "";
   workflow = {
     steps: [
       {
@@ -79,7 +82,8 @@ export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy {
     private router: Router,
     private notificationService: NotificationService,
     private codeEditorService: CodeEditorService,
-    private hubWorkflowService: HubWorkflowService
+    private hubWorkflowService: HubWorkflowService,
+    private location: Location,
   ) {
     if(!this.wid){
       this.wid = this.route.snapshot.params.id;
@@ -88,6 +92,8 @@ export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy {
   }
 
   ngOnInit() {
+    this.isHub = this.route.parent?.snapshot.url.some(segment => segment.path === "detail") ||
+      this.route.snapshot.url.some(segment => segment.path === "detail");
     this.hubWorkflowService
       .getOwnerUser(this.wid)
       .pipe(untilDestroyed(this))
@@ -99,6 +105,12 @@ export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy {
       .pipe(untilDestroyed(this))
       .subscribe(workflowName => {
         this.workflowName = workflowName;
+      });
+    this.hubWorkflowService
+      .getWorkflowDescription(this.wid)
+      .pipe(untilDestroyed(this))
+      .subscribe(workflowDescription => {
+        this.workflowDescription = workflowDescription || "No description available";
       });
   }
 
@@ -208,5 +220,9 @@ export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy {
       .subscribe(wid => {
         this.workflowWebsocketService.reopenWebsocket(wid);
       });
+  }
+
+  goBack(): void {
+    this.location.back();
   }
 }

--- a/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.ts
+++ b/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.ts
@@ -1,4 +1,13 @@
-import { AfterViewInit, Component, OnInit, HostListener, OnDestroy, ViewChild, ViewContainerRef } from "@angular/core";
+import {
+  AfterViewInit,
+  Component,
+  OnInit,
+  HostListener,
+  OnDestroy,
+  ViewChild,
+  ViewContainerRef,
+  Input,
+} from "@angular/core";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { ActivatedRoute, Router } from "@angular/router";
 import { environment } from "../../../../../environments/environment";
@@ -20,14 +29,13 @@ import { User } from "src/app/common/type/user";
 
 @UntilDestroy()
 @Component({
-  selector: "texera-hub-workflow-result",
+  selector: "texera-hub-workflow-detail",
   templateUrl: "hub-workflow-detail.component.html",
   styleUrls: ["hub-workflow-detail.component.scss"],
 })
 export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy {
-  wid: number;
   workflowName: string = "";
-  ownerUser!: User;
+  ownerName: string = "";
   workflow = {
     steps: [
       {
@@ -52,6 +60,7 @@ export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy {
       },
     ],
   };
+  @Input() wid!: number;
 
   public pid?: number = undefined;
   userSystemEnabled = environment.userSystemEnabled;
@@ -71,7 +80,9 @@ export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy {
     private codeEditorService: CodeEditorService,
     private hubWorkflowService: HubWorkflowService
   ) {
-    this.wid = this.route.snapshot.params.id;
+    if(!this.wid){
+      this.wid = this.route.snapshot.params.id;
+    }
   }
 
   ngOnInit() {
@@ -79,7 +90,7 @@ export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy {
       .getOwnerUser(this.wid)
       .pipe(untilDestroyed(this))
       .subscribe(owner => {
-        this.ownerUser = owner;
+        this.ownerName = owner.name;
       });
     this.hubWorkflowService
       .getWorkflowName(this.wid)

--- a/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.ts
+++ b/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.ts
@@ -83,16 +83,17 @@ export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy, OnI
     private notificationService: NotificationService,
     private codeEditorService: CodeEditorService,
     private hubWorkflowService: HubWorkflowService,
-    private location: Location,
+    private location: Location
   ) {
-    if(!this.wid){
+    if (!this.wid) {
       this.wid = this.route.snapshot.params.id;
     }
     this.currentUser = this.userService.getCurrentUser();
   }
 
   ngOnInit() {
-    this.isHub = this.route.parent?.snapshot.url.some(segment => segment.path === "detail") ||
+    this.isHub =
+      this.route.parent?.snapshot.url.some(segment => segment.path === "detail") ||
       this.route.snapshot.url.some(segment => segment.path === "detail");
     this.hubWorkflowService
       .getOwnerUser(this.wid)
@@ -186,7 +187,6 @@ export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy, OnI
       }
     );
   }
-
 
   registerLoadOperatorMetadata() {
     this.operatorMetadataService

--- a/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.ts
+++ b/core/gui/src/app/hub/component/workflow/detail/hub-workflow-detail.component.ts
@@ -64,6 +64,7 @@ export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy {
 
   public pid?: number = undefined;
   userSystemEnabled = environment.userSystemEnabled;
+  private currentUser?: User;
   @ViewChild("codeEditor", { read: ViewContainerRef }) codeEditorViewRef!: ViewContainerRef;
   constructor(
     private userService: UserService,
@@ -83,6 +84,7 @@ export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy {
     if(!this.wid){
       this.wid = this.route.snapshot.params.id;
     }
+    this.currentUser = this.userService.getCurrentUser();
   }
 
   ngOnInit() {
@@ -128,50 +130,51 @@ export class HubWorkflowDetailComponent implements AfterViewInit, OnDestroy {
   loadWorkflowWithId(wid: number): void {
     // disable the workspace until the workflow is fetched from the backend
     this.workflowActionService.disableWorkflowModification();
-    this.hubWorkflowService
-      .retrievePublicWorkflow(wid)
-      .pipe(untilDestroyed(this))
-      .subscribe(
-        (workflow: Workflow) => {
-          this.workflowActionService.setNewSharedModel(wid, this.userService.getCurrentUser());
-          // remember URL fragment
-          const fragment = this.route.snapshot.fragment;
-          // load the fetched workflow
-          this.workflowActionService.reloadWorkflow(workflow);
-          this.workflowActionService.enableWorkflowModification();
-          // set the URL fragment to previous value
-          // because reloadWorkflow will highlight/unhighlight all elements
-          // which will change the URL fragment
-          this.router.navigate([], {
-            relativeTo: this.route,
-            fragment: fragment !== null ? fragment : undefined,
-            preserveFragment: false,
-          });
-          // highlight the operator, comment box, or link in the URL fragment
-          if (fragment) {
-            if (this.workflowActionService.getTexeraGraph().hasElementWithID(fragment)) {
-              this.workflowActionService.highlightElements(false, fragment);
-            } else {
-              this.notificationService.error(`Element ${fragment} doesn't exist`);
-              // remove the fragment from the URL
-              this.router.navigate([], { relativeTo: this.route });
-            }
+    let workflowObservable = this.currentUser
+      ? this.workflowPersistService.retrieveWorkflow(wid)
+      : this.hubWorkflowService.retrievePublicWorkflow(wid);
+    workflowObservable.pipe(untilDestroyed(this)).subscribe(
+      (workflow: Workflow) => {
+        this.workflowActionService.setNewSharedModel(wid, this.userService.getCurrentUser());
+        // remember URL fragment
+        const fragment = this.route.snapshot.fragment;
+        // load the fetched workflow
+        this.workflowActionService.reloadWorkflow(workflow);
+        this.workflowActionService.enableWorkflowModification();
+        // set the URL fragment to previous value
+        // because reloadWorkflow will highlight/unhighlight all elements
+        // which will change the URL fragment
+        this.router.navigate([], {
+          relativeTo: this.route,
+          fragment: fragment !== null ? fragment : undefined,
+          preserveFragment: false,
+        });
+        // highlight the operator, comment box, or link in the URL fragment
+        if (fragment) {
+          if (this.workflowActionService.getTexeraGraph().hasElementWithID(fragment)) {
+            this.workflowActionService.highlightElements(false, fragment);
+          } else {
+            this.notificationService.error(`Element ${fragment} doesn't exist`);
+            // remove the fragment from the URL
+            this.router.navigate([], { relativeTo: this.route });
           }
-          // clear stack
-          this.undoRedoService.clearUndoStack();
-          this.undoRedoService.clearRedoStack();
-        },
-        () => {
-          this.workflowActionService.resetAsNewWorkflow();
-          // enable workspace for modification
-          this.workflowActionService.enableWorkflowModification();
-          // clear stack
-          this.undoRedoService.clearUndoStack();
-          this.undoRedoService.clearRedoStack();
-          this.message.error("You don't have access to this workflow, please log in with an appropriate account");
         }
-      );
+        // clear stack
+        this.undoRedoService.clearUndoStack();
+        this.undoRedoService.clearRedoStack();
+      },
+      () => {
+        this.workflowActionService.resetAsNewWorkflow();
+        // enable workspace for modification
+        this.workflowActionService.enableWorkflowModification();
+        // clear stack
+        this.undoRedoService.clearUndoStack();
+        this.undoRedoService.clearRedoStack();
+        this.message.error("You don't have access to this workflow, please log in with an appropriate account");
+      }
+    );
   }
+
 
   registerLoadOperatorMetadata() {
     this.operatorMetadataService

--- a/core/gui/src/app/hub/service/workflow/hub-workflow.service.ts
+++ b/core/gui/src/app/hub/service/workflow/hub-workflow.service.ts
@@ -40,4 +40,9 @@ export class HubWorkflowService {
       map(WorkflowUtilService.parseWorkflowInfo)
     );
   }
+
+  public getWorkflowDescription(wid: number): Observable<string> {
+    const params = new HttpParams().set("wid", wid);
+    return this.http.get(`${this.BASE_URL}/workflow_description/`, { params, responseType: "text" });
+  }
 }


### PR DESCRIPTION
**Propose:**
Allow workflow owners to preview what the detail page displayed in the hub will look like in advance.

**Change:**
1. Add a button in the list item that only appears for private workflows. Clicking the button will bring up a modal displaying the detail page. 
2. Add a "back to the previous page" button in the detail page, as well as a description section.

**Demo:**
old list item:
![old list item](https://github.com/user-attachments/assets/03a5bc0e-0ef6-4378-b7f3-18655980336a)

new list item:
![new list item](https://github.com/user-attachments/assets/06cea20a-76c2-42d3-bf43-78ef23c1eca7)

after click button:
![after click button](https://github.com/user-attachments/assets/5737c80a-bf45-41f0-85d2-f5de6dba1ac5)

old detail page:
![old detail page](https://github.com/user-attachments/assets/a0d7e43e-6074-4dfd-b944-e18be8f0c7c1)

new detail page:
![new detail page](https://github.com/user-attachments/assets/a8749194-5cf3-46bc-8392-bd5c1fcef1c2)
