### PR TITLE
Add Time Logging in CostBasedRegionPlanGenerator

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerProcessor.scala
@@ -24,7 +24,8 @@ class ControllerProcessor(
 ) extends AmberProcessor(actorId, outputHandler) {
 
   val workflowExecution: WorkflowExecution = WorkflowExecution()
-  val workflowScheduler: WorkflowScheduler = new WorkflowScheduler(workflowContext, opResultStorage)
+  val workflowScheduler: WorkflowScheduler =
+    new WorkflowScheduler(workflowContext, opResultStorage, actorId)
   val workflowExecutionCoordinator: WorkflowExecutionCoordinator = new WorkflowExecutionCoordinator(
     () => this.workflowScheduler.getNextRegions,
     workflowExecution,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/WorkflowScheduler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/WorkflowScheduler.scala
@@ -8,10 +8,14 @@ import edu.uci.ics.amber.engine.architecture.scheduling.{
 }
 import edu.uci.ics.amber.engine.common.AmberConfig
 import edu.uci.ics.amber.engine.common.model.{PhysicalPlan, WorkflowContext}
+import edu.uci.ics.amber.engine.common.virtualidentity.ActorVirtualIdentity
 import edu.uci.ics.texera.workflow.common.storage.OpResultStorage
 
-class WorkflowScheduler(workflowContext: WorkflowContext, opResultStorage: OpResultStorage)
-    extends java.io.Serializable {
+class WorkflowScheduler(
+    workflowContext: WorkflowContext,
+    opResultStorage: OpResultStorage,
+    actorId: ActorVirtualIdentity
+) extends java.io.Serializable {
   var physicalPlan: PhysicalPlan = _
   private var schedule: Schedule = _
 
@@ -25,7 +29,8 @@ class WorkflowScheduler(workflowContext: WorkflowContext, opResultStorage: OpRes
       new CostBasedRegionPlanGenerator(
         workflowContext,
         physicalPlan,
-        opResultStorage
+        opResultStorage,
+        actorId
       ).generate()
     } else {
       // ExpansionGreedyRegionPlanGenerator is the stable default plan generator.

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/CostBasedRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/CostBasedRegionPlanGenerator.scala
@@ -1,10 +1,9 @@
 package edu.uci.ics.amber.engine.architecture.scheduling
 
-import com.typesafe.scalalogging.LazyLogging
-import edu.uci.ics.amber.engine.common.AmberConfig
 import edu.uci.ics.amber.engine.common.model.{PhysicalPlan, WorkflowContext}
-import edu.uci.ics.amber.engine.common.virtualidentity.PhysicalOpIdentity
+import edu.uci.ics.amber.engine.common.virtualidentity.{ActorVirtualIdentity, PhysicalOpIdentity}
 import edu.uci.ics.amber.engine.common.workflow.PhysicalLink
+import edu.uci.ics.amber.engine.common.{AmberConfig, AmberLogging}
 import edu.uci.ics.texera.workflow.common.storage.OpResultStorage
 import org.jgrapht.alg.connectivity.BiconnectivityInspector
 import org.jgrapht.graph.{DirectedAcyclicGraph, DirectedPseudograph}
@@ -15,13 +14,14 @@ import scala.jdk.CollectionConverters._
 class CostBasedRegionPlanGenerator(
     workflowContext: WorkflowContext,
     initialPhysicalPlan: PhysicalPlan,
-    opResultStorage: OpResultStorage
+    opResultStorage: OpResultStorage,
+    val actorId: ActorVirtualIdentity
 ) extends RegionPlanGenerator(
       workflowContext,
       initialPhysicalPlan,
       opResultStorage
     )
-    with LazyLogging {
+    with AmberLogging {
 
   case class SearchResult(
       state: Set[PhysicalLink],

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/CostBasedRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/CostBasedRegionPlanGenerator.scala
@@ -33,7 +33,13 @@ class CostBasedRegionPlanGenerator(
 
   def generate(): (RegionPlan, PhysicalPlan) = {
 
+    val startTime = System.nanoTime()
     val regionDAG = createRegionDAG()
+    val schedulerTime = System.nanoTime() - startTime
+    logger.info(
+      s"WID: ${workflowContext.workflowId.id}, EID: ${workflowContext.executionId.id}, total RPG time: " +
+        s"${schedulerTime / 1e6} ms."
+    )
     (
       RegionPlan(
         regions = regionDAG.iterator().asScala.toSet,
@@ -125,6 +131,10 @@ class CostBasedRegionPlanGenerator(
     val searchResult = bottomUpSearch(globalSearch = AmberConfig.useGlobalSearch)
     // Only a non-dependee blocking link that has not already been materialized should be replaced
     // with a materialization write op + materialization read op.
+    logger.info(
+      s"WID: ${workflowContext.workflowId.id}, EID: ${workflowContext.executionId.id}, search time: " +
+        s"${searchResult.searchTimeNanoSeconds / 1e6} ms."
+    )
     val linksToMaterialize =
       (searchResult.state ++ physicalPlan.getNonMaterializedBlockingAndDependeeLinks).diff(
         physicalPlan.getDependeeLinks

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/CostBasedRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/CostBasedRegionPlanGenerator.scala
@@ -35,10 +35,10 @@ class CostBasedRegionPlanGenerator(
 
     val startTime = System.nanoTime()
     val regionDAG = createRegionDAG()
-    val schedulerTime = System.nanoTime() - startTime
+    val totalRPGTime = System.nanoTime() - startTime
     logger.info(
       s"WID: ${workflowContext.workflowId.id}, EID: ${workflowContext.executionId.id}, total RPG time: " +
-        s"${schedulerTime / 1e6} ms."
+        s"${totalRPGTime / 1e6} ms."
     )
     (
       RegionPlan(

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/CostBasedRegionPlanGeneratorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/CostBasedRegionPlanGeneratorSpec.scala
@@ -1,6 +1,7 @@
 package edu.uci.ics.amber.engine.architecture.scheduling
 
 import edu.uci.ics.amber.engine.common.model.WorkflowContext
+import edu.uci.ics.amber.engine.common.virtualidentity.util.CONTROLLER
 import edu.uci.ics.amber.engine.common.workflow.PortIdentity
 import edu.uci.ics.amber.engine.e2e.TestOperators
 import edu.uci.ics.amber.engine.e2e.TestUtils.buildWorkflow
@@ -57,7 +58,8 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
     val globalSearchNoPruningResult = new CostBasedRegionPlanGenerator(
       workflow.context,
       workflow.physicalPlan,
-      resultStorage
+      resultStorage,
+      CONTROLLER
     ).bottomUpSearch(globalSearch = true, oChains = false, oCleanEdges = false)
 
     // Should have explored all possible states (2^4 states)
@@ -66,7 +68,8 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
     val globalSearchOChainsResult = new CostBasedRegionPlanGenerator(
       workflow.context,
       workflow.physicalPlan,
-      resultStorage
+      resultStorage,
+      CONTROLLER
     ).bottomUpSearch(globalSearch = true, oCleanEdges = false)
 
     // By applying pruning based on Chains alone, it should skip 10 (8 + 2) states. 8 states where CSV->Build is
@@ -78,7 +81,8 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
     val globalSearchOCleanEdgesResult = new CostBasedRegionPlanGenerator(
       workflow.context,
       workflow.physicalPlan,
-      resultStorage
+      resultStorage,
+      CONTROLLER
     ).bottomUpSearch(globalSearch = true, oChains = false)
 
     // By applying pruning based on Clean edges (bridges) alone, it should skip 8 states. There is one clean edge
@@ -88,7 +92,8 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
     val globalSearchAllPruningEnabledResult = new CostBasedRegionPlanGenerator(
       workflow.context,
       workflow.physicalPlan,
-      resultStorage
+      resultStorage,
+      CONTROLLER
     ).bottomUpSearch(globalSearch = true)
 
     // By combining both pruning techniques, only 3 states should be visited (1 state where both CSV->KeywordFilter and

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/BatchSizePropagationSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/BatchSizePropagationSpec.scala
@@ -14,6 +14,7 @@ import edu.uci.ics.amber.engine.architecture.sendsemantics.partitionings.{
 }
 import edu.uci.ics.amber.engine.common.model.WorkflowContext
 import edu.uci.ics.amber.engine.common.model.WorkflowSettings
+import edu.uci.ics.amber.engine.common.virtualidentity.util.CONTROLLER
 import edu.uci.ics.amber.engine.common.workflow.PortIdentity
 import edu.uci.ics.texera.workflow.common.storage.OpResultStorage
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -131,7 +132,7 @@ class BatchSizePropagationSpec
       context
     )
 
-    val workflowScheduler = new WorkflowScheduler(context, resultStorage)
+    val workflowScheduler = new WorkflowScheduler(context, resultStorage, CONTROLLER)
     workflowScheduler.updateSchedule(workflow.physicalPlan)
 
     verifyBatchSizeInPartitioning(workflowScheduler, 1)
@@ -168,7 +169,7 @@ class BatchSizePropagationSpec
       context
     )
 
-    val workflowScheduler = new WorkflowScheduler(context, resultStorage)
+    val workflowScheduler = new WorkflowScheduler(context, resultStorage, CONTROLLER)
     workflowScheduler.updateSchedule(workflow.physicalPlan)
 
     verifyBatchSizeInPartitioning(workflowScheduler, 500)
@@ -213,7 +214,7 @@ class BatchSizePropagationSpec
       context
     )
 
-    val workflowScheduler = new WorkflowScheduler(context, resultStorage)
+    val workflowScheduler = new WorkflowScheduler(context, resultStorage, CONTROLLER)
     workflowScheduler.updateSchedule(workflow.physicalPlan)
 
     verifyBatchSizeInPartitioning(workflowScheduler, 100)
@@ -262,7 +263,7 @@ class BatchSizePropagationSpec
       context
     )
 
-    val workflowScheduler = new WorkflowScheduler(context, resultStorage)
+    val workflowScheduler = new WorkflowScheduler(context, resultStorage, CONTROLLER)
     workflowScheduler.updateSchedule(workflow.physicalPlan)
 
     verifyBatchSizeInPartitioning(workflowScheduler, 300)
@@ -311,7 +312,7 @@ class BatchSizePropagationSpec
       context
     )
 
-    val workflowScheduler = new WorkflowScheduler(context, resultStorage)
+    val workflowScheduler = new WorkflowScheduler(context, resultStorage, CONTROLLER)
     workflowScheduler.updateSchedule(workflow.physicalPlan)
 
     verifyBatchSizeInPartitioning(workflowScheduler, 1)


### PR DESCRIPTION
This PR adds logging of: 
- The time it takes to for CostBasedRegionPlanGenerator to finish search.
- The total time it takes for CostBasedRegionPlanGenerator to produce a region plan (including adding materialization, building region graph on the new physical plan with added materialization, etc).