### PR TITLE
Fixed the browse section showing workflow even when it becomes private

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/hub/workflow/HubWorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/hub/workflow/HubWorkflowResource.scala
@@ -325,6 +325,9 @@ class HubWorkflowResource {
     val topLovedWorkflowsWids = context
       .select(WORKFLOW_USER_LIKES.WID)
       .from(WORKFLOW_USER_LIKES)
+      .join(WORKFLOW)
+      .on(WORKFLOW_USER_LIKES.WID.eq(WORKFLOW.WID))
+      .where(WORKFLOW.IS_PUBLISHED.eq(1.toByte))
       .groupBy(WORKFLOW_USER_LIKES.WID)
       .orderBy(DSL.count(WORKFLOW_USER_LIKES.WID).desc())
       .limit(8)
@@ -344,6 +347,9 @@ class HubWorkflowResource {
     val topClonedWorkflowsWids = context
       .select(WORKFLOW_USER_CLONES.WID)
       .from(WORKFLOW_USER_CLONES)
+      .join(WORKFLOW)
+      .on(WORKFLOW_USER_CLONES.WID.eq(WORKFLOW.WID))
+      .where(WORKFLOW.IS_PUBLISHED.eq(1.toByte))
       .groupBy(WORKFLOW_USER_CLONES.WID)
       .orderBy(DSL.count(WORKFLOW_USER_CLONES.WID).desc())
       .limit(8)


### PR DESCRIPTION
**Propose:**
Fixed an issue in the browse section that would display workflow even if it became private. The previous database search did not determine which is published, resulting in a high number of likes or clones being displayed in browse even if the user made the workflow private.