### PR TITLE
Let RandomKSamplingOp use scheduled worker number count

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/randomksampling/RandomKSamplingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/randomksampling/RandomKSamplingOpDesc.scala
@@ -12,20 +12,12 @@ import edu.uci.ics.texera.workflow.common.operators.filter.FilterOpDesc
 import scala.util.Random
 
 class RandomKSamplingOpDesc extends FilterOpDesc {
-  // Store random seeds for each executor to satisfy the fault tolerance requirement.
-  // If a worker failed, the engine will start a new worker and rerun the computation.
-  // Fault tolerance requires that the restarted worker should produce the exactly same output.
-  // Therefore the seeds have to be stored.
-  @JsonIgnore
-  private val seeds: Array[Int] =
-    Array.fill(AmberConfig.numWorkerPerOperatorByDefault)(Random.nextInt())
+
 
   @JsonProperty(value = "random k sample percentage", required = true)
   @JsonPropertyDescription("random k sampling with given percentage")
   var percentage: Int = _
 
-  @JsonIgnore
-  def getSeed(index: Int): Int = seeds(index)
 
   override def getPhysicalOp(
       workflowId: WorkflowIdentity,
@@ -36,7 +28,7 @@ class RandomKSamplingOpDesc extends FilterOpDesc {
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecInitInfo((idx, _) => new RandomKSamplingOpExec(percentage, idx, getSeed))
+        OpExecInitInfo((idx, workerCount) => new RandomKSamplingOpExec(percentage, idx,     Array.fill(workerCount)(Random.nextInt())))
       )
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/randomksampling/RandomKSamplingOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/randomksampling/RandomKSamplingOpDesc.scala
@@ -1,8 +1,7 @@
 package edu.uci.ics.texera.workflow.operators.randomksampling
 
-import com.fasterxml.jackson.annotation.{JsonIgnore, JsonProperty, JsonPropertyDescription}
+import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import edu.uci.ics.amber.engine.architecture.deploysemantics.layer.OpExecInitInfo
-import edu.uci.ics.amber.engine.common.AmberConfig
 import edu.uci.ics.amber.engine.common.model.PhysicalOp
 import edu.uci.ics.amber.engine.common.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import edu.uci.ics.amber.engine.common.workflow.{InputPort, OutputPort}
@@ -13,11 +12,9 @@ import scala.util.Random
 
 class RandomKSamplingOpDesc extends FilterOpDesc {
 
-
   @JsonProperty(value = "random k sample percentage", required = true)
   @JsonPropertyDescription("random k sampling with given percentage")
   var percentage: Int = _
-
 
   override def getPhysicalOp(
       workflowId: WorkflowIdentity,
@@ -28,7 +25,9 @@ class RandomKSamplingOpDesc extends FilterOpDesc {
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecInitInfo((idx, workerCount) => new RandomKSamplingOpExec(percentage, idx,     Array.fill(workerCount)(Random.nextInt())))
+        OpExecInitInfo((idx, workerCount) =>
+          new RandomKSamplingOpExec(percentage, idx, Array.fill(workerCount)(Random.nextInt()))
+        )
       )
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)


### PR DESCRIPTION
Similar to #3001, make `RandomKSamplingOp` also use the scheduled worker count, instead of the configured number.