### PR TITLE
Improve UI for Result Exportation in Frontend

### DIFF
--- a/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.html
+++ b/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.html
@@ -4,27 +4,6 @@
       <nz-row>
         <nz-col [nzSpan]="24">
           <nz-form-item>
-            <nz-form-label nzFor="destinationInput">Destination</nz-form-label>
-            <nz-form-control>
-              <nz-select
-                id="destinationInput"
-                [(ngModel)]="destination"
-                name="destination"
-                nzPlaceHolder="Select destination">
-                <nz-option
-                  nzValue="local"
-                  nzLabel="Local"></nz-option>
-                <nz-option
-                  nzValue="dataset"
-                  nzLabel="Dataset"></nz-option>
-              </nz-select>
-            </nz-form-control>
-          </nz-form-item>
-        </nz-col>
-      </nz-row>
-      <nz-row>
-        <nz-col [nzSpan]="24">
-          <nz-form-item>
             <nz-form-label nzFor="exportTypeInput">Export Type</nz-form-label>
             <nz-form-control>
               <nz-select
@@ -33,17 +12,35 @@
                 name="exportType"
                 nzPlaceHolder="Select export type">
                 <nz-option
+                  *ngIf="isTableOutput"
                   nzValue="arrow"
-                  nzLabel="Arrow"
-                  [nzDisabled]="!isTableOutput"></nz-option>
+                  nzLabel="Binary Format (.arrow)"></nz-option>
                 <nz-option
+                  *ngIf="isTableOutput && !containsBinaryData"
                   nzValue="csv"
-                  nzLabel="CSV"
-                  [nzDisabled]="!isTableOutput || containsBinaryData"></nz-option>
+                  nzLabel="Comma Separated Values (.csv)"></nz-option>
                 <nz-option
+                  *ngIf="isVisualizationOutput"
                   nzValue="html"
-                  nzLabel="HTML"
-                  [nzDisabled]="!isVisualizationOutput"></nz-option>
+                  nzLabel="Web Page (.html)"></nz-option>
+              </nz-select>
+            </nz-form-control>
+          </nz-form-item>
+        </nz-col>
+      </nz-row>
+      <nz-row>
+        <nz-col [nzSpan]="24">
+          <nz-form-item>
+            <nz-form-label nzFor="destinationInput">Destination</nz-form-label>
+            <nz-form-control>
+              <nz-select
+                id="destinationInput"
+                [(ngModel)]="destination"
+                name="destination"
+                nzPlaceHolder="Select destination">
+                <nz-option
+                  nzValue="dataset"
+                  nzLabel="Dataset"></nz-option>
               </nz-select>
             </nz-form-control>
           </nz-form-item>

--- a/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
+++ b/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
@@ -122,18 +122,5 @@
         </tr>
       </tbody>
     </nz-table>
-
-    <button
-      *ngIf="hasBinaryData"
-      (click)="downloadAllBinaryData()"
-      nz-button
-      nzType="default"
-      nzSize="small"
-      class="download-all-button">
-      <i
-        nz-icon
-        nzType="download"></i>
-      Download All Binary Data
-    </button>
   </div>
 </div>

--- a/core/gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
+++ b/core/gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
@@ -1,4 +1,3 @@
-import * as JSZip from "jszip";
 import * as Papa from "papaparse";
 import { Injectable } from "@angular/core";
 import { environment } from "../../../../environments/environment";
@@ -13,7 +12,6 @@ import { filter } from "rxjs/operators";
 import { OperatorResultService, WorkflowResultService } from "../workflow-result/workflow-result.service";
 import { OperatorPaginationResultService } from "../workflow-result/workflow-result.service";
 import { DownloadService } from "../../../dashboard/service/user/download/download.service";
-import { Buffer } from "buffer";
 
 @Injectable({
   providedIn: "root",
@@ -124,99 +122,6 @@ export class WorkflowResultExportService {
           console.error("Error exporting operator results:", error);
         },
       });
-  }
-
-  /**
-   * Export all binary data as a ZIP file.
-   */
-  exportAllBinaryDataAsZIP(binaryDataColumns: Set<string>, operatorId: string): void {
-    const paginatedResultService = this.workflowResultService.getPaginatedResultService(operatorId);
-
-    if (!paginatedResultService) {
-      return;
-    }
-
-    this.createZipFromPaginatedData(paginatedResultService, binaryDataColumns, operatorId);
-  }
-
-  private createZipFromPaginatedData(
-    paginatedResultService: OperatorPaginationResultService,
-    binaryDataColumns: Set<string>,
-    operatorId: string
-  ): void {
-    const zip = new JSZip();
-    let currentPage = 1;
-    const pageSize = 10;
-
-    paginatedResultService
-      .selectPage(currentPage, pageSize)
-      .pipe(
-        expand((pageData: PaginatedResultEvent) =>
-          pageData.table.length === pageSize ? paginatedResultService.selectPage(++currentPage, pageSize) : EMPTY
-        ),
-        finalize(() => this.finalizeZip(zip, operatorId))
-      )
-      .subscribe({
-        next: (pageData: PaginatedResultEvent) =>
-          this.processPage(pageData, currentPage, pageSize, zip, binaryDataColumns),
-        error: (error: unknown) => {
-          console.error("Error processing paginated data:", error);
-        },
-      });
-  }
-
-  private processPage(
-    pageData: PaginatedResultEvent,
-    currentPage: number,
-    pageSize: number,
-    zip: JSZip,
-    binaryDataColumns: Set<string>
-  ): void {
-    pageData.table.forEach((row, rowIndex) => {
-      const folderName = `row_${(currentPage - 1) * pageSize + rowIndex + 1}`;
-      this.processBinaryDataColumns(row, binaryDataColumns, folderName, zip);
-    });
-  }
-
-  private processBinaryDataColumns(row: any, binaryDataColumns: Set<string>, folderName: string, zip: JSZip): void {
-    binaryDataColumns.forEach(name => {
-      const binaryData = row[name];
-      if (binaryData === null) {
-        return;
-      }
-      const blob = this.base64ToBlob(binaryData);
-      zip.folder(folderName)?.file(name, blob);
-    });
-  }
-
-  private async finalizeZip(zip: JSZip, operatorId: string): Promise<void> {
-    try {
-      const content = await zip.generateAsync({ type: "blob" });
-      const fileName = `binary_data_${operatorId}.zip`;
-      this.downloadService
-        .downloadOperatorsResult(
-          [of([{ filename: fileName, blob: content }])],
-          this.workflowActionService.getWorkflow()
-        )
-        .subscribe({
-          error: (error: unknown) => {
-            console.error("Error exporting binary data:", error);
-          },
-        });
-    } catch (error) {
-      console.error("Error generating ZIP file:", error);
-    }
-  }
-
-  private base64ToBlob(base64: string): Blob {
-    const buffer = Buffer.from(base64.split(",")[1] || base64, "base64");
-    const byteArray = new Uint8Array(buffer);
-
-    for (let i = 0; i < byteArray.length; i++) {
-      byteArray[i] = buffer[i];
-    }
-
-    return new Blob([byteArray]);
   }
 
   /**


### PR DESCRIPTION
This PR improves the UI for result exportation in the frontend to improve usability and clarity. The following key changes have been made:

1. Remove Local Export Option
- The option to export results to the local machine has been removed due to issues with the current implementation.

<img width="490" alt="Screenshot 2024-12-12 at 5 12 16 PM" src="https://github.com/user-attachments/assets/69ffa2f2-d845-46b7-85ca-c78e85de6766" />

2. Reorder "Export Type" and "Destination" Fields
- The "Destination" selection now appears before "Export Type," providing a more natural flow for users selecting export options.

<img width="493" alt="Screenshot 2024-12-12 at 5 11 53 PM" src="https://github.com/user-attachments/assets/12d86074-6694-4858-bf4a-39e92fc10159" />

3.  Remove "Download All Binary Results" Button
- The "Download All Binary Results" button has been removed from the result panel since binary format downloads are now supported for individual table exports.

<img width="1071" alt="Screenshot 2024-12-12 at 5 12 42 PM" src="https://github.com/user-attachments/assets/63624550-d08f-4bd0-a8bb-5358913d3b29" />

4. Hide Unavailable Export Types Instead of Disabling Them
- Following a discussion with Chen, unavailable export type options are now hidden rather than disabled to reduce visual clutter.

<img width="488" alt="Screenshot 2024-12-12 at 5 13 04 PM" src="https://github.com/user-attachments/assets/f6fde3bb-4e84-4773-a100-b9565c20cdda" />

5. Rename Export Types for Better User-Friendliness
- Export type names have been updated to be more intuitive and user-friendly, especially for non-IT users, making it easier for them to understand and select the desired export format.
