### PR TITLE
Prevent Workflow Execution for Inactive Operators

### DIFF
--- a/core/gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.html
+++ b/core/gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.html
@@ -109,7 +109,7 @@
 
   <li
     nz-menu-item
-    [nzDisabled]="!isSelectedOperatorValid()"
+    [nzDisabled]="!canExecuteOperator()"
     (click)="operatorMenuService.executeUpToOperator()">
     <span
       nz-icon

--- a/core/gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.spec.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.spec.ts
@@ -34,14 +34,18 @@ describe("ContextMenuComponent", () => {
     jointGraphWrapperSpy.getCurrentHighlightedOperatorIDs.and.returnValue([]);
     jointGraphWrapperSpy.getCurrentHighlightedCommentBoxIDs.and.returnValue([]);
 
+    const texeraGraphSpy = jasmine.createSpyObj("TexeraGraph", ["isOperatorDisabled"]);
+
     const workflowActionServiceSpy = jasmine.createSpyObj("WorkflowActionService", [
       "getJointGraphWrapper",
       "getWorkflowModificationEnabledStream",
       "deleteOperatorsAndLinks",
       "deleteCommentBox",
+      "getTexeraGraph",
     ]);
     workflowActionServiceSpy.getJointGraphWrapper.and.returnValue(jointGraphWrapperSpy);
     workflowActionServiceSpy.getWorkflowModificationEnabledStream.and.returnValue(of(true));
+    workflowActionServiceSpy.getTexeraGraph.and.returnValue(texeraGraphSpy);
     workflowActionServiceSpy.deleteOperatorsAndLinks.and.returnValue();
     workflowActionServiceSpy.deleteCommentBox.and.returnValue();
 
@@ -153,7 +157,7 @@ describe("ContextMenuComponent", () => {
       jointGraphWrapperSpy.getCurrentHighlightedOperatorIDs.and.returnValue(["op1", "op2"]);
       component.isWorkflowModifiable = true;
 
-      expect(component.isSelectedOperatorValid()).toBeFalse();
+      expect(component.canExecuteOperator()).toBeFalse();
       expect(validationWorkflowService.validateOperator).not.toHaveBeenCalled();
     });
 
@@ -161,7 +165,7 @@ describe("ContextMenuComponent", () => {
       jointGraphWrapperSpy.getCurrentHighlightedOperatorIDs.and.returnValue([]);
       component.isWorkflowModifiable = true;
 
-      expect(component.isSelectedOperatorValid()).toBeFalse();
+      expect(component.canExecuteOperator()).toBeFalse();
       expect(validationWorkflowService.validateOperator).not.toHaveBeenCalled();
     });
 
@@ -169,7 +173,7 @@ describe("ContextMenuComponent", () => {
       jointGraphWrapperSpy.getCurrentHighlightedOperatorIDs.and.returnValue(["op1"]);
       component.isWorkflowModifiable = false;
 
-      expect(component.isSelectedOperatorValid()).toBeFalse();
+      expect(component.canExecuteOperator()).toBeFalse();
       expect(validationWorkflowService.validateOperator).not.toHaveBeenCalled();
     });
 
@@ -178,7 +182,7 @@ describe("ContextMenuComponent", () => {
       component.isWorkflowModifiable = true;
       validationWorkflowService.validateOperator.and.returnValue({ isValid: true });
 
-      expect(component.isSelectedOperatorValid()).toBeTrue();
+      expect(component.canExecuteOperator()).toBeTrue();
       expect(validationWorkflowService.validateOperator).toHaveBeenCalledWith("op1");
     });
 
@@ -187,8 +191,79 @@ describe("ContextMenuComponent", () => {
       component.isWorkflowModifiable = true;
       validationWorkflowService.validateOperator.and.returnValue({ isValid: false, messages: {} });
 
-      expect(component.isSelectedOperatorValid()).toBeFalse();
+      expect(component.canExecuteOperator()).toBeFalse();
       expect(validationWorkflowService.validateOperator).toHaveBeenCalledWith("op1");
+    });
+  });
+
+  describe("canExecuteOperator", () => {
+    let texeraGraphSpy: jasmine.SpyObj<any>;
+
+    beforeEach(() => {
+      texeraGraphSpy = workflowActionService.getTexeraGraph() as jasmine.SpyObj<any>;
+      jointGraphWrapperSpy.getCurrentHighlightedOperatorIDs.and.returnValue(["op1"]);
+      component.isWorkflowModifiable = true;
+      validationWorkflowService.validateOperator.and.returnValue({ isValid: true });
+      texeraGraphSpy.isOperatorDisabled.and.returnValue(false);
+    });
+
+    it("should return false when multiple operators are highlighted", () => {
+      jointGraphWrapperSpy.getCurrentHighlightedOperatorIDs.and.returnValue(["op1", "op2"]);
+
+      expect(component.canExecuteOperator()).toBeFalse();
+      expect(validationWorkflowService.validateOperator).not.toHaveBeenCalled();
+      expect(texeraGraphSpy.isOperatorDisabled).not.toHaveBeenCalled();
+    });
+
+    it("should return false when no operators are highlighted", () => {
+      jointGraphWrapperSpy.getCurrentHighlightedOperatorIDs.and.returnValue([]);
+
+      expect(component.canExecuteOperator()).toBeFalse();
+      expect(validationWorkflowService.validateOperator).not.toHaveBeenCalled();
+      expect(texeraGraphSpy.isOperatorDisabled).not.toHaveBeenCalled();
+    });
+
+    it("should return false when workflow is not modifiable", () => {
+      component.isWorkflowModifiable = false;
+
+      expect(component.canExecuteOperator()).toBeFalse();
+      expect(validationWorkflowService.validateOperator).not.toHaveBeenCalled();
+      expect(texeraGraphSpy.isOperatorDisabled).not.toHaveBeenCalled();
+    });
+
+    it("should return true when all conditions are met (valid, enabled, modifiable)", () => {
+      expect(component.canExecuteOperator()).toBeTrue();
+      expect(validationWorkflowService.validateOperator).toHaveBeenCalledWith("op1");
+      expect(texeraGraphSpy.isOperatorDisabled).toHaveBeenCalledWith("op1");
+    });
+
+    it("should return false when operator is invalid and not check disabled status", () => {
+      validationWorkflowService.validateOperator.and.returnValue({ isValid: false, messages: {} });
+
+      expect(component.canExecuteOperator()).toBeFalse();
+      expect(validationWorkflowService.validateOperator).toHaveBeenCalledWith("op1");
+      expect(texeraGraphSpy.isOperatorDisabled).not.toHaveBeenCalled();
+    });
+
+    it("should return false when operator is valid but disabled", () => {
+      validationWorkflowService.validateOperator.and.returnValue({ isValid: true });
+      texeraGraphSpy.isOperatorDisabled.and.returnValue(true);
+
+      expect(component.canExecuteOperator()).toBeFalse();
+      expect(validationWorkflowService.validateOperator).toHaveBeenCalledWith("op1");
+      expect(texeraGraphSpy.isOperatorDisabled).toHaveBeenCalledWith("op1");
+    });
+
+    it("should check disabled status only for valid operators", () => {
+      // First test with invalid operator
+      validationWorkflowService.validateOperator.and.returnValue({ isValid: false, messages: {} });
+      component.canExecuteOperator();
+      expect(texeraGraphSpy.isOperatorDisabled).not.toHaveBeenCalled();
+
+      // Then test with valid operator
+      validationWorkflowService.validateOperator.and.returnValue({ isValid: true });
+      component.canExecuteOperator();
+      expect(texeraGraphSpy.isOperatorDisabled).toHaveBeenCalledWith("op1");
     });
   });
 });

--- a/core/gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/context-menu/context-menu/context-menu.component.ts
@@ -25,13 +25,28 @@ export class ContextMenuComponent {
     this.registerWorkflowModifiableChangedHandler();
   }
 
-  public isSelectedOperatorValid(): boolean {
-    const highlightedOperatorIDs = this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs();
-    if (highlightedOperatorIDs.length !== 1 || !this.isWorkflowModifiable) {
+  public canExecuteOperator(): boolean {
+    if (!this.hasExactlyOneOperatorSelected() || !this.isWorkflowModifiable) {
       return false;
     }
-    const operatorID = highlightedOperatorIDs[0];
-    return this.validationWorkflowService.validateOperator(operatorID).isValid;
+
+    const operatorID = this.getSelectedOperatorID();
+    return this.isOperatorExecutable(operatorID);
+  }
+
+  private hasExactlyOneOperatorSelected(): boolean {
+    return this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs().length === 1;
+  }
+
+  private getSelectedOperatorID(): string {
+    return this.workflowActionService.getJointGraphWrapper().getCurrentHighlightedOperatorIDs()[0];
+  }
+
+  private isOperatorExecutable(operatorID: string): boolean {
+    return (
+      this.validationWorkflowService.validateOperator(operatorID).isValid &&
+      !this.workflowActionService.getTexeraGraph().isOperatorDisabled(operatorID)
+    );
   }
 
   public onCopy(): void {

--- a/core/gui/src/app/workspace/service/validation/validation-workflow.service.ts
+++ b/core/gui/src/app/workspace/service/validation/validation-workflow.service.ts
@@ -6,6 +6,8 @@ import { WorkflowActionService } from "../workflow-graph/model/workflow-action.s
 import Ajv from "ajv";
 import { map } from "rxjs/operators";
 import { DynamicSchemaService } from "../dynamic-schema/dynamic-schema.service";
+import { untilDestroyed } from "@ngneat/until-destroy";
+import { UntilDestroy } from "@ngneat/until-destroy";
 
 export type ValidationError = {
   isValid: false;
@@ -32,6 +34,7 @@ export type ValidationOutput = {
  *
  * @author Angela Wang
  */
+@UntilDestroy()
 @Injectable({
   providedIn: "root",
 })
@@ -123,12 +126,11 @@ export class ValidationWorkflowService {
 
   private checkIfWorkflowEmpty() {
     const operators = this.workflowActionService.getTexeraGraph().getAllOperators();
-    console.log("operators length: ", operators.length);
     this.workflowEmpty = operators.length === 0;
-    
+
     // If there are operators, check if they're all disabled
     if (!this.workflowEmpty) {
-      this.workflowEmpty = operators.every(operator => 
+      this.workflowEmpty = operators.every(operator =>
         this.workflowActionService.getTexeraGraph().isOperatorDisabled(operator.operatorID)
       );
     }
@@ -137,12 +139,6 @@ export class ValidationWorkflowService {
   private updateValidationStateOnDelete(operatorID: string) {
     this.checkIfWorkflowEmpty();
     delete this.workflowErrors[operatorID];
-    this.workflowValidationErrorStream.next({ errors: this.workflowErrors, workflowEmpty: this.workflowEmpty });
-  }
-
-  // Add a new method to handle workflow empty state updates
-  private updateWorkflowEmptyState(): void {
-    this.checkIfWorkflowEmpty();
     this.workflowValidationErrorStream.next({ errors: this.workflowErrors, workflowEmpty: this.workflowEmpty });
   }
 
@@ -231,12 +227,19 @@ export class ValidationWorkflowService {
           outputs.forEach(link => operatorsToRevalidate.add(link.target.operatorID));
         });
 
-        operatorsToRevalidate.forEach(op => 
-          this.updateValidationState(op, this.validateOperator(op))
-        );
-        
-        // Update empty state after processing disable/enable changes
-        this.updateWorkflowEmptyState();
+        operatorsToRevalidate.forEach(op => this.updateValidationState(op, this.validateOperator(op)));
+      });
+
+    // Add subscription to workflow changes
+    this.workflowActionService
+      .workflowChanged()
+      .pipe(untilDestroyed(this))
+      .subscribe(() => {
+        this.checkIfWorkflowEmpty();
+        this.workflowValidationErrorStream.next({
+          errors: this.workflowErrors,
+          workflowEmpty: this.workflowEmpty,
+        });
       });
   }
 

--- a/core/gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
+++ b/core/gui/src/app/workspace/service/workflow-graph/model/workflow-action.service.ts
@@ -25,6 +25,7 @@ import { isDefined } from "../../../../common/util/predicate";
 import { environment } from "../../../../../environments/environment";
 import { User } from "../../../../common/type/user";
 import { SharedModelChangeHandler } from "./shared-model-change-handler";
+import { ValidationWorkflowService } from "../../validation/validation-workflow.service";
 
 export const DEFAULT_WORKFLOW_NAME = "Untitled Workflow";
 export const DEFAULT_WORKFLOW = {


### PR DESCRIPTION
This PR resolves an issue where the UI allowed execution of workflows containing only inactive operators. Previously, users could initiate such workflows either by clicking the "Run" button or by using the right-click "Execute to this operator" option, even when all operators were inactive.

With this update:
- The "Run" button is disabled if the workflow contains only inactive operators.
- The right-click "Execute to this operator" option is deactivated for inactive operators.

These changes ensure that workflows with only inactive operators cannot be executed, improving the overall user experience and preventing unintended behavior.

https://github.com/user-attachments/assets/863c7361-51e6-4e2c-b25e-a4e9ca85507d

