### PR TITLE
Prevent re-opening websocket connections on metadata update

### DIFF
--- a/core/gui/src/app/workspace/service/workflow-websocket/workflow-websocket.service.ts
+++ b/core/gui/src/app/workspace/service/workflow-websocket/workflow-websocket.service.ts
@@ -105,7 +105,7 @@ export class WorkflowWebsocketService {
   }
 
   public reopenWebsocket(wId: number) {
-    if (this.isConnected && this.connectedWid == wId) {
+    if (this.isConnected && this.connectedWid === wId) {
       // prevent reconnections
       return;
     }


### PR DESCRIPTION
This PR fixes #3085. The issue is caused by a call of `this.workflowActionService.setWorkflowMetadata(updatedWorkflow);` in `persistWorkflow`. This call caused the WebSocket service to detect a workflow metadata update and reopen the WebSocket unnecessarily. Therefore, the bug can be consistently reproduced by hitting the save button on the workflow canvas.

This PR introduces a logic check to skip reopening the WebSocket if the wid remains unchanged, preventing redundant reconnections.