### PR TITLE
Re-add workflow settings assignment to WorkflowContext

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
@@ -42,6 +42,7 @@ class WorkflowExecutionService(
 ) extends SubscriptionManager
     with LazyLogging {
 
+  workflowContext.workflowSettings = request.workflowSettings
   val wsInput = new WebsocketInput(errorHandler)
 
   private val emailNotificationService = userEmailOpt.map(email =>


### PR DESCRIPTION
This PR restores the line that assigns workflowSettings to WorkflowContext in the WorkflowExecutionService.

This line was inadvertently removed in a previous PR, causing workflow settings like dataTransferBatchSize to not be properly applied.

PR caused this issue: #2914 