### PR TITLE
Enable email notifications by default and improve notification content

### DIFF
--- a/core/gui/src/app/workspace/component/menu/menu.component.ts
+++ b/core/gui/src/app/workspace/component/menu/menu.component.ts
@@ -55,7 +55,7 @@ import { ShareAccessComponent } from "src/app/dashboard/component/user/share-acc
 export class MenuComponent implements OnInit {
   public executionState: ExecutionState; // set this to true when the workflow is started
   public ExecutionState = ExecutionState; // make Angular HTML access enum definition
-  public emailNotificationEnabled: boolean = environment.defaultEmailNotificationEnabled;
+  public emailNotificationEnabled: boolean = environment.workflowEmailNotificationEnabled;
   public isWorkflowValid: boolean = true; // this will check whether the workflow error or not
   public isWorkflowEmpty: boolean = false;
   public isSaving: boolean = false;

--- a/core/gui/src/app/workspace/component/menu/menu.component.ts
+++ b/core/gui/src/app/workspace/component/menu/menu.component.ts
@@ -55,7 +55,7 @@ import { ShareAccessComponent } from "src/app/dashboard/component/user/share-acc
 export class MenuComponent implements OnInit {
   public executionState: ExecutionState; // set this to true when the workflow is started
   public ExecutionState = ExecutionState; // make Angular HTML access enum definition
-  public emailNotificationEnabled: boolean = false;
+  public emailNotificationEnabled: boolean = environment.defaultEmailNotificationEnabled;
   public isWorkflowValid: boolean = true; // this will check whether the workflow error or not
   public isWorkflowEmpty: boolean = false;
   public isSaving: boolean = false;

--- a/core/gui/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
+++ b/core/gui/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
@@ -90,40 +90,4 @@ describe("ExecuteWorkflowService", () => {
       new RegExp("cannot resume workflow, the current execution state is " + (service as any).currentState.state)
     );
   });
-
-  it("should generate correct email notification content for successful execution", () => {
-    const workflow = { wid: "123", name: "Test Workflow" };
-    const stateInfo = {
-      state: ExecutionState.Completed,
-      startTime: new Date("2023-04-01T10:00:00Z"),
-      endTime: new Date("2023-04-01T10:30:00Z"),
-    };
-
-    const result = (service as any).getEmailNotificationContent(workflow, stateInfo);
-
-    expect(result.subject).toBe("[Texera] Workflow Test Workflow (123) Status: Completed");
-    expect(result.content).toContain("Your workflow Test Workflow (123) has finished execution.");
-    expect(result.content).toContain("Status: Completed");
-    expect(result.content).toContain("Start time: 2023-04-01 10:00:00 (UTC)");
-    expect(result.content).toContain("End time: 2023-04-01 10:30:00 (UTC)");
-    expect(result.content).toContain("https://texera.example.com/dashboard/user/workspace/123");
-  });
-
-  it("should generate correct email notification content for failed execution", () => {
-    const workflow = { wid: "456", name: "Failed Workflow" };
-    const stateInfo = {
-      state: ExecutionState.Failed,
-      startTime: new Date("2023-04-02T14:00:00Z"),
-      endTime: new Date("2023-04-02T14:15:00Z"),
-    };
-
-    const result = (service as any).getEmailNotificationContent(workflow, stateInfo);
-
-    expect(result.subject).toBe("[Texera] Workflow Failed Workflow (456) Status: Failed");
-    expect(result.content).toContain("Your workflow Failed Workflow (456) has finished execution.");
-    expect(result.content).toContain("Status: Failed");
-    expect(result.content).toContain("Start time: 2023-04-02 14:00:00 (UTC)");
-    expect(result.content).toContain("End time: 2023-04-02 14:15:00 (UTC)");
-    expect(result.content).toContain("https://texera.example.com/dashboard/user/workspace/456");
-  });
 });

--- a/core/gui/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
+++ b/core/gui/src/app/workspace/service/execute-workflow/execute-workflow.service.spec.ts
@@ -30,8 +30,8 @@ describe("ExecuteWorkflowService", () => {
   beforeEach(() => {
     mockDocument = {
       location: {
-        origin: 'https://texera.example.com'
-      }
+        origin: "https://texera.example.com",
+      },
     } as Document;
 
     TestBed.configureTestingModule({
@@ -46,7 +46,7 @@ describe("ExecuteWorkflowService", () => {
           useClass: StubOperatorMetadataService,
         },
         { provide: HttpClient, useClass: StubHttpClient },
-        { provide: DOCUMENT, useValue: mockDocument }
+        { provide: DOCUMENT, useValue: mockDocument },
       ],
     });
 
@@ -92,38 +92,38 @@ describe("ExecuteWorkflowService", () => {
   });
 
   it("should generate correct email notification content for successful execution", () => {
-    const workflow = { wid: '123', name: 'Test Workflow' };
-    const stateInfo = { 
+    const workflow = { wid: "123", name: "Test Workflow" };
+    const stateInfo = {
       state: ExecutionState.Completed,
-      startTime: new Date('2023-04-01T10:00:00Z'),
-      endTime: new Date('2023-04-01T10:30:00Z')
+      startTime: new Date("2023-04-01T10:00:00Z"),
+      endTime: new Date("2023-04-01T10:30:00Z"),
     };
 
     const result = (service as any).getEmailNotificationContent(workflow, stateInfo);
 
-    expect(result.subject).toBe('[Texera] Workflow Test Workflow (123) Status: Completed');
-    expect(result.content).toContain('Your workflow Test Workflow (123) has finished execution.');
-    expect(result.content).toContain('Status: Completed');
-    expect(result.content).toContain('Start time: 2023-04-01 10:00:00 (UTC)');
-    expect(result.content).toContain('End time: 2023-04-01 10:30:00 (UTC)');
-    expect(result.content).toContain('https://texera.example.com/dashboard/user/workspace/123');
+    expect(result.subject).toBe("[Texera] Workflow Test Workflow (123) Status: Completed");
+    expect(result.content).toContain("Your workflow Test Workflow (123) has finished execution.");
+    expect(result.content).toContain("Status: Completed");
+    expect(result.content).toContain("Start time: 2023-04-01 10:00:00 (UTC)");
+    expect(result.content).toContain("End time: 2023-04-01 10:30:00 (UTC)");
+    expect(result.content).toContain("https://texera.example.com/dashboard/user/workspace/123");
   });
 
   it("should generate correct email notification content for failed execution", () => {
-    const workflow = { wid: '456', name: 'Failed Workflow' };
-    const stateInfo = { 
+    const workflow = { wid: "456", name: "Failed Workflow" };
+    const stateInfo = {
       state: ExecutionState.Failed,
-      startTime: new Date('2023-04-02T14:00:00Z'),
-      endTime: new Date('2023-04-02T14:15:00Z')
+      startTime: new Date("2023-04-02T14:00:00Z"),
+      endTime: new Date("2023-04-02T14:15:00Z"),
     };
 
     const result = (service as any).getEmailNotificationContent(workflow, stateInfo);
 
-    expect(result.subject).toBe('[Texera] Workflow Failed Workflow (456) Status: Failed');
-    expect(result.content).toContain('Your workflow Failed Workflow (456) has finished execution.');
-    expect(result.content).toContain('Status: Failed');
-    expect(result.content).toContain('Start time: 2023-04-02 14:00:00 (UTC)');
-    expect(result.content).toContain('End time: 2023-04-02 14:15:00 (UTC)');
-    expect(result.content).toContain('https://texera.example.com/dashboard/user/workspace/456');
+    expect(result.subject).toBe("[Texera] Workflow Failed Workflow (456) Status: Failed");
+    expect(result.content).toContain("Your workflow Failed Workflow (456) has finished execution.");
+    expect(result.content).toContain("Status: Failed");
+    expect(result.content).toContain("Start time: 2023-04-02 14:00:00 (UTC)");
+    expect(result.content).toContain("End time: 2023-04-02 14:15:00 (UTC)");
+    expect(result.content).toContain("https://texera.example.com/dashboard/user/workspace/456");
   });
 });

--- a/core/gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/core/gui/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -398,9 +398,9 @@ export class ExecuteWorkflowService {
       }) + " (UTC)";
 
     const baseUrl = this.document.location.origin;
-    const dashboardUrl = `${baseUrl}/dashboard/workspace/${workflow.wid}`;
+    const dashboardUrl = `${baseUrl}/dashboard/user/workspace/${workflow.wid}`;
 
-    const subject = `Workflow ${workflow.name} (${workflow.wid}) Status: ${stateInfo.state}`;
+    const subject = `[Texera] Workflow ${workflow.name} (${workflow.wid}) Status: ${stateInfo.state}`;
     const content = `
         Hello,
     

--- a/core/gui/src/environments/environment.default.ts
+++ b/core/gui/src/environments/environment.default.ts
@@ -100,6 +100,11 @@ export const defaultEnvironment = {
    * default data transfer batch size for workflows
    */
   defaultDataTransferBatchSize: 400,
+
+  /**
+   * Whether email notification is enabled as default
+   */
+  defaultEmailNotificationEnabled: false,
 };
 
 export type AppEnv = typeof defaultEnvironment;

--- a/core/gui/src/environments/environment.default.ts
+++ b/core/gui/src/environments/environment.default.ts
@@ -102,9 +102,9 @@ export const defaultEnvironment = {
   defaultDataTransferBatchSize: 400,
 
   /**
-   * Whether email notification is enabled as default
+   * Whether to send email notification when workflow execution is completed/failed/paused/killed
    */
-  defaultEmailNotificationEnabled: false,
+  workflowEmailNotificationEnabled: false,
 };
 
 export type AppEnv = typeof defaultEnvironment;


### PR DESCRIPTION
This PR makes the following changes to improve email notifications for workflow executions:

1. Add a parameter to `environment.default.ts` to set whether email notification is enabled as default
2. Updates the email notification subject line to include "[Texera]" prefix
3. Corrects the dashboard URL in the email notification content

These changes are based on the feedback from the demo of the email notification from bioinformaticians in Cornell University.