### PR TITLE
Fix Directory Handling in Dataset Download and Add Start Notification for Large File Downloads

### DIFF
--- a/core/gui/src/app/dashboard/service/user/download/download.service.spec.ts
+++ b/core/gui/src/app/dashboard/service/user/download/download.service.spec.ts
@@ -14,7 +14,10 @@ describe("DownloadService", () => {
   let notificationServiceSpy: jasmine.SpyObj<NotificationService>;
 
   beforeEach(() => {
-    const datasetSpy = jasmine.createSpyObj("DatasetService", ["retrieveDatasetVersionSingleFile"]);
+    const datasetSpy = jasmine.createSpyObj("DatasetService", [
+      "retrieveDatasetVersionSingleFile",
+      "retrieveDatasetZip", // Add this method to the spy
+    ]);
     const fileSaverSpy = jasmine.createSpyObj("FileSaverService", ["saveAs"]);
     const notificationSpy = jasmine.createSpyObj("NotificationService", ["info", "error"]);
     const workflowPersistSpy = jasmine.createSpyObj("WorkflowPersistService", ["getWorkflow"]);
@@ -45,9 +48,10 @@ describe("DownloadService", () => {
     downloadService.downloadSingleFile(filePath).subscribe({
       next: blob => {
         expect(blob).toBe(mockBlob);
+        expect(notificationServiceSpy.info).toHaveBeenCalledWith("Starting to download file test/file.txt");
         expect(datasetServiceSpy.retrieveDatasetVersionSingleFile).toHaveBeenCalledWith(filePath);
         expect(fileSaverServiceSpy.saveAs).toHaveBeenCalledWith(mockBlob, "file.txt");
-        expect(notificationServiceSpy.info).toHaveBeenCalledWith("File test/file.txt is downloading");
+        expect(notificationServiceSpy.info).toHaveBeenCalledWith("File test/file.txt has been downloaded");
         done();
       },
       error: (error: unknown) => {
@@ -68,9 +72,108 @@ describe("DownloadService", () => {
       },
       error: (error: unknown) => {
         expect(error).toBeTruthy();
+        expect(notificationServiceSpy.info).toHaveBeenCalledWith("Starting to download file test/file.txt");
         expect(datasetServiceSpy.retrieveDatasetVersionSingleFile).toHaveBeenCalledWith(filePath);
         expect(fileSaverServiceSpy.saveAs).not.toHaveBeenCalled();
         expect(notificationServiceSpy.error).toHaveBeenCalledWith("Error downloading file 'test/file.txt'");
+        done();
+      },
+    });
+  });
+
+  it("should download a dataset successfully", done => {
+    const datasetId = 1;
+    const datasetName = "TestDataset";
+    const mockBlob = new Blob(["dataset content"], { type: "application/zip" });
+
+    datasetServiceSpy.retrieveDatasetZip.and.returnValue(of(mockBlob));
+
+    downloadService.downloadDataset(datasetId, datasetName).subscribe({
+      next: blob => {
+        expect(blob).toBe(mockBlob);
+        expect(notificationServiceSpy.info).toHaveBeenCalledWith(
+          "Starting to download the latest version of the dataset as ZIP"
+        );
+        expect(datasetServiceSpy.retrieveDatasetZip).toHaveBeenCalledWith({ did: datasetId });
+        expect(fileSaverServiceSpy.saveAs).toHaveBeenCalledWith(mockBlob, "TestDataset.zip");
+        expect(notificationServiceSpy.info).toHaveBeenCalledWith(
+          "The latest version of the dataset has been downloaded as ZIP"
+        );
+        done();
+      },
+      error: (error: unknown) => {
+        fail("Should not have thrown an error");
+      },
+    });
+  });
+
+  it("should handle dataset download failure correctly", done => {
+    const datasetId = 1;
+    const datasetName = "TestDataset";
+    const errorMessage = "Dataset download failed";
+
+    datasetServiceSpy.retrieveDatasetZip.and.returnValue(throwError(() => new Error(errorMessage)));
+
+    downloadService.downloadDataset(datasetId, datasetName).subscribe({
+      next: () => {
+        fail("Should have thrown an error");
+      },
+      error: (error: unknown) => {
+        expect(error).toBeTruthy();
+        expect(notificationServiceSpy.info).toHaveBeenCalledWith(
+          "Starting to download the latest version of the dataset as ZIP"
+        );
+        expect(datasetServiceSpy.retrieveDatasetZip).toHaveBeenCalledWith({ did: datasetId });
+        expect(fileSaverServiceSpy.saveAs).not.toHaveBeenCalled();
+        expect(notificationServiceSpy.error).toHaveBeenCalledWith(
+          "Error downloading the latest version of the dataset as ZIP"
+        );
+        done();
+      },
+    });
+  });
+
+  it("should download a dataset version successfully", done => {
+    const versionPath = "path/to/version";
+    const datasetName = "TestDataset";
+    const versionName = "v1.0";
+    const mockBlob = new Blob(["version content"], { type: "application/zip" });
+
+    datasetServiceSpy.retrieveDatasetZip.and.returnValue(of(mockBlob));
+
+    downloadService.downloadDatasetVersion(versionPath, datasetName, versionName).subscribe({
+      next: blob => {
+        expect(blob).toBe(mockBlob);
+        expect(notificationServiceSpy.info).toHaveBeenCalledWith("Starting to download version v1.0 as ZIP");
+        expect(datasetServiceSpy.retrieveDatasetZip).toHaveBeenCalledWith({ path: versionPath });
+        expect(fileSaverServiceSpy.saveAs).toHaveBeenCalledWith(mockBlob, "TestDataset-v1.0.zip");
+        expect(notificationServiceSpy.info).toHaveBeenCalledWith("Version v1.0 has been downloaded as ZIP");
+        done();
+      },
+      error: (error: unknown) => {
+        fail("Should not have thrown an error");
+      },
+    });
+  });
+
+  it("should handle dataset version download failure correctly", done => {
+    const versionPath = "path/to/version";
+    const datasetName = "TestDataset";
+    const versionName = "v1.0";
+    const errorMessage = "Dataset version download failed";
+
+    datasetServiceSpy.retrieveDatasetZip.and.returnValue(throwError(() => new Error(errorMessage)));
+
+    downloadService.downloadDatasetVersion(versionPath, datasetName, versionName).subscribe({
+      next: () => {
+        fail("Should have thrown an error");
+      },
+      error: (error: unknown) => {
+        expect(error).toBeTruthy();
+        expect(notificationServiceSpy.info).toHaveBeenCalledWith("Starting to download version v1.0 as ZIP");
+        expect(datasetServiceSpy.retrieveDatasetZip).toHaveBeenCalledWith({ path: versionPath });
+        expect(fileSaverServiceSpy.saveAs).not.toHaveBeenCalled();
+        expect(notificationServiceSpy.error).toHaveBeenCalledWith("Error downloading version 'v1.0' as ZIP");
         done();
       },
     });

--- a/core/gui/src/app/dashboard/service/user/download/download.service.ts
+++ b/core/gui/src/app/dashboard/service/user/download/download.service.ts
@@ -33,7 +33,8 @@ export class DownloadService {
     return this.downloadWithNotification(
       () => this.datasetService.retrieveDatasetZip({ did: id }),
       `${name}.zip`,
-      "The latest version of the dataset is downloading as ZIP",
+      "Starting to download the latest version of the dataset as ZIP",
+      "The latest version of the dataset has been downloaded as ZIP",
       "Error downloading the latest version of the dataset as ZIP"
     );
   }
@@ -42,7 +43,8 @@ export class DownloadService {
     return this.downloadWithNotification(
       () => this.datasetService.retrieveDatasetZip({ path: versionPath }),
       `${datasetName}-${versionName}.zip`,
-      `Version ${versionName} is downloading as ZIP`,
+      `Starting to download version ${versionName} as ZIP`,
+      `Version ${versionName} has been downloaded as ZIP`,
       `Error downloading version '${versionName}' as ZIP`
     );
   }
@@ -53,7 +55,8 @@ export class DownloadService {
     return this.downloadWithNotification(
       () => this.datasetService.retrieveDatasetVersionSingleFile(filePath),
       fileName,
-      `File ${filePath} is downloading`,
+      `Starting to download file ${filePath}`,
+      `File ${filePath} has been downloaded`,
       `Error downloading file '${filePath}'`
     );
   }
@@ -61,9 +64,11 @@ export class DownloadService {
   private downloadWithNotification(
     retrieveFunction: () => Observable<Blob>,
     fileName: string,
+    startMessage: string,
     successMessage: string,
     errorMessage: string
   ): Observable<Blob> {
+    this.notificationService.info(startMessage);
     return retrieveFunction().pipe(
       tap(blob => {
         this.fileSaverService.saveAs(blob, fileName);


### PR DESCRIPTION
This PR addresses two issues related to downloading datasets as zip files:

1. Fix Directory Download Issue:

Previously, directories within a dataset were being downloaded as empty files. This PR resolves that issue by ensuring directories are properly handled and their contents are included in the zip file during the download process.

2. Add Start Notification for Large Downloads:

While testing with a large file inside a folder, I discovered that the notification indicating the start of the download process was missing. To improve user experience, I added a frontend notification that informs users when the download has started, especially useful for large files.

https://github.com/user-attachments/assets/2224d01d-a8a6-43aa-83e8-58a98d3f4d28
