### PR TITLE
Fix dashboard items loading issue on Safari

### DIFF
--- a/core/gui/src/app/dashboard/component/user/search-results/search-results.component.html
+++ b/core/gui/src/app/dashboard/component/user/search-results/search-results.component.html
@@ -9,7 +9,7 @@
     itemSize="70"
     class="virtual-scroll-container">
     <nz-list>
-      <ng-container *cdkVirtualFor="let entry of entries">
+      <ng-container *ngFor="let entry of entries">
         <texera-list-item
           (deleted)="deleted.emit(entry)"
           (duplicated)="duplicated.emit(entry)"


### PR DESCRIPTION
This PR fixes issue #3057.
The issue can only be reproduced in production mode. 

It looks like `cdkVirtualFor` is a leftover from the previous implementation, and we don't really need to use it for our current implementation.
