### PR TITLE
Add ground truth reversing function in sklearn prediction operators

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
@@ -17,6 +17,11 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
   @JsonPropertyDescription("attribute name of the prediction result")
   var resultAttribute: String = _
 
+  @JsonProperty(value = "Target Attribute Name", required = false, defaultValue = "")
+  @JsonPropertyDescription("attribute name of the target result (ground truth)")
+  @AutofillAttributeName
+  var targetAttribute: String = _
+
   override def generatePythonCode(): String =
     s"""from pytexera import *
        |from sklearn.pipeline import Pipeline
@@ -26,8 +31,9 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
        |        if port == 0:
        |            self.model = tuple_["$model"]
        |        else:
-       |            required_columns = self.model.feature_names_in_
-       |            input_features = {col: tuple_[col] for col in required_columns if col in tuple_}
+       |            input_features = tuple_
+       |            if "$targetAttribute" != "":
+       |                input_features = Tuple({col: tuple_[col] for col in tuple_.as_dict() if col != "$targetAttribute"})
        |            tuple_["$resultAttribute"] = str(self.model.predict(Table.from_tuple_likes([input_features]))[0])
        |            yield tuple_""".stripMargin
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
@@ -17,10 +17,10 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
   @JsonPropertyDescription("attribute name of the prediction result")
   var resultAttribute: String = _
 
-  @JsonProperty(value = "Target Attribute Name", required = false, defaultValue = "")
-  @JsonPropertyDescription("attribute name of the target result (ground truth)")
+  @JsonProperty(value = "Ground Truth Attribute Name to Ignore", required = false, defaultValue = "")
+  @JsonPropertyDescription("attribute name of the ground truth")
   @AutofillAttributeName
-  var targetAttribute: String = ""
+  var groundTruthAttribute: String = ""
 
   override def generatePythonCode(): String =
     s"""from pytexera import *
@@ -32,8 +32,8 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
        |            self.model = tuple_["$model"]
        |        else:
        |            input_features = tuple_
-       |            if "$targetAttribute" != "" and "$targetAttribute" is not None:
-       |                input_features = Tuple({col: tuple_[col] for col in tuple_.as_dict() if col != "$targetAttribute"})
+       |            if "$groundTruthAttribute" != "":
+       |                input_features = input_features.get_partial_tuple([col for col in tuple_.get_field_names() if col != "$groundTruthAttribute"])
        |            tuple_["$resultAttribute"] = str(self.model.predict(Table.from_tuple_likes([input_features]))[0])
        |            yield tuple_""".stripMargin
 
@@ -53,6 +53,6 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
     Schema
       .builder()
       .add(schemas(1))
-      .add(resultAttribute, AttributeType.STRING)
+        .add(resultAttribute, AttributeType.STRING)
       .build()
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
@@ -17,7 +17,11 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
   @JsonPropertyDescription("attribute name of the prediction result")
   var resultAttribute: String = _
 
-  @JsonProperty(value = "Ground Truth Attribute Name to Ignore", required = false, defaultValue = "")
+  @JsonProperty(
+    value = "Ground Truth Attribute Name to Ignore",
+    required = false,
+    defaultValue = ""
+  )
   @JsonPropertyDescription("attribute name of the ground truth")
   @AutofillAttributeName
   var groundTruthAttribute: String = ""

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
@@ -53,6 +53,6 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
     Schema
       .builder()
       .add(schemas(1))
-        .add(resultAttribute, AttributeType.STRING)
+      .add(resultAttribute, AttributeType.STRING)
       .build()
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
@@ -20,7 +20,7 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
   @JsonProperty(value = "Target Attribute Name", required = false, defaultValue = "")
   @JsonPropertyDescription("attribute name of the target result (ground truth)")
   @AutofillAttributeName
-  var targetAttribute: String = _
+  var targetAttribute: String = ""
 
   override def generatePythonCode(): String =
     s"""from pytexera import *
@@ -32,7 +32,7 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
        |            self.model = tuple_["$model"]
        |        else:
        |            input_features = tuple_
-       |            if "$targetAttribute" != "":
+       |            if "$targetAttribute" != "" and "$targetAttribute" is not None:
        |                input_features = Tuple({col: tuple_[col] for col in tuple_.as_dict() if col != "$targetAttribute"})
        |            tuple_["$resultAttribute"] = str(self.model.predict(Table.from_tuple_likes([input_features]))[0])
        |            yield tuple_""".stripMargin

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
@@ -26,7 +26,9 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
        |        if port == 0:
        |            self.model = tuple_["$model"]
        |        else:
-       |            tuple_["$resultAttribute"] = str(self.model.predict(Table.from_tuple_likes([tuple_]))[0])
+       |            required_columns = self.model.feature_names_in_
+       |            input_features = {col: tuple_[col] for col in required_columns if col in tuple_}
+       |            tuple_["$resultAttribute"] = str(self.model.predict(Table.from_tuple_likes([input_features]))[0])
        |            yield tuple_""".stripMargin
 
   override def operatorInfo: OperatorInfo =


### PR DESCRIPTION
Add a field to the sklearn operator that allows users to reserve the target (ground truth) column for further comparison of results, for example, by using the scoring operator. This PR solves Issue #3087 . Below is a demo of the updated sklearn operator: the top one does not reserve any target column, while the bottom one reserves the 'Purchased' column.

![Screen Recording 2024-11-21 at 1 36 37 AM](https://github.com/user-attachments/assets/983fa080-8e2e-4cfd-9585-60541b923eb4)
