### PR TITLE
Clear the result of previous execution when a new execution starts

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -86,7 +86,7 @@ class WorkflowService(
     s"workflowId=$workflowId",
     cleanUpTimeout,
     () => {
-      opResultStorage.close()
+      opResultStorage.clear()
       WorkflowService.workflowServiceMapping.remove(mkWorkflowStateId(workflowId))
       if (executionService.getValue != null) {
         // shutdown client
@@ -230,7 +230,7 @@ class WorkflowService(
     }
 
     // clean up results from previous run
-    opResultStorage.close() // TODO: change this behavior after enabling cache.
+    opResultStorage.clear() // TODO: change this behavior after enabling cache.
     try {
       val execution = new WorkflowExecutionService(
         controllerConf,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -230,7 +230,7 @@ class WorkflowService(
     }
 
     // clean up results from previous run
-    opResultStorage.close()  // TODO: change this behavior after enabling cache.
+    opResultStorage.close() // TODO: change this behavior after enabling cache.
     try {
       val execution = new WorkflowExecutionService(
         controllerConf,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -229,6 +229,8 @@ class WorkflowService(
       }
     }
 
+    // clean up results from previous run
+    opResultStorage.close()  // TODO: change this behavior after enabling cache.
     try {
       val execution = new WorkflowExecutionService(
         controllerConf,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/storage/OpResultStorage.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/common/storage/OpResultStorage.scala
@@ -76,9 +76,9 @@ class OpResultStorage extends Serializable with LazyLogging {
   }
 
   /**
-    * Close this storage. Used for workflow cleanup.
+    * Clear this storage. Used for workflow cleanup.
     */
-  def close(): Unit = {
+  def clear(): Unit = {
     cache.forEach((_, sinkStorageReader) => sinkStorageReader.clear())
     cache.clear()
   }

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/BatchSizePropagationSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/BatchSizePropagationSpec.scala
@@ -41,7 +41,7 @@ class BatchSizePropagationSpec
 
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
-    resultStorage.close()
+    resultStorage.clear()
   }
 
   def verifyBatchSizeInPartitioning(

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
@@ -45,7 +45,7 @@ class DataProcessingSpec
   }
   override def afterAll(): Unit = {
     TestKit.shutdownActorSystem(system)
-    resultStorage.close()
+    resultStorage.clear()
   }
 
   def executeWorkflow(workflow: Workflow): Map[OperatorIdentity, List[Tuple]] = {


### PR DESCRIPTION
This PR fixes #3036 by resetting the result storage to an empty state for every execution.

Deprecating memory storage is not yet feasible due to MongoDB’s 16MB document size limit. In some cases, the visualization result HTML can exceed the size limit.

**Important note:**
This approach works for now, but once operator result caching is reintroduced, we will need to modify this behavior to allow result reuse.