### PR TITLE
Add padding to the about page

### DIFF
--- a/core/gui/src/app/hub/component/about/about.component.scss
+++ b/core/gui/src/app/hub/component/about/about.component.scss
@@ -1,6 +1,7 @@
 .about-page-container {
   overflow-y: auto;
   height: 100%;
+  padding: 0 133px;
 }
 
 .content {


### PR DESCRIPTION
### Purpose:
The current content of the ”about page“ becomes tightly aligned with the edges when the screen width is less than 1300px. This PR adds additional padding to prevent this issue.

### Change:
Added 133px of padding to the left and right of the ”about page“ content container, aligning it with the padding used on the "landing page".

### Demo:
Before:
Without local login box:
![image](https://github.com/user-attachments/assets/b6fac6a6-47f4-4f9a-b84f-4ee3bd16488c)

With local login box:
![image](https://github.com/user-attachments/assets/e99161eb-84ab-4683-ad61-858f9f2b474e)

After:
Without local login box:
![image](https://github.com/user-attachments/assets/aed2e74a-a9d0-4b2a-acd5-8e71d436b2f6)

With local login box:
![image](https://github.com/user-attachments/assets/a8096d58-a09c-4117-9923-7cc7f6fa125c)
