### PR TITLE
Fix timeout on Python proxy server shutdown

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -86,7 +86,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        python-version: [ '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.9', '3.10', '3.11' ]
 
     steps:
       - name: Checkout Texera

--- a/core/amber/src/main/python/core/proxy/proxy_server.py
+++ b/core/amber/src/main/python/core/proxy/proxy_server.py
@@ -1,5 +1,4 @@
 import threading
-import time
 from functools import wraps
 from inspect import signature
 from typing import Callable, Dict, Iterator, Optional, Tuple

--- a/core/amber/src/main/python/core/proxy/proxy_server.py
+++ b/core/amber/src/main/python/core/proxy/proxy_server.py
@@ -298,8 +298,8 @@ class ProxyServer(FlightServerBase):
     def graceful_shutdown(self):
         """Shut down after a delay."""
         logger.debug("Server is shutting down...")
-        time.sleep(0.2)
-        self.shutdown()
+        super().shutdown()
+        logger.debug("Server is shutdown.")
 
     def get_port_number(self):
         return self._port_number

--- a/core/amber/src/main/python/core/runnables/test_network_receiver.py
+++ b/core/amber/src/main/python/core/runnables/test_network_receiver.py
@@ -30,7 +30,7 @@ class TestNetworkReceiver:
     def network_receiver(self, output_queue):
         network_receiver = NetworkReceiver(output_queue, host="localhost", port=5555)
         yield network_receiver
-        network_receiver._proxy_server.graceful_shutdown()
+        network_receiver.stop()
 
     class MockFlightMetadataReader:
         """
@@ -93,7 +93,7 @@ class TestNetworkReceiver:
             )
         )
 
-    @pytest.mark.timeout(2)
+    @pytest.mark.timeout(10)
     def test_network_receiver_can_receive_data_messages(
         self,
         data_payload,
@@ -109,7 +109,7 @@ class TestNetworkReceiver:
         assert len(element.payload.frame) == len(data_payload.frame)
         assert element.tag == worker_id
 
-    @pytest.mark.timeout(2)
+    @pytest.mark.timeout(10)
     def test_network_receiver_can_receive_data_messages_end_of_upstream(
         self,
         data_payload,
@@ -128,7 +128,7 @@ class TestNetworkReceiver:
         assert element.payload.frame == EndOfInputChannel()
         assert element.tag == worker_id
 
-    @pytest.mark.timeout(2)
+    @pytest.mark.timeout(10)
     def test_network_receiver_can_receive_control_messages(
         self,
         data_payload,


### PR DESCRIPTION
On macOS, the timeout (2s) will easily be reached when shutting down a proxy server (embedding an arrow flight RPC server). We want to keep the grace shutdown method as it will release all resources and connections before shutting down the server. However, the actual reason for such a time increase is unknown. Temporarily, we will increase the timeout to 10s to allow it to complete the gracefully shut down in tests.