### PR TITLE
Add micro-services sbt root project

### DIFF
--- a/core/micro-services/build.sbt
+++ b/core/micro-services/build.sbt
@@ -1,0 +1,21 @@
+// root project definition
+lazy val MicroServices = (project in file("."))
+  .aggregate(TexeraWorkflowCompilingService) // Add all subprojects
+  .settings(
+    name := "micro-services",
+    version := "0.1.0"
+  )
+
+// The template of the subproject: TexeraWorkflowCompilingService(as an example)
+// lazy val TexeraWorkflowCompilingService = (project in file("texera-workflow-compiling-service"))
+//  .settings(
+//    name := "TexeraWorkflowCompilingService",
+//    version := "0.1.0"
+//    libraryDependencies ++= Seq(
+//      "io.dropwizard" % "dropwizard-core" % "4.0.7",
+//      "com.typesafe" % "config" % "1.4.1",
+//      "com.fasterxml.jackson.core" % "jackson-databind" % "2.17.2",       // Jackson Databind for JSON processing
+//      "com.fasterxml.jackson.core" % "jackson-annotations" % "2.17.2",    // Jackson Annotations for JSON properties
+//      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.17.2" // Jackson Scala module
+//    )
+//  )

--- a/core/micro-services/build.sbt
+++ b/core/micro-services/build.sbt
@@ -1,15 +1,14 @@
 // root project definition
 lazy val MicroServices = (project in file("."))
-  .aggregate(TexeraWorkflowCompilingService) // Add all subprojects
   .settings(
     name := "micro-services",
     version := "0.1.0"
   )
 
-// The template of the subproject: TexeraWorkflowCompilingService(as an example)
-// lazy val TexeraWorkflowCompilingService = (project in file("texera-workflow-compiling-service"))
+// The template of the subproject: WorkflowCompilingService(as an example)
+// lazy val WorkflowCompilingService = (project in file("workflow-compiling-service"))
 //  .settings(
-//    name := "TexeraWorkflowCompilingService",
+//    name := "WorkflowCompilingService",
 //    version := "0.1.0"
 //    libraryDependencies ++= Seq(
 //      "io.dropwizard" % "dropwizard-core" % "4.0.7",
@@ -19,3 +18,4 @@ lazy val MicroServices = (project in file("."))
 //      "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.17.2" // Jackson Scala module
 //    )
 //  )
+// once this subproject is defined, aggregate it to the MicroServices definition


### PR DESCRIPTION
This PR adds the `micro-services` directory and `build.sbt` under it. We plan to gradually migrate our backend services in `core/amber` into several sub-projets under `micro-services`.

Once the migration is finished, the directory structure of `micro-services` should look like this:

```
micro-services // root project
     workflow-core ---> workflow-related models
     workflow-executing-service ---> workflow execution
     workflow-compiling-service ---> workflow editing
     language-services
     share-editing-service
     auth-service ---> authentication
     community-service ---> community dashboard
```

