### PR TITLE
Add Download Button to Dashboard Entry

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
@@ -1098,8 +1098,7 @@ class DatasetResource {
               }
             } catch {
               case e: IOException =>
-                // Log the error and continue with the next file
-                println(s"Error processing file: $zipEntryName - ${e.getMessage}")
+                throw new WebApplicationException(s"Error processing file: $zipEntryName", e)
             } finally {
               zipOutputStream.closeEntry()
             }

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
@@ -160,7 +160,7 @@
     <button
       nz-button
       nzType="text"
-      *ngIf="entry.type==='workflow'"
+      *ngIf="entry.type === 'workflow' || entry.type === 'dataset'"
       class="dropdown-item"
       title="Download"
       (click)="onClickDownload()">

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.ts
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.ts
@@ -17,13 +17,9 @@ import {
   WorkflowPersistService,
   DEFAULT_WORKFLOW_NAME,
 } from "src/app/common/service/workflow-persist/workflow-persist.service";
-import { Workflow } from "src/app/common/type/workflow";
-import { FileSaverService } from "src/app/dashboard/service/user/file/file-saver.service";
 import { firstValueFrom } from "rxjs";
 import { SearchService } from "../../../service/user/search.service";
 import { HubWorkflowDetailComponent } from "../../../../hub/component/workflow/detail/hub-workflow-detail.component";
-import { DatasetService } from "src/app/dashboard/service/user/dataset/dataset.service";
-import { NotificationService } from "src/app/common/service/notification/notification.service";
 import { DownloadService } from "src/app/dashboard/service/user/download/download.service";
 
 @UntilDestroy()
@@ -70,10 +66,7 @@ export class ListItemComponent implements OnInit, OnChanges {
     private searchService: SearchService,
     private modalService: NzModalService,
     private workflowPersistService: WorkflowPersistService,
-    private fileSaverService: FileSaverService,
     private modal: NzModalService,
-    private datasetService: DatasetService,
-    private notificationService: NotificationService,
     private downloadService: DownloadService
   ) {}
 

--- a/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -61,21 +61,21 @@ export class DatasetService {
     });
   }
 
-  private retrieveDatasetZip(params: HttpParams): Observable<Blob> {
+  public retrieveDatasetZip(options: { path?: string; did?: number }): Observable<Blob> {
+    let params = new HttpParams();
+
+    if (options.path) {
+      params = params.set("path", encodeURIComponent(options.path));
+    }
+    if (options.did) {
+      params = params.set("did", options.did.toString());
+      params = params.set("getLatest", "true");
+    }
+
     return this.http.get(`${AppSettings.getApiEndpoint()}/${DATASET_BASE_URL}/version-zip`, {
       params,
       responseType: "blob",
     });
-  }
-
-  public retrieveDatasetVersionZip(path: string): Observable<Blob> {
-    const params = new HttpParams().set("path", encodeURIComponent(path));
-    return this.retrieveDatasetZip(params);
-  }
-
-  public retrieveDatasetLatestVersionZip(did: number): Observable<Blob> {
-    const params = new HttpParams().set("getLatest", "true").set("did", did.toString());
-    return this.retrieveDatasetZip(params);
   }
 
   public retrieveAccessibleDatasets(

--- a/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -68,6 +68,12 @@ export class DatasetService {
     });
   }
 
+  public retrieveDatasetLatestVersionZip(did: number): Observable<Blob> {
+    return this.http.get(`${AppSettings.getApiEndpoint()}/${DATASET_BASE_URL}/${did}/latest-version-zip`, {
+      responseType: "blob",
+    });
+  }
+
   public retrieveAccessibleDatasets(
     includeVersions: boolean = false,
     includeFileNodes: boolean = false,

--- a/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -61,6 +61,13 @@ export class DatasetService {
     });
   }
 
+  /**
+   * Retrieves a zip file of a dataset or a specific path within a dataset.
+   * @param options An object containing optional parameters:
+   *   - path: A string representing a specific file or directory path within the dataset
+   *   - did: A number representing the dataset ID
+   * @returns An Observable that emits a Blob containing the zip file
+   */
   public retrieveDatasetZip(options: { path?: string; did?: number }): Observable<Blob> {
     let params = new HttpParams();
 

--- a/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -61,17 +61,21 @@ export class DatasetService {
     });
   }
 
-  public retrieveDatasetVersionZip(path: string): Observable<Blob> {
-    const encodedPath = encodeURIComponent(path);
-    return this.http.get(`${AppSettings.getApiEndpoint()}/${DATASET_BASE_URL}/version-zip?path=${encodedPath}`, {
+  private retrieveDatasetZip(params: HttpParams): Observable<Blob> {
+    return this.http.get(`${AppSettings.getApiEndpoint()}/${DATASET_BASE_URL}/version-zip`, {
+      params,
       responseType: "blob",
     });
   }
 
+  public retrieveDatasetVersionZip(path: string): Observable<Blob> {
+    const params = new HttpParams().set("path", encodeURIComponent(path));
+    return this.retrieveDatasetZip(params);
+  }
+
   public retrieveDatasetLatestVersionZip(did: number): Observable<Blob> {
-    return this.http.get(`${AppSettings.getApiEndpoint()}/${DATASET_BASE_URL}/${did}/latest-version-zip`, {
-      responseType: "blob",
-    });
+    const params = new HttpParams().set("getLatest", "true").set("did", did.toString());
+    return this.retrieveDatasetZip(params);
   }
 
   public retrieveAccessibleDatasets(

--- a/core/gui/src/app/dashboard/service/user/download/download.service.spec.ts
+++ b/core/gui/src/app/dashboard/service/user/download/download.service.spec.ts
@@ -1,0 +1,78 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { DownloadService } from './download.service';
+import { DatasetService } from '../dataset/dataset.service';
+import { FileSaverService } from '../file/file-saver.service';
+import { NotificationService } from '../../../../common/service/notification/notification.service';
+import { WorkflowPersistService } from '../../../../common/service/workflow-persist/workflow-persist.service';
+import { of, throwError } from 'rxjs';
+
+describe('DownloadService', () => {
+  let downloadService: DownloadService;
+  let datasetServiceSpy: jasmine.SpyObj<DatasetService>;
+  let fileSaverServiceSpy: jasmine.SpyObj<FileSaverService>;
+  let notificationServiceSpy: jasmine.SpyObj<NotificationService>;
+
+  beforeEach(() => {
+    const datasetSpy = jasmine.createSpyObj('DatasetService', ['retrieveDatasetVersionSingleFile']);
+    const fileSaverSpy = jasmine.createSpyObj('FileSaverService', ['saveAs']);
+    const notificationSpy = jasmine.createSpyObj('NotificationService', ['info', 'error']);
+    const workflowPersistSpy = jasmine.createSpyObj('WorkflowPersistService', ['getWorkflow']);
+
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [
+        DownloadService,
+        { provide: DatasetService, useValue: datasetSpy },
+        { provide: FileSaverService, useValue: fileSaverSpy },
+        { provide: NotificationService, useValue: notificationSpy },
+        { provide: WorkflowPersistService, useValue: workflowPersistSpy }
+      ]
+    });
+
+    downloadService = TestBed.inject(DownloadService);
+    datasetServiceSpy = TestBed.inject(DatasetService) as jasmine.SpyObj<DatasetService>;
+    fileSaverServiceSpy = TestBed.inject(FileSaverService) as jasmine.SpyObj<FileSaverService>;
+    notificationServiceSpy = TestBed.inject(NotificationService) as jasmine.SpyObj<NotificationService>;
+  });
+
+  it('should download a single file successfully', (done) => {
+    const filePath = 'test/file.txt';
+    const mockBlob = new Blob(['test content'], { type: 'text/plain' });
+    
+    datasetServiceSpy.retrieveDatasetVersionSingleFile.and.returnValue(of(mockBlob));
+
+    downloadService.downloadSingleFile(filePath).subscribe({
+      next: (blob) => {
+        expect(blob).toBe(mockBlob);
+        expect(datasetServiceSpy.retrieveDatasetVersionSingleFile).toHaveBeenCalledWith(filePath);
+        expect(fileSaverServiceSpy.saveAs).toHaveBeenCalledWith(mockBlob, 'file.txt');
+        expect(notificationServiceSpy.info).toHaveBeenCalledWith('File test/file.txt is downloading');
+        done();
+      },
+      error: () => {
+        fail('Should not have thrown an error');
+      }
+    });
+  });
+
+  it('should handle download failure correctly', (done) => {
+    const filePath = 'test/file.txt';
+    const errorMessage = 'Download failed';
+    
+    datasetServiceSpy.retrieveDatasetVersionSingleFile.and.returnValue(throwError(() => new Error(errorMessage)));
+
+    downloadService.downloadSingleFile(filePath).subscribe({
+      next: () => {
+        fail('Should have thrown an error');
+      },
+      error: (error) => {
+        expect(error).toBeTruthy();
+        expect(datasetServiceSpy.retrieveDatasetVersionSingleFile).toHaveBeenCalledWith(filePath);
+        expect(fileSaverServiceSpy.saveAs).not.toHaveBeenCalled();
+        expect(notificationServiceSpy.error).toHaveBeenCalledWith("Error downloading file 'test/file.txt'");
+        done();
+      }
+    });
+  });
+});

--- a/core/gui/src/app/dashboard/service/user/download/download.service.spec.ts
+++ b/core/gui/src/app/dashboard/service/user/download/download.service.spec.ts
@@ -1,23 +1,23 @@
-import { TestBed } from '@angular/core/testing';
-import { HttpClientTestingModule } from '@angular/common/http/testing';
-import { DownloadService } from './download.service';
-import { DatasetService } from '../dataset/dataset.service';
-import { FileSaverService } from '../file/file-saver.service';
-import { NotificationService } from '../../../../common/service/notification/notification.service';
-import { WorkflowPersistService } from '../../../../common/service/workflow-persist/workflow-persist.service';
-import { of, throwError } from 'rxjs';
+import { TestBed } from "@angular/core/testing";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { DownloadService } from "./download.service";
+import { DatasetService } from "../dataset/dataset.service";
+import { FileSaverService } from "../file/file-saver.service";
+import { NotificationService } from "../../../../common/service/notification/notification.service";
+import { WorkflowPersistService } from "../../../../common/service/workflow-persist/workflow-persist.service";
+import { of, throwError } from "rxjs";
 
-describe('DownloadService', () => {
+describe("DownloadService", () => {
   let downloadService: DownloadService;
   let datasetServiceSpy: jasmine.SpyObj<DatasetService>;
   let fileSaverServiceSpy: jasmine.SpyObj<FileSaverService>;
   let notificationServiceSpy: jasmine.SpyObj<NotificationService>;
 
   beforeEach(() => {
-    const datasetSpy = jasmine.createSpyObj('DatasetService', ['retrieveDatasetVersionSingleFile']);
-    const fileSaverSpy = jasmine.createSpyObj('FileSaverService', ['saveAs']);
-    const notificationSpy = jasmine.createSpyObj('NotificationService', ['info', 'error']);
-    const workflowPersistSpy = jasmine.createSpyObj('WorkflowPersistService', ['getWorkflow']);
+    const datasetSpy = jasmine.createSpyObj("DatasetService", ["retrieveDatasetVersionSingleFile"]);
+    const fileSaverSpy = jasmine.createSpyObj("FileSaverService", ["saveAs"]);
+    const notificationSpy = jasmine.createSpyObj("NotificationService", ["info", "error"]);
+    const workflowPersistSpy = jasmine.createSpyObj("WorkflowPersistService", ["getWorkflow"]);
 
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
@@ -26,8 +26,8 @@ describe('DownloadService', () => {
         { provide: DatasetService, useValue: datasetSpy },
         { provide: FileSaverService, useValue: fileSaverSpy },
         { provide: NotificationService, useValue: notificationSpy },
-        { provide: WorkflowPersistService, useValue: workflowPersistSpy }
-      ]
+        { provide: WorkflowPersistService, useValue: workflowPersistSpy },
+      ],
     });
 
     downloadService = TestBed.inject(DownloadService);
@@ -36,43 +36,43 @@ describe('DownloadService', () => {
     notificationServiceSpy = TestBed.inject(NotificationService) as jasmine.SpyObj<NotificationService>;
   });
 
-  it('should download a single file successfully', (done) => {
-    const filePath = 'test/file.txt';
-    const mockBlob = new Blob(['test content'], { type: 'text/plain' });
-    
+  it("should download a single file successfully", done => {
+    const filePath = "test/file.txt";
+    const mockBlob = new Blob(["test content"], { type: "text/plain" });
+
     datasetServiceSpy.retrieveDatasetVersionSingleFile.and.returnValue(of(mockBlob));
 
     downloadService.downloadSingleFile(filePath).subscribe({
-      next: (blob) => {
+      next: blob => {
         expect(blob).toBe(mockBlob);
         expect(datasetServiceSpy.retrieveDatasetVersionSingleFile).toHaveBeenCalledWith(filePath);
-        expect(fileSaverServiceSpy.saveAs).toHaveBeenCalledWith(mockBlob, 'file.txt');
-        expect(notificationServiceSpy.info).toHaveBeenCalledWith('File test/file.txt is downloading');
+        expect(fileSaverServiceSpy.saveAs).toHaveBeenCalledWith(mockBlob, "file.txt");
+        expect(notificationServiceSpy.info).toHaveBeenCalledWith("File test/file.txt is downloading");
         done();
       },
-      error: () => {
-        fail('Should not have thrown an error');
-      }
+      error: (error: unknown) => {
+        fail("Should not have thrown an error");
+      },
     });
   });
 
-  it('should handle download failure correctly', (done) => {
-    const filePath = 'test/file.txt';
-    const errorMessage = 'Download failed';
-    
+  it("should handle download failure correctly", done => {
+    const filePath = "test/file.txt";
+    const errorMessage = "Download failed";
+
     datasetServiceSpy.retrieveDatasetVersionSingleFile.and.returnValue(throwError(() => new Error(errorMessage)));
 
     downloadService.downloadSingleFile(filePath).subscribe({
       next: () => {
-        fail('Should have thrown an error');
+        fail("Should have thrown an error");
       },
-      error: (error) => {
+      error: (error: unknown) => {
         expect(error).toBeTruthy();
         expect(datasetServiceSpy.retrieveDatasetVersionSingleFile).toHaveBeenCalledWith(filePath);
         expect(fileSaverServiceSpy.saveAs).not.toHaveBeenCalled();
         expect(notificationServiceSpy.error).toHaveBeenCalledWith("Error downloading file 'test/file.txt'");
         done();
-      }
+      },
     });
   });
 });

--- a/core/gui/src/app/dashboard/service/user/download/download.service.ts
+++ b/core/gui/src/app/dashboard/service/user/download/download.service.ts
@@ -1,0 +1,78 @@
+import { Injectable } from "@angular/core";
+import { Observable, throwError } from "rxjs";
+import { map, tap, catchError } from "rxjs/operators";
+import { FileSaverService } from "../file/file-saver.service";
+import { NotificationService } from "../../../../common/service/notification/notification.service";
+import { DatasetService } from "../dataset/dataset.service";
+import { WorkflowPersistService } from "src/app/common/service/workflow-persist/workflow-persist.service";
+
+@Injectable({
+  providedIn: "root",
+})
+export class DownloadService {
+  constructor(
+    private fileSaverService: FileSaverService,
+    private notificationService: NotificationService,
+    private datasetService: DatasetService,
+    private workflowPersistService: WorkflowPersistService
+  ) {}
+
+  downloadWorkflow(id: number, name: string): Observable<{ blob: Blob; fileName: string }> {
+    return this.workflowPersistService.retrieveWorkflow(id).pipe(
+      map(({ wid, creationTime, lastModifiedTime, ...workflowCopy }) => {
+        const workflowJson = JSON.stringify({ ...workflowCopy, readonly: false });
+        const fileName = `${name}.json`;
+        const blob = new Blob([workflowJson], { type: "text/plain;charset=utf-8" });
+        return { blob, fileName };
+      }),
+      tap(({ blob, fileName }) => this.fileSaverService.saveAs(blob, fileName))
+    );
+  }
+
+  downloadDataset(id: number, name: string): Observable<Blob> {
+    return this.downloadWithNotification(
+      () => this.datasetService.retrieveDatasetLatestVersionZip(id),
+      `${name}.zip`,
+      "The latest version of the dataset is downloading as ZIP",
+      "Error downloading the latest version of the dataset as ZIP"
+    );
+  }
+
+  downloadDatasetVersion(versionPath: string, datasetName: string, versionName: string): Observable<Blob> {
+    return this.downloadWithNotification(
+      () => this.datasetService.retrieveDatasetVersionZip(versionPath),
+      `${datasetName}-${versionName}.zip`,
+      `Version ${versionName} is downloading as ZIP`,
+      `Error downloading version '${versionName}' as ZIP`
+    );
+  }
+
+  downloadSingleFile(filePath: string): Observable<Blob> {
+    const DEFAULT_FILE_NAME = "download";
+    const fileName = filePath.split("/").pop() || DEFAULT_FILE_NAME;
+    return this.downloadWithNotification(
+      () => this.datasetService.retrieveDatasetVersionSingleFile(filePath),
+      fileName,
+      `File ${filePath} is downloading`,
+      `Error downloading file '${filePath}'`
+    );
+  }
+
+  private downloadWithNotification(
+    retrieveFunction: () => Observable<Blob>,
+    fileName: string,
+    successMessage: string,
+    errorMessage: string
+  ): Observable<Blob> {
+    return retrieveFunction().pipe(
+      tap(blob => {
+        this.fileSaverService.saveAs(blob, fileName);
+        this.notificationService.info(successMessage);
+      }),
+      catchError((error: Error) => {
+        this.notificationService.error(errorMessage);
+        return throwError(() => error);
+      })
+    );
+  }
+}

--- a/core/gui/src/app/dashboard/service/user/download/download.service.ts
+++ b/core/gui/src/app/dashboard/service/user/download/download.service.ts
@@ -31,7 +31,7 @@ export class DownloadService {
 
   downloadDataset(id: number, name: string): Observable<Blob> {
     return this.downloadWithNotification(
-      () => this.datasetService.retrieveDatasetLatestVersionZip(id),
+      () => this.datasetService.retrieveDatasetZip({ did: id }),
       `${name}.zip`,
       "The latest version of the dataset is downloading as ZIP",
       "Error downloading the latest version of the dataset as ZIP"
@@ -40,7 +40,7 @@ export class DownloadService {
 
   downloadDatasetVersion(versionPath: string, datasetName: string, versionName: string): Observable<Blob> {
     return this.downloadWithNotification(
-      () => this.datasetService.retrieveDatasetVersionZip(versionPath),
+      () => this.datasetService.retrieveDatasetZip({ path: versionPath }),
       `${datasetName}-${versionName}.zip`,
       `Version ${versionName} is downloading as ZIP`,
       `Error downloading version '${versionName}' as ZIP`

--- a/core/gui/src/app/dashboard/service/user/download/download.service.ts
+++ b/core/gui/src/app/dashboard/service/user/download/download.service.ts
@@ -69,7 +69,7 @@ export class DownloadService {
         this.fileSaverService.saveAs(blob, fileName);
         this.notificationService.info(successMessage);
       }),
-      catchError((error: Error) => {
+      catchError((error: unknown) => {
         this.notificationService.error(errorMessage);
         return throwError(() => error);
       })

--- a/core/gui/src/app/dashboard/service/user/file/file-saver.service.ts
+++ b/core/gui/src/app/dashboard/service/user/file/file-saver.service.ts
@@ -5,7 +5,7 @@ import * as FileSaver from "file-saver";
   providedIn: "root",
 })
 export class FileSaverService {
-  saveAs(data: Blob | string, filename?: string, options?: FileSaver.FileSaverOptions): void {
+  saveAs = (data: Blob | string, filename?: string, options?: FileSaver.FileSaverOptions): void => {
     FileSaver.saveAs(data, filename, options);
-  }
+  };
 }

--- a/core/gui/src/app/dashboard/service/user/file/file-saver.service.ts
+++ b/core/gui/src/app/dashboard/service/user/file/file-saver.service.ts
@@ -5,7 +5,7 @@ import * as FileSaver from "file-saver";
   providedIn: "root",
 })
 export class FileSaverService {
-  saveAs = (data: Blob | string, filename?: string, options?: FileSaver.FileSaverOptions): void => {
+  saveAs(data: Blob | string, filename?: string, options?: FileSaver.FileSaverOptions): void {
     FileSaver.saveAs(data, filename, options);
-  };
+  }
 }

--- a/core/gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.spec.ts
+++ b/core/gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.spec.ts
@@ -172,7 +172,7 @@ describe("WorkflowResultExportService", () => {
     resultServiceSpy.getCurrentResultSnapshot.and.returnValue(resultSnapshot);
 
     // Spy on the 'saveAs' method and capture the arguments when it's called
-    fileSaverServiceSpy.saveAs.and.callFake((blob: Blob, filename: string) => {
+    fileSaverServiceSpy.saveAs.and.callFake((data: Blob | string, filename?: string) => {
       expect(filename).toBe("result_operator2_1.html");
 
       const reader = new FileReader();
@@ -181,7 +181,7 @@ describe("WorkflowResultExportService", () => {
         expect(content).toBe("<html><body><p>Visualization</p></body></html>");
         done();
       };
-      reader.readAsText(blob);
+      reader.readAsText(data as Blob);
     });
 
     // Act
@@ -212,10 +212,10 @@ describe("WorkflowResultExportService", () => {
     resultServiceSpy.getCurrentResultSnapshot.and.returnValue(resultSnapshot);
 
     // Spy on the 'saveAs' method and capture the arguments when it's called
-    fileSaverServiceSpy.saveAs.and.callFake((blob: Blob, filename: string) => {
+    fileSaverServiceSpy.saveAs.and.callFake((data: Blob | string, filename?: string) => {
       expect(filename).toBe("results_workflow1_Test Workflow.zip");
 
-      JSZip.loadAsync(blob).then(zip => {
+      JSZip.loadAsync(data).then(zip => {
         expect(Object.keys(zip.files)).toContain("result_operator2_1.html");
         expect(Object.keys(zip.files)).toContain("result_operator2_2.html");
 


### PR DESCRIPTION
This PR introduces a download button to the dashboard, allowing users to easily download the dataset associated with a given entry. Upon clicking the button, users will receive the latest version of the dataset, conveniently compressed into a zip file, ready for download to their local environment.

The related issue: #2905 


https://github.com/user-attachments/assets/421cd811-34d2-45f2-bc77-8eded2e29b49




