### PR TITLE
Fix incorrect Google avatar URL generation to prevent connection errors

### DIFF
--- a/core/gui/src/app/common/service/user/auth.service.ts
+++ b/core/gui/src/app/common/service/user/auth.service.ts
@@ -115,7 +115,7 @@ export class AuthService {
       name: this.jwtHelperService.decodeToken(token).sub,
       email: email,
       googleId: this.jwtHelperService.decodeToken(token).googleId,
-      googleAvatar: "https://lh3.googleusercontent.com/a/" + this.jwtHelperService.decodeToken(token).googleAvatar,
+      googleAvatar: this.jwtHelperService.decodeToken(token).googleAvatar,
       role: role,
     };
   }

--- a/core/gui/src/app/dashboard/component/admin/user/admin-user.component.html
+++ b/core/gui/src/app/dashboard/component/admin/user/admin-user.component.html
@@ -115,7 +115,7 @@
     <tr *ngFor="let user of basicTable.data">
       <td>
         <texera-user-avatar
-          [googleAvatar]="'https://lh3.googleusercontent.com/a/' + user.googleAvatar"
+          [googleAvatar]="user.googleAvatar"
           [userName]="user.name"
           class="user-avatar"></texera-user-avatar>
       </td>

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
@@ -105,7 +105,7 @@
       nzFlex="50px"
       class="resource-info">
       <texera-user-avatar
-        [googleAvatar]="'https://lh3.googleusercontent.com/a/' + (entry.ownerGoogleAvatar || '')"
+        [googleAvatar]="entry.ownerGoogleAvatar"
         userColor="#1E90FF"
         [userName]="entry.ownerName || 'User'"
         [isOwner]="entry.ownerId === this.currentUid">

--- a/core/gui/src/app/dashboard/component/user/user-avatar/user-avatar.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-avatar/user-avatar.component.html
@@ -3,7 +3,7 @@
   style="position: relative">
   <nz-avatar
     [nzAlt]=""
-    [nzSrc]="googleAvatar"
+    [nzSrc]="googleAvatar ? 'https://lh3.googleusercontent.com/a/' + googleAvatar : ''"
     [nzText]="abbreviate(userName || '')"
     [style.background-color]="userColor"
     class="texera-user-avatar">

--- a/core/gui/src/app/dashboard/component/user/user-icon/user-icon.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-icon/user-icon.component.html
@@ -1,5 +1,5 @@
 <texera-user-avatar
-  [googleAvatar]="user?.googleAvatar || '' "
+  [googleAvatar]="user?.googleAvatar"
   [nzDropdownMenu]="menu"
   [userColor]="user?.color || ''"
   [userName]="user?.name || ''"

--- a/core/gui/src/app/hub/component/browse-section/browse-section.component.html
+++ b/core/gui/src/app/hub/component/browse-section/browse-section.component.html
@@ -14,7 +14,7 @@
       <div class="footer">
         <span class="footer-text">Edited: {{ workflow.lastModifiedTime | date }}</span>
         <texera-user-avatar
-          [googleAvatar]="'https://lh3.googleusercontent.com/a/' + workflow.ownerGoogleAvatar || ''"
+          [googleAvatar]="workflow.ownerGoogleAvatar"
           userColor="grey"
           [userName]="workflow.ownerName || ''"
           nz-button>

--- a/core/gui/src/app/workspace/component/menu/coeditor-user-icon/coeditor-user-icon.component.html
+++ b/core/gui/src/app/workspace/component/menu/coeditor-user-icon/coeditor-user-icon.component.html
@@ -1,5 +1,5 @@
 <texera-user-avatar
-  [googleAvatar]="coeditor.googleAvatar || '' "
+  [googleAvatar]="coeditor.googleAvatar"
   [userName]="coeditor.name || ''"
   [userColor]="coeditor.color || ''"
   nz-button


### PR DESCRIPTION
### Purpose:
This PR aims to fix the issue of generating incorrect Google avatar URLs, which leads to connection errors during avatar retrieval. When fetching a user avatar, a connection error is triggered if the avatar is not a Google avatar. The error occurs because, when assigning the Google avatar URL to the google-avatar attribute of the user avatar component, the base URL "https://lh3.googleusercontent.com/a/" is appended regardless of whether the google-avatar value retrieved from the backend is empty or not.

### Changes:
1. Modify `user-avatar.component.html` to complete the base URL internally rather than having it passed from the parent component. Add logic within the component to check whether the provided `googleAvatar` is empty.
2. Modify other components using the `user-avatar` component to directly pass the Google avatar retrieved from the backend to the `user-avatar` component.

### Demo:
old network in home page:
![image](https://github.com/user-attachments/assets/96fbc9fb-04f9-453c-af01-7e1fd4e7f26f)

new network in home page:
![image](https://github.com/user-attachments/assets/0ba66e51-3f79-400c-ba66-580fe732727e)