### PR TITLE
Drop support for Python 3.8

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -86,7 +86,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
 
     steps:
       - name: Checkout Texera


### PR DESCRIPTION
This PR drops support for Python 3.8 as it has reached [end-of-life](https://endoflife.date/python).