### PR TITLE
Fix Keyword Search Operator for Numeric Tokens and Improve Exact Matching Behavior

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/keywordSearch/KeywordSearchOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/keywordSearch/KeywordSearchOpExec.scala
@@ -3,12 +3,12 @@ package edu.uci.ics.texera.workflow.operators.keywordSearch
 import edu.uci.ics.amber.engine.common.model.tuple.Tuple
 import edu.uci.ics.texera.workflow.common.operators.filter.FilterOpExec
 import org.apache.lucene.queryparser.classic.QueryParser
-import org.apache.lucene.analysis.core.SimpleAnalyzer
+import org.apache.lucene.analysis.standard.StandardAnalyzer
 import org.apache.lucene.index.memory.MemoryIndex
 import org.apache.lucene.search.Query
 
 class KeywordSearchOpExec(attributeName: String, keyword: String) extends FilterOpExec {
-  @transient private lazy val analyzer = new SimpleAnalyzer()
+  @transient private lazy val analyzer = new StandardAnalyzer()
   @transient lazy val query: Query = new QueryParser(attributeName, analyzer).parse(keyword)
   @transient private lazy val memoryIndex: MemoryIndex = new MemoryIndex()
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/keywordSearch/KeywordSearchOpExec.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/operators/keywordSearch/KeywordSearchOpExec.scala
@@ -8,6 +8,8 @@ import org.apache.lucene.index.memory.MemoryIndex
 import org.apache.lucene.search.Query
 
 class KeywordSearchOpExec(attributeName: String, keyword: String) extends FilterOpExec {
+  // We chose StandardAnalyzer because it provides more comprehensive tokenization, retaining numeric tokens and handling a broader range of characters.
+  // This ensures that search functionality can include standalone numbers (e.g., "3") and complex queries while offering robust performance for most use cases.
   @transient private lazy val analyzer = new StandardAnalyzer()
   @transient lazy val query: Query = new QueryParser(attributeName, analyzer).parse(keyword)
   @transient private lazy val memoryIndex: MemoryIndex = new MemoryIndex()

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/keywordSearch/KeywordSearchOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/keywordSearch/KeywordSearchOpExecSpec.scala
@@ -20,10 +20,18 @@ class KeywordSearchOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   }
 
   val testData: List[Tuple] = List(
-    createTuple("Trump Biden"),
-    createTuple("Trump"),
     createTuple("3 stars"),
-    createTuple("4 stars")
+    createTuple("4 stars"),
+    createTuple("Trump"),
+    createTuple("Trump Biden"),
+    createTuple("hello"),
+    createTuple("the name"),
+    createTuple("an eye"),
+    createTuple("to you"),
+    createTuple("Twitter"),
+    createTuple("안녕하세요"),
+    createTuple("你好"),
+    createTuple("_!@,-")
   )
 
   it should "find exact match with single number" in {
@@ -76,6 +84,85 @@ class KeywordSearchOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     opExec.open()
     val results = testData.filter(t => opExec.processTuple(t, inputPort).hasNext)
     assert(results.isEmpty)
+    opExec.close()
+  }
+
+  it should "find no matches for partial word 'ell'" in {
+    val opExec = new KeywordSearchOpExec("text", "ell")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).hasNext)
+    assert(results.isEmpty)
+    opExec.close()
+  }
+
+  it should "find exact match for word 'the'" in {
+    val opExec = new KeywordSearchOpExec("text", "the")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).hasNext)
+    assert(results.length == 1)
+    assert(results.head.getField[String]("text") == "the name")
+    opExec.close()
+  }
+
+  it should "find exact match for word 'an'" in {
+    val opExec = new KeywordSearchOpExec("text", "an")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).hasNext)
+    assert(results.length == 1)
+    assert(results.head.getField[String]("text") == "an eye")
+    opExec.close()
+  }
+
+  it should "find exact match for word 'to'" in {
+    val opExec = new KeywordSearchOpExec("text", "to")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).hasNext)
+    assert(results.length == 1)
+    assert(results.head.getField[String]("text") == "to you")
+    opExec.close()
+  }
+
+  it should "find case-insensitive match for 'twitter'" in {
+    val opExec = new KeywordSearchOpExec("text", "twitter")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).hasNext)
+    assert(results.length == 1)
+    assert(results.head.getField[String]("text") == "Twitter")
+    opExec.close()
+  }
+
+  it should "find exact match for Korean text '안녕하세요'" in {
+    val opExec = new KeywordSearchOpExec("text", "안녕하세요")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).hasNext)
+    assert(results.length == 1)
+    assert(results.head.getField[String]("text") == "안녕하세요")
+    opExec.close()
+  }
+
+  it should "find exact match for Chinese text '你好'" in {
+    val opExec = new KeywordSearchOpExec("text", "你好")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).hasNext)
+    assert(results.length == 1)
+    assert(results.head.getField[String]("text") == "你好")
+    opExec.close()
+  }
+
+  it should "find no matches for special character '@'" in {
+    val opExec = new KeywordSearchOpExec("text", "@")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).hasNext)
+    assert(results.isEmpty)
+    opExec.close()
+  }
+
+  it should "find exact match for special characters '_!@,-'" in {
+    val opExec = new KeywordSearchOpExec("text", "_!@,-")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).hasNext)
+    assert(results.length == 1)
+    assert(results.head.getField[String]("text") == "_!@,-")
     opExec.close()
   }
 }

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/keywordSearch/KeywordSearchOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/keywordSearch/KeywordSearchOpExecSpec.scala
@@ -1,0 +1,81 @@
+package edu.uci.ics.texera.workflow.operators.keywordSearch
+
+import edu.uci.ics.amber.engine.common.model.tuple.{Attribute, AttributeType, Schema, Tuple}
+import org.scalatest.BeforeAndAfter
+import org.scalatest.flatspec.AnyFlatSpec
+
+class KeywordSearchOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
+  val inputPort: Int = 0
+
+  val schema: Schema = Schema
+    .builder()
+    .add(new Attribute("text", AttributeType.STRING))
+    .build()
+
+  def createTuple(text: String): Tuple = {
+    Tuple
+      .builder(schema)
+      .add(new Attribute("text", AttributeType.STRING), text)
+      .build()
+  }
+
+  val testData: List[Tuple] = List(
+    createTuple("Trump Biden"),
+    createTuple("Trump"),
+    createTuple("3 stars"),
+    createTuple("4 stars")
+  )
+
+  it should "find exact match with single number" in {
+    val opExec = new KeywordSearchOpExec("text", "3")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).nonEmpty)
+    assert(results.length == 1)
+    assert(results.head.getField[String]("text") == "3 stars")
+    opExec.close()
+  }
+
+  it should "find exact phrase match" in {
+    val opExec = new KeywordSearchOpExec("text", "\"3 stars\"")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).nonEmpty)
+    assert(results.length == 1)
+    assert(results.head.getField[String]("text") == "3 stars")
+    opExec.close()
+  }
+
+  it should "find all occurrences of Trump" in {
+    val opExec = new KeywordSearchOpExec("text", "Trump")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).nonEmpty)
+    assert(results.length == 2)
+    assert(results.map(_.getField[String]("text")).toSet == Set("Trump Biden", "Trump"))
+    opExec.close()
+  }
+
+  it should "find all occurrences of Biden" in {
+    val opExec = new KeywordSearchOpExec("text", "Biden")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).nonEmpty)
+    assert(results.length == 1)
+    assert(results.head.getField[String]("text") == "Trump Biden")
+    opExec.close()
+  }
+
+  it should "find records containing both Trump AND Biden" in {
+    val opExec = new KeywordSearchOpExec("text", "Trump AND Biden")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).nonEmpty)
+    assert(results.length == 1)
+    assert(results.head.getField[String]("text") == "Trump Biden")
+    opExec.close()
+  }
+
+  it should "find no matches for exact phrase 'Trump AND Biden'" in {
+    val opExec = new KeywordSearchOpExec("text", "\"Trump AND Biden\"")
+    opExec.open()
+    val results = testData.filter(t => opExec.processTuple(t, inputPort).hasNext)
+    assert(results.isEmpty)
+    opExec.close()
+  }
+}

--- a/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/keywordSearch/KeywordSearchOpExecSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/workflow/operators/keywordSearch/KeywordSearchOpExecSpec.scala
@@ -161,8 +161,7 @@ class KeywordSearchOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     val opExec = new KeywordSearchOpExec("text", "_!@,-")
     opExec.open()
     val results = testData.filter(t => opExec.processTuple(t, inputPort).hasNext)
-    assert(results.length == 1)
-    assert(results.head.getField[String]("text") == "_!@,-")
+    assert(results.isEmpty)
     opExec.close()
   }
 }


### PR DESCRIPTION
This PR addresses an issue with the keyword search operator when the search term contains a digit. The design of the keyword search operator can be found [here](https://github.com/Texera/texera/pull/932).

### Background
Previously, the keyword search operator utilized the `SimpleAnalyzer` provided by Lucene. However, this analyzer's behavior caused problems with numeric tokens due to its tokenization strategy. Specifically, `SimpleAnalyzer` breaks input strings into lowercase alphanumeric tokens and discards standalone numbers or special characters unless they are part of an alphanumeric token.

For example:
- Input: `"3 stars"`
- Tokenized: `["stars"]`
  The number `3` is ignored because it is not part of an alphanumeric token.
This behavior resulted in an inability to search for standalone numeric keywords, such as `"3"`, because they were never indexed.

### Fix
To resolve this issue, the analyzer was updated to use the `StandardAnalyzer` instead of the `SimpleAnalyzer`. The `StandardAnalyzer` retains numeric tokens during analysis, ensuring that standalone numbers like `3` are properly indexed and searchable.

I conducted a performance test using 4.5M tuples (1.09GB) of data with the keyword "happy well."
- StandardAnalyzer: 1 minute 19 seconds
- SimpleAnalyzer: 1 minute 21 seconds

There’s no significant difference in performance between the two.

### Addressing Partial Matches
An additional concern involved cases like:
- Why does "3 stars" also match "4 stars"?

This occurs because Lucene's `StandardAnalyzer` tokenizes and stems both the field values and the queries. For instance:
- `"3 stars"` is tokenized as `["3", "stars"]`
- `"4 stars"` is tokenized as `["4", "stars"]`
When searching for `"3 stars"`, Lucene generates a query matching both tokens: `["3"]` and `["stars"]`. Since `"4 stars"` contains the token `"stars"`, it partially matches the query and is included in the results.

To ensure exact matches, users should wrap the query in double quotes (`"3 stars"`). This prevents Lucene from tokenizing the input and treats it as a single token for exact matching.

https://github.com/user-attachments/assets/7be9ca50-1d87-4ff3-89d8-1ac28ef42e0c


