### PR TITLE
Disable Display of Binary Files in Dataset File Panel

### DIFF
--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.spec.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.spec.ts
@@ -1,0 +1,36 @@
+import { TestBed } from "@angular/core/testing";
+import { HttpClientTestingModule } from "@angular/common/http/testing";
+import { UserDatasetFileRendererComponent } from "./user-dataset-file-renderer.component";
+import { DatasetService } from "../../../../../service/user/dataset/dataset.service";
+import { NotificationService } from "../../../../../../common/service/notification/notification.service";
+import { DomSanitizer } from "@angular/platform-browser";
+
+describe("UserDatasetFileRendererComponent", () => {
+  let component: UserDatasetFileRendererComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      declarations: [UserDatasetFileRendererComponent],
+      providers: [
+        DatasetService,
+        NotificationService,
+        { provide: DomSanitizer, useValue: jasmine.createSpyObj("DomSanitizer", ["bypassSecurityTrustUrl"]) },
+      ],
+    });
+    const fixture = TestBed.createComponent(UserDatasetFileRendererComponent);
+    component = fixture.componentInstance;
+  });
+
+  it("should return true for supported MIME type", () => {
+    const supportedMimeType = "image/jpeg"; // Example of a supported MIME type
+    const result = component.isPreviewSupported(supportedMimeType);
+    expect(result).toBeTrue();
+  });
+
+  it("should return false for unsupported MIME type", () => {
+    const unsupportedMimeType = "application/unknown"; // Example of an unsupported MIME type
+    const result = component.isPreviewSupported(unsupportedMimeType);
+    expect(result).toBeFalse();
+  });
+});

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/user-dataset-file-renderer/user-dataset-file-renderer.component.ts
@@ -204,7 +204,6 @@ export class UserDatasetFileRendererComponent implements OnInit, OnChanges, OnDe
                 this.displayJson = true;
                 this.readFileAsText(blob);
                 break;
-              case MIME_TYPES.OCTET_STREAM:
               case MIME_TYPES.TXT:
               default:
                 this.displayPlainText = true;
@@ -254,7 +253,7 @@ export class UserDatasetFileRendererComponent implements OnInit, OnChanges, OnDe
   }
 
   isPreviewSupported(mimeType: string) {
-    return Object.hasOwnProperty.call(MIME_TYPE_SIZE_LIMITS_MB, mimeType);
+    return mimeType !== MIME_TYPES.OCTET_STREAM && Object.hasOwnProperty.call(MIME_TYPE_SIZE_LIMITS_MB, mimeType);
   }
 
   private readFileAsText(blob: Blob) {


### PR DESCRIPTION
This PR disables the display of binary files (e.g., `.arrow` files) in the dataset file display panel. This change enhances security and improves user experience, as rendering binary files as plain text is both impractical and confusing for users.
<img width="1728" alt="Screenshot 2024-12-11 at 11 09 05 AM" src="https://github.com/user-attachments/assets/be08bc28-726b-493b-956e-07d14a6f49e1" />
