### PR TITLE
Add Check for Python Language Server Availability

### DIFF
--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -564,17 +564,20 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
           },
         },
       };
-      if (this.language === "python") {
-        userConfig.languageClientConfig = {
-          languageId: "python",
-          options: {
-            $type: "WebSocketUrl",
-            url: getWebsocketUrl("/python-language-server", "3000"),
-          },
-        };
-      }
+      
+      from(this.checkPythonLanguageServerAvailability()).subscribe(isServerAvailable => {
+        if (isServerAvailable && this.language === "python") {
+          userConfig.languageClientConfig = {
+            languageId: "python",
+            options: {
+              $type: "WebSocketUrl",
+              url: getWebsocketUrl("/python-language-server", "3000"),
+            },
+          };
+        }
 
-      this.wrapper.initAndStart(userConfig, this.editorElement.nativeElement);
+        this.wrapper!.initAndStart(userConfig, this.editorElement.nativeElement);
+      });
     }
   }
 

--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -199,18 +199,18 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
   private checkPythonLanguageServerAvailability(): Promise<boolean> {
     return new Promise(resolve => {
       const socket = new WebSocket(getWebsocketUrl("/python-language-server", "3000"));
-  
+
       socket.onopen = () => {
         socket.close();
         resolve(true);
       };
-  
+
       socket.onerror = () => {
         resolve(false);
       };
     });
   }
-  
+
   /**
    * Create a Monaco editor and connect it to MonacoBinding.
    * @private
@@ -237,8 +237,8 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
             },
           },
         },
-      }
-  
+      };
+
       from(this.checkPythonLanguageServerAvailability()).subscribe(isServerAvailable => {
         if (isServerAvailable && this.language === "python") {
           userConfig.languageClientConfig = {
@@ -249,7 +249,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
             },
           };
         }
-  
+
         from(this.wrapper!.initAndStart(userConfig, this.editorElement.nativeElement))
           .pipe(takeUntil(this.componentDestroy))
           .subscribe({

--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -576,19 +576,21 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
         },
       };
 
-      from(this.checkPythonLanguageServerAvailability()).subscribe(isServerAvailable => {
-        if (isServerAvailable && this.language === "python") {
-          userConfig.languageClientConfig = {
-            languageId: "python",
-            options: {
-              $type: "WebSocketUrl",
-              url: getWebsocketUrl("/python-language-server", "3000"),
-            },
-          };
-        }
+      from(this.checkPythonLanguageServerAvailability())
+        .pipe(takeUntil(this.componentDestroy))
+        .subscribe(isServerAvailable => {
+          if (isServerAvailable && this.language === "python") {
+            userConfig.languageClientConfig = {
+              languageId: "python",
+              options: {
+                $type: "WebSocketUrl",
+                url: getWebsocketUrl("/python-language-server", "3000"),
+              },
+            };
+          }
 
-        this.wrapper!.initAndStart(userConfig, this.editorElement.nativeElement);
-      });
+          this.wrapper!.initAndStart(userConfig, this.editorElement.nativeElement);
+        });
     }
   }
 

--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -200,13 +200,11 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
     return new Promise(resolve => {
       const socket = new WebSocket(getWebsocketUrl("/python-language-server", "3000"));
   
-      // 连接成功的情况下，服务器在线
       socket.onopen = () => {
         socket.close();
         resolve(true);
       };
   
-      // 连接失败的情况下，服务器不在线
       socket.onerror = () => {
         resolve(false);
       };
@@ -241,7 +239,6 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
         },
       }
   
-      // 将 Promise 转换为 Observable，然后使用 subscribe 来处理
       from(this.checkPythonLanguageServerAvailability()).subscribe(isServerAvailable => {
         if (isServerAvailable && this.language === "python") {
           userConfig.languageClientConfig = {
@@ -253,7 +250,6 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
           };
         }
   
-        // 初始化Monaco编辑器
         from(this.wrapper!.initAndStart(userConfig, this.editorElement.nativeElement))
           .pipe(takeUntil(this.componentDestroy))
           .subscribe({


### PR DESCRIPTION
This PR introduces a new method to check the availability of the Python language server before initializing the Monaco editor. This ensures that the Monaco editor's language client is configured correctly depending on the server's availability.

fix issue: #2929 