### PR TITLE
Standardize the "is_public" column across the dataset and workflow tables.

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/WorkflowSearchQueryBuilder.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/WorkflowSearchQueryBuilder.scala
@@ -49,12 +49,12 @@ object WorkflowSearchQueryBuilder extends SearchQueryBuilder {
 
     var condition: Condition = DSL.trueCondition()
     if (uid == null) {
-      condition = WORKFLOW.IS_PUBLISHED.eq(1.toByte)
+      condition = WORKFLOW.IS_PUBLIC.eq(1.toByte)
     } else {
       val privateAccessCondition =
         WORKFLOW_USER_ACCESS.UID.eq(uid).or(PROJECT_USER_ACCESS.UID.eq(uid))
       if (includePublic) {
-        condition = privateAccessCondition.or(WORKFLOW.IS_PUBLISHED.eq(1.toByte))
+        condition = privateAccessCondition.or(WORKFLOW.IS_PUBLIC.eq(1.toByte))
       } else {
         condition = privateAccessCondition
       }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/hub/workflow/HubWorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/hub/workflow/HubWorkflowResource.scala
@@ -130,7 +130,7 @@ class HubWorkflowResource {
   def getPublishedWorkflowCount: Integer = {
     context.selectCount
       .from(WORKFLOW)
-      .where(WORKFLOW.IS_PUBLISHED.eq(1.toByte))
+      .where(WORKFLOW.IS_PUBLIC.eq(1.toByte))
       .fetchOne(0, classOf[Integer])
   }
 
@@ -174,7 +174,7 @@ class HubWorkflowResource {
     val workflow = workflowDao.ctx
       .selectFrom(WORKFLOW)
       .where(WORKFLOW.WID.eq(wid))
-      .and(WORKFLOW.IS_PUBLISHED.isTrue)
+      .and(WORKFLOW.IS_PUBLIC.isTrue)
       .fetchOne()
     WorkflowWithPrivilege(
       workflow.getName,
@@ -183,7 +183,7 @@ class HubWorkflowResource {
       workflow.getContent,
       workflow.getCreationTime,
       workflow.getLastModifiedTime,
-      workflow.getIsPublished,
+      workflow.getIsPublic,
       readonly = true
     )
   }
@@ -328,7 +328,7 @@ class HubWorkflowResource {
       .from(WORKFLOW_USER_LIKES)
       .join(WORKFLOW)
       .on(WORKFLOW_USER_LIKES.WID.eq(WORKFLOW.WID))
-      .where(WORKFLOW.IS_PUBLISHED.eq(1.toByte))
+      .where(WORKFLOW.IS_PUBLIC.eq(1.toByte))
       .groupBy(WORKFLOW_USER_LIKES.WID)
       .orderBy(DSL.count(WORKFLOW_USER_LIKES.WID).desc())
       .limit(8)
@@ -350,7 +350,7 @@ class HubWorkflowResource {
       .from(WORKFLOW_USER_CLONES)
       .join(WORKFLOW)
       .on(WORKFLOW_USER_CLONES.WID.eq(WORKFLOW.WID))
-      .where(WORKFLOW.IS_PUBLISHED.eq(1.toByte))
+      .where(WORKFLOW.IS_PUBLIC.eq(1.toByte))
       .groupBy(WORKFLOW_USER_CLONES.WID)
       .orderBy(DSL.count(WORKFLOW_USER_CLONES.WID).desc())
       .limit(8)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowAccessResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowAccessResource.scala
@@ -83,7 +83,7 @@ object WorkflowAccessResource {
 
   def isPublic(wid: UInteger): Boolean = {
     context
-      .select(WORKFLOW.IS_PUBLISHED)
+      .select(WORKFLOW.IS_PUBLIC)
       .from(WORKFLOW)
       .where(WORKFLOW.WID.eq(wid))
       .fetchOneInto(classOf[Boolean])

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowResource.scala
@@ -332,7 +332,7 @@ class WorkflowResource extends LazyLogging {
         workflow.getContent,
         workflow.getCreationTime,
         workflow.getLastModifiedTime,
-        workflow.getIsPublished,
+        workflow.getIsPublic,
         !WorkflowAccessResource.hasWriteAccess(wid, user.getUid)
       )
     } else {
@@ -568,7 +568,7 @@ class WorkflowResource extends LazyLogging {
   @Path("/public/{wid}")
   def makePublic(@PathParam("wid") wid: UInteger, @Auth user: SessionUser): Unit = {
     val workflow: Workflow = workflowDao.fetchOneByWid(wid)
-    workflow.setIsPublished(1.toByte)
+    workflow.setIsPublic(1.toByte)
     workflowDao.update(workflow)
   }
 
@@ -576,7 +576,7 @@ class WorkflowResource extends LazyLogging {
   @Path("/private/{wid}")
   def makePrivate(@PathParam("wid") wid: UInteger): Unit = {
     val workflow: Workflow = workflowDao.fetchOneByWid(wid)
-    workflow.setIsPublished(0.toByte)
+    workflow.setIsPublic(0.toByte)
     workflowDao.update(workflow)
   }
 
@@ -584,7 +584,7 @@ class WorkflowResource extends LazyLogging {
   @Path("/type/{wid}")
   def getWorkflowType(@PathParam("wid") wid: UInteger): String = {
     val workflow: Workflow = workflowDao.fetchOneByWid(wid)
-    if (workflow.getIsPublished == 1.toByte) {
+    if (workflow.getIsPublic == 1.toByte) {
       "Public"
     } else {
       "Private"

--- a/core/dao/src/main/scala/edu/uci/ics/texera/dao/jooq/generated/tables/Workflow.java
+++ b/core/dao/src/main/scala/edu/uci/ics/texera/dao/jooq/generated/tables/Workflow.java
@@ -35,7 +35,7 @@ import org.jooq.types.UInteger;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class Workflow extends TableImpl<WorkflowRecord> {
 
-    private static final long serialVersionUID = -256100701;
+    private static final long serialVersionUID = 1942522218;
 
     /**
      * The reference instance of <code>texera_db.workflow</code>
@@ -81,9 +81,9 @@ public class Workflow extends TableImpl<WorkflowRecord> {
     public final TableField<WorkflowRecord, Timestamp> LAST_MODIFIED_TIME = createField(DSL.name("last_modified_time"), org.jooq.impl.SQLDataType.TIMESTAMP.nullable(false).defaultValue(org.jooq.impl.DSL.field("CURRENT_TIMESTAMP", org.jooq.impl.SQLDataType.TIMESTAMP)), this, "");
 
     /**
-     * The column <code>texera_db.workflow.is_published</code>.
+     * The column <code>texera_db.workflow.is_public</code>.
      */
-    public final TableField<WorkflowRecord, Byte> IS_PUBLISHED = createField(DSL.name("is_published"), org.jooq.impl.SQLDataType.TINYINT.nullable(false).defaultValue(org.jooq.impl.DSL.inline("0", org.jooq.impl.SQLDataType.TINYINT)), this, "");
+    public final TableField<WorkflowRecord, Byte> IS_PUBLIC = createField(DSL.name("is_public"), org.jooq.impl.SQLDataType.TINYINT.nullable(false).defaultValue(org.jooq.impl.DSL.inline("0", org.jooq.impl.SQLDataType.TINYINT)), this, "");
 
     /**
      * Create a <code>texera_db.workflow</code> table reference

--- a/core/dao/src/main/scala/edu/uci/ics/texera/dao/jooq/generated/tables/daos/WorkflowDao.java
+++ b/core/dao/src/main/scala/edu/uci/ics/texera/dao/jooq/generated/tables/daos/WorkflowDao.java
@@ -132,16 +132,16 @@ public class WorkflowDao extends DAOImpl<WorkflowRecord, edu.uci.ics.texera.dao.
     }
 
     /**
-     * Fetch records that have <code>is_published BETWEEN lowerInclusive AND upperInclusive</code>
+     * Fetch records that have <code>is_public BETWEEN lowerInclusive AND upperInclusive</code>
      */
-    public List<edu.uci.ics.texera.dao.jooq.generated.tables.pojos.Workflow> fetchRangeOfIsPublished(Byte lowerInclusive, Byte upperInclusive) {
-        return fetchRange(Workflow.WORKFLOW.IS_PUBLISHED, lowerInclusive, upperInclusive);
+    public List<edu.uci.ics.texera.dao.jooq.generated.tables.pojos.Workflow> fetchRangeOfIsPublic(Byte lowerInclusive, Byte upperInclusive) {
+        return fetchRange(Workflow.WORKFLOW.IS_PUBLIC, lowerInclusive, upperInclusive);
     }
 
     /**
-     * Fetch records that have <code>is_published IN (values)</code>
+     * Fetch records that have <code>is_public IN (values)</code>
      */
-    public List<edu.uci.ics.texera.dao.jooq.generated.tables.pojos.Workflow> fetchByIsPublished(Byte... values) {
-        return fetch(Workflow.WORKFLOW.IS_PUBLISHED, values);
+    public List<edu.uci.ics.texera.dao.jooq.generated.tables.pojos.Workflow> fetchByIsPublic(Byte... values) {
+        return fetch(Workflow.WORKFLOW.IS_PUBLIC, values);
     }
 }

--- a/core/dao/src/main/scala/edu/uci/ics/texera/dao/jooq/generated/tables/interfaces/IWorkflow.java
+++ b/core/dao/src/main/scala/edu/uci/ics/texera/dao/jooq/generated/tables/interfaces/IWorkflow.java
@@ -77,14 +77,14 @@ public interface IWorkflow extends Serializable {
     public Timestamp getLastModifiedTime();
 
     /**
-     * Setter for <code>texera_db.workflow.is_published</code>.
+     * Setter for <code>texera_db.workflow.is_public</code>.
      */
-    public void setIsPublished(Byte value);
+    public void setIsPublic(Byte value);
 
     /**
-     * Getter for <code>texera_db.workflow.is_published</code>.
+     * Getter for <code>texera_db.workflow.is_public</code>.
      */
-    public Byte getIsPublished();
+    public Byte getIsPublic();
 
     // -------------------------------------------------------------------------
     // FROM and INTO

--- a/core/dao/src/main/scala/edu/uci/ics/texera/dao/jooq/generated/tables/pojos/Workflow.java
+++ b/core/dao/src/main/scala/edu/uci/ics/texera/dao/jooq/generated/tables/pojos/Workflow.java
@@ -17,7 +17,7 @@ import org.jooq.types.UInteger;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class Workflow implements IWorkflow {
 
-    private static final long serialVersionUID = -212123101;
+    private static final long serialVersionUID = 1973264418;
 
     private String    name;
     private String    description;
@@ -25,7 +25,7 @@ public class Workflow implements IWorkflow {
     private String    content;
     private Timestamp creationTime;
     private Timestamp lastModifiedTime;
-    private Byte      isPublished;
+    private Byte      isPublic;
 
     public Workflow() {}
 
@@ -36,7 +36,7 @@ public class Workflow implements IWorkflow {
         this.content = value.getContent();
         this.creationTime = value.getCreationTime();
         this.lastModifiedTime = value.getLastModifiedTime();
-        this.isPublished = value.getIsPublished();
+        this.isPublic = value.getIsPublic();
     }
 
     public Workflow(
@@ -46,7 +46,7 @@ public class Workflow implements IWorkflow {
         String    content,
         Timestamp creationTime,
         Timestamp lastModifiedTime,
-        Byte      isPublished
+        Byte      isPublic
     ) {
         this.name = name;
         this.description = description;
@@ -54,7 +54,7 @@ public class Workflow implements IWorkflow {
         this.content = content;
         this.creationTime = creationTime;
         this.lastModifiedTime = lastModifiedTime;
-        this.isPublished = isPublished;
+        this.isPublic = isPublic;
     }
 
     @Override
@@ -118,13 +118,13 @@ public class Workflow implements IWorkflow {
     }
 
     @Override
-    public Byte getIsPublished() {
-        return this.isPublished;
+    public Byte getIsPublic() {
+        return this.isPublic;
     }
 
     @Override
-    public void setIsPublished(Byte isPublished) {
-        this.isPublished = isPublished;
+    public void setIsPublic(Byte isPublic) {
+        this.isPublic = isPublic;
     }
 
     @Override
@@ -137,7 +137,7 @@ public class Workflow implements IWorkflow {
         sb.append(", ").append(content);
         sb.append(", ").append(creationTime);
         sb.append(", ").append(lastModifiedTime);
-        sb.append(", ").append(isPublished);
+        sb.append(", ").append(isPublic);
 
         sb.append(")");
         return sb.toString();
@@ -155,7 +155,7 @@ public class Workflow implements IWorkflow {
         setContent(from.getContent());
         setCreationTime(from.getCreationTime());
         setLastModifiedTime(from.getLastModifiedTime());
-        setIsPublished(from.getIsPublished());
+        setIsPublic(from.getIsPublic());
     }
 
     @Override

--- a/core/dao/src/main/scala/edu/uci/ics/texera/dao/jooq/generated/tables/records/WorkflowRecord.java
+++ b/core/dao/src/main/scala/edu/uci/ics/texera/dao/jooq/generated/tables/records/WorkflowRecord.java
@@ -23,7 +23,7 @@ import org.jooq.types.UInteger;
 @SuppressWarnings({ "all", "unchecked", "rawtypes" })
 public class WorkflowRecord extends UpdatableRecordImpl<WorkflowRecord> implements Record7<String, String, UInteger, String, Timestamp, Timestamp, Byte>, IWorkflow {
 
-    private static final long serialVersionUID = 1544914961;
+    private static final long serialVersionUID = 1992208375;
 
     /**
      * Setter for <code>texera_db.workflow.name</code>.
@@ -122,18 +122,18 @@ public class WorkflowRecord extends UpdatableRecordImpl<WorkflowRecord> implemen
     }
 
     /**
-     * Setter for <code>texera_db.workflow.is_published</code>.
+     * Setter for <code>texera_db.workflow.is_public</code>.
      */
     @Override
-    public void setIsPublished(Byte value) {
+    public void setIsPublic(Byte value) {
         set(6, value);
     }
 
     /**
-     * Getter for <code>texera_db.workflow.is_published</code>.
+     * Getter for <code>texera_db.workflow.is_public</code>.
      */
     @Override
-    public Byte getIsPublished() {
+    public Byte getIsPublic() {
         return (Byte) get(6);
     }
 
@@ -192,7 +192,7 @@ public class WorkflowRecord extends UpdatableRecordImpl<WorkflowRecord> implemen
 
     @Override
     public Field<Byte> field7() {
-        return Workflow.WORKFLOW.IS_PUBLISHED;
+        return Workflow.WORKFLOW.IS_PUBLIC;
     }
 
     @Override
@@ -227,7 +227,7 @@ public class WorkflowRecord extends UpdatableRecordImpl<WorkflowRecord> implemen
 
     @Override
     public Byte component7() {
-        return getIsPublished();
+        return getIsPublic();
     }
 
     @Override
@@ -262,7 +262,7 @@ public class WorkflowRecord extends UpdatableRecordImpl<WorkflowRecord> implemen
 
     @Override
     public Byte value7() {
-        return getIsPublished();
+        return getIsPublic();
     }
 
     @Override
@@ -303,7 +303,7 @@ public class WorkflowRecord extends UpdatableRecordImpl<WorkflowRecord> implemen
 
     @Override
     public WorkflowRecord value7(Byte value) {
-        setIsPublished(value);
+        setIsPublic(value);
         return this;
     }
 
@@ -331,7 +331,7 @@ public class WorkflowRecord extends UpdatableRecordImpl<WorkflowRecord> implemen
         setContent(from.getContent());
         setCreationTime(from.getCreationTime());
         setLastModifiedTime(from.getLastModifiedTime());
-        setIsPublished(from.getIsPublished());
+        setIsPublic(from.getIsPublic());
     }
 
     @Override
@@ -354,7 +354,7 @@ public class WorkflowRecord extends UpdatableRecordImpl<WorkflowRecord> implemen
     /**
      * Create a detached, initialised WorkflowRecord
      */
-    public WorkflowRecord(String name, String description, UInteger wid, String content, Timestamp creationTime, Timestamp lastModifiedTime, Byte isPublished) {
+    public WorkflowRecord(String name, String description, UInteger wid, String content, Timestamp creationTime, Timestamp lastModifiedTime, Byte isPublic) {
         super(Workflow.WORKFLOW);
 
         set(0, name);
@@ -363,6 +363,6 @@ public class WorkflowRecord extends UpdatableRecordImpl<WorkflowRecord> implemen
         set(3, content);
         set(4, creationTime);
         set(5, lastModifiedTime);
-        set(6, isPublished);
+        set(6, isPublic);
     }
 }

--- a/core/scripts/sql/texera_ddl.sql
+++ b/core/scripts/sql/texera_ddl.sql
@@ -244,3 +244,9 @@ CREATE TABLE IF NOT EXISTS workflow_view_count
     PRIMARY KEY (`wid`),
     FOREIGN KEY (`wid`) REFERENCES `workflow` (`wid`) ON DELETE CASCADE
     ) ENGINE = INNODB;
+
+ALTER TABLE dataset
+MODIFY COLUMN is_public BOOLEAN NOT NULL DEFAULT true;
+
+ALTER TABLE workflow
+CHANGE COLUMN is_published is_public BOOLEAN NOT NULL DEFAULT false;

--- a/core/scripts/sql/update/18.sql
+++ b/core/scripts/sql/update/18.sql
@@ -1,0 +1,7 @@
+USE texera_db;
+
+ALTER TABLE dataset
+MODIFY COLUMN is_public BOOLEAN NOT NULL DEFAULT true;
+
+ALTER TABLE workflow
+CHANGE COLUMN is_published is_public BOOLEAN NOT NULL DEFAULT false;


### PR DESCRIPTION
### Purpose:
Although the column indicating publication already exists in both the dataset and workflow tables, they have different names and types.

### Change:
Modified the dataset and workflow tables to unify the format of is_public across different tables. **To complete the database update, please execute `18.sql` located in the update folder.**

