### PR TITLE
Fix monaco editor with timeout and diff mode

### DIFF
--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -244,7 +244,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
     const latestVersionOperator = this.workflowActionService
       .getTempWorkflow()
       ?.content.operators?.find(operator => operator.operatorID === this.currentOperatorId);
-    const latestVersionCode: string = latestVersionOperator?.operatorProperties.code ?? "";
+    const latestVersionCode: string = latestVersionOperator?.operatorProperties?.code ?? "";
     const oldVersionCode: string = this.code?.toString() ?? "";
     const userConfig: UserConfig = {
       wrapperConfig: {

--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -85,7 +85,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
     private workflowActionService: WorkflowActionService,
     private workflowVersionService: WorkflowVersionService,
     public coeditorPresenceService: CoeditorPresenceService,
-    private aiAssistantService: AIAssistantService,
+    private aiAssistantService: AIAssistantService
   ) {
     this.currentOperatorId = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()[0];
     const operatorType = this.workflowActionService.getTexeraGraph().getOperator(this.currentOperatorId).operatorType;
@@ -219,7 +219,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
         switchMap(() => of(this.editorWrapper.getEditor())),
         catchError(() => of(this.editorWrapper.getEditor())),
         filter(isDefined),
-        untilDestroyed(this),
+        untilDestroyed(this)
       )
       .subscribe((editor: IStandaloneCodeEditor) => {
         editor.updateOptions({ readOnly: this.formControl.disabled });
@@ -233,7 +233,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
           this.code,
           editor.getModel()!,
           new Set([editor]),
-          this.workflowActionService.getTexeraGraph().getSharedModelAwareness(),
+          this.workflowActionService.getTexeraGraph().getSharedModelAwareness()
         );
         this.setupAIAssistantActions(editor);
       });
@@ -242,7 +242,8 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
   private initializeDiffEditor(): void {
     const fileSuffix = this.getFileSuffixByLanguage(this.language);
     const oldVersionOperator = this.workflowActionService
-      .getTempWorkflow()?.content.operators?.find(operator => operator.operatorID === this.currentOperatorId);
+      .getTempWorkflow()
+      ?.content.operators?.find(operator => operator.operatorID === this.currentOperatorId);
     const oldVersionCode: string = oldVersionOperator?.operatorProperties.code ?? "";
     const currentVersionCode: string = this.code?.toString() ?? "";
     const userConfig: UserConfig = {
@@ -361,7 +362,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
                       currVariable.startLine,
                       currVariable.startColumn + offset,
                       currVariable.endLine,
-                      currVariable.endColumn + offset,
+                      currVariable.endColumn + offset
                     );
 
                     const highlight = editor.createDecorationsCollection([
@@ -403,7 +404,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
     range: monaco.Range,
     editor: monaco.editor.IStandaloneCodeEditor,
     lineNumber: number,
-    allCode: string,
+    allCode: string
   ): void {
     this.aiAssistantService
       .getTypeAnnotations(code, lineNumber, allCode)
@@ -447,7 +448,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
         this.currentRange.startLineNumber,
         this.currentRange.startColumn,
         this.currentRange.endLineNumber,
-        this.currentRange.endColumn,
+        this.currentRange.endColumn
       );
 
       this.insertTypeAnnotations(this.editorWrapper.getEditor()!, selection, this.currentSuggestion);
@@ -477,7 +478,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
   private insertTypeAnnotations(
     editor: monaco.editor.IStandaloneCodeEditor,
     selection: monaco.Selection,
-    annotations: string,
+    annotations: string
   ) {
     const endLineNumber = selection.endLineNumber;
     const endColumn = selection.endColumn;

--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -241,18 +241,18 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
 
   private initializeDiffEditor(): void {
     const fileSuffix = this.getFileSuffixByLanguage(this.language);
-    const oldVersionOperator = this.workflowActionService
+    const latestVersionOperator = this.workflowActionService
       .getTempWorkflow()
       ?.content.operators?.find(operator => operator.operatorID === this.currentOperatorId);
-    const oldVersionCode: string = oldVersionOperator?.operatorProperties.code ?? "";
-    const currentVersionCode: string = this.code?.toString() ?? "";
+    const latestVersionCode: string = latestVersionOperator?.operatorProperties.code ?? "";
+    const oldVersionCode: string = this.code?.toString() ?? "";
     const userConfig: UserConfig = {
       wrapperConfig: {
         editorAppConfig: {
           $type: "extended",
           codeResources: {
             main: {
-              text: currentVersionCode,
+              text: latestVersionCode,
               uri: `in-memory-${this.currentOperatorId}.${fileSuffix}`,
             },
             original: {

--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -252,12 +252,12 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
           $type: "extended",
           codeResources: {
             main: {
-              text: latestVersionCode,
-              uri: `in-memory-${this.currentOperatorId}.${fileSuffix}`,
-            },
-            original: {
               text: oldVersionCode,
               uri: `in-memory-${this.currentOperatorId}-version.${fileSuffix}`,
+            },
+            original: {
+              text: latestVersionCode,
+              uri: `in-memory-${this.currentOperatorId}.${fileSuffix}`,
             },
           },
           useDiffEditor: true,

--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -252,12 +252,12 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
           $type: "extended",
           codeResources: {
             main: {
-              text: oldVersionCode,
-              uri: `in-memory-${this.currentOperatorId}-version.${fileSuffix}`,
-            },
-            original: {
               text: currentVersionCode,
               uri: `in-memory-${this.currentOperatorId}.${fileSuffix}`,
+            },
+            original: {
+              text: oldVersionCode,
+              uri: `in-memory-${this.currentOperatorId}-version.${fileSuffix}`,
             },
           },
           useDiffEditor: true,

--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -243,7 +243,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
     const fileSuffix = this.getFileSuffixByLanguage(this.language);
     const latestVersionOperator = this.workflowActionService
       .getTempWorkflow()
-      ?.content.operators?.find(operator => operator.operatorID === this.currentOperatorId);
+      ?.content.operators?.find(({ operatorID }) => operatorID === this.currentOperatorId);
     const latestVersionCode: string = latestVersionOperator?.operatorProperties?.code ?? "";
     const oldVersionCode: string = this.code?.toString() ?? "";
     const userConfig: UserConfig = {

--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -5,7 +5,7 @@ import { WorkflowVersionService } from "../../../dashboard/service/user/workflow
 import { YText } from "yjs/dist/src/types/YText";
 import { getWebsocketUrl } from "src/app/common/util/url";
 import { MonacoBinding } from "y-monaco";
-import { catchError, from, of, Subject, take } from "rxjs";
+import { catchError, from, of, Subject, take, timeout } from "rxjs";
 import { CoeditorPresenceService } from "../../service/workflow-graph/model/coeditor-presence.service";
 import { DomSanitizer, SafeStyle } from "@angular/platform-browser";
 import { Coeditor } from "../../../common/type/user";
@@ -23,6 +23,8 @@ import { isDefined } from "../../../common/util/predicate";
 import { editor } from "vscode/editor.api";
 import { filter, switchMap } from "rxjs/operators";
 import IStandaloneCodeEditor = editor.IStandaloneCodeEditor;
+
+export const LANGUAGE_SERVER_CONNECTION_TIMEOUT_MS = 1000;
 
 /**
  * CodeEditorComponent is the content of the dialogue invoked by CodeareaCustomTemplateComponent.
@@ -213,6 +215,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
     // init monaco editor, optionally with attempt on language client.
     from(this.editorWrapper.initAndStart(userConfig, this.editorElement.nativeElement))
       .pipe(
+        timeout(LANGUAGE_SERVER_CONNECTION_TIMEOUT_MS),
         switchMap(() => of(this.editorWrapper.getEditor())),
         catchError(() => of(this.editorWrapper.getEditor())),
         filter(isDefined),

--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -83,7 +83,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
     private workflowActionService: WorkflowActionService,
     private workflowVersionService: WorkflowVersionService,
     public coeditorPresenceService: CoeditorPresenceService,
-    private aiAssistantService: AIAssistantService
+    private aiAssistantService: AIAssistantService,
   ) {
     this.currentOperatorId = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()[0];
     const operatorType = this.workflowActionService.getTexeraGraph().getOperator(this.currentOperatorId).operatorType;
@@ -216,7 +216,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
         switchMap(() => of(this.editorWrapper.getEditor())),
         catchError(() => of(this.editorWrapper.getEditor())),
         filter(isDefined),
-        untilDestroyed(this)
+        untilDestroyed(this),
       )
       .subscribe((editor: IStandaloneCodeEditor) => {
         editor.updateOptions({ readOnly: this.formControl.disabled });
@@ -230,7 +230,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
           this.code,
           editor.getModel()!,
           new Set([editor]),
-          this.workflowActionService.getTexeraGraph().getSharedModelAwareness()
+          this.workflowActionService.getTexeraGraph().getSharedModelAwareness(),
         );
         this.setupAIAssistantActions(editor);
       });
@@ -238,22 +238,21 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
 
   private initializeDiffEditor(): void {
     const fileSuffix = this.getFileSuffixByLanguage(this.language);
-    const currentWorkflowVersionCode = this.workflowActionService
-      .getTempWorkflow()
-      ?.content.operators?.filter(operator => operator.operatorID === this.currentOperatorId)?.[0]
-      .operatorProperties.code;
-
+    const oldVersionOperator = this.workflowActionService
+      .getTempWorkflow()?.content.operators?.find(operator => operator.operatorID === this.currentOperatorId);
+    const oldVersionCode: string = oldVersionOperator?.operatorProperties.code ?? "";
+    const currentVersionCode: string = this.code?.toString() ?? "";
     const userConfig: UserConfig = {
       wrapperConfig: {
         editorAppConfig: {
           $type: "extended",
           codeResources: {
             main: {
-              text: currentWorkflowVersionCode,
+              text: oldVersionCode,
               uri: `in-memory-${this.currentOperatorId}-version.${fileSuffix}`,
             },
             original: {
-              text: this.code?.toString() ?? "",
+              text: currentVersionCode,
               uri: `in-memory-${this.currentOperatorId}.${fileSuffix}`,
             },
           },
@@ -359,7 +358,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
                       currVariable.startLine,
                       currVariable.startColumn + offset,
                       currVariable.endLine,
-                      currVariable.endColumn + offset
+                      currVariable.endColumn + offset,
                     );
 
                     const highlight = editor.createDecorationsCollection([
@@ -401,7 +400,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
     range: monaco.Range,
     editor: monaco.editor.IStandaloneCodeEditor,
     lineNumber: number,
-    allCode: string
+    allCode: string,
   ): void {
     this.aiAssistantService
       .getTypeAnnotations(code, lineNumber, allCode)
@@ -445,7 +444,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
         this.currentRange.startLineNumber,
         this.currentRange.startColumn,
         this.currentRange.endLineNumber,
-        this.currentRange.endColumn
+        this.currentRange.endColumn,
       );
 
       this.insertTypeAnnotations(this.editorWrapper.getEditor()!, selection, this.currentSuggestion);
@@ -475,7 +474,7 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
   private insertTypeAnnotations(
     editor: monaco.editor.IStandaloneCodeEditor,
     selection: monaco.Selection,
-    annotations: string
+    annotations: string,
   ) {
     const endLineNumber = selection.endLineNumber;
     const endColumn = selection.endColumn;

--- a/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
+++ b/core/gui/src/app/workspace/component/code-editor-dialog/code-editor.component.ts
@@ -252,12 +252,12 @@ export class CodeEditorComponent implements AfterViewInit, SafeStyle, OnDestroy 
           $type: "extended",
           codeResources: {
             main: {
-              text: oldVersionCode,
-              uri: `in-memory-${this.currentOperatorId}-version.${fileSuffix}`,
-            },
-            original: {
               text: latestVersionCode,
               uri: `in-memory-${this.currentOperatorId}.${fileSuffix}`,
+            },
+            original: {
+              text: oldVersionCode,
+              uri: `in-memory-${this.currentOperatorId}-version.${fileSuffix}`,
             },
           },
           useDiffEditor: true,


### PR DESCRIPTION
This PR fixes:
1. add a timeout to prevent the language server from connecting forever. currently set to 1 second.
2. handle the diff editor in the case where no code is found. this could happen when an older version contains an operator A but compared to the latest version that has no A's code (A has been removed).