### PR TITLE
Fix nullpointer exception on result panel

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
@@ -8,9 +8,9 @@ import edu.uci.ics.amber.engine.architecture.controller.{ExecutionStateUpdate, F
 import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{
   COMPLETED,
   FAILED,
+  RUNNING,
   KILLED
 }
-import edu.uci.ics.amber.engine.architecture.worker.statistics.WorkerState.RUNNING
 import edu.uci.ics.amber.engine.common.{AmberConfig, AmberRuntime, IncrementalOutputMode}
 import edu.uci.ics.amber.engine.common.client.AmberClient
 import edu.uci.ics.amber.engine.common.model.tuple.Tuple


### PR DESCRIPTION
This bug is caused by a wrong import of the `RUNNING` state introduced in #2950. 