### PR TITLE
Add nz-spin Loader to Workspace

### DIFF
--- a/core/gui/src/app/workspace/component/workspace.component.html
+++ b/core/gui/src/app/workspace/component/workspace.component.html
@@ -1,3 +1,9 @@
+<div class="spinner-container">
+  <nz-spin
+    [nzSpinning]="isLoading"
+    [nzSize]="'large'"
+    nzTip="Loading workflow..."></nz-spin>
+</div>
 <div id="result">
   <texera-result-panel></texera-result-panel>
 </div>

--- a/core/gui/src/app/workspace/component/workspace.component.scss
+++ b/core/gui/src/app/workspace/component/workspace.component.scss
@@ -37,3 +37,10 @@ texera-workflow-editor {
   height: 100%;
   background-color: #f6f6f6;
 }
+
+.spinner-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+}

--- a/core/gui/src/app/workspace/component/workspace.component.ts
+++ b/core/gui/src/app/workspace/component/workspace.component.ts
@@ -40,6 +40,7 @@ export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {
   public gitCommitHash: string = Version.raw;
   public showResultPanel: boolean = false;
   public writeAccess: boolean = false;
+  public isLoading: boolean = false;
   userSystemEnabled = environment.userSystemEnabled;
   @ViewChild("codeEditor", { read: ViewContainerRef }) codeEditorViewRef!: ViewContainerRef;
   constructor(
@@ -159,6 +160,7 @@ export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {
 
   loadWorkflowWithId(wid: number): void {
     // disable the workspace until the workflow is fetched from the backend
+    this.isLoading = true;
     this.workflowActionService.disableWorkflowModification();
     this.workflowPersistService
       .retrieveWorkflow(wid)
@@ -192,6 +194,7 @@ export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {
           // clear stack
           this.undoRedoService.clearUndoStack();
           this.undoRedoService.clearRedoStack();
+          this.isLoading = false;
         },
         () => {
           this.workflowActionService.resetAsNewWorkflow();
@@ -201,6 +204,7 @@ export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {
           this.undoRedoService.clearUndoStack();
           this.undoRedoService.clearRedoStack();
           this.message.error("You don't have access to this workflow, please log in with an appropriate account");
+          this.isLoading = false;
         }
       );
   }


### PR DESCRIPTION
This PR introduces an `nz-spin` loader to the workspace to indicate that a workflow is being loaded. Previously, when uploading a large workflow, the workspace would appear blank during the loading process, leaving users unsure of what was happening. With this change, the `nz-spin` loader ensures users are aware that the workflow loading is in progress, thereby creating a more user-friendly experience.
<img width="1433" alt="Screenshot 2024-10-24 at 3 55 49 PM" src="https://github.com/user-attachments/assets/d76a388c-a15d-48c6-9066-73dd2619cfd7">

https://github.com/user-attachments/assets/3888a5f8-a12c-40f3-9140-ed383db7a3c6

