### PR TITLE
Fetch the file's size from PhysicalFileNode instead of reading from the file system

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/type/DatasetFileNode.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/type/DatasetFileNode.scala
@@ -103,7 +103,7 @@ object DatasetFileNode {
       val fileType =
         if (Files.isDirectory(currentPhysicalNode.getAbsolutePath)) "directory" else "file"
       val fileSize =
-        if (fileType == "file") Some(Files.size(currentPhysicalNode.getAbsolutePath)) else None
+        if (fileType == "file") Some(currentPhysicalNode.getSize) else None
       val existingNode = currentParent.getChildren.find(child =>
         child.getName == nodeName && child.getNodeType == fileType
       )


### PR DESCRIPTION
This PR fixes the size retrieving when constructing the DatasetFileNode. As `PhysicalFileNode` already has the file size, this file size will be directly reused, instead of using file system's API to read the size.

The bug that, when deleting some files to create a new dataset version, the old version's file tree cannot retrieved correctly because the code tries to retrieve the file size using file system's API, but the file does not physically exist anymore.