### PR TITLE
Fix email notification without usersys

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
@@ -44,12 +44,15 @@ class WorkflowExecutionService(
 
   val wsInput = new WebsocketInput(errorHandler)
 
-  private val emailNotificationService =userEmailOpt.map(email=> new EmailNotificationService(new WorkflowEmailNotifier(
-    workflowContext.workflowId.id,
-    email,
-    sessionUri
-  )))
-
+  private val emailNotificationService = userEmailOpt.map(email =>
+    new EmailNotificationService(
+      new WorkflowEmailNotifier(
+        workflowContext.workflowId.id,
+        email,
+        sessionUri
+      )
+    )
+  )
 
   addSubscription(
     executionStateStore.metadataStore.registerDiffHandler((oldState, newState) => {
@@ -146,7 +149,7 @@ class WorkflowExecutionService(
       executionStatsService.unsubscribeAll()
       executionReconfigurationService.unsubscribeAll()
     }
-    if (emailNotificationService.nonEmpty){
+    if (emailNotificationService.nonEmpty) {
       emailNotificationService.get.shutdown()
     }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/OperatorMetadataGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/OperatorMetadataGenerator.scala
@@ -10,6 +10,7 @@ import edu.uci.ics.amber.engine.common.Utils.objectMapper
 import edu.uci.ics.texera.workflow.common.operators.LogicalOp
 import edu.uci.ics.amber.engine.common.workflow.{InputPort, OutputPort}
 import edu.uci.ics.texera.workflow.operators.source.scan.csv.CSVScanSourceOpDesc
+import edu.uci.ics.texera.workflow.operators.udf.python.source.PythonUDFSourceOpDescV2
 
 import java.util
 import scala.jdk.CollectionConverters.{IteratorHasAsScala, ListHasAsScala}
@@ -78,7 +79,7 @@ object OperatorMetadataGenerator {
   def main(args: Array[String]): Unit = {
     // run this if you want to check the json schema generated for an operator descriptor
     // replace the argument with the class of your operator descriptor
-    println(generateOperatorJsonSchema(classOf[CSVScanSourceOpDesc]).toPrettyString)
+    println(generateOperatorJsonSchema(classOf[PythonUDFSourceOpDescV2]).toPrettyString)
   }
 
   def generateOperatorJsonSchema(opDescClass: Class[_ <: LogicalOp]): JsonNode = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/OperatorMetadataGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/metadata/OperatorMetadataGenerator.scala
@@ -10,7 +10,6 @@ import edu.uci.ics.amber.engine.common.Utils.objectMapper
 import edu.uci.ics.texera.workflow.common.operators.LogicalOp
 import edu.uci.ics.amber.engine.common.workflow.{InputPort, OutputPort}
 import edu.uci.ics.texera.workflow.operators.source.scan.csv.CSVScanSourceOpDesc
-import edu.uci.ics.texera.workflow.operators.udf.python.source.PythonUDFSourceOpDescV2
 
 import java.util
 import scala.jdk.CollectionConverters.{IteratorHasAsScala, ListHasAsScala}
@@ -79,7 +78,7 @@ object OperatorMetadataGenerator {
   def main(args: Array[String]): Unit = {
     // run this if you want to check the json schema generated for an operator descriptor
     // replace the argument with the class of your operator descriptor
-    println(generateOperatorJsonSchema(classOf[PythonUDFSourceOpDescV2]).toPrettyString)
+    println(generateOperatorJsonSchema(classOf[CSVScanSourceOpDesc]).toPrettyString)
   }
 
   def generateOperatorJsonSchema(opDescClass: Class[_ <: LogicalOp]): JsonNode = {


### PR DESCRIPTION
When there is no user-sys (or, no user email is provided), the execution service would fail. This PR fixes so that it does not create EmailNotification when no user email is provided.