### PR TITLE
Update File Selection Message for Dataset Creation

### DIFF
--- a/core/gui/src/app/dashboard/component/user/files-uploader/files-uploader.component.ts
+++ b/core/gui/src/app/dashboard/component/user/files-uploader/files-uploader.component.ts
@@ -90,12 +90,12 @@ export class FilesUploaderComponent {
           successfulUploads.forEach(fileUploadItem => {
             this.addFileToNewUploadsFileTree(fileUploadItem.name, fileUploadItem);
           });
-          this.showFileUploadBanner("success", `${successfulUploads.length} files uploaded successfully!`);
+          this.showFileUploadBanner("success", `${successfulUploads.length} files selected successfully!`);
         }
 
         const failedCount = results.length - successfulUploads.length;
         if (failedCount > 0) {
-          this.showFileUploadBanner("error", `${failedCount} files failed to upload.`);
+          this.showFileUploadBanner("error", `${failedCount} files failed to be selected.`);
         }
 
         this.uploadedFiles.emit(Array.from(this.newUploadNodeToFileItems.values()));

--- a/core/gui/src/app/dashboard/component/user/files-uploader/files-uploader.component.ts
+++ b/core/gui/src/app/dashboard/component/user/files-uploader/files-uploader.component.ts
@@ -90,12 +90,14 @@ export class FilesUploaderComponent {
           successfulUploads.forEach(fileUploadItem => {
             this.addFileToNewUploadsFileTree(fileUploadItem.name, fileUploadItem);
           });
-          this.showFileUploadBanner("success", `${successfulUploads.length} files selected successfully!`);
+          const successMessage = `${successfulUploads.length} file${successfulUploads.length > 1 ? "s" : ""} selected successfully!`;
+          this.showFileUploadBanner("success", successMessage);
         }
 
         const failedCount = results.length - successfulUploads.length;
         if (failedCount > 0) {
-          this.showFileUploadBanner("error", `${failedCount} files failed to be selected.`);
+          const errorMessage = `${failedCount} file${failedCount > 1 ? "s" : ""} failed to be selected.`;
+          this.showFileUploadBanner("error", errorMessage);
         }
 
         this.uploadedFiles.emit(Array.from(this.newUploadNodeToFileItems.values()));


### PR DESCRIPTION
This PR improves the user interface by updating the message displayed when a user selects files to create a dataset. Previously, the message read "# files uploaded successfully!" after the files were selected from the local machine. However, based on feedback from @chenlica, the term "uploaded" was found to be misleading, as the files are not yet uploaded to the server at this stage.

To clarify the process, this PR changes the wording from "uploaded" to "selected," making it clear that the files have only been chosen locally and have not yet been transferred to the server.

Additionally, I added a conditional expression to determine whether to use "file" or "files" based on the count.

[Before the change]
<img width="711" alt="Screenshot 2024-10-24 at 11 17 02 AM" src="https://github.com/user-attachments/assets/343b0218-d669-4cfd-9175-cf58f362416b">

[After the change]
<img width="550" alt="Screenshot 2024-10-24 at 11 20 57 AM" src="https://github.com/user-attachments/assets/55f2f537-6bf7-4136-9957-47c964d08f0e">
