### PR TITLE
Set the schema for the result column to be the same as the ground truth column if it exists.

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/machineLearning/Scorer/MachineLearningScorerOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/machineLearning/Scorer/MachineLearningScorerOpDesc.scala
@@ -163,9 +163,7 @@ class MachineLearningScorerOpDesc extends PythonOperatorDescriptor {
          |      else:
          |        # calculate the number of unique labels
          |        labels = list(set(y_true))
-         |        # align the type of y_true and y_pred(str)
-         |        y_true_str = y_true.astype(str)
-         |        result = classification_metrics(y_true_str, y_pred, metric_list, labels)
+         |        result = classification_metrics(y_true, y_pred, metric_list, labels)
          |
          |      yield result
          |""".stripMargin

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
@@ -56,15 +56,15 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
     )
 
   override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    var resultSchema = AttributeType.STRING
+    var resultType = AttributeType.STRING
     if (groundTruthAttribute != "") {
-      resultSchema =
+      resultType =
         schemas(1).attributes.find(attr => attr.getName == groundTruthAttribute).get.getType
     }
     Schema
       .builder()
       .add(schemas(1))
-      .add(resultAttribute, resultSchema)
+      .add(resultAttribute, resultType)
       .build()
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/sklearn/SklearnPredictionOpDesc.scala
@@ -38,7 +38,9 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
        |            input_features = tuple_
        |            if "$groundTruthAttribute" != "":
        |                input_features = input_features.get_partial_tuple([col for col in tuple_.get_field_names() if col != "$groundTruthAttribute"])
-       |            tuple_["$resultAttribute"] = str(self.model.predict(Table.from_tuple_likes([input_features]))[0])
+       |                tuple_["$resultAttribute"] = type(tuple_["$groundTruthAttribute"])(self.model.predict(Table.from_tuple_likes([input_features]))[0])
+       |            else:
+       |                tuple_["$resultAttribute"] = str(self.model.predict(Table.from_tuple_likes([input_features]))[0])
        |            yield tuple_""".stripMargin
 
   override def operatorInfo: OperatorInfo =
@@ -53,10 +55,16 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
       outputPorts = List(OutputPort())
     )
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema =
+  override def getOutputSchema(schemas: Array[Schema]): Schema = {
+    var resultSchema = AttributeType.STRING
+    if (groundTruthAttribute != "") {
+      resultSchema =
+        schemas(1).attributes.find(attr => attr.getName == groundTruthAttribute).get.getType
+    }
     Schema
       .builder()
       .add(schemas(1))
-      .add(resultAttribute, AttributeType.STRING)
+      .add(resultAttribute, resultSchema)
       .build()
+  }
 }


### PR DESCRIPTION
In the original Sklearn prediction operator, all prediction results were cast to the String type to maintain consistency. We are now introducing an option for users to specify whether they have a ground truth column. If a ground truth column exists, the data type of the prediction column will be aligned with the data type of the ground truth column. In this PR, we add a feature that ensures if a ground truth column is present, the prediction column will have the same data type as the ground truth column. If no ground truth column exists, the prediction result will be cast to a String.
![Screen Recording 2024-11-21 at 11 35 28 AM](https://github.com/user-attachments/assets/c94d88e5-d819-4d25-9bf7-59dc60660f84)