### PR TITLE
Resolve storage inside ProgressiveSinkOpExec

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/Controller.scala
@@ -2,7 +2,6 @@ package edu.uci.ics.amber.engine.architecture.controller
 
 import akka.actor.SupervisorStrategy.Stop
 import akka.actor.{AllForOneStrategy, Props, SupervisorStrategy}
-import edu.uci.ics.amber.core.storage.result.OpResultStorage
 import edu.uci.ics.amber.core.workflow.{PhysicalPlan, WorkflowContext}
 import edu.uci.ics.amber.engine.architecture.common.{ExecutorDeployment, WorkflowActor}
 import edu.uci.ics.amber.engine.architecture.common.WorkflowActor.NetworkAck
@@ -43,14 +42,12 @@ object Controller {
   def props(
       workflowContext: WorkflowContext,
       physicalPlan: PhysicalPlan,
-      opResultStorage: OpResultStorage,
       controllerConfig: ControllerConfig = ControllerConfig.default
   ): Props =
     Props(
       new Controller(
         workflowContext,
         physicalPlan,
-        opResultStorage,
         controllerConfig
       )
     )
@@ -59,7 +56,6 @@ object Controller {
 class Controller(
     workflowContext: WorkflowContext,
     physicalPlan: PhysicalPlan,
-    opResultStorage: OpResultStorage,
     controllerConfig: ControllerConfig
 ) extends WorkflowActor(
       controllerConfig.faultToleranceConfOpt,
@@ -70,7 +66,6 @@ class Controller(
   val controllerTimerService = new ControllerTimerService(controllerConfig, actorService)
   var cp = new ControllerProcessor(
     workflowContext,
-    opResultStorage,
     controllerConfig,
     actorId,
     logManager.sendCommitted

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerProcessor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/ControllerProcessor.scala
@@ -1,6 +1,5 @@
 package edu.uci.ics.amber.engine.architecture.controller
 
-import edu.uci.ics.amber.core.storage.result.OpResultStorage
 import edu.uci.ics.amber.core.workflow.WorkflowContext
 import edu.uci.ics.amber.engine.architecture.common.{
   AkkaActorRefMappingService,
@@ -17,7 +16,6 @@ import edu.uci.ics.amber.virtualidentity.ActorVirtualIdentity
 
 class ControllerProcessor(
     workflowContext: WorkflowContext,
-    opResultStorage: OpResultStorage,
     controllerConfig: ControllerConfig,
     actorId: ActorVirtualIdentity,
     outputHandler: Either[MainThreadDelegateMessage, WorkflowFIFOMessage] => Unit
@@ -25,7 +23,7 @@ class ControllerProcessor(
 
   val workflowExecution: WorkflowExecution = WorkflowExecution()
   val workflowScheduler: WorkflowScheduler =
-    new WorkflowScheduler(workflowContext, opResultStorage, actorId)
+    new WorkflowScheduler(workflowContext, actorId)
   val workflowExecutionCoordinator: WorkflowExecutionCoordinator = new WorkflowExecutionCoordinator(
     () => this.workflowScheduler.getNextRegions,
     workflowExecution,

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/WorkflowScheduler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/WorkflowScheduler.scala
@@ -33,7 +33,7 @@ class WorkflowScheduler(
       // ExpansionGreedyRegionPlanGenerator is the stable default plan generator.
       new ExpansionGreedyRegionPlanGenerator(
         workflowContext,
-        physicalPlan,
+        physicalPlan
       ).generate()
     }
     this.physicalPlan = updatedPhysicalPlan

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/WorkflowScheduler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/controller/WorkflowScheduler.scala
@@ -1,6 +1,5 @@
 package edu.uci.ics.amber.engine.architecture.controller
 
-import edu.uci.ics.amber.core.storage.result.OpResultStorage
 import edu.uci.ics.amber.core.workflow.{PhysicalPlan, WorkflowContext}
 import edu.uci.ics.amber.engine.architecture.scheduling.{
   CostBasedRegionPlanGenerator,
@@ -13,7 +12,6 @@ import edu.uci.ics.amber.virtualidentity.ActorVirtualIdentity
 
 class WorkflowScheduler(
     workflowContext: WorkflowContext,
-    opResultStorage: OpResultStorage,
     actorId: ActorVirtualIdentity
 ) extends java.io.Serializable {
   var physicalPlan: PhysicalPlan = _
@@ -29,7 +27,6 @@ class WorkflowScheduler(
       new CostBasedRegionPlanGenerator(
         workflowContext,
         physicalPlan,
-        opResultStorage,
         actorId
       ).generate()
     } else {
@@ -37,7 +34,6 @@ class WorkflowScheduler(
       new ExpansionGreedyRegionPlanGenerator(
         workflowContext,
         physicalPlan,
-        opResultStorage
       ).generate()
     }
     this.physicalPlan = updatedPhysicalPlan

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/CostBasedRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/CostBasedRegionPlanGenerator.scala
@@ -20,12 +20,10 @@ import scala.util.control.Breaks.{break, breakable}
 class CostBasedRegionPlanGenerator(
     workflowContext: WorkflowContext,
     initialPhysicalPlan: PhysicalPlan,
-    opResultStorage: OpResultStorage,
     val actorId: ActorVirtualIdentity
 ) extends RegionPlanGenerator(
       workflowContext,
-      initialPhysicalPlan,
-      opResultStorage
+      initialPhysicalPlan
     )
     with AmberLogging {
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
@@ -2,7 +2,6 @@ package edu.uci.ics.amber.engine.architecture.scheduling
 
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.core.WorkflowRuntimeException
-import edu.uci.ics.amber.core.storage.result.OpResultStorage
 import edu.uci.ics.amber.core.workflow.{PhysicalPlan, WorkflowContext}
 import edu.uci.ics.amber.virtualidentity.PhysicalOpIdentity
 import edu.uci.ics.amber.workflow.PhysicalLink
@@ -16,8 +15,7 @@ import scala.jdk.CollectionConverters.CollectionHasAsScala
 class ExpansionGreedyRegionPlanGenerator(
     workflowContext: WorkflowContext,
     initialPhysicalPlan: PhysicalPlan,
-    opResultStorage: OpResultStorage
-) extends RegionPlanGenerator(workflowContext, initialPhysicalPlan, opResultStorage)
+) extends RegionPlanGenerator(workflowContext, initialPhysicalPlan)
     with LazyLogging {
   def generate(): (RegionPlan, PhysicalPlan) = {
 

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGenerator.scala
@@ -14,7 +14,7 @@ import scala.jdk.CollectionConverters.CollectionHasAsScala
 
 class ExpansionGreedyRegionPlanGenerator(
     workflowContext: WorkflowContext,
-    initialPhysicalPlan: PhysicalPlan,
+    initialPhysicalPlan: PhysicalPlan
 ) extends RegionPlanGenerator(workflowContext, initialPhysicalPlan)
     with LazyLogging {
   def generate(): (RegionPlan, PhysicalPlan) = {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/RegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/RegionPlanGenerator.scala
@@ -203,8 +203,8 @@ abstract class RegionPlanGenerator(
       mode = OpResultStorage.defaultStorageMode,
       schema = Some(schema)
     )
-    matWriter.setStorageKey(
-      matWriter.operatorIdentifier.id
+    matWriter.setUpstreamId(
+      matWriter.operatorIdentifier
     )
 
     matWriter.getPhysicalOp(

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/RegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/RegionPlanGenerator.scala
@@ -4,7 +4,10 @@ import edu.uci.ics.amber.core.storage.result.{OpResultStorage, ResultStorage}
 import edu.uci.ics.amber.core.tuple.Schema
 import edu.uci.ics.amber.core.workflow.{PhysicalOp, PhysicalPlan, WorkflowContext}
 import edu.uci.ics.amber.engine.architecture.scheduling.RegionPlanGenerator.replaceVertex
-import edu.uci.ics.amber.engine.architecture.scheduling.resourcePolicies.{DefaultResourceAllocator, ExecutionClusterInfo}
+import edu.uci.ics.amber.engine.architecture.scheduling.resourcePolicies.{
+  DefaultResourceAllocator,
+  ExecutionClusterInfo
+}
 import edu.uci.ics.amber.operator.sink.managed.ProgressiveSinkOpDesc
 import edu.uci.ics.amber.operator.source.cache.CacheSourceOpDesc
 import edu.uci.ics.amber.virtualidentity.{OperatorIdentity, PhysicalOpIdentity, WorkflowIdentity}
@@ -49,7 +52,7 @@ object RegionPlanGenerator {
 
 abstract class RegionPlanGenerator(
     workflowContext: WorkflowContext,
-    var physicalPlan: PhysicalPlan,
+    var physicalPlan: PhysicalPlan
 ) {
   private val executionClusterInfo = new ExecutionClusterInfo()
 
@@ -198,11 +201,13 @@ abstract class RegionPlanGenerator(
     matWriter.setOperatorId(s"materialized_${getMatIdFromPhysicalLink(physicalLink)}")
     // expect exactly one input port and one output port
     val schema = matWriter.getOutputSchema(inputSchema)
-    ResultStorage.getOpResultStorage(workflowIdentity).create(
-      key = matWriter.operatorIdentifier,
-      mode = OpResultStorage.defaultStorageMode,
-      schema = Some(schema)
-    )
+    ResultStorage
+      .getOpResultStorage(workflowIdentity)
+      .create(
+        key = matWriter.operatorIdentifier,
+        mode = OpResultStorage.defaultStorageMode,
+        schema = Some(schema)
+      )
     matWriter.setUpstreamId(
       matWriter.operatorIdentifier
     )

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/RegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/RegionPlanGenerator.scala
@@ -170,7 +170,7 @@ abstract class RegionPlanGenerator(
       .addLink(readerToDestLink)
   }
 
-  def createMatReader(
+  private def createMatReader(
       matWriterLogicalOpId: OperatorIdentity,
       physicalLink: PhysicalLink,
       workflowIdentity: WorkflowIdentity
@@ -191,7 +191,7 @@ abstract class RegionPlanGenerator(
 
   }
 
-  def createMatWriter(
+  private def createMatWriter(
       physicalLink: PhysicalLink,
       inputSchema: Array[Schema],
       workflowIdentity: WorkflowIdentity

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/RegionPlanGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/RegionPlanGenerator.scala
@@ -198,12 +198,13 @@ abstract class RegionPlanGenerator(
     matWriter.setOperatorId(s"materialized_${getMatIdFromPhysicalLink(physicalLink)}")
     // expect exactly one input port and one output port
     val schema = matWriter.getOutputSchema(inputSchema)
-    matWriter.setStorage(
-      ResultStorage.getOpResultStorage(workflowIdentity).create(
-        key = matWriter.operatorIdentifier,
-        mode = OpResultStorage.defaultStorageMode,
-        schema = Some(schema)
-      )
+    ResultStorage.getOpResultStorage(workflowIdentity).create(
+      key = matWriter.operatorIdentifier,
+      mode = OpResultStorage.defaultStorageMode,
+      schema = Some(schema)
+    )
+    matWriter.setStorageKey(
+      matWriter.operatorIdentifier.id
     )
 
     matWriter.getPhysicalOp(

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/client/AmberClient.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/client/AmberClient.scala
@@ -4,7 +4,6 @@ import akka.actor.{ActorSystem, Address, PoisonPill, Props}
 import akka.pattern._
 import akka.util.Timeout
 import com.twitter.util.{Future, Promise}
-import edu.uci.ics.amber.core.storage.result.OpResultStorage
 import edu.uci.ics.amber.core.workflow.{PhysicalPlan, WorkflowContext}
 import edu.uci.ics.amber.engine.architecture.controller.ControllerConfig
 import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.ControlRequest
@@ -32,7 +31,6 @@ class AmberClient(
     system: ActorSystem,
     workflowContext: WorkflowContext,
     physicalPlan: PhysicalPlan,
-    opResultStorage: OpResultStorage,
     controllerConfig: ControllerConfig,
     errorHandler: Throwable => Unit
 ) {
@@ -46,7 +44,6 @@ class AmberClient(
     clientActor ? InitializeRequest(
       workflowContext,
       physicalPlan,
-      opResultStorage,
       controllerConfig
     ),
     10.seconds

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/client/ClientActor.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/client/ClientActor.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.amber.engine.common.client
 import akka.actor.{Actor, ActorRef}
 import akka.pattern.StatusReply.Ack
 import com.twitter.util.Promise
-import edu.uci.ics.amber.core.storage.result.OpResultStorage
 import edu.uci.ics.amber.core.workflow.{PhysicalPlan, WorkflowContext}
 import edu.uci.ics.amber.engine.architecture.common.WorkflowActor.{
   CreditRequest,
@@ -44,7 +43,6 @@ private[client] object ClientActor {
   case class InitializeRequest(
       workflowContext: WorkflowContext,
       physicalPlan: PhysicalPlan,
-      opResultStorage: OpResultStorage,
       controllerConfig: ControllerConfig
   )
 
@@ -77,10 +75,10 @@ private[client] class ClientActor extends Actor with AmberLogging {
   }
 
   override def receive: Receive = {
-    case InitializeRequest(workflowContext, physicalPlan, opResultStorage, controllerConfig) =>
+    case InitializeRequest(workflowContext, physicalPlan, controllerConfig) =>
       assert(controller == null)
       controller = context.actorOf(
-        Controller.props(workflowContext, physicalPlan, opResultStorage, controllerConfig)
+        Controller.props(workflowContext, physicalPlan, controllerConfig)
       )
       sender() ! Ack
     case CreditRequest(channelId: ChannelIdentity) =>

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/ComputingUnitMaster.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/ComputingUnitMaster.scala
@@ -39,7 +39,6 @@ object ComputingUnitMaster {
   def createAmberRuntime(
       workflowContext: WorkflowContext,
       physicalPlan: PhysicalPlan,
-      opResultStorage: OpResultStorage,
       conf: ControllerConfig,
       errorHandler: Throwable => Unit
   ): AmberClient = {
@@ -47,7 +46,6 @@ object ComputingUnitMaster {
       AmberRuntime.actorSystem,
       workflowContext,
       physicalPlan,
-      opResultStorage,
       conf,
       errorHandler
     )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
@@ -5,10 +5,20 @@ import com.fasterxml.jackson.annotation.{JsonTypeInfo, JsonTypeName}
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.core.storage.StorageConfig
-import edu.uci.ics.amber.core.storage.result.{MongoDocument, OperatorResultMetadata, ResultStorage, WorkflowResultStore}
+import edu.uci.ics.amber.core.storage.result.{
+  MongoDocument,
+  OperatorResultMetadata,
+  ResultStorage,
+  WorkflowResultStore
+}
 import edu.uci.ics.amber.core.tuple.Tuple
 import edu.uci.ics.amber.engine.architecture.controller.{ExecutionStateUpdate, FatalError}
-import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{COMPLETED, FAILED, KILLED, RUNNING}
+import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{
+  COMPLETED,
+  FAILED,
+  KILLED,
+  RUNNING
+}
 import edu.uci.ics.amber.operator.sink.IncrementalOutputMode.{SET_DELTA, SET_SNAPSHOT}
 import edu.uci.ics.amber.engine.common.client.AmberClient
 import edu.uci.ics.amber.engine.common.executionruntimestate.ExecutionMetadataStore
@@ -17,7 +27,11 @@ import edu.uci.ics.amber.operator.sink.IncrementalOutputMode
 import edu.uci.ics.amber.operator.sink.managed.ProgressiveSinkOpDesc
 import edu.uci.ics.amber.virtualidentity.OperatorIdentity
 import edu.uci.ics.texera.web.SubscriptionManager
-import edu.uci.ics.texera.web.model.websocket.event.{PaginatedResultEvent, TexeraWebSocketEvent, WebResultUpdateEvent}
+import edu.uci.ics.texera.web.model.websocket.event.{
+  PaginatedResultEvent,
+  TexeraWebSocketEvent,
+  WebResultUpdateEvent
+}
 import edu.uci.ics.texera.web.model.websocket.request.ResultPaginationRequest
 import edu.uci.ics.texera.web.service.ExecutionResultService.WebResultUpdate
 import edu.uci.ics.texera.web.storage.{ExecutionStateStore, WorkflowStateStore}
@@ -76,7 +90,8 @@ object ExecutionResultService {
       }
     }
 
-    val storage = ResultStorage.getOpResultStorage(sink.getContext.workflowId).get(sink.getUpstreamId.get)
+    val storage =
+      ResultStorage.getOpResultStorage(sink.getContext.workflowId).get(sink.getUpstreamId.get)
     val webUpdate = (webOutputMode, sink.getOutputMode) match {
       case (PaginationMode(), SET_SNAPSHOT) =>
         val numTuples = storage.getCount
@@ -231,10 +246,11 @@ class ExecutionResultService(
               if (
                 StorageConfig.resultStorageMode.toLowerCase == "mongodb"
                 && !opId.id.startsWith("sink")
-
               ) {
                 val sinkOp = sinkOperators(opId)
-                val opStorage = ResultStorage.getOpResultStorage(sinkOp.getContext.workflowId).get(sinkOp.getUpstreamId.get)
+                val opStorage = ResultStorage
+                  .getOpResultStorage(sinkOp.getContext.workflowId)
+                  .get(sinkOp.getUpstreamId.get)
                 opStorage match {
                   case mongoDocument: MongoDocument[Tuple] =>
                     val tableCatStats = mongoDocument.getCategoricalStats
@@ -286,7 +302,11 @@ class ExecutionResultService(
 
       if (sinkOperators.contains(opId)) {
         val sinkOp = sinkOperators(opId)
-        ResultStorage.getOpResultStorage(sinkOp.getContext.workflowId).get(sinkOp.getUpstreamId.get).getRange(from, from + request.pageSize).to(Iterable)
+        ResultStorage
+          .getOpResultStorage(sinkOp.getContext.workflowId)
+          .get(sinkOp.getUpstreamId.get)
+          .getRange(from, from + request.pageSize)
+          .to(Iterable)
       } else {
         Iterable.empty
       }
@@ -305,7 +325,11 @@ class ExecutionResultService(
       val newInfo: Map[OperatorIdentity, OperatorResultMetadata] = sinkOperators.map {
 
         case (id, sink) =>
-          val count = ResultStorage.getOpResultStorage(sink.getContext.workflowId).get(sink.getUpstreamId.get).getCount.toInt
+          val count = ResultStorage
+            .getOpResultStorage(sink.getContext.workflowId)
+            .get(sink.getUpstreamId.get)
+            .getCount
+            .toInt
           val mode = sink.getOutputMode
           val changeDetector =
             if (mode == IncrementalOutputMode.SET_SNAPSHOT) {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
@@ -5,20 +5,10 @@ import com.fasterxml.jackson.annotation.{JsonTypeInfo, JsonTypeName}
 import com.fasterxml.jackson.databind.node.ObjectNode
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.core.storage.StorageConfig
-import edu.uci.ics.amber.core.storage.result.{
-  MongoDocument,
-  OpResultStorage,
-  OperatorResultMetadata,
-  WorkflowResultStore
-}
+import edu.uci.ics.amber.core.storage.result.{MongoDocument, OperatorResultMetadata, WorkflowResultStore}
 import edu.uci.ics.amber.core.tuple.Tuple
 import edu.uci.ics.amber.engine.architecture.controller.{ExecutionStateUpdate, FatalError}
-import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{
-  COMPLETED,
-  FAILED,
-  KILLED,
-  RUNNING
-}
+import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{COMPLETED, FAILED, KILLED, RUNNING}
 import edu.uci.ics.amber.operator.sink.IncrementalOutputMode.{SET_DELTA, SET_SNAPSHOT}
 import edu.uci.ics.amber.engine.common.client.AmberClient
 import edu.uci.ics.amber.engine.common.executionruntimestate.ExecutionMetadataStore
@@ -27,11 +17,7 @@ import edu.uci.ics.amber.operator.sink.IncrementalOutputMode
 import edu.uci.ics.amber.operator.sink.managed.ProgressiveSinkOpDesc
 import edu.uci.ics.amber.virtualidentity.OperatorIdentity
 import edu.uci.ics.texera.web.SubscriptionManager
-import edu.uci.ics.texera.web.model.websocket.event.{
-  PaginatedResultEvent,
-  TexeraWebSocketEvent,
-  WebResultUpdateEvent
-}
+import edu.uci.ics.texera.web.model.websocket.event.{PaginatedResultEvent, TexeraWebSocketEvent, WebResultUpdateEvent}
 import edu.uci.ics.texera.web.model.websocket.request.ResultPaginationRequest
 import edu.uci.ics.texera.web.service.ExecutionResultService.WebResultUpdate
 import edu.uci.ics.texera.web.storage.{ExecutionStateStore, WorkflowStateStore}
@@ -163,7 +149,6 @@ object ExecutionResultService {
   *  - send result update event to the frontend
   */
 class ExecutionResultService(
-    val opResultStorage: OpResultStorage,
     val workflowStateStore: WorkflowStateStore
 ) extends SubscriptionManager
     with LazyLogging {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
@@ -76,7 +76,7 @@ object ExecutionResultService {
       }
     }
 
-    val storage = ResultStorage.getOpResultStorage(sink.getContext.workflowId).get(OperatorIdentity(sink.getStorageKey))
+    val storage = ResultStorage.getOpResultStorage(sink.getContext.workflowId).get(sink.getUpstreamId.get)
     val webUpdate = (webOutputMode, sink.getOutputMode) match {
       case (PaginationMode(), SET_SNAPSHOT) =>
         val numTuples = storage.getCount
@@ -234,7 +234,7 @@ class ExecutionResultService(
 
               ) {
                 val sinkOp = sinkOperators(opId)
-                val opStorage = ResultStorage.getOpResultStorage(sinkOp.getContext.workflowId).get(OperatorIdentity(sinkOp.getStorageKey))
+                val opStorage = ResultStorage.getOpResultStorage(sinkOp.getContext.workflowId).get(sinkOp.getUpstreamId.get)
                 opStorage match {
                   case mongoDocument: MongoDocument[Tuple] =>
                     val tableCatStats = mongoDocument.getCategoricalStats
@@ -286,7 +286,7 @@ class ExecutionResultService(
 
       if (sinkOperators.contains(opId)) {
         val sinkOp = sinkOperators(opId)
-        ResultStorage.getOpResultStorage(sinkOp.getContext.workflowId).get(OperatorIdentity(sinkOp.getStorageKey)).getRange(from, from + request.pageSize).to(Iterable)
+        ResultStorage.getOpResultStorage(sinkOp.getContext.workflowId).get(sinkOp.getUpstreamId.get).getRange(from, from + request.pageSize).to(Iterable)
       } else {
         Iterable.empty
       }
@@ -305,7 +305,7 @@ class ExecutionResultService(
       val newInfo: Map[OperatorIdentity, OperatorResultMetadata] = sinkOperators.map {
 
         case (id, sink) =>
-          val count = ResultStorage.getOpResultStorage(sink.getContext.workflowId).get(OperatorIdentity(sink.getStorageKey)).getCount.toInt
+          val count = ResultStorage.getOpResultStorage(sink.getContext.workflowId).get(sink.getUpstreamId.get).getCount.toInt
           val mode = sink.getOutputMode
           val changeDetector =
             if (mode == IncrementalOutputMode.SET_SNAPSHOT) {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ResultExportService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ResultExportService.scala
@@ -17,7 +17,10 @@ import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.User
 import edu.uci.ics.texera.web.model.websocket.request.ResultExportRequest
 import edu.uci.ics.texera.web.model.websocket.response.ResultExportResponse
 import edu.uci.ics.texera.web.resource.GoogleResource
-import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetResource.{createNewDatasetVersionByAddingFiles, sanitizePath}
+import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetResource.{
+  createNewDatasetVersionByAddingFiles,
+  sanitizePath
+}
 import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowVersionResource
 import org.jooq.types.UInteger
 import edu.uci.ics.amber.util.ArrowUtils

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ResultExportService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ResultExportService.scala
@@ -8,19 +8,16 @@ import com.google.api.services.drive.model.{File, FileList, Permission}
 import com.google.api.services.sheets.v4.Sheets
 import com.google.api.services.sheets.v4.model.{Spreadsheet, SpreadsheetProperties, ValueRange}
 import edu.uci.ics.amber.core.storage.model.VirtualDocument
-import edu.uci.ics.amber.core.storage.result.OpResultStorage
+import edu.uci.ics.amber.core.storage.result.{OpResultStorage, ResultStorage}
 import edu.uci.ics.amber.core.tuple.Tuple
 import edu.uci.ics.amber.engine.common.Utils.retry
 import edu.uci.ics.amber.util.PathUtils
-import edu.uci.ics.amber.virtualidentity.OperatorIdentity
+import edu.uci.ics.amber.virtualidentity.{OperatorIdentity, WorkflowIdentity}
 import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.User
 import edu.uci.ics.texera.web.model.websocket.request.ResultExportRequest
 import edu.uci.ics.texera.web.model.websocket.response.ResultExportResponse
 import edu.uci.ics.texera.web.resource.GoogleResource
-import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetResource.{
-  createNewDatasetVersionByAddingFiles,
-  sanitizePath
-}
+import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetResource.{createNewDatasetVersionByAddingFiles, sanitizePath}
 import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowVersionResource
 import org.jooq.types.UInteger
 import edu.uci.ics.amber.util.ArrowUtils
@@ -52,7 +49,7 @@ object ResultExportService {
     Executors.newFixedThreadPool(3).asInstanceOf[ThreadPoolExecutor]
 }
 
-class ResultExportService(opResultStorage: OpResultStorage, wId: UInteger) {
+class ResultExportService(workflowIdentity: WorkflowIdentity) {
 
   import ResultExportService._
 
@@ -72,7 +69,7 @@ class ResultExportService(opResultStorage: OpResultStorage, wId: UInteger) {
 
     // By now the workflow should finish running
     val operatorResult: VirtualDocument[Tuple] =
-      opResultStorage.get(OperatorIdentity(request.operatorId))
+      ResultStorage.getOpResultStorage(workflowIdentity).get(OperatorIdentity(request.operatorId))
     if (operatorResult == null) {
       return ResultExportResponse("error", "The workflow contains no results")
     }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
@@ -89,7 +89,7 @@ class WorkflowExecutionService(
   def executeWorkflow(): Unit = {
     try {
       workflow = new WorkflowCompiler(workflowContext)
-        .compile(request.logicalPlan, resultService.opResultStorage)
+        .compile(request.logicalPlan)
     } catch {
       case err: Throwable =>
         errorHandler(err)
@@ -98,7 +98,6 @@ class WorkflowExecutionService(
     client = ComputingUnitMaster.createAmberRuntime(
       workflowContext,
       workflow.physicalPlan,
-      resultService.opResultStorage,
       controllerConfig,
       errorHandler
     )

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -6,11 +6,21 @@ import edu.uci.ics.amber.core.WorkflowRuntimeException
 import edu.uci.ics.amber.core.storage.result.{OpResultStorage, ResultStorage}
 import edu.uci.ics.amber.core.workflow.WorkflowContext
 import edu.uci.ics.amber.engine.architecture.controller.ControllerConfig
-import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{COMPLETED, FAILED}
-import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.{FaultToleranceConfig, StateRestoreConfig}
+import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{
+  COMPLETED,
+  FAILED
+}
+import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.{
+  FaultToleranceConfig,
+  StateRestoreConfig
+}
 import edu.uci.ics.amber.engine.common.AmberConfig
 import edu.uci.ics.amber.error.ErrorUtils.{getOperatorFromActorIdOpt, getStackTraceWithAllCauses}
-import edu.uci.ics.amber.virtualidentity.{ChannelMarkerIdentity, ExecutionIdentity, WorkflowIdentity}
+import edu.uci.ics.amber.virtualidentity.{
+  ChannelMarkerIdentity,
+  ExecutionIdentity,
+  WorkflowIdentity
+}
 import edu.uci.ics.amber.workflowruntimestate.FatalErrorType.EXECUTION_FAILURE
 import edu.uci.ics.amber.workflowruntimestate.WorkflowFatalError
 import edu.uci.ics.texera.web.model.jooq.generated.tables.pojos.User
@@ -218,7 +228,9 @@ class WorkflowService(
     }
 
     // clean up results from previous run
-    ResultStorage.getOpResultStorage(workflowId).clear() // TODO: change this behavior after enabling cache.
+    ResultStorage
+      .getOpResultStorage(workflowId)
+      .clear() // TODO: change this behavior after enabling cache.
     try {
       val execution = new WorkflowExecutionService(
         controllerConf,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -3,7 +3,7 @@ package edu.uci.ics.texera.web.service
 import com.google.protobuf.timestamp.Timestamp
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.core.WorkflowRuntimeException
-import edu.uci.ics.amber.core.storage.result.{OpResultStorage, ResultStorage}
+import edu.uci.ics.amber.core.storage.result.ResultStorage
 import edu.uci.ics.amber.core.workflow.WorkflowContext
 import edu.uci.ics.amber.engine.architecture.controller.ControllerConfig
 import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.{
@@ -33,7 +33,6 @@ import edu.uci.ics.texera.web.{SubscriptionManager, WorkflowLifecycleManager}
 import edu.uci.ics.texera.workflow.LogicalPlan
 import io.reactivex.rxjava3.disposables.{CompositeDisposable, Disposable}
 import io.reactivex.rxjava3.subjects.BehaviorSubject
-import org.jooq.types.UInteger
 import play.api.libs.json.Json
 
 import java.net.URI

--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/WorkflowCompiler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/WorkflowCompiler.scala
@@ -205,9 +205,7 @@ class WorkflowCompiler(
           if (sink.getChartType.contains(VisualizationConstants.HTML_VIZ)) OpResultStorage.MEMORY
           else OpResultStorage.defaultStorageMode
         }
-        if (reuseStorageSet.contains(storageKey) && storage.contains(storageKey)) {
-          sink.setStorageKey(storageKey.id)
-        } else {
+        if (!reuseStorageSet.contains(storageKey) || !storage.contains(storageKey)) {
           // get the schema for result storage in certain mode
           val sinkStorageSchema: Option[Schema] =
             if (storageType == OpResultStorage.MONGODB) {
@@ -221,9 +219,6 @@ class WorkflowCompiler(
             storageKey,
             storageType,
             sinkStorageSchema
-          )
-          sink.setStorageKey(
-            storageKey.id
           )
           // add the sink collection name to the JSON array of sinks
           val storageNode = objectMapper.createObjectNode()

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/CostBasedRegionPlanGeneratorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/CostBasedRegionPlanGeneratorSpec.scala
@@ -1,6 +1,5 @@
 package edu.uci.ics.amber.engine.architecture.scheduling
 
-import edu.uci.ics.amber.core.storage.result.OpResultStorage
 import edu.uci.ics.amber.core.workflow.WorkflowContext
 import edu.uci.ics.amber.engine.common.virtualidentity.util.CONTROLLER
 import edu.uci.ics.amber.engine.e2e.TestUtils.buildWorkflow
@@ -17,7 +16,6 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
     val keywordOpDesc = TestOperators.keywordSearchOpDesc("column-1", "Asia")
     val joinOpDesc = TestOperators.joinOpDesc("column-1", "column-1")
     val sink = TestOperators.sinkOpDesc()
-    val resultStorage = new OpResultStorage()
     val workflow = buildWorkflow(
       List(
         headerlessCsvOpDesc1,
@@ -51,14 +49,12 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
           PortIdentity()
         )
       ),
-      resultStorage,
       new WorkflowContext()
     )
 
     val globalSearchNoPruningResult = new CostBasedRegionPlanGenerator(
       workflow.context,
       workflow.physicalPlan,
-      resultStorage,
       CONTROLLER
     ).bottomUpSearch(globalSearch = true, oChains = false, oCleanEdges = false, oEarlyStop = false)
 
@@ -68,7 +64,6 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
     val globalSearchOChainsResult = new CostBasedRegionPlanGenerator(
       workflow.context,
       workflow.physicalPlan,
-      resultStorage,
       CONTROLLER
     ).bottomUpSearch(globalSearch = true, oCleanEdges = false, oEarlyStop = false)
 
@@ -81,7 +76,6 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
     val globalSearchOCleanEdgesResult = new CostBasedRegionPlanGenerator(
       workflow.context,
       workflow.physicalPlan,
-      resultStorage,
       CONTROLLER
     ).bottomUpSearch(globalSearch = true, oChains = false, oEarlyStop = false)
 
@@ -92,7 +86,6 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
     val globalSearchOEarlyStopResult = new CostBasedRegionPlanGenerator(
       workflow.context,
       workflow.physicalPlan,
-      resultStorage,
       CONTROLLER
     ).bottomUpSearch(globalSearch = true, oChains = false, oCleanEdges = false)
 
@@ -103,7 +96,6 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
     val globalSearchAllPruningEnabledResult = new CostBasedRegionPlanGenerator(
       workflow.context,
       workflow.physicalPlan,
-      resultStorage,
       CONTROLLER
     ).bottomUpSearch(globalSearch = true)
 
@@ -119,7 +111,6 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
     val keywordOpDesc = TestOperators.keywordSearchOpDesc("column-1", "Asia")
     val joinOpDesc = TestOperators.joinOpDesc("column-1", "column-1")
     val sink = TestOperators.sinkOpDesc()
-    val resultStorage = new OpResultStorage()
     val workflow = buildWorkflow(
       List(
         headerlessCsvOpDesc1,
@@ -153,14 +144,12 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
           PortIdentity()
         )
       ),
-      resultStorage,
       new WorkflowContext()
     )
 
     val globalSearchNoPruningResult = new CostBasedRegionPlanGenerator(
       workflow.context,
       workflow.physicalPlan,
-      resultStorage,
       CONTROLLER
     ).topDownSearch(globalSearch = true, oChains = false, oCleanEdges = false)
 
@@ -170,7 +159,6 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
     val globalSearchOChainsResult = new CostBasedRegionPlanGenerator(
       workflow.context,
       workflow.physicalPlan,
-      resultStorage,
       CONTROLLER
     ).topDownSearch(globalSearch = true, oCleanEdges = false)
 
@@ -181,7 +169,6 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
     val globalSearchOCleanEdgesResult = new CostBasedRegionPlanGenerator(
       workflow.context,
       workflow.physicalPlan,
-      resultStorage,
       CONTROLLER
     ).topDownSearch(globalSearch = true, oChains = false)
 
@@ -192,7 +179,6 @@ class CostBasedRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactory {
     val globalSearchAllPruningEnabledResult = new CostBasedRegionPlanGenerator(
       workflow.context,
       workflow.physicalPlan,
-      resultStorage,
       CONTROLLER
     ).topDownSearch(globalSearch = true)
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGeneratorSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyRegionPlanGeneratorSpec.scala
@@ -1,6 +1,5 @@
 package edu.uci.ics.amber.engine.architecture.scheduling
 
-import edu.uci.ics.amber.core.storage.result.OpResultStorage
 import edu.uci.ics.amber.core.workflow.WorkflowContext
 import edu.uci.ics.amber.engine.e2e.TestUtils.buildWorkflow
 import edu.uci.ics.amber.operator.TestOperators
@@ -18,7 +17,6 @@ class ExpansionGreedyRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactor
     val headerlessCsvOpDesc = TestOperators.headerlessSmallCsvScanOpDesc()
     val keywordOpDesc = TestOperators.keywordSearchOpDesc("column-1", "Asia")
     val sink = TestOperators.sinkOpDesc()
-    val resultStorage = new OpResultStorage()
     val workflow = buildWorkflow(
       List(headerlessCsvOpDesc, keywordOpDesc, sink),
       List(
@@ -35,14 +33,12 @@ class ExpansionGreedyRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactor
           PortIdentity(0)
         )
       ),
-      resultStorage,
       new WorkflowContext()
     )
 
     val (regionPlan, updatedPhysicalPlan) = new ExpansionGreedyRegionPlanGenerator(
       workflow.context,
-      workflow.physicalPlan,
-      resultStorage
+      workflow.physicalPlan
     ).generate()
 
     assert(regionPlan.regions.size == 1)
@@ -67,7 +63,6 @@ class ExpansionGreedyRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactor
     val headerlessCsvOpDesc2 = TestOperators.headerlessSmallCsvScanOpDesc()
     val joinOpDesc = TestOperators.joinOpDesc("column-1", "column-1")
     val sink = TestOperators.sinkOpDesc()
-    val resultStorage = new OpResultStorage()
     val workflow = buildWorkflow(
       List(
         headerlessCsvOpDesc1,
@@ -95,14 +90,12 @@ class ExpansionGreedyRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactor
           PortIdentity()
         )
       ),
-      resultStorage,
       new WorkflowContext()
     )
 
     val (regionPlan, updatedPhysicalPlan) = new ExpansionGreedyRegionPlanGenerator(
       workflow.context,
-      workflow.physicalPlan,
-      resultStorage
+      workflow.physicalPlan
     ).generate()
 
     assert(regionPlan.regions.size == 2)
@@ -151,7 +144,6 @@ class ExpansionGreedyRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactor
     val keywordOpDesc = TestOperators.keywordSearchOpDesc("column-1", "Asia")
     val joinOpDesc = TestOperators.joinOpDesc("column-1", "column-1")
     val sink = TestOperators.sinkOpDesc()
-    val resultStorage = new OpResultStorage()
     val workflow = buildWorkflow(
       List(
         headerlessCsvOpDesc1,
@@ -185,14 +177,12 @@ class ExpansionGreedyRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactor
           PortIdentity()
         )
       ),
-      resultStorage,
       new WorkflowContext()
     )
 
     val (regionPlan, updatedPhysicalPlan) = new ExpansionGreedyRegionPlanGenerator(
       workflow.context,
-      workflow.physicalPlan,
-      resultStorage
+      workflow.physicalPlan
     ).generate()
 
     assert(regionPlan.regions.size == 2)
@@ -218,7 +208,6 @@ class ExpansionGreedyRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactor
     val hashJoin1 = TestOperators.joinOpDesc("column-1", "Region")
     val hashJoin2 = TestOperators.joinOpDesc("column-2", "Country")
     val sink = TestOperators.sinkOpDesc()
-    val resultStorage = new OpResultStorage()
     val workflow = buildWorkflow(
       List(
         buildCsv,
@@ -259,14 +248,12 @@ class ExpansionGreedyRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactor
           PortIdentity()
         )
       ),
-      resultStorage,
       new WorkflowContext()
     )
 
     val (regionPlan, updatedPhysicalPlan) = new ExpansionGreedyRegionPlanGenerator(
       workflow.context,
-      workflow.physicalPlan,
-      resultStorage
+      workflow.physicalPlan
     ).generate()
 
     assert(regionPlan.regions.size == 2)
@@ -292,7 +279,6 @@ class ExpansionGreedyRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactor
     val training = new PythonUDFOpDescV2()
     val inference = new DualInputPortsPythonUDFOpDescV2()
     val sink = TestOperators.sinkOpDesc()
-    val resultStorage = new OpResultStorage()
     val workflow = buildWorkflow(
       List(
         csv,
@@ -333,14 +319,12 @@ class ExpansionGreedyRegionPlanGeneratorSpec extends AnyFlatSpec with MockFactor
           PortIdentity()
         )
       ),
-      resultStorage,
       new WorkflowContext()
     )
 
     val (regionPlan, updatedPhysicalPlan) = new ExpansionGreedyRegionPlanGenerator(
       workflow.context,
-      workflow.physicalPlan,
-      resultStorage
+      workflow.physicalPlan
     ).generate()
 
     assert(regionPlan.regions.size == 2)

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/BatchSizePropagationSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/BatchSizePropagationSpec.scala
@@ -122,11 +122,10 @@ class BatchSizePropagationSpec
           PortIdentity()
         )
       ),
-      resultStorage,
       context
     )
 
-    val workflowScheduler = new WorkflowScheduler(context, resultStorage, CONTROLLER)
+    val workflowScheduler = new WorkflowScheduler(context, CONTROLLER)
     workflowScheduler.updateSchedule(workflow.physicalPlan)
 
     verifyBatchSizeInPartitioning(workflowScheduler, 1)
@@ -159,11 +158,10 @@ class BatchSizePropagationSpec
           PortIdentity()
         )
       ),
-      resultStorage,
       context
     )
 
-    val workflowScheduler = new WorkflowScheduler(context, resultStorage, CONTROLLER)
+    val workflowScheduler = new WorkflowScheduler(context, CONTROLLER)
     workflowScheduler.updateSchedule(workflow.physicalPlan)
 
     verifyBatchSizeInPartitioning(workflowScheduler, 500)
@@ -204,11 +202,10 @@ class BatchSizePropagationSpec
           PortIdentity()
         )
       ),
-      resultStorage,
       context
     )
 
-    val workflowScheduler = new WorkflowScheduler(context, resultStorage, CONTROLLER)
+    val workflowScheduler = new WorkflowScheduler(context, CONTROLLER)
     workflowScheduler.updateSchedule(workflow.physicalPlan)
 
     verifyBatchSizeInPartitioning(workflowScheduler, 100)
@@ -253,11 +250,10 @@ class BatchSizePropagationSpec
           PortIdentity()
         )
       ),
-      resultStorage,
       context
     )
 
-    val workflowScheduler = new WorkflowScheduler(context, resultStorage, CONTROLLER)
+    val workflowScheduler = new WorkflowScheduler(context, CONTROLLER)
     workflowScheduler.updateSchedule(workflow.physicalPlan)
 
     verifyBatchSizeInPartitioning(workflowScheduler, 300)
@@ -302,11 +298,10 @@ class BatchSizePropagationSpec
           PortIdentity()
         )
       ),
-      resultStorage,
       context
     )
 
-    val workflowScheduler = new WorkflowScheduler(context, resultStorage, CONTROLLER)
+    val workflowScheduler = new WorkflowScheduler(context, CONTROLLER)
     workflowScheduler.updateSchedule(workflow.physicalPlan)
 
     verifyBatchSizeInPartitioning(workflowScheduler, 1)

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
@@ -7,7 +7,7 @@ import akka.util.Timeout
 import ch.vorburger.mariadb4j.DB
 import com.twitter.util.{Await, Duration, Promise}
 import edu.uci.ics.amber.clustering.SingleNodeListener
-import edu.uci.ics.amber.core.storage.result.OpResultStorage
+import edu.uci.ics.amber.core.storage.result.{OpResultStorage, ResultStorage}
 import edu.uci.ics.amber.core.tuple.{AttributeType, Tuple}
 import edu.uci.ics.amber.core.workflow.WorkflowContext
 import edu.uci.ics.amber.engine.architecture.controller._
@@ -37,8 +37,8 @@ class DataProcessingSpec
   implicit val timeout: Timeout = Timeout(5.seconds)
 
   var inMemoryMySQLInstance: Option[DB] = None
-
-  val resultStorage = new OpResultStorage() {}
+  val workflowContext: WorkflowContext = new WorkflowContext()
+  val resultStorage: OpResultStorage = ResultStorage.getOpResultStorage(workflowContext.workflowId)
 
   override def beforeAll(): Unit = {
     system.actorOf(Props[SingleNodeListener](), "cluster-info")
@@ -56,7 +56,6 @@ class DataProcessingSpec
       system,
       workflow.context,
       workflow.physicalPlan,
-      resultStorage,
       ControllerConfig.default,
       error => {}
     )
@@ -137,8 +136,7 @@ class DataProcessingSpec
           PortIdentity()
         )
       ),
-      resultStorage,
-      new WorkflowContext()
+      workflowContext
     )
     val results = executeWorkflow(workflow)(sink.operatorIdentifier)
 
@@ -158,8 +156,7 @@ class DataProcessingSpec
           PortIdentity()
         )
       ),
-      resultStorage,
-      new WorkflowContext()
+      workflowContext
     )
     val results = executeWorkflow(workflow)(sink.operatorIdentifier)
 
@@ -179,8 +176,7 @@ class DataProcessingSpec
           PortIdentity()
         )
       ),
-      resultStorage,
-      new WorkflowContext()
+      workflowContext
     )
     val results = executeWorkflow(workflow)(sink.operatorIdentifier)
 
@@ -211,8 +207,7 @@ class DataProcessingSpec
           PortIdentity()
         )
       ),
-      resultStorage,
-      new WorkflowContext()
+      workflowContext
     )
     val results = executeWorkflow(workflow)(sink.operatorIdentifier)
 
@@ -250,8 +245,7 @@ class DataProcessingSpec
           PortIdentity()
         )
       ),
-      resultStorage,
-      new WorkflowContext()
+      workflowContext
     )
     executeWorkflow(workflow)
   }
@@ -269,8 +263,7 @@ class DataProcessingSpec
           PortIdentity()
         )
       ),
-      resultStorage,
-      new WorkflowContext()
+      workflowContext
     )
     executeWorkflow(workflow)
   }
@@ -295,8 +288,7 @@ class DataProcessingSpec
           PortIdentity()
         )
       ),
-      resultStorage,
-      new WorkflowContext()
+      workflowContext
     )
     executeWorkflow(workflow)
   }
@@ -329,8 +321,7 @@ class DataProcessingSpec
           PortIdentity()
         )
       ),
-      resultStorage,
-      new WorkflowContext()
+      workflowContext
     )
     executeWorkflow(workflow)
   }
@@ -367,8 +358,7 @@ class DataProcessingSpec
           PortIdentity()
         )
       ),
-      resultStorage,
-      new WorkflowContext()
+      workflowContext
     )
     executeWorkflow(workflow)
   }
@@ -405,8 +395,7 @@ class DataProcessingSpec
           PortIdentity()
         )
       ),
-      resultStorage,
-      new WorkflowContext()
+      workflowContext
     )
     executeWorkflow(workflow)
   }
@@ -447,8 +436,7 @@ class DataProcessingSpec
           PortIdentity()
         )
       ),
-      resultStorage,
-      new WorkflowContext()
+      workflowContext
     )
     executeWorkflow(workflow)
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/PauseSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/PauseSpec.scala
@@ -46,13 +46,12 @@ class PauseSpec
       links: List[LogicalLink]
   ): Unit = {
     val resultStorage = new OpResultStorage()
-    val workflow = TestUtils.buildWorkflow(operators, links, resultStorage, new WorkflowContext())
+    val workflow = TestUtils.buildWorkflow(operators, links, new WorkflowContext())
     val client =
       new AmberClient(
         system,
         workflow.context,
         workflow.physicalPlan,
-        resultStorage,
         ControllerConfig.default,
         error => {}
       )

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/TestUtils.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/TestUtils.scala
@@ -1,6 +1,5 @@
 package edu.uci.ics.amber.engine.e2e
 
-import edu.uci.ics.amber.core.storage.result.OpResultStorage
 import edu.uci.ics.amber.core.workflow.WorkflowContext
 import edu.uci.ics.amber.engine.architecture.controller.Workflow
 import edu.uci.ics.amber.operator.LogicalOp
@@ -12,15 +11,13 @@ object TestUtils {
   def buildWorkflow(
       operators: List[LogicalOp],
       links: List[LogicalLink],
-      resultStorage: OpResultStorage,
       context: WorkflowContext
   ): Workflow = {
     val workflowCompiler = new WorkflowCompiler(
       context
     )
     workflowCompiler.compile(
-      LogicalPlanPojo(operators, links, List(), List()),
-      resultStorage
+      LogicalPlanPojo(operators, links, List(), List())
     )
   }
 

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/faulttolerance/CheckpointSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/faulttolerance/CheckpointSpec.scala
@@ -41,7 +41,6 @@ class CheckpointSpec extends AnyFlatSpecLike with BeforeAndAfterAll {
         PortIdentity()
       )
     ),
-    resultStorage,
     new WorkflowContext()
   )
 
@@ -55,7 +54,6 @@ class CheckpointSpec extends AnyFlatSpecLike with BeforeAndAfterAll {
     val cp =
       new ControllerProcessor(
         workflow.context,
-        resultStorage,
         ControllerConfig.default,
         CONTROLLER,
         msg => {}

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/result/ResultStorage.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/result/ResultStorage.scala
@@ -1,0 +1,15 @@
+package edu.uci.ics.amber.core.storage.result
+
+import edu.uci.ics.amber.virtualidentity.WorkflowIdentity
+
+object ResultStorage {
+
+  val workflowToOpResultMapping: scala.collection.mutable.Map[
+    edu.uci.ics.amber.virtualidentity.WorkflowIdentity,
+    edu.uci.ics.amber.core.storage.result.OpResultStorage
+  ] = scala.collection.mutable.Map.empty
+
+  def getOpResultStorage (workflowIdentity: WorkflowIdentity) : OpResultStorage = {
+    workflowToOpResultMapping.getOrElseUpdate(workflowIdentity, new OpResultStorage())
+  }
+}

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/result/ResultStorage.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/result/ResultStorage.scala
@@ -9,7 +9,7 @@ object ResultStorage {
     edu.uci.ics.amber.core.storage.result.OpResultStorage
   ] = scala.collection.mutable.Map.empty
 
-  def getOpResultStorage (workflowIdentity: WorkflowIdentity) : OpResultStorage = {
+  def getOpResultStorage(workflowIdentity: WorkflowIdentity): OpResultStorage = {
     workflowToOpResultMapping.getOrElseUpdate(workflowIdentity, new OpResultStorage())
   }
 }

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/result/ResultStorage.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/result/ResultStorage.scala
@@ -2,14 +2,14 @@ package edu.uci.ics.amber.core.storage.result
 
 import edu.uci.ics.amber.virtualidentity.WorkflowIdentity
 
+import scala.collection.mutable
+
 object ResultStorage {
 
-  val workflowToOpResultMapping: scala.collection.mutable.Map[
-    edu.uci.ics.amber.virtualidentity.WorkflowIdentity,
-    edu.uci.ics.amber.core.storage.result.OpResultStorage
-  ] = scala.collection.mutable.Map.empty
+  private val workflowIdToOpResultMapping: mutable.Map[WorkflowIdentity, OpResultStorage] =
+    mutable.Map.empty
 
   def getOpResultStorage(workflowIdentity: WorkflowIdentity): OpResultStorage = {
-    workflowToOpResultMapping.getOrElseUpdate(workflowIdentity, new OpResultStorage())
+    workflowIdToOpResultMapping.getOrElseUpdate(workflowIdentity, new OpResultStorage())
   }
 }

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/result/ResultStorage.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/result/ResultStorage.scala
@@ -4,6 +4,18 @@ import edu.uci.ics.amber.virtualidentity.WorkflowIdentity
 
 import scala.collection.mutable
 
+/**
+  * ResultStorage is a singleton for accessing storage objects. It maintains a mapping from workflow ID to OpResultStorage.
+  *
+  * Using a workflow ID and an operator ID, the corresponding OpResultStorage object can be resolved and retrieved globally.
+  *
+  * This design has one limitation: the singleton is only accessible on the master node. Consequently, all sink executors
+  * must execute on the master node. While this aligns with the current system design, improvements are needed in the
+  * future to enhance scalability and flexibility.
+  *
+  * TODO: Move the storage mappings to an external, distributed, and persistent location to eliminate the master-node
+  *   dependency and enable sink executors to run on other nodes.
+  */
 object ResultStorage {
 
   private val workflowIdToOpResultMapping: mutable.Map[WorkflowIdentity, OpResultStorage] =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sink/managed/ProgressiveSinkOpDesc.java
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sink/managed/ProgressiveSinkOpDesc.java
@@ -4,10 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Preconditions;
 import edu.uci.ics.amber.core.executor.OpExecInitInfo;
 import edu.uci.ics.amber.core.executor.OperatorExecutor;
-import edu.uci.ics.amber.core.storage.model.BufferedItemWriter;
-import edu.uci.ics.amber.core.storage.model.VirtualDocument;
 import edu.uci.ics.amber.core.tuple.Schema;
-import edu.uci.ics.amber.core.tuple.Tuple;
 import edu.uci.ics.amber.core.workflow.PhysicalOp;
 import edu.uci.ics.amber.core.workflow.SchemaPropagationFunc;
 import edu.uci.ics.amber.operator.metadata.OperatorGroupConstants;
@@ -45,9 +42,6 @@ public class ProgressiveSinkOpDesc extends SinkOpDesc {
     @JsonIgnore
     private Option<String> chartType = Option.empty();
 
-    // TODO: remove this from Desc
-    @JsonIgnore
-    private String storageKey = null;
 
     // corresponding upstream operator ID and output port, will be set by workflow compiler
     @JsonIgnore
@@ -65,7 +59,7 @@ public class ProgressiveSinkOpDesc extends SinkOpDesc {
                         operatorIdentifier(),
                         OpExecInitInfo.apply(
                                 (Function<Tuple2<Object, Object>, OperatorExecutor> & java.io.Serializable)
-                                        worker -> new edu.uci.ics.amber.operator.sink.managed.ProgressiveSinkOpExec(outputMode, this.storageKey, workflowId)
+                                        worker -> new edu.uci.ics.amber.operator.sink.managed.ProgressiveSinkOpExec(outputMode, this.getUpstreamId().get().id(), workflowId)
                         )
                 )
                 .withInputPorts(this.operatorInfo().inputPorts())
@@ -155,28 +149,23 @@ public class ProgressiveSinkOpDesc extends SinkOpDesc {
         this.chartType = Option.apply(chartType);
     }
 
-    @JsonIgnore
-    public void setStorageKey(String storageKey) {
-        this.storageKey = storageKey;
-    }
 
     @JsonIgnore
-    public String getStorageKey() {
-        return this.storageKey;
-    }
-
     public Option<OperatorIdentity> getUpstreamId() {
         return upstreamId;
     }
 
+    @JsonIgnore
     public void setUpstreamId(OperatorIdentity upstreamId) {
         this.upstreamId = Option.apply(upstreamId);
     }
 
+    @JsonIgnore
     public Option<Integer> getUpstreamPort() {
         return upstreamPort;
     }
 
+    @JsonIgnore
     public void setUpstreamPort(Integer upstreamPort) {
         this.upstreamPort = Option.apply(upstreamPort);
     }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sink/managed/ProgressiveSinkOpExec.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sink/managed/ProgressiveSinkOpExec.scala
@@ -2,15 +2,18 @@ package edu.uci.ics.amber.operator.sink.managed
 
 import edu.uci.ics.amber.core.executor.SinkOperatorExecutor
 import edu.uci.ics.amber.core.storage.model.BufferedItemWriter
+import edu.uci.ics.amber.core.storage.result.ResultStorage
 import edu.uci.ics.amber.core.tuple.{Tuple, TupleLike}
 import edu.uci.ics.amber.operator.sink.{IncrementalOutputMode, ProgressiveUtils}
+import edu.uci.ics.amber.virtualidentity.{OperatorIdentity, WorkflowIdentity}
 import edu.uci.ics.amber.workflow.PortIdentity
 
-class ProgressiveSinkOpExec(outputMode: IncrementalOutputMode, storage: BufferedItemWriter[Tuple])
+class ProgressiveSinkOpExec(outputMode: IncrementalOutputMode, storageKey:String, workflowIdentity:WorkflowIdentity)
     extends SinkOperatorExecutor {
+  val writer: BufferedItemWriter[Tuple] =  ResultStorage.getOpResultStorage(workflowIdentity).get(OperatorIdentity(storageKey)).writer()
 
   override def open(): Unit = {
-    storage.open()
+    writer.open()
   }
 
   override def consumeTuple(
@@ -19,7 +22,7 @@ class ProgressiveSinkOpExec(outputMode: IncrementalOutputMode, storage: Buffered
   ): Unit = {
     outputMode match {
       case IncrementalOutputMode.SET_SNAPSHOT => updateSetSnapshot(tuple)
-      case IncrementalOutputMode.SET_DELTA    => storage.putOne(tuple)
+      case IncrementalOutputMode.SET_DELTA    => writer.putOne(tuple)
     }
   }
 
@@ -27,14 +30,14 @@ class ProgressiveSinkOpExec(outputMode: IncrementalOutputMode, storage: Buffered
     val (isInsertion, tupleValue) = ProgressiveUtils.getTupleFlagAndValue(deltaUpdate)
 
     if (isInsertion) {
-      storage.putOne(tupleValue)
+      writer.putOne(tupleValue)
     } else {
-      storage.removeOne(tupleValue)
+      writer.removeOne(tupleValue)
     }
   }
 
   override def onFinishMultiPort(port: Int): Iterator[(TupleLike, Option[PortIdentity])] = {
-    storage.close()
+    writer.close()
     Iterator.empty
   }
 

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sink/managed/ProgressiveSinkOpExec.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sink/managed/ProgressiveSinkOpExec.scala
@@ -8,9 +8,13 @@ import edu.uci.ics.amber.operator.sink.{IncrementalOutputMode, ProgressiveUtils}
 import edu.uci.ics.amber.virtualidentity.{OperatorIdentity, WorkflowIdentity}
 import edu.uci.ics.amber.workflow.PortIdentity
 
-class ProgressiveSinkOpExec(outputMode: IncrementalOutputMode, storageKey:String, workflowIdentity:WorkflowIdentity)
-    extends SinkOperatorExecutor {
-  val writer: BufferedItemWriter[Tuple] =  ResultStorage.getOpResultStorage(workflowIdentity).get(OperatorIdentity(storageKey)).writer()
+class ProgressiveSinkOpExec(
+    outputMode: IncrementalOutputMode,
+    storageKey: String,
+    workflowIdentity: WorkflowIdentity
+) extends SinkOperatorExecutor {
+  val writer: BufferedItemWriter[Tuple] =
+    ResultStorage.getOpResultStorage(workflowIdentity).get(OperatorIdentity(storageKey)).writer()
 
   override def open(): Unit = {
     writer.open()


### PR DESCRIPTION
In the previous implementation, the storage object was resolved and assigned directly within the descriptor. This caused issues during compilation, as the storage object in this setup was not serializable.

This PR introduces a change in the lifecycle management of storage resolution. The descriptor (logical layer) now only records the upstream operator’s ID. The actual storage object is resolved later, within the ProgressiveSinkOpExec, using the upstream operator’s ID.

To facilitate resolving storage objects inside ProgressiveSinkOpExec, a `ResultStorage` singleton has been introduced. This singleton maintains a mapping of all workflows’ `OpResultStorage` objects against their workflow IDs. However, this approach has one limitation: the singleton is only available on the master node. As a result, all sink executors must run on the master node. While this is consistent with the current design, in the future, we should address this by moving the storage mappings to an external, distributed, and persistent location.