### PR TITLE
Fix the glitching error frame in result panel

### DIFF
--- a/core/gui/src/app/workspace/component/result-panel/error-frame/error-frame.component.scss
+++ b/core/gui/src/app/workspace/component/result-panel/error-frame/error-frame.component.scss
@@ -22,8 +22,10 @@
   font-weight: 200;
   line-height: 14px;
   color: red;
+  overflow-x: auto;
   white-space: pre-line;
   margin-left: 30px;
+  user-select: text;
 }
 
 .error-category {

--- a/core/gui/src/app/workspace/component/result-panel/result-panel.component.scss
+++ b/core/gui/src/app/workspace/component/result-panel/result-panel.component.scss
@@ -45,6 +45,8 @@ $type-colors: (
 #content {
   overflow-y: auto;
   padding-top: 38px;
+  width: inherit;
+  height: inherit;
 }
 
 #result-buttons {

--- a/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.ts
+++ b/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.ts
@@ -188,7 +188,7 @@ export class ResultTableFrameComponent implements OnInit, OnChanges {
   }
 
   private adjustPageSizeBasedOnPanelSize(panelHeight: number) {
-    const rowHeight = 36;
+    const rowHeight = 39; // use the rendered height of a row.
     let extra: number;
 
     if (this.sinkStorageMode == "mongodb") {


### PR DESCRIPTION
This PR addresses issue #2886 by ensuring that the width and height of the panel content are inherited from the resizable panel. Additionally, it enables users to copy the content of error messages.

With the result panel now scrollable, this PR also adjusts the row height calculation in the result table to reduce glitches and improve overall display consistency.

Before:

https://github.com/user-attachments/assets/a184f520-5c68-4363-bc71-b90f1d5d0657

After:

https://github.com/user-attachments/assets/c59d0559-4c35-4fc2-a970-6d6700214c12

