### PR TITLE
Bump sklearn version

### DIFF
--- a/core/amber/operator-requirements.txt
+++ b/core/amber/operator-requirements.txt
@@ -4,4 +4,4 @@ praw==7.6.1
 pillow==10.2.0
 pybase64==1.3.2
 torch==2.4.1
-scikit-learn==1.3.2
+scikit-learn==1.4.1

--- a/core/amber/operator-requirements.txt
+++ b/core/amber/operator-requirements.txt
@@ -4,4 +4,4 @@ praw==7.6.1
 pillow==10.2.0
 pybase64==1.3.2
 torch==2.4.1
-scikit-learn==1.4.1
+scikit-learn==1.4.0


### PR DESCRIPTION
Bump the sklearn version to 1.4.0 in order to support the root_mean_squared_error function introduced in PR##2675.
This PR will resolve issue #3088.

Ref:
https://github.com/scikit-learn/scikit-learn/issues/28900