### PR TITLE
Address "Too Many Connections" Issue for Workflow Runtime Statistics

### DIFF
--- a/core/gui/src/app/dashboard/component/user/user-workflow/ngbd-modal-workflow-executions/workflow-runtime-statistics/workflow-runtime-statistics.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-workflow/ngbd-modal-workflow-executions/workflow-runtime-statistics/workflow-runtime-statistics.component.ts
@@ -1,6 +1,6 @@
 import { Component, inject, OnInit } from "@angular/core";
 import { UntilDestroy } from "@ngneat/until-destroy";
-import { WorkflowRuntimeStatistics } from "../../../../../type/workflow-runtime-statistics";
+import { OperatorRuntimeStatistics } from "../../../../../type/operator-runtime-statistics";
 import * as Plotly from "plotly.js-basic-dist-min";
 import { NzTabChangeEvent } from "ng-zorro-antd/tabs";
 import { NZ_MODAL_DATA } from "ng-zorro-antd/modal";
@@ -12,9 +12,9 @@ import { NZ_MODAL_DATA } from "ng-zorro-antd/modal";
   styleUrls: ["./workflow-runtime-statistics.component.scss"],
 })
 export class WorkflowRuntimeStatisticsComponent implements OnInit {
-  readonly workflowRuntimeStatistics: WorkflowRuntimeStatistics[] = inject(NZ_MODAL_DATA).workflowRuntimeStatistics;
+  readonly workflowRuntimeStatistics: OperatorRuntimeStatistics[] = inject(NZ_MODAL_DATA).workflowRuntimeStatistics;
 
-  private groupedStats?: Record<string, WorkflowRuntimeStatistics[]>;
+  private groupedStats?: Record<string, OperatorRuntimeStatistics[]>;
   public metrics: string[] = [
     "Input Tuple Count",
     "Output Tuple Count",
@@ -43,13 +43,13 @@ export class WorkflowRuntimeStatisticsComponent implements OnInit {
   /**
    * Convert an array into a record by combining stats to the same metric and accumulate tuple counts
    */
-  private groupStatsByOperatorId(): Record<string, WorkflowRuntimeStatistics[]> {
+  private groupStatsByOperatorId(): Record<string, OperatorRuntimeStatistics[]> {
     if (!this.workflowRuntimeStatistics) {
       return {};
     }
 
     const beginTimestamp = this.workflowRuntimeStatistics[0].timestamp;
-    return this.workflowRuntimeStatistics.reduce((acc: Record<string, WorkflowRuntimeStatistics[]>, stat) => {
+    return this.workflowRuntimeStatistics.reduce((acc: Record<string, OperatorRuntimeStatistics[]>, stat) => {
       const statsArray = acc[stat.operatorId] || [];
       const lastStat = statsArray[statsArray.length - 1];
 

--- a/core/gui/src/app/dashboard/service/user/workflow-executions/workflow-executions.service.ts
+++ b/core/gui/src/app/dashboard/service/user/workflow-executions/workflow-executions.service.ts
@@ -3,7 +3,7 @@ import { Observable } from "rxjs";
 import { AppSettings } from "../../../../common/app-setting";
 import { HttpClient } from "@angular/common/http";
 import { WorkflowExecutionsEntry } from "../../../type/workflow-executions-entry";
-import { WorkflowRuntimeStatistics } from "../../../type/workflow-runtime-statistics";
+import { OperatorRuntimeStatistics } from "../../../type/operator-runtime-statistics";
 
 export const WORKFLOW_EXECUTIONS_API_BASE_URL = `${AppSettings.getApiEndpoint()}/executions`;
 
@@ -43,7 +43,7 @@ export class WorkflowExecutionsService {
     });
   }
 
-  retrieveWorkflowRuntimeStatistics(wid: number, eId: number): Observable<WorkflowRuntimeStatistics[]> {
-    return this.http.get<WorkflowRuntimeStatistics[]>(`${WORKFLOW_EXECUTIONS_API_BASE_URL}/${wid}/${eId}`);
+  retrieveWorkflowRuntimeStatistics(wid: number, eId: number): Observable<OperatorRuntimeStatistics[]> {
+    return this.http.get<OperatorRuntimeStatistics[]>(`${WORKFLOW_EXECUTIONS_API_BASE_URL}/${wid}/${eId}`);
   }
 }

--- a/core/gui/src/app/dashboard/type/operator-runtime-statistics.ts
+++ b/core/gui/src/app/dashboard/type/operator-runtime-statistics.ts
@@ -1,4 +1,4 @@
-export interface WorkflowRuntimeStatistics {
+export interface OperatorRuntimeStatistics {
   [key: string]: any;
   operatorId: string;
   inputTupleCount: number;


### PR DESCRIPTION
This PR addresses the "Too many connections" issue encountered when storing runtime statistics for workflows. Previously, a new JDBC connection was created for each workflow execution, which led to scalability issues when handling a large number of users or concurrent workflows.

Fix
This update introduces a single, shared JDBC connection that is reused across all workflow executions, significantly improving scalability and reducing the risk of connection overload.