### PR TITLE
Remove string cast on result row display

### DIFF
--- a/core/gui/src/app/common/util/json.ts
+++ b/core/gui/src/app/common/util/json.ts
@@ -29,7 +29,7 @@ export function formatBinaryData(value: string): string {
   return `bytes'${leadingBytes}...${trailingBytes}' (length: ${length})`;
 }
 
-export function trimAndFormatData(value: any, attributeType: AttributeType, maxLen: number): string {
+export function trimAndFormatData(value: any, attributeType: AttributeType, maxLen: number): any {
   if (value === null) {
     return "NULL";
   }
@@ -41,7 +41,7 @@ export function trimAndFormatData(value: any, attributeType: AttributeType, maxL
       return value.substring(0, maxLen) + "...";
     }
   }
-  return value;
+  return value ?? "";
 }
 
 export function trimDisplayJsonData(

--- a/core/gui/src/app/common/util/json.ts
+++ b/core/gui/src/app/common/util/json.ts
@@ -41,7 +41,7 @@ export function trimAndFormatData(value: any, attributeType: AttributeType, maxL
       return value.substring(0, maxLen) + "...";
     }
   }
-  return value?.toString() ?? "";
+  return value;
 }
 
 export function trimDisplayJsonData(


### PR DESCRIPTION
This PR removes the casting of the row field to a string type in the display JSON. It fixes #3058.
<img width="514" alt="截屏2024-11-15 下午3 12 13" src="https://github.com/user-attachments/assets/e6cf4268-ee84-4e39-9802-ecd32134401c">

