### PR TITLE
Let ReservoirSampling use scheduled worker number count 

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/reservoirsampling/ReservoirSamplingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/reservoirsampling/ReservoirSamplingOpDesc.scala
@@ -29,7 +29,13 @@ class ReservoirSamplingOpDesc extends LogicalOp {
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecInitInfo((idx, workerCount) => new ReservoirSamplingOpExec(idx, equallyPartitionGoal(k, workerCount),  Array.fill(workerCount)(Random.nextInt())))
+        OpExecInitInfo((idx, workerCount) =>
+          new ReservoirSamplingOpExec(
+            idx,
+            equallyPartitionGoal(k, workerCount),
+            Array.fill(workerCount)(Random.nextInt())
+          )
+        )
       )
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/reservoirsampling/ReservoirSamplingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/reservoirsampling/ReservoirSamplingOpDesc.scala
@@ -1,9 +1,8 @@
 package edu.uci.ics.texera.workflow.operators.reservoirsampling
 
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonPropertyDescription}
+import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.google.common.base.Preconditions
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfo
-import edu.uci.ics.amber.engine.common.AmberConfig
 import edu.uci.ics.amber.engine.common.model.PhysicalOp
 import edu.uci.ics.amber.engine.common.model.tuple.Schema
 import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
@@ -19,7 +18,7 @@ class ReservoirSamplingOpDesc extends LogicalOp {
   @JsonProperty(value = "number of item sampled in reservoir sampling", required = true)
   @JsonPropertyDescription("reservoir sampling with k items being kept randomly")
   var k: Int = _
-  
+
   override def getPhysicalOp(
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/reservoirsampling/ReservoirSamplingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/reservoirsampling/ReservoirSamplingOpDesc.scala
@@ -15,33 +15,11 @@ import edu.uci.ics.texera.workflow.operators.util.OperatorDescriptorUtils.equall
 import scala.util.Random
 
 class ReservoirSamplingOpDesc extends LogicalOp {
-  // kPerActor needed because one operator can have multiple executor (a.k.a. worker/actor)
-  // In order to make sure the total output is k, each executor should produce (k / n) items
-  // (n is the number of the executors)
-  @JsonIgnore
-  private lazy val kPerActor: List[Int] =
-    equallyPartitionGoal(k, AmberConfig.numWorkerPerOperatorByDefault)
-
-  // Store random seeds for each executor to satisfy the fault tolerance requirement.
-  // If a worker failed, the engine will start a new worker and rerun the computation.
-  // Fault tolerance requires that the restarted worker should produce the exactly same output.
-  // Therefore the seeds have to be stored.
-  @JsonIgnore
-  private val seeds: Array[Int] =
-    Array.fill(AmberConfig.numWorkerPerOperatorByDefault)(Random.nextInt())
 
   @JsonProperty(value = "number of item sampled in reservoir sampling", required = true)
   @JsonPropertyDescription("reservoir sampling with k items being kept randomly")
   var k: Int = _
-
-  @JsonIgnore
-  def getSeed(index: Int): Int = seeds(index)
-
-  @JsonIgnore
-  def getKForActor(actor: Int): Int = {
-    kPerActor(actor)
-  }
-
+  
   override def getPhysicalOp(
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity
@@ -51,7 +29,7 @@ class ReservoirSamplingOpDesc extends LogicalOp {
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecInitInfo((idx, _) => new ReservoirSamplingOpExec(idx, getKForActor, getSeed))
+        OpExecInitInfo((idx, workerCount) => new ReservoirSamplingOpExec(idx, equallyPartitionGoal(k, workerCount),  Array.fill(workerCount)(Random.nextInt())))
       )
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)


### PR DESCRIPTION
In `ReservoirSamplingOp`, it relies on the worker number from the configuration to calculate the number assigned for each worker. This is actually not correct, as the number of workers should be decided by the scheduler rather than statically read from config. This PR changes the logic so that it respects the allocated worker number properly.