### PR TITLE
Retrieve Schema from Backend to Fix Binary Data Issues

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/model/websocket/event/PaginatedResultEvent.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/model/websocket/event/PaginatedResultEvent.scala
@@ -1,11 +1,16 @@
 package edu.uci.ics.texera.web.model.websocket.event
 
 import com.fasterxml.jackson.databind.node.ObjectNode
+import edu.uci.ics.amber.engine.common.model.tuple.Attribute
 import edu.uci.ics.texera.web.model.websocket.request.ResultPaginationRequest
 
 object PaginatedResultEvent {
-  def apply(req: ResultPaginationRequest, table: List[ObjectNode]): PaginatedResultEvent = {
-    PaginatedResultEvent(req.requestID, req.operatorID, req.pageIndex, table)
+  def apply(
+      req: ResultPaginationRequest,
+      table: List[ObjectNode],
+      schema: List[Attribute]
+  ): PaginatedResultEvent = {
+    PaginatedResultEvent(req.requestID, req.operatorID, req.pageIndex, table, schema)
   }
 }
 
@@ -13,5 +18,6 @@ case class PaginatedResultEvent(
     requestID: String,
     operatorID: String,
     pageIndex: Int,
-    table: List[ObjectNode]
+    table: List[ObjectNode],
+    schema: List[Attribute]
 ) extends TexeraWebSocketEvent

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
@@ -330,7 +330,10 @@ class ExecutionResultService(
     val mappedResults = paginationIterable
       .map(tuple => tuple.asKeyValuePairJson())
       .toList
-    PaginatedResultEvent.apply(request, mappedResults)
+    val attributes = paginationIterable.headOption
+      .map(_.getSchema.getAttributes)
+      .getOrElse(List.empty)
+    PaginatedResultEvent.apply(request, mappedResults, attributes)
   }
 
   private def onResultUpdate(): Unit = {

--- a/core/gui/src/app/workspace/component/result-panel/result-panel-modal.component.ts
+++ b/core/gui/src/app/workspace/component/result-panel/result-panel-modal.component.ts
@@ -45,7 +45,7 @@ export class RowModalComponent implements OnChanges {
       ?.selectTuple(this.rowIndex, this.resizeService.pageSize)
       .pipe(untilDestroyed(this))
       .subscribe(res => {
-        this.currentDisplayRowData = trimDisplayJsonData(res, PRETTY_JSON_TEXT_LIMIT);
+        this.currentDisplayRowData = trimDisplayJsonData(res.tuple, res.schema, PRETTY_JSON_TEXT_LIMIT);
       });
   }
 }

--- a/core/gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.spec.ts
+++ b/core/gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.spec.ts
@@ -116,18 +116,30 @@ describe("WorkflowResultExportService", () => {
         operatorID: "operator1",
         pageIndex: 0,
         table: Array.from({ length: 10 }, (_, i) => ({ column1: `value${i}`, column2: `value${i}` })),
+        schema: [
+          { attributeName: "column1", attributeType: "string" },
+          { attributeName: "column2", attributeType: "string" },
+        ],
       },
       {
         requestID: "request1",
         operatorID: "operator1",
         pageIndex: 1,
         table: Array.from({ length: 10 }, (_, i) => ({ column1: `value${i + 10}`, column2: `value${i + 10}` })),
+        schema: [
+          { attributeName: "column1", attributeType: "string" },
+          { attributeName: "column2", attributeType: "string" },
+        ],
       },
       {
         requestID: "request1",
         operatorID: "operator1",
         pageIndex: 2,
         table: [{ column1: "value20", column2: "value20" }],
+        schema: [
+          { attributeName: "column1", attributeType: "string" },
+          { attributeName: "column2", attributeType: "string" },
+        ],
       },
     ];
 

--- a/core/gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
+++ b/core/gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
@@ -13,7 +13,6 @@ import { filter } from "rxjs/operators";
 import { OperatorResultService, WorkflowResultService } from "../workflow-result/workflow-result.service";
 import { OperatorPaginationResultService } from "../workflow-result/workflow-result.service";
 import { DownloadService } from "../../../dashboard/service/user/download/download.service";
-import { isBase64, isBinary } from "src/app/common/util/json";
 import { Buffer } from "buffer";
 
 @Injectable({
@@ -180,12 +179,11 @@ export class WorkflowResultExportService {
   private processBinaryDataColumns(row: any, binaryDataColumns: Set<string>, folderName: string, zip: JSZip): void {
     binaryDataColumns.forEach(name => {
       const binaryData = row[name];
-      if (typeof binaryData === "string" && (isBase64(binaryData) || isBinary(binaryData))) {
-        const blob = this.base64ToBlob(binaryData);
-        zip.folder(folderName)?.file(name, blob);
-      } else {
-        console.warn(`Invalid binary data for column ${name} in ${folderName}`);
+      if (binaryData === null) {
+        return;
       }
+      const blob = this.base64ToBlob(binaryData);
+      zip.folder(folderName)?.file(name, blob);
     });
   }
 

--- a/core/gui/src/app/workspace/service/workflow-result/workflow-result.service.spec.ts
+++ b/core/gui/src/app/workspace/service/workflow-result/workflow-result.service.spec.ts
@@ -1,6 +1,8 @@
 import { TestBed } from "@angular/core/testing";
-
-import { WorkflowResultService } from "./workflow-result.service";
+import { WorkflowResultService, OperatorPaginationResultService } from "./workflow-result.service";
+import { WorkflowWebsocketService } from "../workflow-websocket/workflow-websocket.service";
+import { of, Subject } from "rxjs";
+import { SchemaAttribute } from "../dynamic-schema/schema-propagation/schema-propagation.service";
 
 describe("WorkflowResultService", () => {
   let service: WorkflowResultService;
@@ -11,5 +13,90 @@ describe("WorkflowResultService", () => {
 
   it("should be created", () => {
     expect(service).toBeTruthy();
+  });
+});
+
+describe("OperatorPaginationResultService", () => {
+  let service: OperatorPaginationResultService;
+  let mockWorkflowWebsocketService: jasmine.SpyObj<WorkflowWebsocketService>;
+
+  beforeEach(() => {
+    mockWorkflowWebsocketService = jasmine.createSpyObj("WorkflowWebsocketService", ["subscribeToEvent", "send"]);
+    mockWorkflowWebsocketService.subscribeToEvent.and.returnValue(new Subject());
+
+    service = new OperatorPaginationResultService("testOperator", mockWorkflowWebsocketService);
+  });
+
+  describe("getSchema", () => {
+    it("should return the current schema", () => {
+      const testSchema: SchemaAttribute[] = [
+        { attributeName: "id", attributeType: "integer" },
+        { attributeName: "name", attributeType: "string" },
+      ];
+      service["schema"] = testSchema;
+
+      expect(service.getSchema()).toEqual(testSchema);
+    });
+  });
+
+  describe("selectTuple", () => {
+    it("should return the correct tuple and schema", done => {
+      const testSchema: SchemaAttribute[] = [
+        { attributeName: "id", attributeType: "integer" },
+        { attributeName: "name", attributeType: "string" },
+      ];
+      service["schema"] = testSchema;
+
+      const testTable = [
+        { id: 1, name: "Alice" },
+        { id: 2, name: "Bob" },
+        { id: 3, name: "Charlie" },
+      ];
+
+      spyOn(service, "selectPage").and.returnValue(
+        of({
+          requestID: "test",
+          operatorID: "testOperator",
+          pageIndex: 1,
+          table: testTable,
+          schema: testSchema,
+        })
+      );
+
+      service.selectTuple(1, 3).subscribe(result => {
+        expect(result.tuple).toEqual({ id: 2, name: "Bob" });
+        expect(result.schema).toEqual(testSchema);
+        done();
+      });
+    });
+
+    it("should handle out-of-bounds tuple index", done => {
+      const testSchema: SchemaAttribute[] = [
+        { attributeName: "id", attributeType: "integer" },
+        { attributeName: "name", attributeType: "string" },
+      ];
+      service["schema"] = testSchema;
+
+      const testTable = [
+        { id: 1, name: "Alice" },
+        { id: 2, name: "Bob" },
+      ];
+
+      spyOn(service, "selectPage").and.returnValue(
+        of({
+          requestID: "test",
+          operatorID: "testOperator",
+          pageIndex: 1,
+          table: testTable,
+          schema: testSchema,
+        })
+      );
+
+      service.selectTuple(2, 3).subscribe(result => {
+        expect(result.tuple).toBeUndefined();
+        expect(result.schema).toEqual(testSchema);
+        done();
+      });
+    });
   });
 });

--- a/core/gui/src/app/workspace/types/workflow-websocket.interface.ts
+++ b/core/gui/src/app/workspace/types/workflow-websocket.interface.ts
@@ -1,3 +1,4 @@
+import { SchemaAttribute } from "../service/dynamic-schema/schema-propagation/schema-propagation.service";
 import {
   ExecutionState,
   LogicalOperator,
@@ -81,6 +82,7 @@ export type PaginatedResultEvent = Readonly<{
   operatorID: string;
   pageIndex: number;
   table: ReadonlyArray<IndexableObject>;
+  schema: ReadonlyArray<SchemaAttribute>;
 }>;
 
 export type ResultExportRequest = Readonly<{


### PR DESCRIPTION
This PR enhances the schema handling by retrieving schema information directly from the backend, rather than having the frontend infer it. Accurate schema retrieval is needed due to the binary data.

Previously, binary data was incorrectly treated as a string on the frontend, leading to issues differentiating between string and binary types. For instance, strings containing '0' and '1' were misinterpreted as binary data, resulting in byte representations being displayed in the result panel. This update ensures that the frontend receives the correct schema information, improving data type accuracy and presentation.

By aligning the schema across the backend and frontend, this change resolves existing issues and provides more reliable handling of binary data.

<img width="1530" alt="Screenshot 2024-10-15 at 1 41 20 AM" src="https://github.com/user-attachments/assets/d8a13536-34ea-4c2c-89a2-969b9ee1f8fb">
