### PR TITLE
Make scalapb marked as source in sbt project

### DIFF
--- a/core/amber/.scalafmt.conf
+++ b/core/amber/.scalafmt.conf
@@ -1,4 +1,7 @@
 version=2.6.4
 maxColumn = 100
 
-project.excludeFilters = ["src/main/scala/com/kjetland/.*"]
+project.excludeFilters = [
+    "src/main/scala/com/kjetland/.*",
+    "src/main/scalapb/.*"
+]

--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -166,6 +166,7 @@ PB.protocVersion := "3.19.4"
 enablePlugins(Fs2Grpc)
 
 fs2GrpcOutputPath := (Compile / sourceDirectory).value / "scalapb"
+Compile / unmanagedSourceDirectories += (Compile / sourceDirectory).value / "scalapb"
 
 Compile / PB.targets := Seq(
   scalapb.gen(


### PR DESCRIPTION
IntelliJ may not automatically mark `core/amber/src/main/scalapb` as a generated source root, and the developers have to manually mark the folder as a generated source root. This PR makes it automatically marking the "scalapb" directory as source.