### PR TITLE
Fix Workflow Version Restore Button Behavior

### DIFF
--- a/core/gui/src/app/dashboard/service/user/workflow-version/workflow-version.service.spec.ts
+++ b/core/gui/src/app/dashboard/service/user/workflow-version/workflow-version.service.spec.ts
@@ -1,0 +1,41 @@
+import { TestBed } from "@angular/core/testing";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { WorkflowVersionService } from "./workflow-version.service";
+import { WorkflowActionService } from "src/app/workspace/service/workflow-graph/model/workflow-action.service";
+import { OperatorMetadataService } from "src/app/workspace/service/operator-metadata/operator-metadata.service";
+
+describe("WorkflowVersionService", () => {
+  let service: WorkflowVersionService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [WorkflowVersionService, WorkflowActionService, OperatorMetadataService],
+    });
+    service = TestBed.inject(WorkflowVersionService);
+  });
+
+  describe("canRestoreVersion", () => {
+    it("should return true when modificationEnabledBeforeTempWorkflow is true", () => {
+      // Arrange
+      service["modificationEnabledBeforeTempWorkflow"] = true;
+
+      // Act
+      const result = service.canRestoreVersion;
+
+      // Assert
+      expect(result).toBe(true);
+    });
+
+    it("should return false when modificationEnabledBeforeTempWorkflow is undefined", () => {
+      // Arrange
+      service["modificationEnabledBeforeTempWorkflow"] = undefined;
+
+      // Act
+      const result = service.canRestoreVersion;
+
+      // Assert
+      expect(result).toBe(false);
+    });
+  });
+});

--- a/core/gui/src/app/workspace/component/menu/menu.component.html
+++ b/core/gui/src/app/workspace/component/menu/menu.component.html
@@ -41,7 +41,7 @@
           *ngIf="displayParticularWorkflowVersion"
           nz-button
           nzType="primary"
-          [disabled]="!workflowVersionService.modificationEnabledBeforeTempWorkflow"
+          [disabled]="!workflowVersionService.canRestoreVersion"
           (click)="revertToVersion()"
           style="width: 160px">
           Restore this version


### PR DESCRIPTION
This PR addresses an issue with the workflow version restore button, which exhibited unexpected behavior. The observed symptom was as follows:
- When clicking on an old version A, the "Restore this version" button was enabled as expected.
- However, upon clicking a different old version B immediately after, the "Restore this version" button became disabled, even though it should remain enabled.

This PR ensures the "Restore this version" button behaves correctly:
- The button stays enabled when multiple old versions are clicked consecutively, as long as workflow modification is allowed.
- The button is disabled only if workflow modifications were previously disabled (e.g., after pausing the workflow).

With this fix, the restore button will remain active across multiple version selections unless explicitly disabled due to workflow state.

https://github.com/user-attachments/assets/ec27629d-1bb4-4eed-8580-ad23d5877a24


