### PR TITLE
Fix Sink Operator Storage Flush Logic

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/managed/ProgressiveSinkOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sink/managed/ProgressiveSinkOpExec.scala
@@ -4,6 +4,7 @@ import edu.uci.ics.amber.engine.common.{IncrementalOutputMode, ProgressiveUtils}
 import edu.uci.ics.amber.engine.common.executor.SinkOperatorExecutor
 import edu.uci.ics.amber.engine.common.model.tuple.{Tuple, TupleLike}
 import edu.uci.ics.amber.engine.common.IncrementalOutputMode._
+import edu.uci.ics.amber.engine.common.workflow.PortIdentity
 import edu.uci.ics.texera.workflow.operators.sink.storage.SinkStorageWriter
 
 class ProgressiveSinkOpExec(outputMode: IncrementalOutputMode, storage: SinkStorageWriter)
@@ -33,8 +34,9 @@ class ProgressiveSinkOpExec(outputMode: IncrementalOutputMode, storage: SinkStor
     }
   }
 
-  override def close(): Unit = {
+  override def onFinishMultiPort(port: Int): Iterator[(TupleLike, Option[PortIdentity])] = {
     storage.close()
+    Iterator.empty
   }
 
   override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] = Iterator.empty

--- a/core/micro-services/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sink/managed/ProgressiveSinkOpExec.scala
+++ b/core/micro-services/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sink/managed/ProgressiveSinkOpExec.scala
@@ -4,6 +4,7 @@ import edu.uci.ics.amber.core.tuple.{Tuple, TupleLike}
 import edu.uci.ics.amber.core.storage.result.SinkStorageWriter
 import edu.uci.ics.amber.operator.sink.IncrementalOutputMode.{SET_DELTA, SET_SNAPSHOT}
 import edu.uci.ics.amber.core.executor.SinkOperatorExecutor
+import edu.uci.ics.amber.workflow.PortIdentity
 import edu.uci.ics.amber.operator.sink.IncrementalOutputMode
 
 class ProgressiveSinkOpExec(outputMode: IncrementalOutputMode, storage: SinkStorageWriter)
@@ -33,8 +34,9 @@ class ProgressiveSinkOpExec(outputMode: IncrementalOutputMode, storage: SinkStor
     }
   }
 
-  override def close(): Unit = {
+  override def onFinishMultiPort(port: Int): Iterator[(TupleLike, Option[PortIdentity])] = {
     storage.close()
+    Iterator.empty
   }
 
   override def processTuple(tuple: Tuple, port: Int): Iterator[TupleLike] = Iterator.empty


### PR DESCRIPTION
This PR fixes #3056. The reason for the random behavior of #3056 is: 
- There is an additional materialization pairs added after `DISTINCT`, and the next operator would belong to a new region. 
- The current sink operator implementation, which does batch write, only flushes the storage writer when the operator closes.
- The completion of the region that a sink operator belongs to is marked by the completion its input port. This causes the next region to be started as soon as its the input port is finished, and there is a chance that the materialized write is not flushed yet.
- The fix is to move the storage flush to as soon as the input port of the sink is finished.