### PR TITLE
Fix the schema fetching during sink storage assignment

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/WorkflowCompiler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/WorkflowCompiler.scala
@@ -71,7 +71,7 @@ class WorkflowCompiler(
         // assign the sinks to toAddSink operators' external output ports
         subPlan
           .topologicalIterator()
-          .map(subPlan.getOperator)
+          .map(physicalPlan.getOperator)
           .flatMap { physicalOp =>
             physicalOp.outputPorts.map(outputPort => (physicalOp, outputPort))
           }


### PR DESCRIPTION
This PR fixes the issue that, when MongoDB is used as the result storage, the execution keeps failing.

The root cause is:

when using MongoDB as the result storage, the schema has to be extracted from the physical op
the code implementation uses the physical ops in subPlan to extract the schema out, which is incorrect as subPlan's physical ops are not propagated for output schemas
How the fix is done is: using physicalPlan.getOperator, instead of subPlan.getOperator. In this way, the operator that is flowing to the downstream is from `physicalPlan`, not `subPlan`