### PR TITLE
Introduce globle reset and close buttons for panels

### DIFF
--- a/core/gui/src/app/workspace/component/left-panel/left-panel.component.ts
+++ b/core/gui/src/app/workspace/component/left-panel/left-panel.component.ts
@@ -1,5 +1,5 @@
 import { Component, HostListener, OnDestroy, OnInit, Type } from "@angular/core";
-import { UntilDestroy } from "@ngneat/until-destroy";
+import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { NzResizeEvent } from "ng-zorro-antd/resizable";
 import { CdkDragDrop, moveItemInArray } from "@angular/cdk/drag-drop";
 import { environment } from "../../../../environments/environment";
@@ -9,6 +9,7 @@ import { WorkflowExecutionHistoryComponent } from "../../../dashboard/component/
 import { TimeTravelComponent } from "./time-travel/time-travel.component";
 import { SettingsComponent } from "./settings/settings.component";
 import { calculateTotalTranslate3d } from "../../../common/util/panel-dock";
+import { PanelService } from "../../service/panel/panel.service";
 @UntilDestroy()
 @Component({
   selector: "texera-left-panel",
@@ -52,7 +53,7 @@ export class LeftPanelComponent implements OnDestroy, OnInit {
   returnPosition = { x: 0, y: 0 };
   isDocked = true;
 
-  constructor() {
+  constructor(private panelService: PanelService) {
     const savedOrder = localStorage.getItem("left-panel-order")?.split(",").map(Number);
     this.order = savedOrder && new Set(savedOrder).size === new Set(this.order).size ? savedOrder : this.order;
 
@@ -70,6 +71,11 @@ export class LeftPanelComponent implements OnDestroy, OnInit {
     const [xOffset, yOffset, _] = calculateTotalTranslate3d(translates);
     this.returnPosition = { x: -xOffset, y: -yOffset };
     this.isDocked = this.dragPosition.x === this.returnPosition.x && this.dragPosition.y === this.returnPosition.y;
+    this.panelService.closePanelStream.pipe(untilDestroyed(this)).subscribe(() => this.openFrame(0));
+    this.panelService.resetPanelStream.pipe(untilDestroyed(this)).subscribe(() => {
+      this.resetPanelPosition();
+      this.openFrame(1);
+    });
   }
 
   @HostListener("window:beforeunload")

--- a/core/gui/src/app/workspace/component/menu/menu.component.html
+++ b/core/gui/src/app/workspace/component/menu/menu.component.html
@@ -139,6 +139,22 @@
       <ng-template #utilities>
         <nz-button-group>
           <button
+            (click)="onClickClosePanels()"
+            nz-button
+            title="close panels">
+            <i
+              nz-icon
+              nzType="minus"></i>
+          </button>
+          <button
+            (click)="onClickResetPanels()"
+            nz-button
+            title="reset panels">
+            <i
+              nz-icon
+              nzType="clear"></i>
+          </button>
+          <button
             (click)="onClickGenerateReport()"
             nz-button
             title="generate report">

--- a/core/gui/src/app/workspace/component/menu/menu.component.ts
+++ b/core/gui/src/app/workspace/component/menu/menu.component.ts
@@ -30,6 +30,7 @@ import { NzModalService } from "ng-zorro-antd/modal";
 import { ResultExportationComponent } from "../result-exportation/result-exportation.component";
 import { ReportGenerationService } from "../../service/report-generation/report-generation.service";
 import { ShareAccessComponent } from "src/app/dashboard/component/user/share-access/share-access.component";
+import { PanelService } from "../../service/panel/panel.service";
 /**
  * MenuComponent is the top level menu bar that shows
  *  the Texera title and workflow execution button
@@ -101,7 +102,8 @@ export class MenuComponent implements OnInit {
     public operatorMenu: OperatorMenuService,
     public coeditorPresenceService: CoeditorPresenceService,
     private modalService: NzModalService,
-    private reportGenerationService: ReportGenerationService
+    private reportGenerationService: ReportGenerationService,
+    private panelService: PanelService
   ) {
     workflowWebsocketService
       .subscribeToEvent("ExecutionDurationUpdateEvent")
@@ -269,6 +271,14 @@ export class MenuComponent implements OnInit {
 
   public handleCheckpoint(): void {
     this.executeWorkflowService.takeGlobalCheckpoint();
+  }
+
+  public onClickClosePanels(): void {
+    this.panelService.closePanels();
+  }
+
+  public onClickResetPanels(): void {
+    this.panelService.resetPanels();
   }
 
   /**

--- a/core/gui/src/app/workspace/component/property-editor/property-editor.component.html
+++ b/core/gui/src/app/workspace/component/property-editor/property-editor.component.html
@@ -13,7 +13,7 @@
   </li>
   <li
     nz-menu-item
-    (click)="width = 280; height = 300"
+    (click)="openPanel()"
     *ngIf="!width"
     nz-tooltip="Property Editor">
     <span

--- a/core/gui/src/app/workspace/component/property-editor/property-editor.component.ts
+++ b/core/gui/src/app/workspace/component/property-editor/property-editor.component.ts
@@ -7,6 +7,7 @@ import { filter } from "rxjs/operators";
 import { PortPropertyEditFrameComponent } from "./port-property-edit-frame/port-property-edit-frame.component";
 import { NzResizeEvent } from "ng-zorro-antd/resizable";
 import { calculateTotalTranslate3d } from "../../../common/util/panel-dock";
+import { PanelService } from "../../service/panel/panel.service";
 /**
  * PropertyEditorComponent is the panel that allows user to edit operator properties.
  * Depending on the highlighted operator or link, it displays OperatorPropertyEditFrameComponent
@@ -30,7 +31,8 @@ export class PropertyEditorComponent implements OnInit, OnDestroy {
   returnPosition = { x: 0, y: 0 };
   constructor(
     public workflowActionService: WorkflowActionService,
-    private changeDetectorRef: ChangeDetectorRef
+    private changeDetectorRef: ChangeDetectorRef,
+    private panelService: PanelService
   ) {
     const width = localStorage.getItem("right-panel-width");
     if (width) this.width = Number(width);
@@ -44,6 +46,11 @@ export class PropertyEditorComponent implements OnInit, OnDestroy {
     const [xOffset, yOffset, _] = calculateTotalTranslate3d(translates);
     this.returnPosition = { x: -xOffset, y: -yOffset };
     this.registerHighlightEventsHandler();
+    this.panelService.closePanelStream.pipe(untilDestroyed(this)).subscribe(() => this.closePanel());
+    this.panelService.resetPanelStream.pipe(untilDestroyed(this)).subscribe(() => {
+      this.resetPanelPosition();
+      this.openPanel();
+    });
   }
 
   @HostListener("window:beforeunload")
@@ -109,6 +116,11 @@ export class PropertyEditorComponent implements OnInit, OnDestroy {
       this.width = width!;
       this.height = height!;
     });
+  }
+
+  openPanel() {
+    this.width = 280;
+    this.height = 300;
   }
 
   closePanel() {

--- a/core/gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -18,6 +18,8 @@ import { VisualizationFrameContentComponent } from "../visualization-panel-conte
 import { calculateTotalTranslate3d } from "../../../common/util/panel-dock";
 import { PanelService } from "../../service/panel/panel.service";
 
+export const DEFAULT_WIDTH = 800
+export const DEFAULT_HEIGHT = 300
 /**
  * ResultPanelComponent is the bottom level area that displays the
  *  execution result of a workflow after the execution finishes.
@@ -28,12 +30,13 @@ import { PanelService } from "../../service/panel/panel.service";
   templateUrl: "./result-panel.component.html",
   styleUrls: ["./result-panel.component.scss"],
 })
+
 export class ResultPanelComponent implements OnInit, OnDestroy {
   frameComponentConfigs: Map<string, { component: Type<any>; componentInputs: {} }> = new Map();
   protected readonly window = window;
   id = -1;
-  width = 800;
-  height = 300;
+  width = DEFAULT_WIDTH;
+  height = DEFAULT_HEIGHT;
   operatorTitle = "";
   dragPosition = { x: 0, y: 0 };
   returnPosition = { x: 0, y: 0 };
@@ -271,8 +274,8 @@ export class ResultPanelComponent implements OnInit, OnDestroy {
   }
 
   openPanel() {
-    this.height = 800;
-    this.width = 300;
+    this.height = DEFAULT_HEIGHT;
+    this.width = DEFAULT_WIDTH;
   }
 
   closePanel() {

--- a/core/gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -34,10 +34,6 @@ export class ResultPanelComponent implements OnInit, OnDestroy {
   id = -1;
   width = 800;
   height = 300;
-  prevWidth = 800;
-  prevHeight = 300;
-  maxWidth = window.innerWidth;
-  maxHeight = window.innerHeight;
   operatorTitle = "";
   dragPosition = { x: 0, y: 0 };
   returnPosition = { x: 0, y: 0 };
@@ -275,13 +271,11 @@ export class ResultPanelComponent implements OnInit, OnDestroy {
   }
 
   openPanel() {
-    this.height = this.prevHeight;
-    this.width = this.prevWidth;
+    this.height = 800;
+    this.width = 300;
   }
 
   closePanel() {
-    this.prevHeight = this.height;
-    this.prevWidth = this.width;
     this.height = 32.5;
     this.width = 0;
   }

--- a/core/gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -18,8 +18,8 @@ import { VisualizationFrameContentComponent } from "../visualization-panel-conte
 import { calculateTotalTranslate3d } from "../../../common/util/panel-dock";
 import { PanelService } from "../../service/panel/panel.service";
 
-export const DEFAULT_WIDTH = 800
-export const DEFAULT_HEIGHT = 300
+export const DEFAULT_WIDTH = 800;
+export const DEFAULT_HEIGHT = 300;
 /**
  * ResultPanelComponent is the bottom level area that displays the
  *  execution result of a workflow after the execution finishes.
@@ -30,7 +30,6 @@ export const DEFAULT_HEIGHT = 300
   templateUrl: "./result-panel.component.html",
   styleUrls: ["./result-panel.component.scss"],
 })
-
 export class ResultPanelComponent implements OnInit, OnDestroy {
   frameComponentConfigs: Map<string, { component: Type<any>; componentInputs: {} }> = new Map();
   protected readonly window = window;

--- a/core/gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -16,6 +16,7 @@ import { WorkflowConsoleService } from "../../service/workflow-console/workflow-
 import { NzResizeEvent } from "ng-zorro-antd/resizable";
 import { VisualizationFrameContentComponent } from "../visualization-panel-content/visualization-frame-content.component";
 import { calculateTotalTranslate3d } from "../../../common/util/panel-dock";
+import { PanelService } from "../../service/panel/panel.service";
 
 /**
  * ResultPanelComponent is the bottom level area that displays the
@@ -53,7 +54,8 @@ export class ResultPanelComponent implements OnInit, OnDestroy {
     private workflowVersionService: WorkflowVersionService,
     private changeDetectorRef: ChangeDetectorRef,
     private workflowConsoleService: WorkflowConsoleService,
-    private resizeService: PanelResizeService
+    private resizeService: PanelResizeService,
+    private panelService: PanelService
   ) {
     const width = localStorage.getItem("result-panel-width");
     if (width) this.width = Number(width);
@@ -70,6 +72,11 @@ export class ResultPanelComponent implements OnInit, OnDestroy {
     this.registerAutoRerenderResultPanel();
     this.registerAutoOpenResultPanel();
     this.handleResultPanelForVersionPreview();
+    this.panelService.closePanelStream.pipe(untilDestroyed(this)).subscribe(() => this.closePanel());
+    this.panelService.resetPanelStream.pipe(untilDestroyed(this)).subscribe(() => {
+      this.resetPanelPosition();
+      this.openPanel();
+    });
   }
 
   @HostListener("window:beforeunload")

--- a/core/gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.ts
@@ -4,6 +4,7 @@ import { WorkflowActionService } from "../../../service/workflow-graph/model/wor
 import { MAIN_CANVAS } from "../workflow-editor.component";
 import * as joint from "jointjs";
 import { JointGraphWrapper } from "../../../service/workflow-graph/model/joint-graph-wrapper";
+import { PanelService } from "../../../service/panel/panel.service";
 
 @UntilDestroy()
 @Component({
@@ -17,7 +18,10 @@ export class MiniMapComponent implements AfterViewInit, OnDestroy {
   dragging = false;
   hidden = false;
 
-  constructor(private workflowActionService: WorkflowActionService) {}
+  constructor(
+    private workflowActionService: WorkflowActionService,
+    private panelService: PanelService
+  ) {}
 
   ngAfterViewInit() {
     const map = document.getElementById("mini-map")!;
@@ -44,6 +48,9 @@ export class MiniMapComponent implements AfterViewInit, OnDestroy {
         mainPaper.on("resize", () => this.updateNavigator());
       });
     this.hidden = JSON.parse(localStorage.getItem("mini-map") as string) || false;
+
+    this.panelService.closePanelStream.pipe(untilDestroyed(this)).subscribe(() => (this.hidden = true));
+    this.panelService.resetPanelStream.pipe(untilDestroyed(this)).subscribe(() => (this.hidden = false));
   }
 
   @HostListener("window:beforeunload")

--- a/core/gui/src/app/workspace/service/panel/panel.service.ts
+++ b/core/gui/src/app/workspace/service/panel/panel.service.ts
@@ -1,0 +1,26 @@
+import { Subject } from "rxjs";
+import { Injectable } from "@angular/core";
+
+@Injectable({
+  providedIn: "root",
+})
+export class PanelService {
+  private closePanelSubject = new Subject<void>();
+  private resetPanelSubject = new Subject<void>();
+
+  get resetPanelStream() {
+    return this.resetPanelSubject.asObservable();
+  }
+
+  resetPanels() {
+    this.resetPanelSubject.next();
+  }
+
+  get closePanelStream() {
+    return this.closePanelSubject.asObservable();
+  }
+
+  closePanels() {
+    this.closePanelSubject.next();
+  }
+}


### PR DESCRIPTION
This PR introduces two buttons on the workspace menu, which will be applied to all workspace panels.
![image](https://github.com/user-attachments/assets/29be6f92-dd36-4bdb-a56f-bb9e40a1d222)

1. The `close` button will close all panels on click.
![Animation](https://github.com/user-attachments/assets/3eb6ee6e-df17-487f-a221-c8b7d921b7e5)

2. The `reset` button will reset all panels to the default location on click.
![Animation2](https://github.com/user-attachments/assets/2c8845d1-0d97-48a7-b4d7-ada4ec6aa4b2)