### PR TITLE
Remove scrollbar in workflow workspace

### DIFF
--- a/core/gui/src/app/workspace/component/left-panel/left-panel.component.scss
+++ b/core/gui/src/app/workspace/component/left-panel/left-panel.component.scss
@@ -1,5 +1,4 @@
 :host {
-  display: block;
   height: 100%;
 }
 

--- a/core/gui/src/app/workspace/component/workspace.component.scss
+++ b/core/gui/src/app/workspace/component/workspace.component.scss
@@ -42,5 +42,5 @@ texera-workflow-editor {
   display: flex;
   justify-content: center;
   align-items: center;
-  height: 100vh;
+  height: 100%;
 }


### PR DESCRIPTION
## Purpose
Remove scrollbar bug in the workflow workspace
## Changes
Remove display: block for left panel
Change spinner-container height from 100vh to 100%
## Demo
Before
![image](https://github.com/user-attachments/assets/a66c9b34-48fd-4f3b-8dc0-264c4c151bd8)
After
![image](https://github.com/user-attachments/assets/be39176b-2a64-40a5-baf7-6bef3d86ec64)
