### PR TITLE
Update Schedule Generation to Use a Total Order of Regions

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/Schedule.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/Schedule.scala
@@ -1,20 +1,15 @@
 package edu.uci.ics.amber.engine.architecture.scheduling
 
 import scala.collection.mutable
-import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 case class Schedule(private val regionPlan: RegionPlan) extends Iterator[Set[Region]] {
   private val levels = mutable.Map.empty[RegionIdentity, Int]
   private val levelSets = mutable.Map.empty[Int, mutable.Set[RegionIdentity]]
   private var currentLevel = 0
 
+  // A schedule is a total order of the region plan.
   regionPlan.topologicalIterator().foreach { currentVertex =>
-    val level = regionPlan.dag.incomingEdgesOf(currentVertex).asScala.foldLeft(0) {
-      (maxLevel, incomingEdge) =>
-        val sourceVertex = regionPlan.dag.getEdgeSource(incomingEdge)
-        math.max(maxLevel, levels.getOrElse(sourceVertex, 0) + 1)
-    }
-
+    val level = levelSets.size
     levels(currentVertex) = level
     levelSets.getOrElseUpdate(level, mutable.Set.empty).add(currentVertex)
   }


### PR DESCRIPTION
This PR changes the schedule generation process to use a total order of the regions, i.e., each "level" only has one region. As a result, after this change, a workflow will execute one region at a time and there will be no parallel region execution.

We could also move the schedule generation process to be part of RegionPlanGenerator, but that would require both CostBasedRegionPlanGenerator and ExpansionGreedyRegionPlanGenerator to generate schedules instead of region plans.