### PR TITLE
Fix Reverse Interpretation of Limit and Offset in Text Input Operator

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextInputSourceOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/source/scan/text/TextInputSourceOpExec.scala
@@ -8,8 +8,8 @@ import edu.uci.ics.texera.workflow.operators.source.scan.FileAttributeType
 class TextInputSourceOpExec private[text] (
     fileAttributeType: FileAttributeType,
     textInput: String,
-    fileScanOffset: Option[Int] = None,
-    fileScanLimit: Option[Int] = None
+    fileScanLimit: Option[Int] = None,
+    fileScanOffset: Option[Int] = None
 ) extends SourceOperatorExecutor {
 
   override def produceTuple(): Iterator[TupleLike] = {


### PR DESCRIPTION
This PR resolves an issue with the Limit and Offset properties in the Text Input operator. Previously, the backend function interpreted these values in reverse order. This has been corrected to ensure proper functionality.

<img width="1728" alt="Screenshot 2024-11-14 at 11 36 59 PM" src="https://github.com/user-attachments/assets/039ef644-f125-451a-919f-002f4576a15d">
