### PR TITLE
Improve the resource item layout on small browser windows

### DIFF
--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
@@ -3,25 +3,30 @@
   class="list-item-card"
   [class.selected]="entry.checked"
   [class.has-button-group]="isPrivateSearch">
-  <div
-    class="checkbox-container"
-    [class.always-show-checkbox]="entry.checked"
-    (click)="$event.stopPropagation()"
-    *ngIf="isPrivateSearch && entry.type==='workflow'">
-    <label class="clickable-area">
-      <input
-        type="checkbox"
-        class="large-checkbox"
-        [checked]="entry.checked"
-        (change)="onCheckboxChange(entry)" />
-    </label>
-  </div>
 
   <div
     [routerLink]="entryLink"
     nz-row
     nzAlign="middle"
     class="custom-row">
+    <div
+      nz-col
+      nzSpan = "1">
+      <div
+      class="checkbox-container"
+      [class.always-show-checkbox]="entry.checked"
+      (click)="$event.stopPropagation()"
+      *ngIf="isPrivateSearch && entry.type==='workflow'">
+      <label class="clickable-area">
+        <input
+          type="checkbox"
+          class="large-checkbox"
+          [checked]="entry.checked"
+          (change)="onCheckboxChange(entry)" />
+      </label>
+    </div>
+    </div>
+
     <div
       nz-col
       nzSpan="1">
@@ -35,7 +40,7 @@
     <!-- ID Column -->
     <div
       nz-col
-      nzSpan="1">
+      nzSpan="2">
       <div class="resource-id">
         <em>#{{ entry.id }}</em>
       </div>
@@ -54,8 +59,7 @@
             nzType="text"
             class="edit-name-button"
             title="Rename"
-            (click)="onEditName()"
-            (click)="$event.stopPropagation()">
+            (click)="onEditName(); $event.stopPropagation()">
             <i
               nz-icon
               nzTheme="outline"
@@ -81,7 +85,7 @@
       </div>
 
       <!-- Description -->
-      <div cladd="description-container">
+      <div class="description-container">
         <!-- Edit Description Buttons -->
         <div
           class="edit-button-group"
@@ -91,8 +95,7 @@
             nzType="text"
             class="edit-description-button"
             title="Edit Description"
-            (click)="onEditDescription()"
-            (click)="$event.stopPropagation()">
+            (click)="onEditDescription(); $event.stopPropagation()">
             <i
               nz-icon
               nzTheme="outline"
@@ -118,7 +121,7 @@
 
     <div
       nz-col
-      [nzSpan]="12">
+      [nzSpan]="10">
       <div class="edit-info">
         <div class="resource-owner">
           <texera-user-avatar

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
@@ -3,7 +3,6 @@
   class="list-item-card"
   [class.selected]="entry.checked"
   [class.has-button-group]="isPrivateSearch">
-
   <div
     [routerLink]="entryLink"
     nz-row
@@ -11,20 +10,20 @@
     class="custom-row">
     <div
       nz-col
-      nzSpan = "1">
+      nzSpan="1">
       <div
-      class="checkbox-container"
-      [class.always-show-checkbox]="entry.checked"
-      (click)="$event.stopPropagation()"
-      *ngIf="isPrivateSearch && entry.type==='workflow'">
-      <label class="clickable-area">
-        <input
-          type="checkbox"
-          class="large-checkbox"
-          [checked]="entry.checked"
-          (change)="onCheckboxChange(entry)" />
-      </label>
-    </div>
+        class="checkbox-container"
+        [class.always-show-checkbox]="entry.checked"
+        (click)="$event.stopPropagation()"
+        *ngIf="isPrivateSearch && entry.type==='workflow'">
+        <label class="clickable-area">
+          <input
+            type="checkbox"
+            class="large-checkbox"
+            [checked]="entry.checked"
+            (change)="onCheckboxChange(entry)" />
+        </label>
+      </div>
     </div>
 
     <div

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.scss
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.scss
@@ -212,7 +212,7 @@
 }
 
 .resource-id {
-  font-size: clamp(10px, 2vw, 17px);;
+  font-size: clamp(10px, 2vw, 17px);
   font-weight: 600;
   margin-left: 5px;
   text-align: center;

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.scss
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.scss
@@ -195,8 +195,7 @@
 
 .type-icon-div {
   text-align: center;
-  font-size: 38px;
-  margin-left: 30px;
+  font-size: clamp(12px, 3vw, 38px);
 }
 
 .custom-row {
@@ -213,9 +212,10 @@
 }
 
 .resource-id {
-  font-size: 17px;
+  font-size: clamp(10px, 2vw, 17px);;
   font-weight: 600;
   margin-left: 5px;
+  text-align: center;
 }
 
 .clickable-area {


### PR DESCRIPTION
This PR:
1. added the leftmost checkbox into the `nz-row`, allowing the layout to consider the checkbox when allocating space.
2. improved CSS for the icon and resource ID to ensure they auto-scale with the browser window size.
3. made minor HTML code improvements.

Before:
<video src='https://github.com/user-attachments/assets/c5545533-5225-4100-8c63-987c30f75310' width=180/>


After:
<video src='https://github.com/user-attachments/assets/79ebc141-5b83-4b74-8a37-edbc474b546d' width=180/>


