### PR TITLE
Fix view result

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/WorkflowCompiler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/WorkflowCompiler.scala
@@ -28,7 +28,7 @@ class WorkflowCompiler(
       errorList: Option[ArrayBuffer[(OperatorIdentity, Throwable)]]
   ): PhysicalPlan = {
     val terminalLogicalOps = logicalPlan.getTerminalOperatorIds
-    val toAddSink = (terminalLogicalOps ++ logicalOpsToViewResult).toSet
+    val toAddSink = (terminalLogicalOps ++ logicalOpsToViewResult.map(OperatorIdentity(_))).toSet
     var physicalPlan = PhysicalPlan(operators = Set.empty, links = Set.empty)
     // create a JSON object that holds pointers to the workflow's results in Mongo
     val resultsJSON = objectMapper.createObjectNode()


### PR DESCRIPTION
This PR fixes an issue where operators marked for viewing results did not display the expected results due to a mismatch caused by string-based comparison instead of using operator identities. By updating the matching logic to rely on operator identities, this change ensures accurate identification of marked operators and correct display of their results.