### PR TITLE
Refactor compilation service

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWorkflowCompilingService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWorkflowCompilingService.scala
@@ -5,14 +5,8 @@ import com.github.toastshaman.dropwizard.auth.jwt.JwtAuthFilter
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.common.AmberConfig
 import edu.uci.ics.texera.Utils
-import edu.uci.ics.texera.web.TexeraWebApplication.parseArgs
 import edu.uci.ics.texera.web.auth.JwtAuth.jwtConsumer
-import edu.uci.ics.texera.web.auth.{
-  GuestAuthFilter,
-  SessionUser,
-  UserAuthenticator,
-  UserRoleAuthorizer
-}
+import edu.uci.ics.texera.web.auth.{GuestAuthFilter, SessionUser, UserAuthenticator, UserRoleAuthorizer}
 import edu.uci.ics.texera.web.resource.WorkflowCompilationResource
 import io.dropwizard.auth.{AuthDynamicFeature, AuthValueFactoryProvider}
 import io.dropwizard.setup.{Bootstrap, Environment}
@@ -20,7 +14,6 @@ import org.glassfish.jersey.server.filter.RolesAllowedDynamicFeature
 
 object TexeraWorkflowCompilingService {
   def main(args: Array[String]): Unit = {
-    val argMap = parseArgs(args)
 
     new TexeraWorkflowCompilingService().run(
       "server",
@@ -49,7 +42,7 @@ class TexeraWorkflowCompilingService
       environment: Environment
   ): Unit = {
     // serve backend at /api/texera
-    environment.jersey.setUrlPattern("/api/texera/*")
+    environment.jersey.setUrlPattern("/api/texera/compile/*")
 
     // register the compilation endpoint
     environment.jersey.register(classOf[WorkflowCompilationResource])

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWorkflowCompilingService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWorkflowCompilingService.scala
@@ -42,7 +42,7 @@ class TexeraWorkflowCompilingService
       environment: Environment
   ): Unit = {
     // serve backend at /api/texera
-    environment.jersey.setUrlPattern("/api/texera/compile/*")
+    environment.jersey.setUrlPattern("/api/texera/*")
 
     // register the compilation endpoint
     environment.jersey.register(classOf[WorkflowCompilationResource])

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowCompilationResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowCompilationResource.scala
@@ -2,7 +2,6 @@ package edu.uci.ics.texera.web.resource
 
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.common.virtualidentity.WorkflowIdentity
-import edu.uci.ics.texera.Utils
 import edu.uci.ics.texera.web.model.websocket.request.LogicalPlanPojo
 import edu.uci.ics.texera.workflow.common.WorkflowContext
 import edu.uci.ics.texera.workflow.common.tuple.schema.Attribute
@@ -10,52 +9,61 @@ import edu.uci.ics.texera.workflow.common.workflow.{PhysicalPlan, WorkflowCompil
 import org.jooq.types.UInteger
 
 import javax.annotation.security.RolesAllowed
-import javax.ws.rs.core.MediaType
 import javax.ws.rs._
+import javax.ws.rs.core.MediaType
 
-case class WorkflowCompilationResponse(
-    physicalPlan: Option[PhysicalPlan],
-    operatorInputSchemas: Map[String, List[Option[List[Attribute]]]],
+trait WorkflowCompilationResponse
+case class WorkflowCompilationSuccess(
+    plan: Option[PhysicalPlan],
+    operatorInputSchemas: Map[String, List[Option[List[Attribute]]]]
+) extends WorkflowCompilationResponse
+
+case class WorkflowCompilationFailure(
     operatorErrors: Map[String, String]
-)
+) extends WorkflowCompilationResponse
 
 @Consumes(Array(MediaType.APPLICATION_JSON))
 @Produces(Array(MediaType.APPLICATION_JSON))
 @RolesAllowed(Array("REGULAR", "ADMIN"))
 @Path("/compile")
 class WorkflowCompilationResource extends LazyLogging {
+
   @POST
   @Path("/{wid}")
   def compileWorkflow(
-      workflowStr: String,
+      logicalPlanPojo: LogicalPlanPojo,
       @PathParam("wid") wid: UInteger
   ): WorkflowCompilationResponse = {
-    val logicalPlanPojo = Utils.objectMapper.readValue(workflowStr, classOf[LogicalPlanPojo])
-
+    // Create workflow context from wid
     val context = new WorkflowContext(
       workflowId = WorkflowIdentity(wid.toString.toLong)
     )
 
-    // compile the pojo using WorkflowCompiler
-    val workflowCompilationResult =
-      new WorkflowCompiler(context).compile(logicalPlanPojo)
-    // return the result
-    WorkflowCompilationResponse(
-      physicalPlan = workflowCompilationResult.physicalPlan,
-      operatorInputSchemas = workflowCompilationResult.operatorIdToInputSchemas.map {
-        case (operatorIdentity, schemas) =>
-          val opId = operatorIdentity.id
-          val attributes = schemas.map { schema =>
-            if (schema.isEmpty)
-              None
-            else
-              Some(schema.get.attributes)
-          }
-          (opId, attributes)
-      },
-      operatorErrors = workflowCompilationResult.operatorIdToError.map {
+    // Compile the pojo using WorkflowCompiler
+    val compilationResult = new WorkflowCompiler(context).compile(logicalPlanPojo)
+
+    // Handle success case: No errors in the compilation result
+    if (compilationResult.operatorIdToError.isEmpty) {
+      WorkflowCompilationSuccess(
+        plan = compilationResult.physicalPlan,
+        operatorInputSchemas = compilationResult.operatorIdToInputSchemas.map {
+          case (operatorIdentity, schemas) =>
+            val opId = operatorIdentity.id
+            val attributes = schemas.map { schema =>
+              if (schema.isEmpty)
+                None
+              else
+                Some(schema.get.attributes)
+            }
+            (opId, attributes)
+        }
+      )
+    }
+    // Handle failure case: Errors found during compilation
+    else {
+      WorkflowCompilationFailure(operatorErrors = compilationResult.operatorIdToError.map {
         case (operatorIdentity, error) => (operatorIdentity.id, error.toString)
-      }
-    )
+      })
+    }
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowCompilationResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowCompilationResource.scala
@@ -14,7 +14,7 @@ import javax.ws.rs.core.MediaType
 
 trait WorkflowCompilationResponse
 case class WorkflowCompilationSuccess(
-    plan: Option[PhysicalPlan],
+    physicalPlan: PhysicalPlan,
     operatorInputSchemas: Map[String, List[Option[List[Attribute]]]]
 ) extends WorkflowCompilationResponse
 
@@ -43,9 +43,9 @@ class WorkflowCompilationResource extends LazyLogging {
     val compilationResult = new WorkflowCompiler(context).compile(logicalPlanPojo)
 
     // Handle success case: No errors in the compilation result
-    if (compilationResult.operatorIdToError.isEmpty) {
+    if (compilationResult.operatorIdToError.isEmpty && compilationResult.physicalPlan.nonEmpty) {
       WorkflowCompilationSuccess(
-        plan = compilationResult.physicalPlan,
+        physicalPlan = compilationResult.physicalPlan.get,
         operatorInputSchemas = compilationResult.operatorIdToInputSchemas.map {
           case (operatorIdentity, schemas) =>
             val opId = operatorIdentity.id

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowCompilationResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowCompilationResource.scala
@@ -10,8 +10,8 @@ import edu.uci.ics.texera.workflow.common.workflow.{PhysicalPlan, WorkflowCompil
 import org.jooq.types.UInteger
 
 import javax.annotation.security.RolesAllowed
-import javax.ws.rs.{Consumes, POST, Path, PathParam, Produces}
 import javax.ws.rs.core.MediaType
+import javax.ws.rs._
 
 case class WorkflowCompilationResponse(
     physicalPlan: Option[PhysicalPlan],
@@ -22,7 +22,7 @@ case class WorkflowCompilationResponse(
 @Consumes(Array(MediaType.APPLICATION_JSON))
 @Produces(Array(MediaType.APPLICATION_JSON))
 @RolesAllowed(Array("REGULAR", "ADMIN"))
-@Path("/compilation")
+@Path("/compile")
 class WorkflowCompilationResource extends LazyLogging {
   @POST
   @Path("/{wid}")


### PR DESCRIPTION
This PR changes a few things in the new compilation service:
1. Changed the endpoint to use `compile`, the verb, instead of `compilation` which is a noun.
2. Sepearted the response into Success and Failure, and moved information accordingly.
3. Changed the input to be a JSON Object (LogicalPlanPojo) instead of a String.