### PR TITLE
Fix Issues with Workflow Name and Description Modification

### DIFF
--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.spec.ts
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.spec.ts
@@ -1,0 +1,87 @@
+import { ComponentFixture, TestBed } from "@angular/core/testing";
+import { ListItemComponent } from "./list-item.component";
+import { WorkflowPersistService } from "src/app/common/service/workflow-persist/workflow-persist.service";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { NzModalService } from "ng-zorro-antd/modal";
+import { of, throwError } from "rxjs";
+import { NO_ERRORS_SCHEMA } from "@angular/core";
+
+describe("ListItemComponent", () => {
+  let component: ListItemComponent;
+  let fixture: ComponentFixture<ListItemComponent>;
+  let workflowPersistService: jasmine.SpyObj<WorkflowPersistService>;
+  let nzModalService: jasmine.SpyObj<NzModalService>;
+
+  beforeEach(async () => {
+    const workflowPersistServiceSpy = jasmine.createSpyObj("WorkflowPersistService", [
+      "updateWorkflowName",
+      "updateWorkflowDescription",
+    ]);
+    const nzModalServiceSpy = jasmine.createSpyObj("NzModalService", ["create"]);
+
+    await TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      declarations: [ListItemComponent],
+      providers: [
+        { provide: WorkflowPersistService, useValue: workflowPersistServiceSpy },
+        { provide: NzModalService, useValue: nzModalServiceSpy },
+      ],
+      schemas: [NO_ERRORS_SCHEMA],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ListItemComponent);
+    component = fixture.componentInstance;
+    workflowPersistService = TestBed.inject(WorkflowPersistService) as jasmine.SpyObj<WorkflowPersistService>;
+    nzModalService = TestBed.inject(NzModalService) as jasmine.SpyObj<NzModalService>;
+  });
+
+  it("should update workflow name successfully", () => {
+    const newName = "New Workflow Name";
+    component.entry = { id: 1, name: "Old Name" } as any;
+    workflowPersistService.updateWorkflowName.and.returnValue(of({} as Response));
+
+    component.confirmUpdateWorkflowCustomName(newName);
+
+    expect(workflowPersistService.updateWorkflowName).toHaveBeenCalledWith(1, newName);
+    expect(component.entry.name).toBe(newName);
+    expect(component.editingName).toBeFalse();
+  });
+
+  it("should handle error when updating workflow name", () => {
+    const newName = "New Workflow Name";
+    component.entry = { id: 1, name: "Old Name" } as any;
+    component.originalName = "Old Name";
+    workflowPersistService.updateWorkflowName.and.returnValue(throwError(() => new Error("Error")));
+
+    component.confirmUpdateWorkflowCustomName(newName);
+
+    expect(workflowPersistService.updateWorkflowName).toHaveBeenCalledWith(1, newName);
+    expect(component.entry.name).toBe("Old Name");
+    expect(component.editingName).toBeFalse();
+  });
+
+  it("should update workflow description successfully", () => {
+    const newDescription = "New Description";
+    component.entry = { id: 1, description: "Old Description" } as any;
+    workflowPersistService.updateWorkflowDescription.and.returnValue(of({} as Response));
+
+    component.confirmUpdateWorkflowCustomDescription(newDescription);
+
+    expect(workflowPersistService.updateWorkflowDescription).toHaveBeenCalledWith(1, newDescription);
+    expect(component.entry.description).toBe(newDescription);
+    expect(component.editingDescription).toBeFalse();
+  });
+
+  it("should handle error when updating workflow description", () => {
+    const newDescription = "New Description";
+    component.entry = { id: 1, description: "Old Description" } as any;
+    component.originalDescription = "Old Description";
+    workflowPersistService.updateWorkflowDescription.and.returnValue(throwError(() => new Error("Error")));
+
+    component.confirmUpdateWorkflowCustomDescription(newDescription);
+
+    expect(workflowPersistService.updateWorkflowDescription).toHaveBeenCalledWith(1, newDescription);
+    expect(component.entry.description).toBe("Old Description");
+    expect(component.editingDescription).toBeFalse();
+  });
+});

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.ts
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.ts
@@ -186,7 +186,7 @@ export class ListItemComponent implements OnInit, OnChanges {
 
   public confirmUpdateWorkflowCustomName(name: string): void {
     const workflowName = name || DEFAULT_WORKFLOW_NAME;
-    
+
     this.workflowPersistService
       .updateWorkflowName(this.entry.id, workflowName)
       .pipe(untilDestroyed(this))
@@ -194,14 +194,14 @@ export class ListItemComponent implements OnInit, OnChanges {
         next: () => {
           this.entry.name = workflowName;
         },
-        error: (err) => {
+        error: (err: unknown) => {
           console.error("Failed to update workflow name:", err);
           this.entry.name = this.originalName;
           this.editingName = false;
         },
         complete: () => {
           this.editingName = false;
-        }
+        },
       });
   }
 


### PR DESCRIPTION
This PR addresses two issues related to modifying the workflow name and description:

1. Write Access Issue: Previously, when a user with write access tried to modify the workflow name or description, the backend would block the action due to an unnecessary validation check. This PR removes the redundant check, allowing users with write access to update the workflow as expected.

2. Read-Only Access Issue: Users with read-only access were able to modify the workflow name or description in the frontend, but the backend would correctly reject these changes. However, the frontend continued to display the modified values until the page was refreshed, leading to a confusing user experience. This PR improves the frontend logic to revert the workflow name and description to their original state if the backend returns an error, ensuring a more consistent and user-friendly experience.

https://github.com/user-attachments/assets/ed6aa9c4-67fe-46f3-8b33-64c68198d82a

