### PR TITLE
Add Top-down Search In CostBasedRegionPlanGenerator

### DIFF
--- a/core/amber/src/main/resources/application.conf
+++ b/core/amber/src/main/resources/application.conf
@@ -74,6 +74,7 @@ fault-tolerance {
 region-plan-generator {
     enable-cost-based-region-plan-generator = false
     use-global-search = false
+    use-top-down-search = false
 }
 
 python-language-server{

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberConfig.scala
@@ -78,6 +78,8 @@ object AmberConfig {
   val enableCostBasedRegionPlanGenerator: Boolean =
     getConfSource.getBoolean("region-plan-generator.enable-cost-based-region-plan-generator")
   val useGlobalSearch: Boolean = getConfSource.getBoolean("region-plan-generator.use-global-search")
+  val useTopDownSearch: Boolean =
+    getConfSource.getBoolean("region-plan-generator.use-top-down-search")
 
   // Storage configuration
   val sinkStorageTTLInSecs: Int = getConfSource.getInt("result-cleanup.ttl-in-seconds")


### PR DESCRIPTION
This PR adds another search method using the top-down direction in CostBasedRegionPlanGenerator as an alternative to the existing bottom-up search method.
- A configurable option is added to switch between the two search directions.
- Optimizations based on Chains and Clean Edges are included. These two techniques are used by updating the seed state of the search.
- There is another optimization, Early Stopping based on hopeless state, that is not included in this PR due to its complexity of implementation. We can add it in another PR.
- Also added test cases similar to those for the bottom-up search.