### PR TITLE
Fix issues of updating email address in the admin page

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
@@ -18,6 +18,8 @@ import edu.uci.ics.texera.web.resource.dashboard.user.quota.UserQuotaResource.{
   deleteMongoCollection,
   MongoStorage
 }
+import javax.ws.rs.core.Response
+import javax.ws.rs.WebApplicationException
 
 object AdminUserResource {
   final private lazy val context = SqlServer.createDSLContext()
@@ -43,6 +45,10 @@ class AdminUserResource {
   @PUT
   @Path("/update")
   def updateUser(user: User): Unit = {
+    val existingUser = userDao.fetchOneByEmail(user.getEmail)
+    if (existingUser != null && existingUser.getUid != user.getUid) {
+      throw new WebApplicationException("Email already exists", Response.Status.CONFLICT)
+    }
     val updatedUser = userDao.fetchOneByUid(user.getUid)
     updatedUser.setName(user.getName)
     updatedUser.setEmail(user.getEmail)

--- a/core/gui/src/app/dashboard/component/admin/user/admin-user.component.ts
+++ b/core/gui/src/app/dashboard/component/admin/user/admin-user.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from "@angular/core";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 import { NzTableFilterFn, NzTableSortFn } from "ng-zorro-antd/table";
 import { NzModalService } from "ng-zorro-antd/modal";
+import { NzMessageService } from "ng-zorro-antd/message";
 import { AdminUserService } from "../../../service/admin/user/admin-user.service";
 import { Role, User } from "../../../../common/type/user";
 import { UserService } from "../../../../common/service/user/user.service";
@@ -28,7 +29,8 @@ export class AdminUserComponent implements OnInit {
   constructor(
     private adminUserService: AdminUserService,
     private userService: UserService,
-    private modalService: NzModalService
+    private modalService: NzModalService,
+    private messageService: NzMessageService
   ) {
     this.currentUid = this.userService.getCurrentUser()?.uid;
   }
@@ -69,7 +71,10 @@ export class AdminUserComponent implements OnInit {
     this.adminUserService
       .updateUser(currentUid, this.editName, this.editEmail, this.editRole)
       .pipe(untilDestroyed(this))
-      .subscribe(() => this.ngOnInit());
+      .subscribe({
+        next: () => this.ngOnInit(),
+        error: (err: unknown) => this.messageService.error(err.message),
+      });
   }
 
   stopEdit(): void {

--- a/core/gui/src/app/dashboard/component/admin/user/admin-user.component.ts
+++ b/core/gui/src/app/dashboard/component/admin/user/admin-user.component.ts
@@ -73,7 +73,7 @@ export class AdminUserComponent implements OnInit {
       .pipe(untilDestroyed(this))
       .subscribe({
         next: () => this.ngOnInit(),
-        error: (err: unknown) => this.messageService.error(err.message),
+        error: (err: unknown) => this.messageService.error((err as Error).message),
       });
   }
 

--- a/core/gui/src/app/dashboard/service/admin/user/admin-user.service.ts
+++ b/core/gui/src/app/dashboard/service/admin/user/admin-user.service.ts
@@ -1,4 +1,4 @@
-import { HttpClient, HttpHeaders, HttpParams } from "@angular/common/http";
+import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from "@angular/common/http";
 import { Injectable } from "@angular/core";
 import { Observable } from "rxjs";
 import { AppSettings } from "../../../../common/app-setting";
@@ -41,7 +41,7 @@ export class AdminUserService {
       })
       .pipe(
         catchError((error: unknown) => {
-          if (error.status === 409) {
+          if ((error as HttpErrorResponse).status === 409) {
             return throwError(() => new Error("Email already exists"));
           }
           return throwError(() => error);

--- a/core/gui/src/app/dashboard/service/admin/user/admin-user.service.ts
+++ b/core/gui/src/app/dashboard/service/admin/user/admin-user.service.ts
@@ -4,6 +4,8 @@ import { Observable } from "rxjs";
 import { AppSettings } from "../../../../common/app-setting";
 import { Role, User, File, Workflow, MongoExecution } from "../../../../common/type/user";
 import { DatasetQuota } from "src/app/dashboard/type/quota-statistic.interface";
+import { catchError } from "rxjs/operators";
+import { throwError } from "rxjs";
 
 export const USER_BASE_URL = `${AppSettings.getApiEndpoint()}/admin/user`;
 export const USER_LIST_URL = `${USER_BASE_URL}/list`;
@@ -30,12 +32,21 @@ export class AdminUserService {
   }
 
   public updateUser(uid: number, name: string, email: string, role: Role): Observable<void> {
-    return this.http.put<void>(`${USER_UPDATE_URL}`, {
-      uid: uid,
-      name: name,
-      email: email,
-      role: role,
-    });
+    return this.http
+      .put<void>(`${USER_UPDATE_URL}`, {
+        uid: uid,
+        name: name,
+        email: email,
+        role: role,
+      })
+      .pipe(
+        catchError((error: unknown) => {
+          if (error.status === 409) {
+            return throwError(() => new Error("Email already exists"));
+          }
+          return throwError(() => error);
+        })
+      );
   }
 
   public addUser(): Observable<Response> {


### PR DESCRIPTION
This PR addresses the issue where attempting to update a user's email address to one already associated with another user did not display an error message on the frontend. Previously, when an admin tried to update the email address under these circumstances, the frontend provided no feedback, leaving the user unaware of the issue.

**Fix:**
The frontend now displays a clear error message when the backend reports that the email address already exists. This ensures admins receive immediate feedback and can take corrective action.


https://github.com/user-attachments/assets/3a86621a-3f09-45e5-a5c6-c02cdbf83da6

