### PR TITLE
Change the icon image and position for report generation

### DIFF
--- a/core/gui/src/app/workspace/component/menu/menu.component.html
+++ b/core/gui/src/app/workspace/component/menu/menu.component.html
@@ -118,18 +118,17 @@
             nz-icon
             nzType="download"></i>
         </button>
-
-        <button
-          (click)="onClickGenerateReport()"
-          nz-button
-          title="generate report">
-          <i
-            nz-icon
-            nzType="cloud-download"></i>
-        </button>
       </nz-button-group>
       <ng-template #utilities>
         <nz-button-group>
+          <button
+            (click)="onClickGenerateReport()"
+            nz-button
+            title="generate report">
+            <i
+              nz-icon
+              nzType="printer"></i>
+          </button>
           <button
             (click)="onClickToggleGrids()"
             nz-button


### PR DESCRIPTION
Moved the icon from the left to the center and replaced it with a "printer" icon, as shown in the image.

![image](https://github.com/user-attachments/assets/09d6e745-5cfc-48eb-97d6-e09c0200e0df)
