### PR TITLE
Remove logical schema propagation

### DIFF
--- a/core/workflow-compiling-service/src/main/scala/edu/uci/ics/amber/compiler/WorkflowCompiler.scala
+++ b/core/workflow-compiling-service/src/main/scala/edu/uci/ics/amber/compiler/WorkflowCompiler.scala
@@ -110,6 +110,8 @@ class WorkflowCompiler(
     logicalPlan.getTopologicalOpIds.asScala.foreach(logicalOpId =>
       Try {
         val logicalOp = logicalPlan.getOperator(logicalOpId)
+        val allUpstreamLinks = logicalPlan
+          .getUpstreamLinks(logicalOp.operatorIdentifier)
 
         val subPlan = logicalOp.getPhysicalPlan(context.workflowId, context.executionId)
         subPlan
@@ -117,8 +119,7 @@ class WorkflowCompiler(
           .map(subPlan.getOperator)
           .foreach({ physicalOp =>
             {
-              val externalLinks = logicalPlan
-                .getUpstreamLinks(logicalOp.operatorIdentifier)
+              val externalLinks = allUpstreamLinks
                 .filter(link => physicalOp.inputPorts.contains(link.toPortId))
                 .flatMap { link =>
                   physicalPlan

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/workflow/PhysicalPlan.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/workflow/PhysicalPlan.scala
@@ -2,13 +2,9 @@ package edu.uci.ics.amber.core.workflow
 
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.typesafe.scalalogging.LazyLogging
+import edu.uci.ics.amber.core.tuple.Schema
+import edu.uci.ics.amber.core.virtualidentity.{ActorVirtualIdentity, OperatorIdentity, PhysicalOpIdentity}
 import edu.uci.ics.amber.util.VirtualIdentityUtils
-import edu.uci.ics.amber.core.virtualidentity.{
-  ActorVirtualIdentity,
-  OperatorIdentity,
-  PhysicalOpIdentity
-}
-import edu.uci.ics.amber.core.workflow.PhysicalLink
 import org.jgrapht.alg.connectivity.BiconnectivityInspector
 import org.jgrapht.alg.shortestpath.AllDirectedPaths
 import org.jgrapht.graph.DirectedAcyclicGraph
@@ -285,4 +281,28 @@ case class PhysicalPlan(
     chains.filter(s1 => chains.forall(s2 => s1 == s2 || !s1.subsetOf(s2))).toSet
   }
 
+  def propagateSchema(inputSchemas: Map[PortIdentity, Schema]): PhysicalPlan = {
+    var physicalPlan = PhysicalPlan(operators = Set.empty, links = Set.empty)
+    this
+      .topologicalIterator()
+      .map(this.getOperator)
+      .foreach({ physicalOp =>
+        {
+          val propagatedPhysicalOp = physicalOp.inputPorts.keys.foldLeft(physicalOp) {
+            (op, inputPortId) =>
+              op.propagateSchema(inputSchemas.get(inputPortId).map(schema => (inputPortId, schema)))
+          }
+
+          // Add the operator to the physical plan
+          physicalPlan = physicalPlan.addOperator(propagatedPhysicalOp.propagateSchema())
+
+          // Add internal links to the physical plan
+          physicalPlan =
+            getUpstreamPhysicalLinks(physicalOp.id).foldLeft(physicalPlan) { (plan, link) =>
+              plan.addLink(link)
+            }
+        }
+      })
+    physicalPlan
+  }
 }

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/workflow/PhysicalPlan.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/workflow/PhysicalPlan.scala
@@ -3,7 +3,11 @@ package edu.uci.ics.amber.core.workflow
 import com.fasterxml.jackson.annotation.JsonIgnore
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.core.tuple.Schema
-import edu.uci.ics.amber.core.virtualidentity.{ActorVirtualIdentity, OperatorIdentity, PhysicalOpIdentity}
+import edu.uci.ics.amber.core.virtualidentity.{
+  ActorVirtualIdentity,
+  OperatorIdentity,
+  PhysicalOpIdentity
+}
 import edu.uci.ics.amber.util.VirtualIdentityUtils
 import org.jgrapht.alg.connectivity.BiconnectivityInspector
 import org.jgrapht.alg.shortestpath.AllDirectedPaths
@@ -297,10 +301,10 @@ case class PhysicalPlan(
           physicalPlan = physicalPlan.addOperator(propagatedPhysicalOp.propagateSchema())
 
           // Add internal links to the physical plan
-          physicalPlan =
-            getUpstreamPhysicalLinks(physicalOp.id).foldLeft(physicalPlan) { (plan, link) =>
+          physicalPlan = getUpstreamPhysicalLinks(physicalOp.id).foldLeft(physicalPlan) {
+            (plan, link) =>
               plan.addLink(link)
-            }
+          }
         }
       })
     physicalPlan

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/LogicalOp.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/LogicalOp.scala
@@ -358,7 +358,11 @@ abstract class LogicalOp extends PortDescriptor with Serializable {
           .filterNot { case (port, _, _) => port.id.internal } // Exclude internal ports
           .map {
             case (port, _, schemaEither) =>
-              port.id -> schemaEither.toOption.get // Map external port ID to its schema
+              schemaEither match {
+                case Left(error) => throw error
+                case Right(schema) =>
+                  port.id -> schema // Map external port ID to its schema
+              }
           }
       }
       .toMap

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/LogicalOp.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/LogicalOp.scala
@@ -5,7 +5,11 @@ import com.fasterxml.jackson.annotation._
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.core.executor.OperatorExecutor
 import edu.uci.ics.amber.core.tuple.Schema
-import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, OperatorIdentity, WorkflowIdentity}
+import edu.uci.ics.amber.core.virtualidentity.{
+  ExecutionIdentity,
+  OperatorIdentity,
+  WorkflowIdentity
+}
 import edu.uci.ics.amber.core.workflow.WorkflowContext.{DEFAULT_EXECUTION_ID, DEFAULT_WORKFLOW_ID}
 import edu.uci.ics.amber.core.workflow.{PhysicalOp, PhysicalPlan, PortIdentity}
 import edu.uci.ics.amber.operator.aggregate.AggregateOpDesc
@@ -16,13 +20,21 @@ import edu.uci.ics.amber.operator.distinct.DistinctOpDesc
 import edu.uci.ics.amber.operator.dummy.DummyOpDesc
 import edu.uci.ics.amber.operator.filter.SpecializedFilterOpDesc
 import edu.uci.ics.amber.operator.hashJoin.HashJoinOpDesc
-import edu.uci.ics.amber.operator.huggingFace.{HuggingFaceIrisLogisticRegressionOpDesc, HuggingFaceSentimentAnalysisOpDesc, HuggingFaceSpamSMSDetectionOpDesc, HuggingFaceTextSummarizationOpDesc}
+import edu.uci.ics.amber.operator.huggingFace.{
+  HuggingFaceIrisLogisticRegressionOpDesc,
+  HuggingFaceSentimentAnalysisOpDesc,
+  HuggingFaceSpamSMSDetectionOpDesc,
+  HuggingFaceTextSummarizationOpDesc
+}
 import edu.uci.ics.amber.operator.intersect.IntersectOpDesc
 import edu.uci.ics.amber.operator.intervalJoin.IntervalJoinOpDesc
 import edu.uci.ics.amber.operator.keywordSearch.KeywordSearchOpDesc
 import edu.uci.ics.amber.operator.limit.LimitOpDesc
 import edu.uci.ics.amber.operator.machineLearning.Scorer.MachineLearningScorerOpDesc
-import edu.uci.ics.amber.operator.machineLearning.sklearnAdvanced.KNNTrainer.{SklearnAdvancedKNNClassifierTrainerOpDesc, SklearnAdvancedKNNRegressorTrainerOpDesc}
+import edu.uci.ics.amber.operator.machineLearning.sklearnAdvanced.KNNTrainer.{
+  SklearnAdvancedKNNClassifierTrainerOpDesc,
+  SklearnAdvancedKNNRegressorTrainerOpDesc
+}
 import edu.uci.ics.amber.operator.machineLearning.sklearnAdvanced.SVCTrainer.SklearnAdvancedSVCTrainerOpDesc
 import edu.uci.ics.amber.operator.machineLearning.sklearnAdvanced.SVRTrainer.SklearnAdvancedSVRTrainerOpDesc
 import edu.uci.ics.amber.operator.metadata.{OPVersion, OperatorInfo, PropertyNameConstants}
@@ -35,7 +47,10 @@ import edu.uci.ics.amber.operator.sklearn._
 import edu.uci.ics.amber.operator.sort.SortOpDesc
 import edu.uci.ics.amber.operator.sortPartitions.SortPartitionsOpDesc
 import edu.uci.ics.amber.operator.source.apis.reddit.RedditSearchSourceOpDesc
-import edu.uci.ics.amber.operator.source.apis.twitter.v2.{TwitterFullArchiveSearchSourceOpDesc, TwitterSearchSourceOpDesc}
+import edu.uci.ics.amber.operator.source.apis.twitter.v2.{
+  TwitterFullArchiveSearchSourceOpDesc,
+  TwitterSearchSourceOpDesc
+}
 import edu.uci.ics.amber.operator.source.fetcher.URLFetcherOpDesc
 import edu.uci.ics.amber.operator.source.scan.FileScanSourceOpDesc
 import edu.uci.ics.amber.operator.source.scan.arrow.ArrowSourceOpDesc

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/LogicalOp.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/LogicalOp.scala
@@ -315,7 +315,6 @@ abstract class LogicalOp extends PortDescriptor with Serializable {
 
   def operatorInfo: OperatorInfo
 
-  def getOutputSchema(schemas: Array[Schema]): Schema
 
   private def getOperatorVersion: String = {
     val path = "core/amber/src/main/scala/"
@@ -323,10 +322,7 @@ abstract class LogicalOp extends PortDescriptor with Serializable {
     OPVersion.getVersion(this.getClass.getSimpleName, operatorPath)
   }
 
-  // override if the operator has multiple output ports, schema must be specified for each port
-  def getOutputSchemas(schemas: Array[Schema]): Array[Schema] = {
-    Array.fill(1)(getOutputSchema(schemas))
-  }
+
 
   override def hashCode: Int = HashCodeBuilder.reflectionHashCode(this)
 

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/PythonOperatorDescriptor.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/PythonOperatorDescriptor.scala
@@ -30,8 +30,7 @@ trait PythonOperatorDescriptor extends LogicalOp {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withParallelizable(parallelizable())
-      .withPropagateSchema(SchemaPropagationFunc(inputSchemas => getOutputSchemas(inputSchemas))
-      )
+      .withPropagateSchema(SchemaPropagationFunc(inputSchemas => getOutputSchemas(inputSchemas)))
   }
 
   def parallelizable(): Boolean = false
@@ -45,7 +44,6 @@ trait PythonOperatorDescriptor extends LogicalOp {
     * @return a String representation of the executable Python source code.
     */
   def generatePythonCode(): String
-
 
   def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema]
 

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/PythonOperatorDescriptor.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/PythonOperatorDescriptor.scala
@@ -1,8 +1,9 @@
 package edu.uci.ics.amber.operator
 
 import edu.uci.ics.amber.core.executor.OpExecWithCode
+import edu.uci.ics.amber.core.tuple.Schema
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
-import edu.uci.ics.amber.core.workflow.{PhysicalOp, SchemaPropagationFunc}
+import edu.uci.ics.amber.core.workflow.{PhysicalOp, PortIdentity, SchemaPropagationFunc}
 
 trait PythonOperatorDescriptor extends LogicalOp {
   override def getPhysicalOp(
@@ -29,14 +30,7 @@ trait PythonOperatorDescriptor extends LogicalOp {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withParallelizable(parallelizable())
-      .withPropagateSchema(
-        SchemaPropagationFunc(inputSchemas =>
-          Map(
-            operatorInfo.outputPorts.head.id -> getOutputSchema(
-              operatorInfo.inputPorts.map(_.id).map(inputSchemas(_)).toArray
-            )
-          )
-        )
+      .withPropagateSchema(SchemaPropagationFunc(inputSchemas => getOutputSchemas(inputSchemas))
       )
   }
 
@@ -51,5 +45,8 @@ trait PythonOperatorDescriptor extends LogicalOp {
     * @return a String representation of the executable Python source code.
     */
   def generatePythonCode(): String
+
+
+  def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema]
 
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/cartesianProduct/CartesianProductOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/cartesianProduct/CartesianProductOpDesc.scala
@@ -59,7 +59,8 @@ class CartesianProductOpDesc extends LogicalOp {
 
             // Resolve duplicate names by appending a suffix
             while (outputAttributeNames.contains(newName)) {
-              val suffixIndex = """#@(\d+)$""".r.findFirstMatchIn(newName).map(_.group(1).toInt + 1).getOrElse(1)
+              val suffixIndex =
+                """#@(\d+)$""".r.findFirstMatchIn(newName).map(_.group(1).toInt + 1).getOrElse(1)
               newName = s"${attr.getName}#@$suffixIndex"
             }
 

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/cartesianProduct/CartesianProductOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/cartesianProduct/CartesianProductOpDesc.scala
@@ -22,61 +22,61 @@ class CartesianProductOpDesc extends LogicalOp {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withPropagateSchema(
-        SchemaPropagationFunc(inputSchemas =>
-          Map(
-            operatorInfo.outputPorts.head.id -> getOutputSchema(
-              Array(
-                inputSchemas(operatorInfo.inputPorts.head.id),
-                inputSchemas(operatorInfo.inputPorts.last.id)
-              )
-            )
-          )
-        )
+        SchemaPropagationFunc(inputSchemas => {
+
+          // Combines the left and right input schemas into a single output schema.
+          //
+          // - The output schema includes all attributes from the left schema first, followed by
+          //   attributes from the right schema.
+          // - Duplicate attribute names are resolved by appending an increasing suffix (e.g., `#@1`, `#@2`).
+          // - Attributes from the left schema retain their original names in the output schema.
+          //
+          // Example:
+          // Left schema: (dup, dup#@1, dup#@2)
+          // Right schema: (r1, r2, dup)
+          // Output schema: (dup, dup#@1, dup#@2, r1, r2, dup#@3)
+          //
+          // In this example, the last attribute from the right schema (`dup`) is renamed to `dup#@3`
+          // to avoid conflicts.
+
+          // Initialize a schema builder
+          val builder = Schema.builder()
+
+          // Retrieve the left and right schemas
+          val leftSchema = inputSchemas(operatorInfo.inputPorts.head.id)
+          val rightSchema = inputSchemas(operatorInfo.inputPorts.last.id)
+
+          // Extract attribute names for conflict resolution
+          val leftAttributeNames = leftSchema.getAttributeNames.toSet
+          val outputAttributeNames = scala.collection.mutable.Set[String]() ++ leftAttributeNames
+
+          // Add all attributes from the left schema to the builder
+          builder.add(leftSchema)
+
+          // Process attributes from the right schema
+          rightSchema.getAttributes.foreach { attr =>
+            var newName = attr.getName
+
+            // Resolve duplicate names by appending a suffix
+            while (outputAttributeNames.contains(newName)) {
+              val suffixIndex = """#@(\d+)$""".r.findFirstMatchIn(newName).map(_.group(1).toInt + 1).getOrElse(1)
+              newName = s"${attr.getName}#@$suffixIndex"
+            }
+
+            // Add the resolved attribute to the builder
+            builder.add(new Attribute(newName, attr.getType))
+            outputAttributeNames.add(newName)
+          }
+
+          // Build the output schema and associate it with the output port
+          val outputSchema = builder.build()
+          Map(operatorInfo.outputPorts.head.id -> outputSchema)
+        })
       )
       // TODO : refactor to parallelize this operator for better performance and scalability:
       //  can consider hash partition on larger input, broadcast smaller table to each partition
       .withParallelizable(false)
 
-  }
-
-  /**
-    * returns a Schema in order of the left input attributes followed by the right attributes
-    * duplicate attribute names are handled with an increasing suffix count
-    *
-    * Left schema attributes should always retain the same name in output schema
-    *
-    * For example, Left(dup, dup#@1, dup#@2) cartesian product with Right(r1, r2, dup)
-    * has output schema: (dup, dup#@1, dup#@2, r1, r2, dup#@3)
-    *
-    * Since the last attribute of Right is a duplicate, it increases suffix until it is
-    * no longer a duplicate, resulting in dup#@3
-    */
-  def getOutputSchemaInternal(schemas: Array[Schema]): Schema = {
-    // merge left / right schemas together, sequentially with left schema first
-    val builder = Schema.builder()
-    val leftSchema = schemas(0)
-    val leftAttributeNames = leftSchema.getAttributeNames
-    val rightSchema = schemas(1)
-    val rightAttributeNames = rightSchema.getAttributeNames
-    builder.add(leftSchema)
-    rightSchema.getAttributes.foreach(attr => {
-      var newName = attr.getName
-      while (
-        leftAttributeNames.contains(newName) || rightAttributeNames
-          .filterNot(attrName => attrName == attr.getName)
-          .contains(newName)
-      ) {
-        newName = s"$newName#@1"
-      }
-      if (newName == attr.getName) {
-        // non-duplicate attribute, add to builder as is
-        builder.add(attr)
-      } else {
-        // renamed the duplicate attribute, construct new Attribute
-        builder.add(new Attribute(newName, attr.getType))
-      }
-    })
-    builder.build()
   }
 
   override def operatorInfo: OperatorInfo =
@@ -90,9 +90,4 @@ class CartesianProductOpDesc extends LogicalOp {
       ),
       outputPorts = List(OutputPort())
     )
-
-  // remove duplicates in attribute names
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    getOutputSchemaInternal(schemas)
-  }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/dictionary/DictionaryMatcherOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/dictionary/DictionaryMatcherOpDesc.scala
@@ -4,13 +4,12 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.google.common.base.Preconditions
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
 import edu.uci.ics.amber.core.tuple.{AttributeType, Schema}
-import edu.uci.ics.amber.core.workflow.{PhysicalOp, SchemaPropagationFunc}
+import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PhysicalOp, SchemaPropagationFunc}
 import edu.uci.ics.amber.operator.map.MapOpDesc
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.util.JSONUtils.objectMapper
-import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
 
 /**
   * Dictionary matcher operator matches a tuple if the specified column is in the given dictionary.
@@ -48,9 +47,16 @@ class DictionaryMatcherOpDesc extends MapOpDesc {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withPropagateSchema(
-        SchemaPropagationFunc(inputSchemas =>
-          Map(operatorInfo.outputPorts.head.id -> getOutputSchema(inputSchemas.values.toArray))
-        )
+        SchemaPropagationFunc(inputSchemas => {
+          if (resultAttribute == null || resultAttribute.trim.isEmpty) return null
+          Map(
+            operatorInfo.outputPorts.head.id -> Schema
+              .builder()
+              .add(inputSchemas.values.head)
+              .add(resultAttribute, AttributeType.BOOLEAN)
+              .build()
+          )
+        })
       )
   }
 
@@ -63,10 +69,4 @@ class DictionaryMatcherOpDesc extends MapOpDesc {
       outputPorts = List(OutputPort()),
       supportReconfiguration = true
     )
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Preconditions.checkArgument(schemas.length == 1)
-    if (resultAttribute == null || resultAttribute.trim.isEmpty) return null
-    Schema.builder().add(schemas(0)).add(resultAttribute, AttributeType.BOOLEAN).build()
-  }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/dictionary/DictionaryMatcherOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/dictionary/DictionaryMatcherOpDesc.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.amber.operator.dictionary
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
-import com.google.common.base.Preconditions
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
 import edu.uci.ics.amber.core.tuple.{AttributeType, Schema}
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/distinct/DistinctOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/distinct/DistinctOpDesc.scala
@@ -1,13 +1,10 @@
 package edu.uci.ics.amber.operator.distinct
 
-import com.google.common.base.Preconditions
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
-import edu.uci.ics.amber.core.tuple.Schema
-import edu.uci.ics.amber.core.workflow.{HashPartition, PhysicalOp}
+import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import edu.uci.ics.amber.core.workflow.{HashPartition, InputPort, OutputPort, PhysicalOp}
 import edu.uci.ics.amber.operator.LogicalOp
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
-import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
 
 class DistinctOpDesc extends LogicalOp {
 
@@ -26,6 +23,7 @@ class DistinctOpDesc extends LogicalOp {
       .withOutputPorts(operatorInfo.outputPorts)
       .withPartitionRequirement(List(Option(HashPartition())))
       .withDerivePartition(_ => HashPartition())
+
   }
 
   override def operatorInfo: OperatorInfo =
@@ -36,10 +34,5 @@ class DistinctOpDesc extends LogicalOp {
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(blocking = true))
     )
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Preconditions.checkArgument(schemas.forall(_ == schemas(0)))
-    schemas(0)
-  }
 
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/dummy/DummyOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/dummy/DummyOpDesc.scala
@@ -48,6 +48,4 @@ class DummyOpDesc extends LogicalOp with PortDescriptor {
       allowPortCustomization = true
     )
   }
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema = schemas(0)
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/dummy/DummyOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/dummy/DummyOpDesc.scala
@@ -2,7 +2,6 @@ package edu.uci.ics.amber.operator.dummy
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
-import edu.uci.ics.amber.core.tuple.Schema
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.{LogicalOp, PortDescription, PortDescriptor}
 import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/filter/FilterOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/filter/FilterOpDesc.scala
@@ -1,19 +1,12 @@
 package edu.uci.ics.amber.operator.filter
 
-import com.google.common.base.Preconditions
-import edu.uci.ics.amber.core.tuple.Schema
+import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import edu.uci.ics.amber.core.workflow.PhysicalOp
 import edu.uci.ics.amber.operator.{LogicalOp, StateTransferFunc}
-import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 
 import scala.util.{Success, Try}
 
 abstract class FilterOpDesc extends LogicalOp {
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Preconditions.checkArgument(schemas.length == 1)
-    schemas(0)
-  }
 
   override def runtimeReconfiguration(
       workflowId: WorkflowIdentity,

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/hashJoin/HashJoinOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/hashJoin/HashJoinOpDesc.scala
@@ -118,7 +118,7 @@ class HashJoinOpDesc[K] extends LogicalOp {
         .withDerivePartition(_ => HashPartition(List(probeAttributeName)))
         .withParallelizable(true)
         .withPropagateSchema(
-          SchemaPropagationFunc(inputSchemas =>{
+          SchemaPropagationFunc(inputSchemas => {
             val buildSchema = inputSchemas(PortIdentity(internal = true))
             val probeSchema = inputSchemas(PortIdentity(1))
             val builder = Schema.builder()
@@ -143,9 +143,7 @@ class HashJoinOpDesc[K] extends LogicalOp {
               }
             val outputSchema = builder.build()
             Map(PortIdentity() -> outputSchema)
-          }
-
-          )
+          })
         )
 
     PhysicalPlan(

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/hashJoin/HashJoinOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/hashJoin/HashJoinOpDesc.scala
@@ -118,12 +118,33 @@ class HashJoinOpDesc[K] extends LogicalOp {
         .withDerivePartition(_ => HashPartition(List(probeAttributeName)))
         .withParallelizable(true)
         .withPropagateSchema(
-          SchemaPropagationFunc(inputSchemas =>
-            Map(
-              PortIdentity() -> getOutputSchema(
-                Array(inputSchemas(PortIdentity(internal = true)), inputSchemas(PortIdentity(1)))
-              )
-            )
+          SchemaPropagationFunc(inputSchemas =>{
+            val buildSchema = inputSchemas(PortIdentity(internal = true))
+            val probeSchema = inputSchemas(PortIdentity(1))
+            val builder = Schema.builder()
+            builder.add(buildSchema)
+            builder.removeIfExists(HASH_JOIN_INTERNAL_KEY_NAME)
+            val leftAttributeNames = buildSchema.getAttributeNames
+            val rightAttributeNames =
+              probeSchema.getAttributeNames.filterNot(name => name == probeAttributeName)
+
+            // Create a Map from rightTuple's fields, renaming conflicts
+            rightAttributeNames
+              .foreach { name =>
+                var newName = name
+                while (
+                  leftAttributeNames.contains(newName) || rightAttributeNames
+                    .filter(attrName => name != attrName)
+                    .contains(newName)
+                ) {
+                  newName = s"$newName#@1"
+                }
+                builder.add(new Attribute(newName, probeSchema.getAttribute(name).getType))
+              }
+            val outputSchema = builder.build()
+            Map(PortIdentity() -> outputSchema)
+          }
+
           )
         )
 
@@ -151,31 +172,4 @@ class HashJoinOpDesc[K] extends LogicalOp {
       ),
       outputPorts = List(OutputPort())
     )
-
-  // remove the probe attribute in the output
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    val buildSchema = schemas(0)
-    val probeSchema = schemas(1)
-    val builder = Schema.builder()
-    builder.add(buildSchema)
-    builder.removeIfExists(HASH_JOIN_INTERNAL_KEY_NAME)
-    val leftAttributeNames = buildSchema.getAttributeNames
-    val rightAttributeNames =
-      probeSchema.getAttributeNames.filterNot(name => name == probeAttributeName)
-
-    // Create a Map from rightTuple's fields, renaming conflicts
-    rightAttributeNames
-      .foreach { name =>
-        var newName = name
-        while (
-          leftAttributeNames.contains(newName) || rightAttributeNames
-            .filter(attrName => name != attrName)
-            .contains(newName)
-        ) {
-          newName = s"$newName#@1"
-        }
-        builder.add(new Attribute(newName, probeSchema.getAttribute(name).getType))
-      }
-    builder.build()
-  }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceIrisLogisticRegressionOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceIrisLogisticRegressionOpDesc.scala
@@ -90,17 +90,21 @@ class HuggingFaceIrisLogisticRegressionOpDesc extends PythonOperatorDescriptor {
       outputPorts = List(OutputPort())
     )
 
-  override def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
+  override def getOutputSchemas(
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     if (
       predictionClassName == null || predictionClassName.trim.isEmpty ||
       predictionProbabilityName == null || predictionProbabilityName.trim.isEmpty
     )
       throw new RuntimeException("Result attribute name should not be empty")
-    Map(operatorInfo.outputPorts.head.id -> Schema
-      .builder()
-      .add(inputSchemas(operatorInfo.inputPorts.head.id))
-      .add(predictionClassName, AttributeType.STRING)
-      .add(predictionProbabilityName, AttributeType.DOUBLE)
-      .build())
+    Map(
+      operatorInfo.outputPorts.head.id -> Schema
+        .builder()
+        .add(inputSchemas(operatorInfo.inputPorts.head.id))
+        .add(predictionClassName, AttributeType.STRING)
+        .add(predictionProbabilityName, AttributeType.DOUBLE)
+        .build()
+    )
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceIrisLogisticRegressionOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceIrisLogisticRegressionOpDesc.scala
@@ -5,7 +5,7 @@ import edu.uci.ics.amber.core.tuple.{AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 class HuggingFaceIrisLogisticRegressionOpDesc extends PythonOperatorDescriptor {
 
   @JsonProperty(value = "petalLengthCmAttribute", required = true)
@@ -90,17 +90,17 @@ class HuggingFaceIrisLogisticRegressionOpDesc extends PythonOperatorDescriptor {
       outputPorts = List(OutputPort())
     )
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
+  override def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
     if (
       predictionClassName == null || predictionClassName.trim.isEmpty ||
       predictionProbabilityName == null || predictionProbabilityName.trim.isEmpty
     )
       throw new RuntimeException("Result attribute name should not be empty")
-    Schema
+    Map(operatorInfo.outputPorts.head.id -> Schema
       .builder()
-      .add(schemas(0))
+      .add(inputSchemas(operatorInfo.inputPorts.head.id))
       .add(predictionClassName, AttributeType.STRING)
       .add(predictionProbabilityName, AttributeType.DOUBLE)
-      .build()
+      .build())
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceSentimentAnalysisOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceSentimentAnalysisOpDesc.scala
@@ -77,19 +77,23 @@ class HuggingFaceSentimentAnalysisOpDesc extends PythonOperatorDescriptor {
       supportReconfiguration = true
     )
 
-  override def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
+  override def getOutputSchemas(
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     if (
       resultAttributePositive == null || resultAttributePositive.trim.isEmpty ||
       resultAttributeNeutral == null || resultAttributeNeutral.trim.isEmpty ||
       resultAttributeNegative == null || resultAttributeNegative.trim.isEmpty
     )
       return null
-    Map(operatorInfo.outputPorts.head.id -> Schema
-      .builder()
-      .add(inputSchemas(operatorInfo.inputPorts.head.id))
-      .add(resultAttributePositive, AttributeType.DOUBLE)
-      .add(resultAttributeNeutral, AttributeType.DOUBLE)
-      .add(resultAttributeNegative, AttributeType.DOUBLE)
-      .build())
+    Map(
+      operatorInfo.outputPorts.head.id -> Schema
+        .builder()
+        .add(inputSchemas(operatorInfo.inputPorts.head.id))
+        .add(resultAttributePositive, AttributeType.DOUBLE)
+        .add(resultAttributeNeutral, AttributeType.DOUBLE)
+        .add(resultAttributeNegative, AttributeType.DOUBLE)
+        .build()
+    )
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceSentimentAnalysisOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceSentimentAnalysisOpDesc.scala
@@ -2,7 +2,7 @@ package edu.uci.ics.amber.operator.huggingFace
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import edu.uci.ics.amber.core.tuple.{AttributeType, Schema}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
@@ -77,19 +77,19 @@ class HuggingFaceSentimentAnalysisOpDesc extends PythonOperatorDescriptor {
       supportReconfiguration = true
     )
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
+  override def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
     if (
       resultAttributePositive == null || resultAttributePositive.trim.isEmpty ||
       resultAttributeNeutral == null || resultAttributeNeutral.trim.isEmpty ||
       resultAttributeNegative == null || resultAttributeNegative.trim.isEmpty
     )
       return null
-    Schema
+    Map(operatorInfo.outputPorts.head.id -> Schema
       .builder()
-      .add(schemas(0))
+      .add(inputSchemas(operatorInfo.inputPorts.head.id))
       .add(resultAttributePositive, AttributeType.DOUBLE)
       .add(resultAttributeNeutral, AttributeType.DOUBLE)
       .add(resultAttributeNegative, AttributeType.DOUBLE)
-      .build()
+      .build())
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceSpamSMSDetectionOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceSpamSMSDetectionOpDesc.scala
@@ -5,7 +5,7 @@ import edu.uci.ics.amber.core.tuple.{AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 class HuggingFaceSpamSMSDetectionOpDesc extends PythonOperatorDescriptor {
   @JsonProperty(value = "attribute", required = true)
   @JsonPropertyDescription("column to perform spam detection on")
@@ -54,12 +54,14 @@ class HuggingFaceSpamSMSDetectionOpDesc extends PythonOperatorDescriptor {
       outputPorts = List(OutputPort())
     )
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema
-      .builder()
-      .add(schemas(0))
-      .add(resultAttributeSpam, AttributeType.BOOLEAN)
-      .add(resultAttributeProbability, AttributeType.DOUBLE)
-      .build()
+  override def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
+    Map(
+      operatorInfo.outputPorts.head.id -> Schema
+        .builder()
+        .add(inputSchemas.values.head)
+        .add(resultAttributeSpam, AttributeType.BOOLEAN)
+        .add(resultAttributeProbability, AttributeType.DOUBLE)
+        .build()
+    )
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceSpamSMSDetectionOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceSpamSMSDetectionOpDesc.scala
@@ -54,7 +54,9 @@ class HuggingFaceSpamSMSDetectionOpDesc extends PythonOperatorDescriptor {
       outputPorts = List(OutputPort())
     )
 
-  override def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
+  override def getOutputSchemas(
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     Map(
       operatorInfo.outputPorts.head.id -> Schema
         .builder()

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceTextSummarizationOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceTextSummarizationOpDesc.scala
@@ -57,13 +57,17 @@ class HuggingFaceTextSummarizationOpDesc extends PythonOperatorDescriptor {
       outputPorts = List(OutputPort())
     )
 
-  override def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
+  override def getOutputSchemas(
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     if (resultAttribute == null || resultAttribute.trim.isEmpty)
       throw new RuntimeException("Result attribute name should be given")
-    Map(operatorInfo.outputPorts.head.id -> Schema
-      .builder()
-      .add(inputSchemas.values.head)
-      .add(resultAttribute, AttributeType.STRING)
-      .build())
+    Map(
+      operatorInfo.outputPorts.head.id -> Schema
+        .builder()
+        .add(inputSchemas.values.head)
+        .add(resultAttribute, AttributeType.STRING)
+        .build()
+    )
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceTextSummarizationOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/huggingFace/HuggingFaceTextSummarizationOpDesc.scala
@@ -2,7 +2,7 @@ package edu.uci.ics.amber.operator.huggingFace
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import edu.uci.ics.amber.core.tuple.{AttributeType, Schema}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
@@ -57,13 +57,13 @@ class HuggingFaceTextSummarizationOpDesc extends PythonOperatorDescriptor {
       outputPorts = List(OutputPort())
     )
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
+  override def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
     if (resultAttribute == null || resultAttribute.trim.isEmpty)
       throw new RuntimeException("Result attribute name should be given")
-    Schema
+    Map(operatorInfo.outputPorts.head.id -> Schema
       .builder()
-      .add(schemas(0))
+      .add(inputSchemas.values.head)
       .add(resultAttribute, AttributeType.STRING)
-      .build()
+      .build())
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/intersect/IntersectOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/intersect/IntersectOpDesc.scala
@@ -1,13 +1,10 @@
 package edu.uci.ics.amber.operator.intersect
 
-import com.google.common.base.Preconditions
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
-import edu.uci.ics.amber.core.tuple.Schema
-import edu.uci.ics.amber.core.workflow.{HashPartition, PhysicalOp}
+import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import edu.uci.ics.amber.core.workflow._
 import edu.uci.ics.amber.operator.LogicalOp
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
-import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 
 class IntersectOpDesc extends LogicalOp {
 
@@ -36,10 +33,4 @@ class IntersectOpDesc extends LogicalOp {
       inputPorts = List(InputPort(PortIdentity()), InputPort(PortIdentity(1))),
       outputPorts = List(OutputPort(blocking = true))
     )
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Preconditions.checkArgument(schemas.forall(_ == schemas(0)))
-    schemas(0)
-  }
-
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/intervalJoin/IntervalJoinOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/intervalJoin/IntervalJoinOpDesc.scala
@@ -91,15 +91,23 @@ class IntervalJoinOpDesc extends LogicalOp {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withPropagateSchema(
-        SchemaPropagationFunc(inputSchemas =>
-          Map(
-            operatorInfo.outputPorts.head.id -> getOutputSchema(
-              Array(
-                inputSchemas(operatorInfo.inputPorts.head.id),
-                inputSchemas(operatorInfo.inputPorts.last.id)
-              )
-            )
-          )
+        SchemaPropagationFunc(inputSchemas =>{
+          val builder: Schema.Builder = Schema.builder()
+          val leftTableSchema: Schema = inputSchemas(operatorInfo.inputPorts.head.id)
+          val rightTableSchema: Schema =         inputSchemas(operatorInfo.inputPorts.last.id)
+          builder.add(leftTableSchema)
+          rightTableSchema.getAttributes
+            .map(attr => {
+              if (leftTableSchema.containsAttribute(attr.getName)) {
+                builder.add(new Attribute(s"${attr.getName}#@1", attr.getType))
+              } else {
+                builder.add(attr.getName, attr.getType)
+              }
+            })
+          val outputSchema = builder.build()
+          Map(operatorInfo.outputPorts.head.id -> outputSchema)
+        }
+
         )
       )
       .withPartitionRequirement(partitionRequirement)
@@ -136,22 +144,6 @@ class IntervalJoinOpDesc extends LogicalOp {
     this.includeLeftBound = includeLeftBound
     this.includeRightBound = includeRightBound
     this.timeIntervalType = Some(timeIntervalType)
-  }
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    val builder: Schema.Builder = Schema.builder()
-    val leftTableSchema: Schema = schemas(0)
-    val rightTableSchema: Schema = schemas(1)
-    builder.add(leftTableSchema)
-    rightTableSchema.getAttributes
-      .map(attr => {
-        if (leftTableSchema.containsAttribute(attr.getName)) {
-          builder.add(new Attribute(s"${attr.getName}#@1", attr.getType))
-        } else {
-          builder.add(attr.getName, attr.getType)
-        }
-      })
-    builder.build()
   }
 
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/intervalJoin/IntervalJoinOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/intervalJoin/IntervalJoinOpDesc.scala
@@ -91,10 +91,10 @@ class IntervalJoinOpDesc extends LogicalOp {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withPropagateSchema(
-        SchemaPropagationFunc(inputSchemas =>{
+        SchemaPropagationFunc(inputSchemas => {
           val builder: Schema.Builder = Schema.builder()
           val leftTableSchema: Schema = inputSchemas(operatorInfo.inputPorts.head.id)
-          val rightTableSchema: Schema =         inputSchemas(operatorInfo.inputPorts.last.id)
+          val rightTableSchema: Schema = inputSchemas(operatorInfo.inputPorts.last.id)
           builder.add(leftTableSchema)
           rightTableSchema.getAttributes
             .map(attr => {
@@ -106,9 +106,7 @@ class IntervalJoinOpDesc extends LogicalOp {
             })
           val outputSchema = builder.build()
           Map(operatorInfo.outputPorts.head.id -> outputSchema)
-        }
-
-        )
+        })
       )
       .withPartitionRequirement(partitionRequirement)
   }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/limit/LimitOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/limit/LimitOpDesc.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.amber.operator.limit
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
-import edu.uci.ics.amber.core.tuple.Schema
 import edu.uci.ics.amber.core.workflow.PhysicalOp
 import edu.uci.ics.amber.operator.{LogicalOp, StateTransferFunc}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/limit/LimitOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/limit/LimitOpDesc.scala
@@ -49,8 +49,6 @@ class LimitOpDesc extends LogicalOp {
       supportReconfiguration = true
     )
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = schemas(0)
-
   override def runtimeReconfiguration(
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity,

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/machineLearning/Scorer/MachineLearningScorerOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/machineLearning/Scorer/MachineLearningScorerOpDesc.scala
@@ -1,16 +1,12 @@
 package edu.uci.ics.amber.operator.machineLearning.Scorer
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
-import com.kjetland.jackson.jsonSchema.annotations.{
-  JsonSchemaInject,
-  JsonSchemaString,
-  JsonSchemaTitle
-}
+import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaString, JsonSchemaTitle}
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.{AutofillAttributeName, HideAnnotation}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 
 class MachineLearningScorerOpDesc extends PythonOperatorDescriptor {
   @JsonProperty(required = true, defaultValue = "false")
@@ -64,7 +60,7 @@ class MachineLearningScorerOpDesc extends PythonOperatorDescriptor {
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort())
     )
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
+  override def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
     val outputSchemaBuilder = Schema.builder()
     if (!isRegression) {
       outputSchemaBuilder.add(new Attribute("Class", AttributeType.STRING))
@@ -79,7 +75,7 @@ class MachineLearningScorerOpDesc extends PythonOperatorDescriptor {
       outputSchemaBuilder.add(new Attribute(metricName, AttributeType.DOUBLE))
     })
 
-    outputSchemaBuilder.build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchemaBuilder.build())
   }
 
 //  private def getClassificationScorerName(scorer: classificationMetricsFnc): String = {

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/machineLearning/Scorer/MachineLearningScorerOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/machineLearning/Scorer/MachineLearningScorerOpDesc.scala
@@ -1,7 +1,11 @@
 package edu.uci.ics.amber.operator.machineLearning.Scorer
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
-import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaString, JsonSchemaTitle}
+import com.kjetland.jackson.jsonSchema.annotations.{
+  JsonSchemaInject,
+  JsonSchemaString,
+  JsonSchemaTitle
+}
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
@@ -60,7 +64,9 @@ class MachineLearningScorerOpDesc extends PythonOperatorDescriptor {
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort())
     )
-  override def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
+  override def getOutputSchemas(
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchemaBuilder = Schema.builder()
     if (!isRegression) {
       outputSchemaBuilder.add(new Attribute("Class", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/machineLearning/sklearnAdvanced/base/SklearnAdvancedBaseDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/machineLearning/sklearnAdvanced/base/SklearnAdvancedBaseDesc.scala
@@ -149,7 +149,9 @@ abstract class SklearnMLOperatorDescriptor[T <: ParamClass] extends PythonOperat
     )
   }
 
-  override def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
+  override def getOutputSchemas(
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchemaBuilder = Schema.builder()
     outputSchemaBuilder.add(new Attribute("Model", AttributeType.BINARY))
     outputSchemaBuilder.add(new Attribute("Parameters", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/machineLearning/sklearnAdvanced/base/SklearnAdvancedBaseDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/machineLearning/sklearnAdvanced/base/SklearnAdvancedBaseDesc.scala
@@ -149,9 +149,11 @@ abstract class SklearnMLOperatorDescriptor[T <: ParamClass] extends PythonOperat
     )
   }
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
+  override def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
     val outputSchemaBuilder = Schema.builder()
     outputSchemaBuilder.add(new Attribute("Model", AttributeType.BINARY))
-    outputSchemaBuilder.add(new Attribute("Parameters", AttributeType.STRING)).build()
+    outputSchemaBuilder.add(new Attribute("Parameters", AttributeType.STRING))
+
+    Map(operatorInfo.outputPorts.head.id -> outputSchemaBuilder.build())
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/map/MapOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/map/MapOpDesc.scala
@@ -4,7 +4,7 @@ import edu.uci.ics.amber.core.workflow.PhysicalOp
 import edu.uci.ics.amber.operator.{LogicalOp, StateTransferFunc}
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 
-import scala.util.{Failure, Success, Try}
+import scala.util.{Success, Try}
 
 abstract class MapOpDesc extends LogicalOp {
 

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/map/MapOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/map/MapOpDesc.scala
@@ -14,22 +14,6 @@ abstract class MapOpDesc extends LogicalOp {
       oldOpDesc: LogicalOp,
       newOpDesc: LogicalOp
   ): Try[(PhysicalOp, Option[StateTransferFunc])] = {
-    val inputSchemas = oldOpDesc.operatorInfo.inputPorts
-      .map(inputPort => oldOpDesc.inputPortToSchemaMapping(inputPort.id))
-      .toArray
-    val outputSchemas = oldOpDesc.operatorInfo.outputPorts
-      .map(outputPort => oldOpDesc.outputPortToSchemaMapping(outputPort.id))
-      .toArray
-    val newOutputSchema = newOpDesc.getOutputSchema(inputSchemas)
-    if (!newOutputSchema.equals(outputSchemas.head)) {
-      Failure(
-        new UnsupportedOperationException(
-          "reconfigurations that change output schema are not supported"
-        )
-      )
-    } else {
-      Success(newOpDesc.getPhysicalOp(workflowId, executionId), None)
-    }
+    Success(newOpDesc.getPhysicalOp(workflowId, executionId), None)
   }
-
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/reservoirsampling/ReservoirSamplingOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/reservoirsampling/ReservoirSamplingOpDesc.scala
@@ -44,9 +44,4 @@ class ReservoirSamplingOpDesc extends LogicalOp {
       outputPorts = List(OutputPort())
     )
   }
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Preconditions.checkArgument(schemas.length == 1)
-    schemas(0)
-  }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/reservoirsampling/ReservoirSamplingOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/reservoirsampling/ReservoirSamplingOpDesc.scala
@@ -1,9 +1,7 @@
 package edu.uci.ics.amber.operator.reservoirsampling
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
-import com.google.common.base.Preconditions
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
-import edu.uci.ics.amber.core.tuple.Schema
 import edu.uci.ics.amber.core.workflow.PhysicalOp
 import edu.uci.ics.amber.operator.LogicalOp
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sentiment/SentimentAnalysisOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sentiment/SentimentAnalysisOpDesc.scala
@@ -55,13 +55,17 @@ class SentimentAnalysisOpDesc extends MapOpDesc {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withPropagateSchema(
-        SchemaPropagationFunc(inputSchemas =>{
+        SchemaPropagationFunc(inputSchemas => {
           if (resultAttribute == null || resultAttribute.trim.isEmpty)
             return null
-          Map(operatorInfo.outputPorts.head.id -> Schema.builder().add(inputSchemas.values.head).add(resultAttribute, AttributeType.INTEGER).build())
-        }
-
-        )
+          Map(
+            operatorInfo.outputPorts.head.id -> Schema
+              .builder()
+              .add(inputSchemas.values.head)
+              .add(resultAttribute, AttributeType.INTEGER)
+              .build()
+          )
+        })
       )
   }
 

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sentiment/SentimentAnalysisOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sentiment/SentimentAnalysisOpDesc.scala
@@ -55,8 +55,12 @@ class SentimentAnalysisOpDesc extends MapOpDesc {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withPropagateSchema(
-        SchemaPropagationFunc(inputSchemas =>
-          Map(operatorInfo.outputPorts.head.id -> getOutputSchema(inputSchemas.values.toArray))
+        SchemaPropagationFunc(inputSchemas =>{
+          if (resultAttribute == null || resultAttribute.trim.isEmpty)
+            return null
+          Map(operatorInfo.outputPorts.head.id -> Schema.builder().add(inputSchemas.values.head).add(resultAttribute, AttributeType.INTEGER).build())
+        }
+
         )
       )
   }
@@ -71,9 +75,4 @@ class SentimentAnalysisOpDesc extends MapOpDesc {
       supportReconfiguration = true
     )
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    if (resultAttribute == null || resultAttribute.trim.isEmpty)
-      return null
-    Schema.builder().add(schemas(0)).add(resultAttribute, AttributeType.INTEGER).build()
-  }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sklearn/SklearnClassifierOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sklearn/SklearnClassifierOpDesc.scala
@@ -106,11 +106,13 @@ abstract class SklearnClassifierOpDesc extends PythonOperatorDescriptor {
       outputPorts = List(OutputPort(blocking = true))
     )
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    Map(operatorInfo.outputPorts.head.id -> Schema
       .builder()
       .add("model_name", AttributeType.STRING)
       .add("model", AttributeType.BINARY)
-      .build()
+      .build())
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sklearn/SklearnClassifierOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sklearn/SklearnClassifierOpDesc.scala
@@ -107,12 +107,14 @@ abstract class SklearnClassifierOpDesc extends PythonOperatorDescriptor {
     )
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
-    Map(operatorInfo.outputPorts.head.id -> Schema
-      .builder()
-      .add("model_name", AttributeType.STRING)
-      .add("model", AttributeType.BINARY)
-      .build())
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
+    Map(
+      operatorInfo.outputPorts.head.id -> Schema
+        .builder()
+        .add("model_name", AttributeType.STRING)
+        .add("model", AttributeType.BINARY)
+        .build()
+    )
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sklearn/SklearnLinearRegressionOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sklearn/SklearnLinearRegressionOpDesc.scala
@@ -60,13 +60,15 @@ class SklearnLinearRegressionOpDesc extends PythonOperatorDescriptor {
     )
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
-    Map(operatorInfo.outputPorts.head.id -> Schema
-      .builder()
-      .add("model_name", AttributeType.STRING)
-      .add("model", AttributeType.BINARY)
-      .build())
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
+    Map(
+      operatorInfo.outputPorts.head.id -> Schema
+        .builder()
+        .add("model_name", AttributeType.STRING)
+        .add("model", AttributeType.BINARY)
+        .build()
+    )
   }
 
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sklearn/SklearnLinearRegressionOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sklearn/SklearnLinearRegressionOpDesc.scala
@@ -59,12 +59,14 @@ class SklearnLinearRegressionOpDesc extends PythonOperatorDescriptor {
       outputPorts = List(OutputPort(blocking = true))
     )
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    Map(operatorInfo.outputPorts.head.id -> Schema
       .builder()
       .add("model_name", AttributeType.STRING)
       .add("model", AttributeType.BINARY)
-      .build()
+      .build())
   }
 
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sklearn/SklearnPredictionOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sklearn/SklearnPredictionOpDesc.scala
@@ -59,18 +59,20 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
     )
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     var resultType = AttributeType.STRING
     val inputSchema = inputSchemas(operatorInfo.inputPorts(1).id)
     if (groundTruthAttribute != "") {
       resultType =
         inputSchema.attributes.find(attr => attr.getName == groundTruthAttribute).get.getType
     }
-    Map(operatorInfo.outputPorts.head.id -> Schema
-      .builder()
-      .add(inputSchema)
-      .add(resultAttribute, resultType)
-      .build())
+    Map(
+      operatorInfo.outputPorts.head.id -> Schema
+        .builder()
+        .add(inputSchema)
+        .add(resultAttribute, resultType)
+        .build()
+    )
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sklearn/SklearnPredictionOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sklearn/SklearnPredictionOpDesc.scala
@@ -58,16 +58,19 @@ class SklearnPredictionOpDesc extends PythonOperatorDescriptor {
       outputPorts = List(OutputPort())
     )
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
     var resultType = AttributeType.STRING
+    val inputSchema = inputSchemas(operatorInfo.inputPorts(1).id)
     if (groundTruthAttribute != "") {
       resultType =
-        schemas(1).attributes.find(attr => attr.getName == groundTruthAttribute).get.getType
+        inputSchema.attributes.find(attr => attr.getName == groundTruthAttribute).get.getType
     }
-    Schema
+    Map(operatorInfo.outputPorts.head.id -> Schema
       .builder()
-      .add(schemas(1))
+      .add(inputSchema)
       .add(resultAttribute, resultType)
-      .build()
+      .build())
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sort/SortOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sort/SortOpDesc.scala
@@ -40,7 +40,6 @@ class SortOpDesc extends PythonOperatorDescriptor {
        |        yield sorted_df""".stripMargin
   }
 
-
   def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
     Map(operatorInfo.outputPorts.head.id -> inputSchemas.values.head)
   }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sort/SortOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sort/SortOpDesc.scala
@@ -2,7 +2,7 @@ package edu.uci.ics.amber.operator.sort
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import edu.uci.ics.amber.core.tuple.Schema
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 class SortOpDesc extends PythonOperatorDescriptor {
@@ -40,6 +40,11 @@ class SortOpDesc extends PythonOperatorDescriptor {
        |        yield sorted_df""".stripMargin
   }
 
+
+  def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
+    Map(operatorInfo.outputPorts.head.id -> inputSchemas.values.head)
+  }
+
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
       "Sort",
@@ -49,5 +54,4 @@ class SortOpDesc extends PythonOperatorDescriptor {
       outputPorts = List(OutputPort(blocking = true))
     )
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = schemas(0)
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sortPartitions/SortPartitionsOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sortPartitions/SortPartitionsOpDesc.scala
@@ -1,10 +1,8 @@
 package edu.uci.ics.amber.operator.sortPartitions
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
-import com.google.common.base.Preconditions
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
-import edu.uci.ics.amber.core.tuple.Schema
 import edu.uci.ics.amber.core.workflow.{PhysicalOp, RangePartition}
 import edu.uci.ics.amber.operator.LogicalOp
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sortPartitions/SortPartitionsOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sortPartitions/SortPartitionsOpDesc.scala
@@ -68,9 +68,4 @@ class SortPartitionsOpDesc extends LogicalOp {
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(blocking = true))
     )
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Preconditions.checkArgument(schemas.length == 1)
-    schemas(0)
-  }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/source/SourceOperatorDescriptor.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/source/SourceOperatorDescriptor.scala
@@ -1,15 +1,9 @@
 package edu.uci.ics.amber.operator.source
 
-import com.google.common.base.Preconditions
 import edu.uci.ics.amber.core.tuple.Schema
 import edu.uci.ics.amber.operator.LogicalOp
 
 abstract class SourceOperatorDescriptor extends LogicalOp {
 
   def sourceSchema(): Schema
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Preconditions.checkArgument(schemas.isEmpty)
-    sourceSchema()
-  }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/source/apis/reddit/RedditSearchSourceOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/source/apis/reddit/RedditSearchSourceOpDesc.scala
@@ -5,7 +5,7 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.source.PythonSourceOperatorDescriptor
-import edu.uci.ics.amber.core.workflow.OutputPort
+import edu.uci.ics.amber.core.workflow.{OutputPort, PortIdentity}
 
 class RedditSearchSourceOpDesc extends PythonSourceOperatorDescriptor {
   @JsonProperty(required = true)
@@ -134,4 +134,8 @@ class RedditSearchSourceOpDesc extends PythonSourceOperatorDescriptor {
         new Attribute("subreddit", AttributeType.STRING)
       )
       .build()
+
+  def getOutputSchemas(inputSchemas: Map[PortIdentity, Schema]): Map[PortIdentity, Schema] = {
+    Map(operatorInfo.outputPorts.head.id -> sourceSchema())
+  }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/split/SplitOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/split/SplitOpDesc.scala
@@ -4,12 +4,11 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.google.common.base.Preconditions
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
 import edu.uci.ics.amber.core.tuple.Schema
-import edu.uci.ics.amber.core.workflow.{PhysicalOp, SchemaPropagationFunc}
+import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import edu.uci.ics.amber.core.workflow._
 import edu.uci.ics.amber.operator.LogicalOp
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.util.JSONUtils.objectMapper
-import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 
 import scala.util.Random
 class SplitOpDesc extends LogicalOp {
@@ -40,12 +39,11 @@ class SplitOpDesc extends LogicalOp {
       .withOutputPorts(operatorInfo.outputPorts)
       .withParallelizable(false)
       .withPropagateSchema(
-        SchemaPropagationFunc(inputSchemas =>
-          operatorInfo.outputPorts
-            .map(_.id)
-            .map(id => id -> inputSchemas(operatorInfo.inputPorts.head.id))
-            .toMap
-        )
+        SchemaPropagationFunc(inputSchemas => {
+          Preconditions.checkArgument(inputSchemas.size == 1)
+          val outputSchema = inputSchemas.values.head
+          operatorInfo.outputPorts.map(port => port.id -> outputSchema).toMap
+        })
       )
   }
 
@@ -64,10 +62,4 @@ class SplitOpDesc extends LogicalOp {
     )
   }
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = throw new NotImplementedError()
-
-  override def getOutputSchemas(schemas: Array[Schema]): Array[Schema] = {
-    Preconditions.checkArgument(schemas.length == 1)
-    Array(schemas(0), schemas(0))
-  }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/split/SplitOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/split/SplitOpDesc.scala
@@ -3,7 +3,6 @@ package edu.uci.ics.amber.operator.split
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.google.common.base.Preconditions
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
-import edu.uci.ics.amber.core.tuple.Schema
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import edu.uci.ics.amber.core.workflow._
 import edu.uci.ics.amber.operator.LogicalOp

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/symmetricDifference/SymmetricDifferenceOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/symmetricDifference/SymmetricDifferenceOpDesc.scala
@@ -2,8 +2,14 @@ package edu.uci.ics.amber.operator.symmetricDifference
 
 import com.google.common.base.Preconditions
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
-import edu.uci.ics.amber.core.tuple.Schema
-import edu.uci.ics.amber.core.workflow.{HashPartition, InputPort, OutputPort, PhysicalOp, PortIdentity, SchemaPropagationFunc}
+import edu.uci.ics.amber.core.workflow.{
+  HashPartition,
+  InputPort,
+  OutputPort,
+  PhysicalOp,
+  PortIdentity,
+  SchemaPropagationFunc
+}
 import edu.uci.ics.amber.operator.LogicalOp
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/symmetricDifference/SymmetricDifferenceOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/symmetricDifference/SymmetricDifferenceOpDesc.scala
@@ -3,11 +3,10 @@ package edu.uci.ics.amber.operator.symmetricDifference
 import com.google.common.base.Preconditions
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
 import edu.uci.ics.amber.core.tuple.Schema
-import edu.uci.ics.amber.core.workflow.{HashPartition, PhysicalOp}
+import edu.uci.ics.amber.core.workflow.{HashPartition, InputPort, OutputPort, PhysicalOp, PortIdentity, SchemaPropagationFunc}
 import edu.uci.ics.amber.operator.LogicalOp
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 
 class SymmetricDifferenceOpDesc extends LogicalOp {
 
@@ -29,6 +28,11 @@ class SymmetricDifferenceOpDesc extends LogicalOp {
       .withOutputPorts(operatorInfo.outputPorts)
       .withPartitionRequirement(List(Option(HashPartition()), Option(HashPartition())))
       .withDerivePartition(_ => HashPartition(List()))
+      .withPropagateSchema(SchemaPropagationFunc(inputSchemas => {
+        Preconditions.checkArgument(inputSchemas.values.toSet.size == 1)
+        val outputSchema = inputSchemas.values.head
+        operatorInfo.outputPorts.map(port => port.id -> outputSchema).toMap
+      }))
   }
 
   override def operatorInfo: OperatorInfo =
@@ -39,10 +43,5 @@ class SymmetricDifferenceOpDesc extends LogicalOp {
       inputPorts = List(InputPort(PortIdentity(0)), InputPort(PortIdentity(1))),
       outputPorts = List(OutputPort(blocking = true))
     )
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Preconditions.checkArgument(schemas.forall(_ == schemas(0)))
-    schemas(0)
-  }
 
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/typecasting/TypeCastingOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/typecasting/TypeCastingOpDesc.scala
@@ -54,10 +54,4 @@ class TypeCastingOpDesc extends MapOpDesc {
       List(OutputPort())
     )
   }
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    typeCastingUnits.foldLeft(schemas.head) { (schema, unit) =>
-      AttributeTypeUtils.SchemaCasting(schema, unit.attribute, unit.resultType)
-    }
-  }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/java/JavaUDFOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/java/JavaUDFOpDesc.scala
@@ -157,26 +157,6 @@ class JavaUDFOpDesc extends LogicalOp {
     )
   }
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    //    Preconditions.checkArgument(schemas.length == 1)
-    val inputSchema = schemas(0)
-    val outputSchemaBuilder = Schema.Builder()
-    // keep the same schema from input
-    if (retainInputColumns) outputSchemaBuilder.add(inputSchema)
-    // for any javaUDFType, it can add custom output columns (attributes).
-    if (outputColumns != null) {
-      if (retainInputColumns) { // check if columns are duplicated
-
-        for (column <- outputColumns) {
-          if (inputSchema.containsAttribute(column.getName))
-            throw new RuntimeException("Column name " + column.getName + " already exists!")
-        }
-      }
-      outputSchemaBuilder.add(outputColumns)
-    }
-    outputSchemaBuilder.build()
-  }
-
   override def runtimeReconfiguration(
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity,

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/DualInputPortsPythonUDFOpDescV2.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/DualInputPortsPythonUDFOpDescV2.scala
@@ -84,7 +84,8 @@ class DualInputPortsPythonUDFOpDescV2 extends LogicalOp {
         )
         .withParallelizable(false)
     }
-    physicalOp.withDerivePartition(_ => UnknownPartition())
+    physicalOp
+      .withDerivePartition(_ => UnknownPartition())
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withPropagateSchema(
@@ -105,10 +106,8 @@ class DualInputPortsPythonUDFOpDescV2 extends LogicalOp {
             }
             outputSchemaBuilder.add(outputColumns).build()
           }
-          Map(operatorInfo.outputPorts.head.id ->  outputSchemaBuilder.build())
-        }
-
-        )
+          Map(operatorInfo.outputPorts.head.id -> outputSchemaBuilder.build())
+        })
       )
   }
 
@@ -128,6 +127,5 @@ class DualInputPortsPythonUDFOpDescV2 extends LogicalOp {
       ),
       outputPorts = List(OutputPort())
     )
-
 
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/DualInputPortsPythonUDFOpDescV2.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/DualInputPortsPythonUDFOpDescV2.scala
@@ -64,7 +64,7 @@ class DualInputPortsPythonUDFOpDescV2 extends LogicalOp {
       executionId: ExecutionIdentity
   ): PhysicalOp = {
     Preconditions.checkArgument(workers >= 1, "Need at least 1 worker.", Array())
-    if (workers > 1) {
+    val physicalOp = if (workers > 1) {
       PhysicalOp
         .oneToOnePhysicalOp(
           workflowId,
@@ -72,15 +72,7 @@ class DualInputPortsPythonUDFOpDescV2 extends LogicalOp {
           operatorIdentifier,
           OpExecWithCode(code, "python")
         )
-        .withDerivePartition(_ => UnknownPartition())
         .withParallelizable(true)
-        .withInputPorts(operatorInfo.inputPorts)
-        .withOutputPorts(operatorInfo.outputPorts)
-        .withPropagateSchema(
-          SchemaPropagationFunc(inputSchemas =>
-            Map(operatorInfo.outputPorts.head.id -> getOutputSchema(inputSchemas.values.toArray))
-          )
-        )
         .withSuggestedWorkerNum(workers)
     } else {
       PhysicalOp
@@ -90,20 +82,34 @@ class DualInputPortsPythonUDFOpDescV2 extends LogicalOp {
           operatorIdentifier,
           OpExecWithCode(code, "python")
         )
-        .withDerivePartition(_ => UnknownPartition())
         .withParallelizable(false)
-        .withInputPorts(operatorInfo.inputPorts)
-        .withOutputPorts(operatorInfo.outputPorts)
-        .withPropagateSchema(
-          SchemaPropagationFunc(inputSchemas =>
-            Map(
-              operatorInfo.outputPorts.head.id -> getOutputSchema(
-                operatorInfo.inputPorts.map(_.id).map(inputSchemas(_)).toArray
-              )
-            )
-          )
-        )
     }
+    physicalOp.withDerivePartition(_ => UnknownPartition())
+      .withInputPorts(operatorInfo.inputPorts)
+      .withOutputPorts(operatorInfo.outputPorts)
+      .withPropagateSchema(
+        SchemaPropagationFunc(inputSchemas => {
+          Preconditions.checkArgument(inputSchemas.size == 2)
+          val inputSchema = inputSchemas(operatorInfo.inputPorts(1).id)
+          val outputSchemaBuilder = Schema.builder()
+          // keep the same schema from input
+          if (retainInputColumns) outputSchemaBuilder.add(inputSchema)
+          // for any pythonUDFType, it can add custom output columns (attributes).
+          if (outputColumns != null) {
+            if (retainInputColumns) { // check if columns are duplicated
+
+              for (column <- outputColumns) {
+                if (inputSchema.containsAttribute(column.getName))
+                  throw new RuntimeException("Column name " + column.getName + " already exists!")
+              }
+            }
+            outputSchemaBuilder.add(outputColumns).build()
+          }
+          Map(operatorInfo.outputPorts.head.id ->  outputSchemaBuilder.build())
+        }
+
+        )
+      )
   }
 
   override def operatorInfo: OperatorInfo =
@@ -123,23 +129,5 @@ class DualInputPortsPythonUDFOpDescV2 extends LogicalOp {
       outputPorts = List(OutputPort())
     )
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Preconditions.checkArgument(schemas.length == 2)
-    val inputSchema = schemas(1)
-    val outputSchemaBuilder = Schema.builder()
-    // keep the same schema from input
-    if (retainInputColumns) outputSchemaBuilder.add(inputSchema)
-    // for any pythonUDFType, it can add custom output columns (attributes).
-    if (outputColumns != null) {
-      if (retainInputColumns) { // check if columns are duplicated
 
-        for (column <- outputColumns) {
-          if (inputSchema.containsAttribute(column.getName))
-            throw new RuntimeException("Column name " + column.getName + " already exists!")
-        }
-      }
-      outputSchemaBuilder.add(outputColumns).build()
-    }
-    outputSchemaBuilder.build()
-  }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/PythonLambdaFunctionOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/PythonLambdaFunctionOpDesc.scala
@@ -11,10 +11,9 @@ class PythonLambdaFunctionOpDesc extends PythonOperatorDescriptor {
   @JsonSchemaTitle("Add/Modify column(s)")
   var lambdaAttributeUnits: List[LambdaAttributeUnit] = List()
 
-
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     Preconditions.checkArgument(inputSchemas.size == 1)
     Preconditions.checkArgument(lambdaAttributeUnits.nonEmpty)
     val inputSchema = inputSchemas.values.head

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/PythonLambdaFunctionOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/PythonLambdaFunctionOpDesc.scala
@@ -5,16 +5,19 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.core.tuple.{AttributeTypeUtils, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 
 class PythonLambdaFunctionOpDesc extends PythonOperatorDescriptor {
   @JsonSchemaTitle("Add/Modify column(s)")
   var lambdaAttributeUnits: List[LambdaAttributeUnit] = List()
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Preconditions.checkArgument(schemas.length == 1)
+
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    Preconditions.checkArgument(inputSchemas.size == 1)
     Preconditions.checkArgument(lambdaAttributeUnits.nonEmpty)
-    val inputSchema = schemas(0)
+    val inputSchema = inputSchemas.values.head
     val outputSchemaBuilder = Schema.builder()
     // keep the same schema from input
     outputSchemaBuilder.add(inputSchema)
@@ -37,7 +40,8 @@ class PythonLambdaFunctionOpDesc extends PythonOperatorDescriptor {
         outputSchema =
           AttributeTypeUtils.SchemaCasting(outputSchema, unit.attributeName, unit.attributeType)
     }
-    outputSchema
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
+
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/source/PythonUDFSourceOpDescV2.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/source/PythonUDFSourceOpDescV2.scala
@@ -8,7 +8,7 @@ import edu.uci.ics.amber.core.workflow.{PhysicalOp, SchemaPropagationFunc}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.source.SourceOperatorDescriptor
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
-import edu.uci.ics.amber.core.workflow.{OutputPort, PortIdentity}
+import edu.uci.ics.amber.core.workflow.OutputPort
 
 class PythonUDFSourceOpDescV2 extends SourceOperatorDescriptor {
 
@@ -46,7 +46,9 @@ class PythonUDFSourceOpDescV2 extends SourceOperatorDescriptor {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withIsOneToManyOp(true)
-      .withPropagateSchema(SchemaPropagationFunc(_ =>Map(operatorInfo.outputPorts.head.id -> sourceSchema())))
+      .withPropagateSchema(
+        SchemaPropagationFunc(_ => Map(operatorInfo.outputPorts.head.id -> sourceSchema()))
+      )
       .withLocationPreference(Option.empty)
 
     if (workers > 1) {

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/source/PythonUDFSourceOpDescV2.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/source/PythonUDFSourceOpDescV2.scala
@@ -41,18 +41,12 @@ class PythonUDFSourceOpDescV2 extends SourceOperatorDescriptor {
       executionId: ExecutionIdentity
   ): PhysicalOp = {
     require(workers >= 1, "Need at least 1 worker.")
-
-    val func = SchemaPropagationFunc { _: Map[PortIdentity, Schema] =>
-      val outputSchema = sourceSchema()
-      Map(operatorInfo.outputPorts.head.id -> outputSchema)
-    }
-
     val physicalOp = PhysicalOp
       .sourcePhysicalOp(workflowId, executionId, operatorIdentifier, OpExecWithCode(code, "python"))
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withIsOneToManyOp(true)
-      .withPropagateSchema(func)
+      .withPropagateSchema(SchemaPropagationFunc(_ =>Map(operatorInfo.outputPorts.head.id -> sourceSchema())))
       .withLocationPreference(Option.empty)
 
     if (workers > 1) {

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/r/RUDFOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/r/RUDFOpDesc.scala
@@ -110,7 +110,7 @@ class RUDFOpDesc extends LogicalOp {
           OpExecWithCode(code, r_operator_type)
         )
         .withParallelizable(false)
-    }        .withDerivePartition(_ => UnknownPartition())
+    }.withDerivePartition(_ => UnknownPartition())
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withPartitionRequirement(partitionRequirement)

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/r/RUDFOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/r/RUDFOpDesc.scala
@@ -91,7 +91,7 @@ class RUDFOpDesc extends LogicalOp {
     }
 
     val r_operator_type = if (useTupleAPI) "r-tuple" else "r-table"
-    if (workers > 1)
+    if (workers > 1) {
       PhysicalOp
         .oneToOnePhysicalOp(
           workflowId,
@@ -99,15 +99,9 @@ class RUDFOpDesc extends LogicalOp {
           operatorIdentifier,
           OpExecWithCode(code, r_operator_type)
         )
-        .withDerivePartition(_ => UnknownPartition())
-        .withInputPorts(operatorInfo.inputPorts)
-        .withOutputPorts(operatorInfo.outputPorts)
-        .withPartitionRequirement(partitionRequirement)
-        .withIsOneToManyOp(true)
         .withParallelizable(true)
         .withSuggestedWorkerNum(workers)
-        .withPropagateSchema(SchemaPropagationFunc(propagateSchema))
-    else
+    } else {
       PhysicalOp
         .manyToOnePhysicalOp(
           workflowId,
@@ -115,13 +109,14 @@ class RUDFOpDesc extends LogicalOp {
           operatorIdentifier,
           OpExecWithCode(code, r_operator_type)
         )
-        .withDerivePartition(_ => UnknownPartition())
-        .withInputPorts(operatorInfo.inputPorts)
-        .withOutputPorts(operatorInfo.outputPorts)
-        .withPartitionRequirement(partitionRequirement)
-        .withIsOneToManyOp(true)
         .withParallelizable(false)
-        .withPropagateSchema(SchemaPropagationFunc(propagateSchema))
+    }        .withDerivePartition(_ => UnknownPartition())
+      .withInputPorts(operatorInfo.inputPorts)
+      .withOutputPorts(operatorInfo.outputPorts)
+      .withPartitionRequirement(partitionRequirement)
+      .withIsOneToManyOp(true)
+      .withPropagateSchema(SchemaPropagationFunc(propagateSchema))
+
   }
 
   override def operatorInfo: OperatorInfo = {
@@ -151,30 +146,8 @@ class RUDFOpDesc extends LogicalOp {
       "User-defined function operator in R script",
       OperatorGroupConstants.R_GROUP,
       inputPortInfo,
-      outputPortInfo,
-      dynamicInputPorts = false,
-      dynamicOutputPorts = false,
-      supportReconfiguration = false,
-      allowPortCustomization = false
+      outputPortInfo
     )
-  }
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    val inputSchema = schemas(0)
-    val outputSchemaBuilder = Schema.Builder()
-    // keep the same schema from input
-    if (retainInputColumns) outputSchemaBuilder.add(inputSchema)
-    if (outputColumns != null) {
-      if (retainInputColumns) { // check if columns are duplicated
-
-        for (column <- outputColumns) {
-          if (inputSchema.containsAttribute(column.getName))
-            throw new RuntimeException("Column name " + column.getName + " already exists!")
-        }
-      }
-      outputSchemaBuilder.add(outputColumns)
-    }
-    outputSchemaBuilder.build()
   }
 
   override def runtimeReconfiguration(

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/r/RUDFSourceOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/r/RUDFSourceOpDesc.scala
@@ -51,11 +51,6 @@ class RUDFSourceOpDesc extends SourceOperatorDescriptor {
     val rOperatorType = if (useTupleAPI) "r-tuple" else "r-table"
     require(workers >= 1, "Need at least 1 worker.")
 
-    val func = SchemaPropagationFunc { _: Map[PortIdentity, Schema] =>
-      val outputSchema = sourceSchema()
-      Map(operatorInfo.outputPorts.head.id -> outputSchema)
-    }
-
     val physicalOp = PhysicalOp
       .sourcePhysicalOp(
         workflowId,
@@ -66,7 +61,7 @@ class RUDFSourceOpDesc extends SourceOperatorDescriptor {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withIsOneToManyOp(true)
-      .withPropagateSchema(func)
+      .withPropagateSchema(SchemaPropagationFunc(_ => Map(operatorInfo.outputPorts.head.id -> sourceSchema())))
       .withLocationPreference(None)
 
     if (workers > 1) {

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/r/RUDFSourceOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/r/RUDFSourceOpDesc.scala
@@ -8,7 +8,7 @@ import edu.uci.ics.amber.core.workflow.{PhysicalOp, SchemaPropagationFunc}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.source.SourceOperatorDescriptor
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
-import edu.uci.ics.amber.core.workflow.{OutputPort, PortIdentity}
+import edu.uci.ics.amber.core.workflow.OutputPort
 
 class RUDFSourceOpDesc extends SourceOperatorDescriptor {
 
@@ -61,7 +61,9 @@ class RUDFSourceOpDesc extends SourceOperatorDescriptor {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withIsOneToManyOp(true)
-      .withPropagateSchema(SchemaPropagationFunc(_ => Map(operatorInfo.outputPorts.head.id -> sourceSchema())))
+      .withPropagateSchema(
+        SchemaPropagationFunc(_ => Map(operatorInfo.outputPorts.head.id -> sourceSchema()))
+      )
       .withLocationPreference(None)
 
     if (workers > 1) {

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/union/UnionOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/union/UnionOpDesc.scala
@@ -1,13 +1,10 @@
 package edu.uci.ics.amber.operator.union
 
-import com.google.common.base.Preconditions
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
-import edu.uci.ics.amber.core.tuple.Schema
-import edu.uci.ics.amber.core.workflow.PhysicalOp
+import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PhysicalOp, PortIdentity}
 import edu.uci.ics.amber.operator.LogicalOp
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
-import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 
 class UnionOpDesc extends LogicalOp {
 
@@ -34,10 +31,4 @@ class UnionOpDesc extends LogicalOp {
       inputPorts = List(InputPort(PortIdentity(0), allowMultiLinks = true)),
       outputPorts = List(OutputPort())
     )
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Preconditions.checkArgument(schemas.forall(_ == schemas(0)))
-    schemas(0)
-  }
-
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/unneststring/UnnestStringOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/unneststring/UnnestStringOpDesc.scala
@@ -53,19 +53,13 @@ class UnnestStringOpDesc extends FlatMapOpDesc {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withPropagateSchema(
-        SchemaPropagationFunc(inputSchemas =>
-          Map(
-            operatorInfo.outputPorts.head.id -> getOutputSchema(
-              operatorInfo.inputPorts.map(_.id).map(inputSchemas(_)).toArray
-            )
-          )
+        SchemaPropagationFunc(inputSchemas =>{
+          val outputSchema = if (resultAttribute == null || resultAttribute.trim.isEmpty) null else
+          Schema.builder().add(inputSchemas.values.head).add(resultAttribute, AttributeType.STRING).build()
+          Map(operatorInfo.outputPorts.head.id -> outputSchema)
+        }
+
         )
       )
-  }
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Preconditions.checkArgument(schemas.forall(_ == schemas(0)))
-    if (resultAttribute == null || resultAttribute.trim.isEmpty) return null
-    Schema.builder().add(schemas(0)).add(resultAttribute, AttributeType.STRING).build()
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/unneststring/UnnestStringOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/unneststring/UnnestStringOpDesc.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.amber.operator.unneststring
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
-import com.google.common.base.Preconditions
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
 import edu.uci.ics.amber.core.tuple.{AttributeType, Schema}
 import edu.uci.ics.amber.core.workflow.{PhysicalOp, SchemaPropagationFunc}
@@ -53,13 +52,17 @@ class UnnestStringOpDesc extends FlatMapOpDesc {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withPropagateSchema(
-        SchemaPropagationFunc(inputSchemas =>{
-          val outputSchema = if (resultAttribute == null || resultAttribute.trim.isEmpty) null else
-          Schema.builder().add(inputSchemas.values.head).add(resultAttribute, AttributeType.STRING).build()
+        SchemaPropagationFunc(inputSchemas => {
+          val outputSchema =
+            if (resultAttribute == null || resultAttribute.trim.isEmpty) null
+            else
+              Schema
+                .builder()
+                .add(inputSchemas.values.head)
+                .add(resultAttribute, AttributeType.STRING)
+                .build()
           Map(operatorInfo.outputPorts.head.id -> outputSchema)
-        }
-
-        )
+        })
       )
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/DotPlot/DotPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/DotPlot/DotPlotOpDesc.scala
@@ -18,8 +18,8 @@ class DotPlotOpDesc extends PythonOperatorDescriptor {
   var countAttribute: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/DotPlot/DotPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/DotPlot/DotPlotOpDesc.scala
@@ -5,7 +5,7 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 
@@ -17,8 +17,14 @@ class DotPlotOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var countAttribute: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/IcicleChart/IcicleChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/IcicleChart/IcicleChartOpDesc.scala
@@ -35,8 +35,8 @@ class IcicleChartOpDesc extends PythonOperatorDescriptor {
   var value: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/IcicleChart/IcicleChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/IcicleChart/IcicleChartOpDesc.scala
@@ -8,7 +8,7 @@ import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.visualization.hierarchychart.HierarchySection
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 
 // type constraint: value can only be numeric
 @JsonSchemaInject(json = """
@@ -34,8 +34,14 @@ class IcicleChartOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var value: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ImageViz/ImageVisualizerOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ImageViz/ImageVisualizerOpDesc.scala
@@ -17,8 +17,8 @@ class ImageVisualizerOpDesc extends PythonOperatorDescriptor {
   var binaryContent: String = _
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ImageViz/ImageVisualizerOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ImageViz/ImageVisualizerOpDesc.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
@@ -16,8 +16,14 @@ class ImageVisualizerOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var binaryContent: String = _
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ScatterMatrixChart/ScatterMatrixChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ScatterMatrixChart/ScatterMatrixChartOpDesc.scala
@@ -5,7 +5,10 @@ import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchema
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
-import edu.uci.ics.amber.operator.metadata.annotations.{AutofillAttributeName, AutofillAttributeNameList}
+import edu.uci.ics.amber.operator.metadata.annotations.{
+  AutofillAttributeName,
+  AutofillAttributeNameList
+}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
 @JsonSchemaInject(json = """
@@ -32,8 +35,8 @@ class ScatterMatrixChartOpDesc extends PythonOperatorDescriptor {
   var color: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ScatterMatrixChart/ScatterMatrixChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ScatterMatrixChart/ScatterMatrixChartOpDesc.scala
@@ -3,12 +3,9 @@ package edu.uci.ics.amber.operator.visualization.ScatterMatrixChart
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
-import edu.uci.ics.amber.operator.metadata.annotations.{
-  AutofillAttributeName,
-  AutofillAttributeNameList
-}
+import edu.uci.ics.amber.operator.metadata.annotations.{AutofillAttributeName, AutofillAttributeNameList}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
 @JsonSchemaInject(json = """
@@ -34,8 +31,14 @@ class ScatterMatrixChartOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var color: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/barChart/BarChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/barChart/BarChartOpDesc.scala
@@ -3,11 +3,11 @@ package edu.uci.ics.amber.operator.visualization.barChart
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
-import edu.uci.ics.amber.operator.PythonOperatorDescriptor
-import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
-import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
+import edu.uci.ics.amber.operator.PythonOperatorDescriptor
+import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
+import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 
 //type constraint: value can only be numeric
 @JsonSchemaInject(json = """
@@ -50,8 +50,14 @@ class BarChartOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var pattern: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxPlot/BoxPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxPlot/BoxPlotOpDesc.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
@@ -37,8 +37,14 @@ class BoxPlotOpDesc extends PythonOperatorDescriptor {
   )
   var quertiletype: BoxPlotQuartileFunction = _
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxPlot/BoxPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxPlot/BoxPlotOpDesc.scala
@@ -38,8 +38,8 @@ class BoxPlotOpDesc extends PythonOperatorDescriptor {
   var quertiletype: BoxPlotQuartileFunction = _
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/bubbleChart/BubbleChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/bubbleChart/BubbleChartOpDesc.scala
@@ -44,8 +44,8 @@ class BubbleChartOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName var colorCategory: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/bubbleChart/BubbleChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/bubbleChart/BubbleChartOpDesc.scala
@@ -5,7 +5,7 @@ import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 
@@ -43,8 +43,14 @@ class BubbleChartOpDesc extends PythonOperatorDescriptor {
   @JsonPropertyDescription("Picks data column to color bubbles with if color is enabled")
   @AutofillAttributeName var colorCategory: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/candlestickChart/CandlestickChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/candlestickChart/CandlestickChartOpDesc.scala
@@ -7,7 +7,7 @@ import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 
 class CandlestickChartOpDesc extends PythonOperatorDescriptor {
 
@@ -41,8 +41,14 @@ class CandlestickChartOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var close: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/candlestickChart/CandlestickChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/candlestickChart/CandlestickChartOpDesc.scala
@@ -42,8 +42,8 @@ class CandlestickChartOpDesc extends PythonOperatorDescriptor {
   var close: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/continuousErrorBands/ContinuousErrorBandsOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/continuousErrorBands/ContinuousErrorBandsOpDesc.scala
@@ -26,8 +26,8 @@ class ContinuousErrorBandsOpDesc extends PythonOperatorDescriptor {
   var bands: util.List[BandConfig] = _
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/continuousErrorBands/ContinuousErrorBandsOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/continuousErrorBands/ContinuousErrorBandsOpDesc.scala
@@ -6,7 +6,7 @@ import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 
 import java.util
 import scala.jdk.CollectionConverters.ListHasAsScala
@@ -25,8 +25,14 @@ class ContinuousErrorBandsOpDesc extends PythonOperatorDescriptor {
   @JsonProperty(value = "bands", required = true)
   var bands: util.List[BandConfig] = _
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/contourPlot/ContourPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/contourPlot/ContourPlotOpDesc.scala
@@ -47,8 +47,8 @@ class ContourPlotOpDesc extends PythonOperatorDescriptor {
   var coloringMethod: ContourPlotColoringFunction = _
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/contourPlot/ContourPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/contourPlot/ContourPlotOpDesc.scala
@@ -7,7 +7,7 @@ import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 
 class ContourPlotOpDesc extends PythonOperatorDescriptor {
 
@@ -46,8 +46,14 @@ class ContourPlotOpDesc extends PythonOperatorDescriptor {
   )
   var coloringMethod: ContourPlotColoringFunction = _
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/dumbbellPlot/DumbbellPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/dumbbellPlot/DumbbellPlotOpDesc.scala
@@ -60,8 +60,8 @@ class DumbbellPlotOpDesc extends PythonOperatorDescriptor {
   var showLegends: Boolean = false;
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/dumbbellPlot/DumbbellPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/dumbbellPlot/DumbbellPlotOpDesc.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 
@@ -59,8 +59,14 @@ class DumbbellPlotOpDesc extends PythonOperatorDescriptor {
   @JsonPropertyDescription("whether show legends in the graph")
   var showLegends: Boolean = false;
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/figureFactoryTable/FigureFactoryTableOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/figureFactoryTable/FigureFactoryTableOpDesc.scala
@@ -6,7 +6,7 @@ import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 class FigureFactoryTableOpDesc extends PythonOperatorDescriptor {
 
   @JsonProperty(required = false)
@@ -104,7 +104,13 @@ class FigureFactoryTableOpDesc extends PythonOperatorDescriptor {
     )
   }
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/figureFactoryTable/FigureFactoryTableOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/figureFactoryTable/FigureFactoryTableOpDesc.scala
@@ -105,8 +105,8 @@ class FigureFactoryTableOpDesc extends PythonOperatorDescriptor {
   }
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
@@ -46,8 +46,14 @@ class FilledAreaPlotOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var pattern: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
@@ -47,8 +47,8 @@ class FilledAreaPlotOpDesc extends PythonOperatorDescriptor {
   var pattern: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/funnelPlot/FunnelPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/funnelPlot/FunnelPlotOpDesc.scala
@@ -7,7 +7,7 @@ import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 @JsonSchemaInject(json = """
 {
   "attributeTypeRules": {
@@ -35,8 +35,14 @@ class FunnelPlotOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var color: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/funnelPlot/FunnelPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/funnelPlot/FunnelPlotOpDesc.scala
@@ -36,8 +36,8 @@ class FunnelPlotOpDesc extends PythonOperatorDescriptor {
   var color: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ganttChart/GanttChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ganttChart/GanttChartOpDesc.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
@@ -53,8 +53,14 @@ class GanttChartOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var pattern: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ganttChart/GanttChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ganttChart/GanttChartOpDesc.scala
@@ -54,8 +54,8 @@ class GanttChartOpDesc extends PythonOperatorDescriptor {
   var pattern: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/heatMap/HeatMapOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/heatMap/HeatMapOpDesc.scala
@@ -29,8 +29,8 @@ class HeatMapOpDesc extends PythonOperatorDescriptor {
   var value: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/heatMap/HeatMapOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/heatMap/HeatMapOpDesc.scala
@@ -7,7 +7,7 @@ import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 class HeatMapOpDesc extends PythonOperatorDescriptor {
 
   @JsonProperty(value = "x", required = true)
@@ -28,8 +28,14 @@ class HeatMapOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var value: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/hierarchychart/HierarchyChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/hierarchychart/HierarchyChartOpDesc.scala
@@ -3,11 +3,10 @@ package edu.uci.ics.amber.operator.visualization.hierarchychart
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
-
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 // type constraint: value can only be numeric
 @JsonSchemaInject(json = """
@@ -38,8 +37,14 @@ class HierarchyChartOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var value: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/hierarchychart/HierarchyChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/hierarchychart/HierarchyChartOpDesc.scala
@@ -38,8 +38,8 @@ class HierarchyChartOpDesc extends PythonOperatorDescriptor {
   var value: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/histogram/HistogramChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/histogram/HistogramChartOpDesc.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
@@ -94,8 +94,14 @@ class HistogramChartOpDesc extends PythonOperatorDescriptor {
     finalCode
   }
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/histogram/HistogramChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/histogram/HistogramChartOpDesc.scala
@@ -95,8 +95,8 @@ class HistogramChartOpDesc extends PythonOperatorDescriptor {
   }
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/htmlviz/HtmlVizOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/htmlviz/HtmlVizOpDesc.scala
@@ -4,14 +4,13 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
-import edu.uci.ics.amber.core.workflow.{PhysicalOp, SchemaPropagationFunc}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PhysicalOp, PortIdentity, SchemaPropagationFunc}
 import edu.uci.ics.amber.operator.LogicalOp
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.util.JSONUtils.objectMapper
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
 
 /**
   * HTML Visualization operator to render any given HTML code
@@ -40,11 +39,13 @@ class HtmlVizOpDesc extends LogicalOp {
       .withOutputPorts(operatorInfo.outputPorts)
       .withPropagateSchema(
         SchemaPropagationFunc(inputSchemas =>
-          Map(
-            operatorInfo.outputPorts.head.id -> getOutputSchema(
-              operatorInfo.inputPorts.map(_.id).map(inputSchemas(_)).toArray
-            )
-          )
+          {
+            val outputSchema = Schema
+              .builder()
+              .add(new Attribute("html-content", AttributeType.STRING))
+              .build()
+            Map(operatorInfo.outputPorts.head.id -> outputSchema)
+          }
         )
       )
   }
@@ -58,6 +59,5 @@ class HtmlVizOpDesc extends LogicalOp {
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema =
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/htmlviz/HtmlVizOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/htmlviz/HtmlVizOpDesc.scala
@@ -4,12 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
-import edu.uci.ics.amber.core.workflow.{
-  InputPort,
-  OutputPort,
-  PhysicalOp,
-  SchemaPropagationFunc
-}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PhysicalOp, SchemaPropagationFunc}
 import edu.uci.ics.amber.operator.LogicalOp
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/htmlviz/HtmlVizOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/htmlviz/HtmlVizOpDesc.scala
@@ -4,7 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PhysicalOp, PortIdentity, SchemaPropagationFunc}
+import edu.uci.ics.amber.core.workflow.{
+  InputPort,
+  OutputPort,
+  PhysicalOp,
+  SchemaPropagationFunc
+}
 import edu.uci.ics.amber.operator.LogicalOp
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
@@ -38,15 +43,13 @@ class HtmlVizOpDesc extends LogicalOp {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withPropagateSchema(
-        SchemaPropagationFunc(inputSchemas =>
-          {
-            val outputSchema = Schema
-              .builder()
-              .add(new Attribute("html-content", AttributeType.STRING))
-              .build()
-            Map(operatorInfo.outputPorts.head.id -> outputSchema)
-          }
-        )
+        SchemaPropagationFunc(inputSchemas => {
+          val outputSchema = Schema
+            .builder()
+            .add(new Attribute("html-content", AttributeType.STRING))
+            .build()
+          Map(operatorInfo.outputPorts.head.id -> outputSchema)
+        })
       )
   }
 
@@ -58,6 +61,5 @@ class HtmlVizOpDesc extends LogicalOp {
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )
-
 
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/lineChart/LineChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/lineChart/LineChartOpDesc.scala
@@ -6,7 +6,7 @@ import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 
 import java.util
 import scala.jdk.CollectionConverters.ListHasAsScala
@@ -26,8 +26,14 @@ class LineChartOpDesc extends PythonOperatorDescriptor {
   @JsonProperty(value = "lines", required = true)
   var lines: util.List[LineConfig] = _
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/lineChart/LineChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/lineChart/LineChartOpDesc.scala
@@ -27,8 +27,8 @@ class LineChartOpDesc extends PythonOperatorDescriptor {
   var lines: util.List[LineConfig] = _
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/pieChart/PieChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/pieChart/PieChartOpDesc.scala
@@ -5,7 +5,7 @@ import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchema
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 
@@ -33,8 +33,14 @@ class PieChartOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var name: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/pieChart/PieChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/pieChart/PieChartOpDesc.scala
@@ -34,8 +34,8 @@ class PieChartOpDesc extends PythonOperatorDescriptor {
   var name: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/quiverPlot/QuiverPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/quiverPlot/QuiverPlotOpDesc.scala
@@ -5,7 +5,7 @@ import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchema
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 
@@ -42,8 +42,14 @@ class QuiverPlotOpDesc extends PythonOperatorDescriptor {
   @JsonPropertyDescription("column for the vector component in the y-direction")
   @AutofillAttributeName var v: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/quiverPlot/QuiverPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/quiverPlot/QuiverPlotOpDesc.scala
@@ -43,8 +43,8 @@ class QuiverPlotOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName var v: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/sankeyDiagram/SankeyDiagramOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/sankeyDiagram/SankeyDiagramOpDesc.scala
@@ -7,7 +7,7 @@ import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 
 class SankeyDiagramOpDesc extends PythonOperatorDescriptor {
 
@@ -29,8 +29,14 @@ class SankeyDiagramOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var valueAttribute: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/sankeyDiagram/SankeyDiagramOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/sankeyDiagram/SankeyDiagramOpDesc.scala
@@ -30,8 +30,8 @@ class SankeyDiagramOpDesc extends PythonOperatorDescriptor {
   var valueAttribute: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatter3DChart/Scatter3dChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatter3DChart/Scatter3dChartOpDesc.scala
@@ -35,8 +35,8 @@ class Scatter3dChartOpDesc extends PythonOperatorDescriptor {
   var z: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatter3DChart/Scatter3dChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatter3DChart/Scatter3dChartOpDesc.scala
@@ -3,7 +3,7 @@ package edu.uci.ics.amber.operator.visualization.scatter3DChart
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
@@ -34,8 +34,14 @@ class Scatter3dChartOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var z: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatterplot/ScatterplotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatterplot/ScatterplotOpDesc.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
@@ -60,8 +60,14 @@ class ScatterplotOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var hoverName: String = ""
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatterplot/ScatterplotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatterplot/ScatterplotOpDesc.scala
@@ -61,8 +61,8 @@ class ScatterplotOpDesc extends PythonOperatorDescriptor {
   var hoverName: String = ""
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/tablesChart/TablesPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/tablesChart/TablesPlotOpDesc.scala
@@ -81,8 +81,8 @@ class TablesPlotOpDesc extends PythonOperatorDescriptor {
   }
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/tablesChart/TablesPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/tablesChart/TablesPlotOpDesc.scala
@@ -5,7 +5,7 @@ import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 class TablesPlotOpDesc extends PythonOperatorDescriptor {
 
   @JsonPropertyDescription("List of columns to include in the table chart")
@@ -80,7 +80,13 @@ class TablesPlotOpDesc extends PythonOperatorDescriptor {
     )
   }
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ternaryPlot/TernaryPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ternaryPlot/TernaryPlotOpDesc.scala
@@ -58,8 +58,8 @@ class TernaryPlotOpDesc extends PythonOperatorDescriptor {
     )
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ternaryPlot/TernaryPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ternaryPlot/TernaryPlotOpDesc.scala
@@ -7,7 +7,7 @@ import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 
 /**
   * Visualization Operator for Ternary Plots.
@@ -57,9 +57,14 @@ class TernaryPlotOpDesc extends PythonOperatorDescriptor {
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )
 
-  /** Returns the output schema set as html-content */
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   /** Returns a Python string that drops any tuples with missing values */

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/urlviz/UrlVizOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/urlviz/UrlVizOpDesc.scala
@@ -4,10 +4,9 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
-import edu.uci.ics.amber.core.workflow.{PhysicalOp, SchemaPropagationFunc}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PhysicalOp, PortIdentity, SchemaPropagationFunc}
 import edu.uci.ics.amber.operator.LogicalOp
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.util.JSONUtils.objectMapper
@@ -50,12 +49,14 @@ class UrlVizOpDesc extends LogicalOp {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withPropagateSchema(
-        SchemaPropagationFunc(inputSchemas =>
-          Map(
-            operatorInfo.outputPorts.head.id -> getOutputSchema(
-              operatorInfo.inputPorts.map(_.id).map(inputSchemas(_)).toArray
-            )
-          )
+        SchemaPropagationFunc(_ =>{
+          val outputSchema = Schema
+            .builder()
+            .add(new Attribute("html-content", AttributeType.STRING))
+            .build()
+          Map(operatorInfo.outputPorts.head.id -> outputSchema)
+        }
+
         )
       )
   }
@@ -68,8 +69,5 @@ class UrlVizOpDesc extends LogicalOp {
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )
-
-  override def getOutputSchema(schemas: Array[Schema]): Schema =
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
 
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/urlviz/UrlVizOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/urlviz/UrlVizOpDesc.scala
@@ -4,7 +4,12 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PhysicalOp, PortIdentity, SchemaPropagationFunc}
+import edu.uci.ics.amber.core.workflow.{
+  InputPort,
+  OutputPort,
+  PhysicalOp,
+  SchemaPropagationFunc
+}
 import edu.uci.ics.amber.operator.LogicalOp
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
@@ -49,15 +54,13 @@ class UrlVizOpDesc extends LogicalOp {
       .withInputPorts(operatorInfo.inputPorts)
       .withOutputPorts(operatorInfo.outputPorts)
       .withPropagateSchema(
-        SchemaPropagationFunc(_ =>{
+        SchemaPropagationFunc(_ => {
           val outputSchema = Schema
             .builder()
             .add(new Attribute("html-content", AttributeType.STRING))
             .build()
           Map(operatorInfo.outputPorts.head.id -> outputSchema)
-        }
-
-        )
+        })
       )
   }
 

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/urlviz/UrlVizOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/urlviz/UrlVizOpDesc.scala
@@ -4,12 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaTitle}
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
-import edu.uci.ics.amber.core.workflow.{
-  InputPort,
-  OutputPort,
-  PhysicalOp,
-  SchemaPropagationFunc
-}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PhysicalOp, SchemaPropagationFunc}
 import edu.uci.ics.amber.operator.LogicalOp
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/waterfallChart/WaterfallChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/waterfallChart/WaterfallChartOpDesc.scala
@@ -24,8 +24,8 @@ class WaterfallChartOpDesc extends PythonOperatorDescriptor {
   var yColumn: String = _
 
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/waterfallChart/WaterfallChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/waterfallChart/WaterfallChartOpDesc.scala
@@ -7,7 +7,7 @@ import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 
 class WaterfallChartOpDesc extends PythonOperatorDescriptor {
 
@@ -23,8 +23,14 @@ class WaterfallChartOpDesc extends PythonOperatorDescriptor {
   @AutofillAttributeName
   var yColumn: String = _
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/wordCloud/WordCloudOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/wordCloud/WordCloudOpDesc.scala
@@ -1,18 +1,14 @@
 package edu.uci.ics.amber.operator.visualization.wordCloud
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.kjetland.jackson.jsonSchema.annotations.{
-  JsonSchemaInject,
-  JsonSchemaInt,
-  JsonSchemaTitle
-}
+import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaInt, JsonSchemaTitle}
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.operator.visualization.ImageUtility
 import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
-import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort}
+import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 class WordCloudOpDesc extends PythonOperatorDescriptor {
   @JsonProperty(required = true)
   @JsonSchemaTitle("Text column")
@@ -24,8 +20,15 @@ class WordCloudOpDesc extends PythonOperatorDescriptor {
   @JsonSchemaInject(ints = Array(new JsonSchemaInt(path = "exclusiveMinimum", value = 0)))
   var topN: Integer = 100
 
-  override def getOutputSchema(schemas: Array[Schema]): Schema = {
-    Schema.builder().add(new Attribute("html-content", AttributeType.STRING)).build()
+
+  override def getOutputSchemas(
+                                 inputSchemas: Map[PortIdentity, Schema]
+                               ): Map[PortIdentity, Schema] = {
+    val outputSchema = Schema
+      .builder()
+      .add(new Attribute("html-content", AttributeType.STRING))
+      .build()
+    Map(operatorInfo.outputPorts.head.id -> outputSchema)
   }
 
   override def operatorInfo: OperatorInfo =

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/wordCloud/WordCloudOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/wordCloud/WordCloudOpDesc.scala
@@ -1,7 +1,11 @@
 package edu.uci.ics.amber.operator.visualization.wordCloud
 
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.kjetland.jackson.jsonSchema.annotations.{JsonSchemaInject, JsonSchemaInt, JsonSchemaTitle}
+import com.kjetland.jackson.jsonSchema.annotations.{
+  JsonSchemaInject,
+  JsonSchemaInt,
+  JsonSchemaTitle
+}
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
 import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName
@@ -20,10 +24,9 @@ class WordCloudOpDesc extends PythonOperatorDescriptor {
   @JsonSchemaInject(ints = Array(new JsonSchemaInt(path = "exclusiveMinimum", value = 0)))
   var topN: Integer = 100
 
-
   override def getOutputSchemas(
-                                 inputSchemas: Map[PortIdentity, Schema]
-                               ): Map[PortIdentity, Schema] = {
+      inputSchemas: Map[PortIdentity, Schema]
+  ): Map[PortIdentity, Schema] = {
     val outputSchema = Schema
       .builder()
       .add(new Attribute("html-content", AttributeType.STRING))

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/cartesianProduct/CartesianProductOpExecSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/cartesianProduct/CartesianProductOpExecSpec.scala
@@ -1,13 +1,7 @@
 package edu.uci.ics.amber.operator.cartesianProduct
 
-import edu.uci.ics.amber.core.tuple.{
-  Attribute,
-  AttributeType,
-  Schema,
-  SchemaEnforceable,
-  Tuple,
-  TupleLike
-}
+import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema, SchemaEnforceable, Tuple, TupleLike}
+import edu.uci.ics.amber.core.workflow.PortIdentity
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -102,8 +96,8 @@ class CartesianProductOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       .add(generate_schema("right", numRightSchemaAttributes - 1))
       .add(duplicateAttribute)
       .build()
-    val inputSchemas = Array(leftSchema, rightSchema)
-    val outputSchema = opDesc.getOutputSchema(inputSchemas)
+    val inputSchemas = Map(PortIdentity() -> leftSchema, PortIdentity(1)-> rightSchema)
+    val outputSchema = opDesc.getExternalOutputSchemas(inputSchemas).values.head
 
     // verify output schema is as expected & has no duplicates
     assert(

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/cartesianProduct/CartesianProductOpExecSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/cartesianProduct/CartesianProductOpExecSpec.scala
@@ -1,6 +1,13 @@
 package edu.uci.ics.amber.operator.cartesianProduct
 
-import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema, SchemaEnforceable, Tuple, TupleLike}
+import edu.uci.ics.amber.core.tuple.{
+  Attribute,
+  AttributeType,
+  Schema,
+  SchemaEnforceable,
+  Tuple,
+  TupleLike
+}
 import edu.uci.ics.amber.core.workflow.PortIdentity
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
@@ -96,7 +103,7 @@ class CartesianProductOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       .add(generate_schema("right", numRightSchemaAttributes - 1))
       .add(duplicateAttribute)
       .build()
-    val inputSchemas = Map(PortIdentity() -> leftSchema, PortIdentity(1)-> rightSchema)
+    val inputSchemas = Map(PortIdentity() -> leftSchema, PortIdentity(1) -> rightSchema)
     val outputSchema = opDesc.getExternalOutputSchemas(inputSchemas).values.head
 
     // verify output schema is as expected & has no duplicates

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/dictionary/DictionaryMatcherOpExecSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/dictionary/DictionaryMatcherOpExecSpec.scala
@@ -1,6 +1,7 @@
 package edu.uci.ics.amber.operator.dictionary
 
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema, SchemaEnforceable, Tuple}
+import edu.uci.ics.amber.core.workflow.PortIdentity
 import edu.uci.ics.amber.util.JSONUtils.objectMapper
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
@@ -35,7 +36,7 @@ class DictionaryMatcherOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.dictionary = dictionaryScan
     opDesc.resultAttribute = "matched"
     opDesc.matchingType = MatchingType.SCANBASED
-    outputSchema = opDesc.getOutputSchema(Array(tupleSchema))
+    outputSchema = opDesc.getExternalOutputSchemas(Map(PortIdentity() -> tupleSchema)).values.head
   }
 
   it should "open" in {

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/hashJoin/HashJoinOpSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/hashJoin/HashJoinOpSpec.scala
@@ -3,14 +3,8 @@ package edu.uci.ics.amber.operator.hashJoin
 import edu.uci.ics.amber.operator.hashJoin.HashJoinOpDesc.HASH_JOIN_INTERNAL_KEY_NAME
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
-import edu.uci.ics.amber.core.tuple.{
-  Attribute,
-  AttributeType,
-  Schema,
-  SchemaEnforceable,
-  Tuple,
-  TupleLike
-}
+import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema, SchemaEnforceable, Tuple, TupleLike}
+import edu.uci.ics.amber.core.workflow.PortIdentity
 import edu.uci.ics.amber.operator.hashJoin.HashJoinBuildOpExec
 import edu.uci.ics.amber.util.JSONUtils.objectMapper
 class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
@@ -53,8 +47,8 @@ class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.buildAttributeName = "build_1"
     opDesc.probeAttributeName = "probe_1"
     opDesc.joinType = JoinType.INNER
-    val inputSchemas = Array(schema("build"), schema("probe"))
-    val outputSchema = opDesc.getOutputSchema(inputSchemas)
+    val inputSchemas = Map(PortIdentity() -> schema("build"), PortIdentity(1)-> schema("probe"))
+    val outputSchema = opDesc.getExternalOutputSchemas(inputSchemas).values.head
 
     buildOpExec = new HashJoinBuildOpExec[String](objectMapper.writeValueAsString(opDesc))
     buildOpExec.open()
@@ -79,7 +73,7 @@ class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
             buildOpOutputIterator
               .next()
               .asInstanceOf[SchemaEnforceable]
-              .enforceSchema(getInternalHashTableSchema(inputSchemas.head)),
+              .enforceSchema(getInternalHashTableSchema(inputSchemas.head._2)),
             build
           )
           .isEmpty
@@ -109,8 +103,8 @@ class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.buildAttributeName = "same"
     opDesc.probeAttributeName = "same"
     opDesc.joinType = JoinType.INNER
-    val inputSchemas = Array(schema("same", 1), schema("same", 2))
-    val outputSchema = opDesc.getOutputSchema(inputSchemas)
+    val inputSchemas = Map(PortIdentity() -> schema("same", 1), PortIdentity(1)-> schema("same", 2))
+    val outputSchema = opDesc.getExternalOutputSchemas(inputSchemas).values.head
 
     buildOpExec = new HashJoinBuildOpExec[String](objectMapper.writeValueAsString(opDesc))
     buildOpExec.open()
@@ -134,7 +128,7 @@ class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
             buildOpOutputIterator
               .next()
               .asInstanceOf[SchemaEnforceable]
-              .enforceSchema(getInternalHashTableSchema(inputSchemas.head)),
+              .enforceSchema(getInternalHashTableSchema(inputSchemas.head._2)),
             build
           )
           .isEmpty
@@ -163,8 +157,8 @@ class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.buildAttributeName = "same"
     opDesc.probeAttributeName = "same"
     opDesc.joinType = JoinType.FULL_OUTER
-    val inputSchemas = Array(schema("same", 1), schema("same", 2))
-    val outputSchema = opDesc.getOutputSchema(inputSchemas)
+    val inputSchemas = Map(PortIdentity() -> schema("same",1), PortIdentity(1)-> schema("same",2))
+    val outputSchema = opDesc.getExternalOutputSchemas(inputSchemas).values.head
 
     buildOpExec = new HashJoinBuildOpExec[String](objectMapper.writeValueAsString(opDesc))
     buildOpExec.open()
@@ -188,7 +182,7 @@ class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
             buildOpOutputIterator
               .next()
               .asInstanceOf[SchemaEnforceable]
-              .enforceSchema(getInternalHashTableSchema(inputSchemas.head)),
+              .enforceSchema(getInternalHashTableSchema(inputSchemas.head._2)),
             build
           )
           .isEmpty

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/hashJoin/HashJoinOpSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/hashJoin/HashJoinOpSpec.scala
@@ -3,7 +3,14 @@ package edu.uci.ics.amber.operator.hashJoin
 import edu.uci.ics.amber.operator.hashJoin.HashJoinOpDesc.HASH_JOIN_INTERNAL_KEY_NAME
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
-import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema, SchemaEnforceable, Tuple, TupleLike}
+import edu.uci.ics.amber.core.tuple.{
+  Attribute,
+  AttributeType,
+  Schema,
+  SchemaEnforceable,
+  Tuple,
+  TupleLike
+}
 import edu.uci.ics.amber.core.workflow.PortIdentity
 import edu.uci.ics.amber.operator.hashJoin.HashJoinBuildOpExec
 import edu.uci.ics.amber.util.JSONUtils.objectMapper
@@ -47,7 +54,7 @@ class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.buildAttributeName = "build_1"
     opDesc.probeAttributeName = "probe_1"
     opDesc.joinType = JoinType.INNER
-    val inputSchemas = Map(PortIdentity() -> schema("build"), PortIdentity(1)-> schema("probe"))
+    val inputSchemas = Map(PortIdentity() -> schema("build"), PortIdentity(1) -> schema("probe"))
     val outputSchema = opDesc.getExternalOutputSchemas(inputSchemas).values.head
 
     buildOpExec = new HashJoinBuildOpExec[String](objectMapper.writeValueAsString(opDesc))
@@ -103,7 +110,8 @@ class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.buildAttributeName = "same"
     opDesc.probeAttributeName = "same"
     opDesc.joinType = JoinType.INNER
-    val inputSchemas = Map(PortIdentity() -> schema("same", 1), PortIdentity(1)-> schema("same", 2))
+    val inputSchemas =
+      Map(PortIdentity() -> schema("same", 1), PortIdentity(1) -> schema("same", 2))
     val outputSchema = opDesc.getExternalOutputSchemas(inputSchemas).values.head
 
     buildOpExec = new HashJoinBuildOpExec[String](objectMapper.writeValueAsString(opDesc))
@@ -157,7 +165,8 @@ class HashJoinOpSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.buildAttributeName = "same"
     opDesc.probeAttributeName = "same"
     opDesc.joinType = JoinType.FULL_OUTER
-    val inputSchemas = Map(PortIdentity() -> schema("same",1), PortIdentity(1)-> schema("same",2))
+    val inputSchemas =
+      Map(PortIdentity() -> schema("same", 1), PortIdentity(1) -> schema("same", 2))
     val outputSchema = opDesc.getExternalOutputSchemas(inputSchemas).values.head
 
     buildOpExec = new HashJoinBuildOpExec[String](objectMapper.writeValueAsString(opDesc))

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/intervalJoin/IntervalOpExecSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/intervalJoin/IntervalOpExecSpec.scala
@@ -213,7 +213,10 @@ class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       rightInput: Array[T]
   ): Unit = {
     val inputSchemas =
-      Map(PortIdentity() -> schema(leftKey, dataType), PortIdentity(1) -> schema(rightKey, dataType))
+      Map(
+        PortIdentity() -> schema(leftKey, dataType),
+        PortIdentity(1) -> schema(rightKey, dataType)
+      )
     opDesc = new IntervalJoinOpDesc(
       leftKey,
       rightKey,

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/intervalJoin/IntervalOpExecSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/intervalJoin/IntervalOpExecSpec.scala
@@ -213,7 +213,7 @@ class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       rightInput: Array[T]
   ): Unit = {
     val inputSchemas =
-      Array(schema(leftKey, dataType), schema(rightKey, dataType))
+      Map(PortIdentity() -> schema(leftKey, dataType), PortIdentity(1) -> schema(rightKey, dataType))
     opDesc = new IntervalJoinOpDesc(
       leftKey,
       rightKey,
@@ -222,7 +222,7 @@ class IntervalOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
       includeRightBound,
       timeIntervalType
     )
-    val outputSchema = opDesc.getOutputSchema(inputSchemas)
+    val outputSchema = opDesc.getExternalOutputSchemas(inputSchemas).values.head
     val opExec = new IntervalJoinOpExec(objectMapper.writeValueAsString(opDesc))
     opExec.open()
     counter = 0

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/projection/ProjectionOpDescSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/projection/ProjectionOpDescSpec.scala
@@ -69,19 +69,6 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
 
   }
 
-  it should "raise IllegalArgumentException with multiple input source Schema" in {
-
-    projectionOpDesc.attributes ++= List(
-      new AttributeUnit("field2", "f2"),
-      new AttributeUnit("field1", "f1")
-    )
-
-    assertThrows[IllegalArgumentException] {
-      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity() -> schema)).values.head
-    }
-
-  }
-
   it should "raise RuntimeException on duplicate alias" in {
 
     projectionOpDesc.attributes ++= List(

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/projection/ProjectionOpDescSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/projection/ProjectionOpDescSpec.scala
@@ -1,6 +1,7 @@
 package edu.uci.ics.amber.operator.projection
 
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
+import edu.uci.ics.amber.core.workflow.PortIdentity
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
@@ -30,7 +31,7 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
       new AttributeUnit("field1", "f1"),
       new AttributeUnit("field2", "f2")
     )
-    val outputSchema = projectionOpDesc.getOutputSchema(Array(schema))
+    val outputSchema = projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
     assert(outputSchema.getAttributes.length == 2)
 
   }
@@ -40,7 +41,7 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
       new AttributeUnit("field2", "f2"),
       new AttributeUnit("field1", "f1")
     )
-    val outputSchema = projectionOpDesc.getOutputSchema(Array(schema))
+    val outputSchema = projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
     assert(outputSchema.getAttributes.length == 2)
     assert(outputSchema.getIndex("f2") == 0)
     assert(outputSchema.getIndex("f1") == 1)
@@ -53,7 +54,7 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
       new AttributeUnit("field---6", "f6")
     )
     assertThrows[RuntimeException] {
-      projectionOpDesc.getOutputSchema(Array(schema))
+      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
     }
 
   }
@@ -61,7 +62,7 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
   it should "raise IllegalArgumentException on empty attributes" in {
 
     assertThrows[IllegalArgumentException] {
-      projectionOpDesc.getOutputSchema(Array(schema))
+      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
     }
 
   }
@@ -74,7 +75,7 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
     )
 
     assertThrows[IllegalArgumentException] {
-      projectionOpDesc.getOutputSchema(Array(schema, schema))
+      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
     }
 
   }
@@ -86,7 +87,7 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
       new AttributeUnit("field1", "f")
     )
     assertThrows[RuntimeException] {
-      projectionOpDesc.getOutputSchema(Array(schema))
+      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
     }
   }
 
@@ -95,7 +96,7 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
       new AttributeUnit("field1", "f1"),
       new AttributeUnit("field2", "")
     )
-    val outputSchema = projectionOpDesc.getOutputSchema(Array(schema))
+    val outputSchema = projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
     assert(outputSchema.getAttributes.length == 2)
 
   }

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/projection/ProjectionOpDescSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/projection/ProjectionOpDescSpec.scala
@@ -31,7 +31,8 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
       new AttributeUnit("field1", "f1"),
       new AttributeUnit("field2", "f2")
     )
-    val outputSchema = projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
+    val outputSchema =
+      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity() -> schema)).values.head
     assert(outputSchema.getAttributes.length == 2)
 
   }
@@ -41,7 +42,8 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
       new AttributeUnit("field2", "f2"),
       new AttributeUnit("field1", "f1")
     )
-    val outputSchema = projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
+    val outputSchema =
+      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity() -> schema)).values.head
     assert(outputSchema.getAttributes.length == 2)
     assert(outputSchema.getIndex("f2") == 0)
     assert(outputSchema.getIndex("f1") == 1)
@@ -54,7 +56,7 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
       new AttributeUnit("field---6", "f6")
     )
     assertThrows[RuntimeException] {
-      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
+      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity() -> schema)).values.head
     }
 
   }
@@ -62,7 +64,7 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
   it should "raise IllegalArgumentException on empty attributes" in {
 
     assertThrows[IllegalArgumentException] {
-      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
+      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity() -> schema)).values.head
     }
 
   }
@@ -75,7 +77,7 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
     )
 
     assertThrows[IllegalArgumentException] {
-      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
+      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity() -> schema)).values.head
     }
 
   }
@@ -87,7 +89,7 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
       new AttributeUnit("field1", "f")
     )
     assertThrows[RuntimeException] {
-      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
+      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity() -> schema)).values.head
     }
   }
 
@@ -96,7 +98,8 @@ class ProjectionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
       new AttributeUnit("field1", "f1"),
       new AttributeUnit("field2", "")
     )
-    val outputSchema = projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
+    val outputSchema =
+      projectionOpDesc.getExternalOutputSchemas(Map(PortIdentity() -> schema)).values.head
     assert(outputSchema.getAttributes.length == 2)
 
   }

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/source/scan/csv/CSVScanSourceOpDescSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/source/scan/csv/CSVScanSourceOpDescSpec.scala
@@ -4,7 +4,6 @@ import edu.uci.ics.amber.core.storage.FileResolver
 import edu.uci.ics.amber.core.tuple.{AttributeType, Schema}
 import edu.uci.ics.amber.core.workflow.WorkflowContext.{DEFAULT_EXECUTION_ID, DEFAULT_WORKFLOW_ID}
 import edu.uci.ics.amber.operator.TestOperators
-import edu.uci.ics.amber.core.workflow.PortIdentity
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 
@@ -14,11 +13,7 @@ class CSVScanSourceOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
   var parallelCsvScanSourceOpDesc: ParallelCSVScanSourceOpDesc = _
   before {
     csvScanSourceOpDesc = new CSVScanSourceOpDesc()
-    csvScanSourceOpDesc.outputPortToSchemaMapping(PortIdentity()) =
-      csvScanSourceOpDesc.getOutputSchema(Array())
     parallelCsvScanSourceOpDesc = new ParallelCSVScanSourceOpDesc()
-    parallelCsvScanSourceOpDesc.outputPortToSchemaMapping(PortIdentity()) =
-      parallelCsvScanSourceOpDesc.getOutputSchema(Array())
   }
 
   it should "infer schema from single-line-data csv" in {

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/udf/python/PythonLambdaFunctionOpDescSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/udf/python/PythonLambdaFunctionOpDescSpec.scala
@@ -1,6 +1,7 @@
 package edu.uci.ics.amber.operator.udf.python
 
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType, Schema}
+import edu.uci.ics.amber.core.workflow.PortIdentity
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
 class PythonLambdaFunctionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
@@ -25,7 +26,7 @@ class PythonLambdaFunctionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
         AttributeType.STRING
       )
     )
-    val outputSchema = opDesc.getOutputSchema(Array(schema))
+    val outputSchema = opDesc.getExternalOutputSchemas(Map(PortIdentity() -> schema)).values.head
     assert(outputSchema.getAttributes.length == 4)
   }
 
@@ -44,7 +45,7 @@ class PythonLambdaFunctionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
         AttributeType.INTEGER
       )
     )
-    val outputSchema = opDesc.getOutputSchema(Array(schema))
+    val outputSchema = opDesc.getExternalOutputSchemas(Map(PortIdentity() -> schema)).values.head
     assert(outputSchema.getAttributes.length == 5)
   }
 
@@ -57,7 +58,7 @@ class PythonLambdaFunctionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
         AttributeType.STRING
       )
     )
-    val outputSchema = opDesc.getOutputSchema(Array(schema))
+    val outputSchema = opDesc.getExternalOutputSchemas(Map(PortIdentity() -> schema)).values.head
     assert(outputSchema.getAttributes.length == 3)
   }
 
@@ -72,7 +73,7 @@ class PythonLambdaFunctionOpDescSpec extends AnyFlatSpec with BeforeAndAfter {
     )
 
     assertThrows[RuntimeException] {
-      opDesc.getOutputSchema(Array(schema))
+      opDesc.getExternalOutputSchemas(Map(PortIdentity() -> schema)).values.head
     }
 
   }

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/unneststring/UnnestStringOpExecSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/unneststring/UnnestStringOpExecSpec.scala
@@ -28,15 +28,13 @@ class UnnestStringOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.attribute = "field1"
     opDesc.delimiter = "-"
     opDesc.resultAttribute = "split"
-    opDesc.inputPortToSchemaMapping(PortIdentity()) = tupleSchema
-    opDesc.outputPortToSchemaMapping(PortIdentity()) = opDesc.getOutputSchema(Array(tupleSchema))
   }
 
   it should "open" in {
     opDesc.attribute = "field1"
     opDesc.delimiter = "-"
     opExec = new UnnestStringOpExec(objectMapper.writeValueAsString(opDesc))
-    outputSchema = opDesc.getOutputSchema(Array(tupleSchema))
+    outputSchema = opDesc.getExternalOutputSchemas(Map(PortIdentity() -> tupleSchema)).values.head
     opExec.open()
     assert(opExec.flatMapFunc != null)
   }
@@ -45,7 +43,7 @@ class UnnestStringOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.attribute = "field1"
     opDesc.delimiter = "-"
     opExec = new UnnestStringOpExec(objectMapper.writeValueAsString(opDesc))
-    outputSchema = opDesc.getOutputSchema(Array(tupleSchema))
+    outputSchema = opDesc.getExternalOutputSchemas(Map(PortIdentity() -> tupleSchema)).values.head
     opExec.open()
     val processedTuple = opExec
       .processTuple(tuple, 0)
@@ -61,7 +59,7 @@ class UnnestStringOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.attribute = "field3"
     opDesc.delimiter = "-"
     opExec = new UnnestStringOpExec(objectMapper.writeValueAsString(opDesc))
-    outputSchema = opDesc.getOutputSchema(Array(tupleSchema))
+    outputSchema = opDesc.getExternalOutputSchemas(Map(PortIdentity() -> tupleSchema)).values.head
     opExec.open()
     val processedTuple = opExec
       .processTuple(tuple, 0)
@@ -75,7 +73,7 @@ class UnnestStringOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.attribute = "field1"
     opDesc.delimiter = "/"
     opExec = new UnnestStringOpExec(objectMapper.writeValueAsString(opDesc))
-    outputSchema = opDesc.getOutputSchema(Array(tupleSchema))
+    outputSchema = opDesc.getExternalOutputSchemas(Map(PortIdentity() -> tupleSchema)).values.head
     val tuple: Tuple = Tuple
       .builder(tupleSchema)
       .add(new Attribute("field1", AttributeType.STRING), "//a//b/")
@@ -97,7 +95,7 @@ class UnnestStringOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
     opDesc.attribute = "field1"
     opDesc.delimiter = "<\\d*>"
     opExec = new UnnestStringOpExec(objectMapper.writeValueAsString(opDesc))
-    outputSchema = opDesc.getOutputSchema(Array(tupleSchema))
+    outputSchema = opDesc.getExternalOutputSchemas(Map(PortIdentity() -> tupleSchema)).values.head
     val tuple: Tuple = Tuple
       .builder(tupleSchema)
       .add(new Attribute("field1", AttributeType.STRING), "<>a<1>b<12>")

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/visualization/htmlviz/HtmlVizOpExecSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/visualization/htmlviz/HtmlVizOpExecSpec.scala
@@ -1,9 +1,7 @@
 package edu.uci.ics.amber.operator.visualization.htmlviz
 
 import edu.uci.ics.amber.core.tuple._
-import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import edu.uci.ics.amber.core.workflow.PortIdentity
-import edu.uci.ics.amber.core.workflow.WorkflowContext.{DEFAULT_EXECUTION_ID, DEFAULT_WORKFLOW_ID}
 import edu.uci.ics.amber.util.JSONUtils.objectMapper
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
@@ -14,7 +12,8 @@ class HtmlVizOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   )
   val opDesc: HtmlVizOpDesc = new HtmlVizOpDesc()
 
-  val outputSchema: Schema = opDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
+  val outputSchema: Schema =
+    opDesc.getExternalOutputSchemas(Map(PortIdentity() -> schema)).values.head
 
   def tuple(): Tuple =
     Tuple

--- a/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/visualization/htmlviz/HtmlVizOpExecSpec.scala
+++ b/core/workflow-operator/src/test/scala/edu/uci/ics/amber/operator/visualization/htmlviz/HtmlVizOpExecSpec.scala
@@ -1,6 +1,9 @@
 package edu.uci.ics.amber.operator.visualization.htmlviz
 
 import edu.uci.ics.amber.core.tuple._
+import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
+import edu.uci.ics.amber.core.workflow.PortIdentity
+import edu.uci.ics.amber.core.workflow.WorkflowContext.{DEFAULT_EXECUTION_ID, DEFAULT_WORKFLOW_ID}
 import edu.uci.ics.amber.util.JSONUtils.objectMapper
 import org.scalatest.BeforeAndAfter
 import org.scalatest.flatspec.AnyFlatSpec
@@ -11,7 +14,7 @@ class HtmlVizOpExecSpec extends AnyFlatSpec with BeforeAndAfter {
   )
   val opDesc: HtmlVizOpDesc = new HtmlVizOpDesc()
 
-  val outputSchema: Schema = opDesc.getOutputSchema(Array(schema))
+  val outputSchema: Schema = opDesc.getExternalOutputSchemas(Map(PortIdentity()-> schema)).values.head
 
   def tuple(): Tuple =
     Tuple


### PR DESCRIPTION
This PR removes all schema propagation functions from the logical plan. Developers are now required to implement `SchemaPropagationFunc` directly within the PhysicalPlan. This ensures that each PhysicalOp has its own distinct schema propagation logic, aligning schema handling more closely with the execution layer.

To accommodate the need for schema propagation in the logical plan (primarily for testing purposes), a new method, `getExternalOutputSchemas`, has been introduced. This method facilitates the propagation of schemas across all PhysicalOps within a logical operator, ensuring compatibility with existing testing workflows.