### PR TITLE
Fix import in JavaUDF template

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/java/JavaUDFOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/udf/java/JavaUDFOpDesc.scala
@@ -19,8 +19,8 @@ class JavaUDFOpDesc extends LogicalOp {
     required = true,
     defaultValue =
       "import edu.uci.ics.texera.workflow.common.operators.map.MapOpExec;\n" +
-        "import edu.uci.ics.texera.workflow.common.tuple.Tuple;\n" +
-        "import edu.uci.ics.amber.engine.common.tuple.amber.TupleLike;\n" +
+        "import edu.uci.ics.amber.engine.common.model.tuple.Tuple;\n" +
+        "import edu.uci.ics.amber.engine.common.model.tuple.TupleLike;\n" +
         "import scala.Function1;\n" +
         "import java.io.Serializable;\n" +
         "\n" +


### PR DESCRIPTION
This PR fixes #2951. Due to #2913, the change of the package for Tuple and TupleLike should be reflected on the JavaUDF template.