### PR TITLE
Improve selecting source file experience

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
@@ -409,7 +409,6 @@ object DatasetResource {
 
   case class ListDatasetsResponse(
       datasets: List[DashboardDataset],
-      fileNodes: List[DatasetFileNode]
   )
 
   case class DatasetVersionRootFileNodes(fileNodes: List[DatasetFileNode])
@@ -692,9 +691,7 @@ class DatasetResource {
   @GET
   @Path("")
   def listDatasets(
-      @Auth user: SessionUser,
-      @QueryParam("includeVersions") includeVersions: Boolean = false,
-      @QueryParam("includeFileNodes") includeFileNodes: Boolean = false
+      @Auth user: SessionUser
   ): ListDatasetsResponse = {
     val uid = user.getUid
     withTransaction(context)(ctx => {
@@ -744,48 +741,8 @@ class DatasetResource {
         }
       }
 
-      val fileNodesMap = mutable.Map[(String, String, String), List[PhysicalFileNode]]()
-
-      // iterate over datasets and retrieve the version
-      accessibleDatasets = accessibleDatasets.map { dataset =>
-        val did = dataset.dataset.getDid
-        val size = DatasetResource.calculateLatestDatasetVersionSize(did)
-
-        DashboardDataset(
-          isOwner = dataset.isOwner,
-          dataset = dataset.dataset,
-          ownerEmail = dataset.ownerEmail,
-          accessPrivilege = dataset.accessPrivilege,
-          versions = if (includeVersions || includeFileNodes) {
-            getDatasetVersions(ctx, did, uid).map { version =>
-              if (includeFileNodes) {
-                fileNodesMap += ((
-                  dataset.ownerEmail,
-                  dataset.dataset.getName,
-                  version.getName
-                ) -> GitVersionControlLocalFileStorage
-                  .retrieveRootFileNodesOfVersion(
-                    PathUtils.getDatasetPath(did),
-                    version.getVersionHash
-                  )
-                  .asScala
-                  .toList)
-              }
-              DashboardDatasetVersion(
-                version,
-                List()
-              )
-            }
-          } else {
-            dataset.versions
-          },
-          size = size
-        )
-      }
-
       ListDatasetsResponse(
         accessibleDatasets.toList,
-        DatasetFileNode.fromPhysicalFileNodes(fileNodesMap.toMap)
       )
     })
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
@@ -408,7 +408,7 @@ object DatasetResource {
   )
 
   case class ListDatasetsResponse(
-      datasets: List[DashboardDataset],
+      datasets: List[DashboardDataset]
   )
 
   case class DatasetVersionRootFileNodes(fileNodes: List[DatasetFileNode])
@@ -742,7 +742,7 @@ class DatasetResource {
       }
 
       ListDatasetsResponse(
-        accessibleDatasets.toList,
+        accessibleDatasets.toList
       )
     })
   }

--- a/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -81,20 +81,9 @@ export class DatasetService {
     });
   }
 
-  public retrieveAccessibleDatasets(
-    includeVersions: boolean = false,
-    includeFileNodes: boolean = false
-  ): Observable<{ datasets: DashboardDataset[]; fileNodes: DatasetFileNode[] }> {
-    let params = new HttpParams();
-    if (includeVersions) {
-      params = params.set("includeVersions", "true");
-    }
-    if (includeFileNodes) {
-      params = params.set("includeFileNodes", "true");
-    }
+  public retrieveAccessibleDatasets(): Observable<{ datasets: DashboardDataset[]; fileNodes: DatasetFileNode[] }> {
     return this.http.get<{ datasets: DashboardDataset[]; fileNodes: DatasetFileNode[] }>(
-      `${AppSettings.getApiEndpoint()}/${DATASET_BASE_URL}`,
-      { params: params }
+      `${AppSettings.getApiEndpoint()}/${DATASET_BASE_URL}`
     );
   }
   public createDatasetVersion(

--- a/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -81,8 +81,8 @@ export class DatasetService {
     });
   }
 
-  public retrieveAccessibleDatasets(): Observable<{ datasets: DashboardDataset[]; fileNodes: DatasetFileNode[] }> {
-    return this.http.get<{ datasets: DashboardDataset[]; fileNodes: DatasetFileNode[] }>(
+  public retrieveAccessibleDatasets(): Observable<{ datasets: DashboardDataset[] }> {
+    return this.http.get<{ datasets: DashboardDataset[] }>(
       `${AppSettings.getApiEndpoint()}/${DATASET_BASE_URL}`
     );
   }

--- a/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -82,9 +82,7 @@ export class DatasetService {
   }
 
   public retrieveAccessibleDatasets(): Observable<{ datasets: DashboardDataset[] }> {
-    return this.http.get<{ datasets: DashboardDataset[] }>(
-      `${AppSettings.getApiEndpoint()}/${DATASET_BASE_URL}`
-    );
+    return this.http.get<{ datasets: DashboardDataset[] }>(`${AppSettings.getApiEndpoint()}/${DATASET_BASE_URL}`);
   }
   public createDatasetVersion(
     did: number,

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.html
@@ -1,55 +1,58 @@
-<div class="container">
-  <div class="selection-row">
-    <nz-select
-      nzShowSearch
-      nzAllowClear
-      nzPlaceHolder="Select dataset"
-      [(ngModel)]="selectedDataset"
-      (ngModelChange)="onDatasetChange()"
-      [ngStyle]="{'width': isDatasetSelected ? '60%' : '100%'}"
-      class="select-dataset">
-      <nz-option
-        *ngFor="let dataset of datasets"
-        [nzValue]="dataset"
-        [nzLabel]="dataset.dataset.name"
-        [nzCustomContent]="true">
-        <div class="dataset-option">
-          <div class="dataset-id-container">{{ dataset.dataset.did }}</div>
-          <span class="dataset-name">{{ dataset.dataset.name }}</span>
-          <span
-            class="dataset-owner"
-            *ngIf="dataset.isOwner"
-            >OWNER</span
-          >
-          <span
-            class="dataset-access-privilege"
-            *ngIf="!dataset.isOwner">
-            {{ dataset.accessPrivilege }}
-          </span>
-        </div>
-      </nz-option>
-    </nz-select>
+<nz-spin [nzSpinning]="isAccessibleDatasetsLoading">
+  <div class="container">
+    <div class="selection-row">
+      <nz-select
+        nzShowSearch
+        nzAllowClear
+        nzPlaceHolder="Select dataset"
+        [(ngModel)]="selectedDataset"
+        (ngModelChange)="onDatasetChange()"
+        [ngStyle]="{'width': isDatasetSelected ? '60%' : '100%'}"
+        class="select-dataset">
+        <nz-option
+          *ngFor="let dataset of datasets"
+          [nzValue]="dataset"
+          [nzLabel]="dataset.dataset.name"
+          [nzCustomContent]="true">
+          <div class="dataset-option">
+            <div class="dataset-id-container">{{ dataset.dataset.did }}</div>
+            <span class="dataset-name">{{ dataset.dataset.name }}</span>
+            <span
+              class="dataset-owner"
+              *ngIf="dataset.isOwner">
+              OWNER
+            </span>
+            <span
+              class="dataset-access-privilege"
+              *ngIf="!dataset.isOwner">
+              {{ dataset.accessPrivilege }}
+            </span>
+          </div>
+        </nz-option>
+      </nz-select>
 
-    <nz-select
-      *ngIf="selectedDataset"
-      nzShowSearch
-      nzAllowClear
-      nzPlaceHolder="Select version"
-      [(ngModel)]="selectedVersion"
-      (ngModelChange)="onVersionChange()"
-      class="select-version">
-      <nz-option
-        *ngFor="let version of datasetVersions"
-        [nzValue]="version"
-        [nzLabel]="version.name">
-      </nz-option>
-    </nz-select>
+      <nz-select
+        *ngIf="selectedDataset"
+        nzShowSearch
+        nzAllowClear
+        nzPlaceHolder="Select version"
+        [(ngModel)]="selectedVersion"
+        (ngModelChange)="onVersionChange()"
+        class="select-version">
+        <nz-option
+          *ngFor="let version of datasetVersions"
+          [nzValue]="version"
+          [nzLabel]="version.name">
+        </nz-option>
+      </nz-select>
+    </div>
+
+    <texera-user-dataset-version-filetree
+      *ngIf="suggestedFileTreeNodes.length > 0"
+      [isExpandAllAfterViewInit]="true"
+      [fileTreeNodes]="suggestedFileTreeNodes"
+      (selectedTreeNode)="onFileTreeNodeSelected($event)"
+      class="texera-user-dataset-version-filetree">
+    </texera-user-dataset-version-filetree>
   </div>
-
-  <texera-user-dataset-version-filetree
-    *ngIf="suggestedFileTreeNodes.length > 0"
-    [isExpandAllAfterViewInit]="true"
-    [fileTreeNodes]="suggestedFileTreeNodes"
-    (selectedTreeNode)="onFileTreeNodeSelected($event)"
-    class="texera-user-dataset-version-filetree"></texera-user-dataset-version-filetree>
-</div>
+</nz-spin>

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -14,8 +14,10 @@ import { parseFilePathToDatasetFile } from "../../../common/type/dataset-file";
   styleUrls: ["file-selection.component.scss"],
 })
 export class FileSelectionComponent implements OnInit {
-  readonly datasets: ReadonlyArray<DashboardDataset> = inject(NZ_MODAL_DATA).datasets;
   readonly selectedFilePath: string = inject(NZ_MODAL_DATA).selectedFilePath;
+
+  datasets: DashboardDataset[] = [];
+  isAccessibleDatasetsLoading = true;
 
   selectedDataset?: DashboardDataset;
   selectedVersion?: DatasetVersion;
@@ -29,25 +31,33 @@ export class FileSelectionComponent implements OnInit {
   ) {}
 
   ngOnInit() {
-    // if users already select some file, then show that selected dataset & related version
-    if (this.selectedFilePath && this.selectedFilePath !== "") {
-      const selectedDatasetFile = parseFilePathToDatasetFile(this.selectedFilePath);
-      this.selectedDataset = this.datasets.find(
-        d => d.ownerEmail === selectedDatasetFile.ownerEmail && d.dataset.name === selectedDatasetFile.datasetName
-      );
-      this.isDatasetSelected = !!this.selectedDataset;
+    // retrieve all the accessible datasets from the backend
+    this.datasetService
+      .retrieveAccessibleDatasets()
+      .pipe(untilDestroyed(this))
+      .subscribe(response => {
+        this.datasets = response.datasets;
+        this.isAccessibleDatasetsLoading = false;
 
-      if (this.selectedDataset && this.selectedDataset.dataset.did !== undefined) {
-        this.datasetService
-          .retrieveDatasetVersionList(this.selectedDataset.dataset.did)
-          .pipe(untilDestroyed(this))
-          .subscribe(versions => {
-            this.datasetVersions = versions;
-            this.selectedVersion = this.datasetVersions.find(v => v.name === selectedDatasetFile.versionName);
-            this.onVersionChange();
-          });
-      }
-    }
+        // if users already select some file, then ONLY show that selected dataset & related version
+        if (this.selectedFilePath && this.selectedFilePath !== "") {
+          const selectedDatasetFile = parseFilePathToDatasetFile(this.selectedFilePath);
+          this.selectedDataset = this.datasets.find(
+            d => d.ownerEmail === selectedDatasetFile.ownerEmail && d.dataset.name === selectedDatasetFile.datasetName
+          );
+          this.isDatasetSelected = !!this.selectedDataset;
+          if (this.selectedDataset && this.selectedDataset.dataset.did !== undefined) {
+            this.datasetService
+              .retrieveDatasetVersionList(this.selectedDataset.dataset.did)
+              .pipe(untilDestroyed(this))
+              .subscribe(versions => {
+                this.datasetVersions = versions;
+                this.selectedVersion = this.datasetVersions.find(v => v.name === selectedDatasetFile.versionName);
+                this.onVersionChange();
+              });
+          }
+        }
+      })
   }
 
   onDatasetChange() {

--- a/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
+++ b/core/gui/src/app/workspace/component/file-selection/file-selection.component.ts
@@ -57,7 +57,7 @@ export class FileSelectionComponent implements OnInit {
               });
           }
         }
-      })
+      });
   }
 
   onDatasetChange() {

--- a/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
+++ b/core/gui/src/app/workspace/component/input-autocomplete/input-autocomplete.component.ts
@@ -24,26 +24,19 @@ export class InputAutoCompleteComponent extends FieldType<FieldTypeConfig> {
   }
 
   onClickOpenFileSelectionModal(): void {
-    this.datasetService
-      .retrieveAccessibleDatasets()
-      .pipe(untilDestroyed(this))
-      .subscribe(response => {
-        const datasets = response.datasets;
-        const modal = this.modalService.create({
-          nzTitle: "Please select one file from datasets",
-          nzContent: FileSelectionComponent,
-          nzFooter: null,
-          nzData: {
-            datasets: datasets,
-            selectedFilePath: this.formControl.getRawValue(),
-          },
-        });
-        // Handle the selection from the modal
-        modal.afterClose.pipe(untilDestroyed(this)).subscribe(fileNode => {
-          const node: DatasetFileNode = fileNode as DatasetFileNode;
-          this.formControl.setValue(getFullPathFromDatasetFileNode(node));
-        });
-      });
+    const modal = this.modalService.create({
+      nzTitle: "Please select one file from datasets",
+      nzContent: FileSelectionComponent,
+      nzFooter: null,
+      nzData: {
+        selectedFilePath: this.formControl.getRawValue(),
+      },
+    });
+    // Handle the selection from the modal
+    modal.afterClose.pipe(untilDestroyed(this)).subscribe(fileNode => {
+      const node: DatasetFileNode = fileNode as DatasetFileNode;
+      this.formControl.setValue(getFullPathFromDatasetFileNode(node));
+    });
   }
 
   get isFileSelectionEnabled(): boolean {


### PR DESCRIPTION
This PR improves the selecting source file from datasets experience. 

Previous experience delays the pop-up window appearance. Now the new experience put the delay to the procedure after the window pop-up. And a spinning wheel is added, pending the window before the dataset loading is finished.

This PR also clears up the unused backend & gui codes regarding the endpoint of retrieving accessible datasets for users.

### Current Experience

![2024-11-04 18 36 33](https://github.com/user-attachments/assets/ffbdee29-e162-4a32-afea-569363f936d6)


