### PR TITLE
Update docker scripts due to the change of folder structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR /core
 COPY .git ../.git
 COPY --from=nodegui /gui/dist ./gui/dist
 
-RUN scripts/build-docker.sh
+RUN scripts/build-services.sh
 
 CMD ["scripts/deploy-docker.sh"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,6 @@ FROM sbtscala/scala-sbt:eclipse-temurin-jammy-11.0.17_8_1.9.3_2.13.11
 WORKDIR /core
 COPY core/ .
 
-WORKDIR /core/amber
-RUN sbt clean package
 RUN apt-get update
 RUN apt-get install -y netcat unzip python3-pip
 RUN pip3 install python-lsp-server python-lsp-server[websockets]

--- a/core/scripts/build-docker.sh
+++ b/core/scripts/build-docker.sh
@@ -1,7 +1,0 @@
-cd amber
-sbt clean dist
-unzip target/universal/texera-0.1-SNAPSHOT.zip -d target/universal/
-rm target/universal/texera-0.1-SNAPSHOT.zip
-
-cd ..
-./scripts/build-services.sh

--- a/core/scripts/build-services.sh
+++ b/core/scripts/build-services.sh
@@ -1,3 +1,6 @@
 sbt clean dist
 unzip workflow-compiling-service/target/universal/workflow-compiling-service-0.1.0.zip -d target/
 rm workflow-compiling-service/target/universal/workflow-compiling-service-0.1.0.zip
+
+unzip amber/target/universal/texera-0.1-SNAPSHOT.zip -d target/
+rm amber/target/universal/texera-0.1-SNAPSHOT.zip

--- a/core/scripts/build-services.sh
+++ b/core/scripts/build-services.sh
@@ -2,5 +2,5 @@ sbt clean dist
 unzip workflow-compiling-service/target/universal/workflow-compiling-service-0.1.0.zip -d target/
 rm workflow-compiling-service/target/universal/workflow-compiling-service-0.1.0.zip
 
-unzip amber/target/universal/texera-0.1-SNAPSHOT.zip -d target/
+unzip amber/target/universal/texera-0.1-SNAPSHOT.zip -d amber/target/
 rm amber/target/universal/texera-0.1-SNAPSHOT.zip

--- a/core/scripts/build.sh
+++ b/core/scripts/build.sh
@@ -1,7 +1,2 @@
-cd amber
-sbt clean dist
-unzip target/universal/texera-0.1-SNAPSHOT.zip -d target/universal/
-rm target/universal/texera-0.1-SNAPSHOT.zip
-cd ..
 ./scripts/build-services.sh
 ./scripts/gui.sh

--- a/core/scripts/deploy-daemon.sh
+++ b/core/scripts/deploy-daemon.sh
@@ -13,16 +13,8 @@ done
 
 if  ! $skipCompilation
 then
-  echo "${green}Compiling Amber...${reset}"
-  cd amber
-  sbt clean dist
-  unzip target/universal/texera-0.1-SNAPSHOT.zip -d target/universal/
-  rm target/universal/texera-0.1-SNAPSHOT.zip
-  echo "${green}Amber compiled.${reset}"
-  echo
-
   echo "${green}Compiling Services...${reset}"
-  cd .. && bash scripts/build-services.sh
+  bash scripts/build-services.sh
   echo "${green}Services compiled.${reset}"
 
   echo "${green}Compiling GUI...${reset}"
@@ -35,7 +27,7 @@ fi
 echo "${green}Starting TexeraWebApplication in daemon...${reset}"
 setsid nohup ./scripts/server.sh >/dev/null 2>&1 &
 echo "${green}Waiting TexeraWebApplication to launch on 8080...${reset}"
-while ! nc -z localhost 8080; do   
+while ! nc -z localhost 8080; do
 	sleep 0.1 # wait 100ms before check again
 done
 echo "${green}TexeraWebApplication launched at $(pgrep -f TexeraWebApplication)${reset}"

--- a/core/scripts/server.sh
+++ b/core/scripts/server.sh
@@ -2,7 +2,7 @@ pylsp --ws --port 3000 &
 cd amber
 if [ ! -z $1 ] 
 then 
-    target/universal/texera-0.1-SNAPSHOT/bin/texera-web-application  --cluster $1
+    target/texera-0.1-SNAPSHOT/bin/texera-web-application  --cluster $1
 else
-    target/universal/texera-0.1-SNAPSHOT/bin/texera-web-application
+    target/texera-0.1-SNAPSHOT/bin/texera-web-application
 fi

--- a/core/scripts/server.sh
+++ b/core/scripts/server.sh
@@ -1,4 +1,5 @@
 pylsp --ws --port 3000 &
+cd amber
 if [ ! -z $1 ] 
 then 
     target/texera-0.1-SNAPSHOT/bin/texera-web-application  --cluster $1

--- a/core/scripts/server.sh
+++ b/core/scripts/server.sh
@@ -1,5 +1,4 @@
 pylsp --ws --port 3000 &
-cd amber
 if [ ! -z $1 ] 
 then 
     target/texera-0.1-SNAPSHOT/bin/texera-web-application  --cluster $1

--- a/core/scripts/worker.sh
+++ b/core/scripts/worker.sh
@@ -1,4 +1,5 @@
 if [ ! -z $1 ]
+cd amber
 then 
     target/texera-0.1-SNAPSHOT/bin/texera-run-worker --serverAddr $1
 else

--- a/core/scripts/worker.sh
+++ b/core/scripts/worker.sh
@@ -1,7 +1,7 @@
 cd amber
 if [ ! -z $1 ] 
 then 
-    target/universal/texera-0.1-SNAPSHOT/bin/texera-run-worker --serverAddr $1 
+    target/texera-0.1-SNAPSHOT/bin/texera-run-worker --serverAddr $1
 else
-    target/universal/texera-0.1-SNAPSHOT/bin/texera-run-worker
+    target/texera-0.1-SNAPSHOT/bin/texera-run-worker
 fi

--- a/core/scripts/worker.sh
+++ b/core/scripts/worker.sh
@@ -1,5 +1,5 @@
-if [ ! -z $1 ]
 cd amber
+if [ ! -z $1 ]
 then 
     target/texera-0.1-SNAPSHOT/bin/texera-run-worker --serverAddr $1
 else

--- a/core/scripts/worker.sh
+++ b/core/scripts/worker.sh
@@ -1,5 +1,4 @@
-cd amber
-if [ ! -z $1 ] 
+if [ ! -z $1 ]
 then 
     target/texera-0.1-SNAPSHOT/bin/texera-run-worker --serverAddr $1
 else


### PR DESCRIPTION
Since #3111, amber has been built together with other micro-services. So we need to change the docker scripts and all other amber-related scripts to adapt this change. This PR updates those scripts.

Important notes:
1. build-docker.sh is removed. We build everything using build-services.sh.
2. After building amber, we put the binary back into the amber folder for it to find `amberHomePath`.