### PR TITLE
Fix "NullpointerException" when an operator is created initially

### DIFF
--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/dictionary/DictionaryMatcherOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/dictionary/DictionaryMatcherOpDesc.scala
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
 import edu.uci.ics.amber.core.tuple.{Attribute, AttributeType}
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
-import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PhysicalOp, SchemaPropagationFunc}
 import edu.uci.ics.amber.operator.map.MapOpDesc
 import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/projection/ProjectionOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/projection/ProjectionOpDesc.scala
@@ -3,7 +3,7 @@ package edu.uci.ics.amber.operator.projection
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaTitle
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
-import edu.uci.ics.amber.core.tuple.{Attribute, Schema}
+import edu.uci.ics.amber.core.tuple.Schema
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import edu.uci.ics.amber.core.workflow.PhysicalOp.oneToOnePhysicalOp
 import edu.uci.ics.amber.core.workflow._

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sort/SortCriteriaUnit.java
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sort/SortCriteriaUnit.java
@@ -6,12 +6,13 @@ import edu.uci.ics.amber.operator.metadata.annotations.AutofillAttributeName;
 
 public class SortCriteriaUnit {
 
-    @JsonProperty(value = "attribute", required = true)
-    @JsonPropertyDescription("Attribute name to sort by")
-    @AutofillAttributeName
-    public String attributeName;
+	@JsonProperty(value = "attribute", required = true)
+	@JsonPropertyDescription("Attribute name to sort by")
+	@AutofillAttributeName
+	public String attributeName;
 
-    @JsonProperty(value = "sortPreference", required = true)
-    @JsonPropertyDescription("Sort preference (ASC or DESC)")
-    public edu.uci.ics.amber.operator.sort.SortPreference sortPreference;
+	@JsonProperty(value = "sortPreference", required = true, defaultValue = "ASC")
+	@JsonPropertyDescription("Sort preference (ASC or DESC)")
+	public edu.uci.ics.amber.operator.sort.SortPreference sortPreference;
+
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sort/SortOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/sort/SortOpDesc.scala
@@ -8,7 +8,7 @@ import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo
 class SortOpDesc extends PythonOperatorDescriptor {
   @JsonProperty(required = true)
   @JsonPropertyDescription("column to perform sorting on")
-  var attributes: List[SortCriteriaUnit] = _
+  var attributes: List[SortCriteriaUnit] = List()
 
   override def generatePythonCode(): String = {
     val attributeName = "[" + attributes

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/IcicleChart/IcicleChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/IcicleChart/IcicleChartOpDesc.scala
@@ -64,7 +64,6 @@ class IcicleChartOpDesc extends PythonOperatorDescriptor {
   }
 
   def createPlotlyFigure(): String = {
-    assert(hierarchy.nonEmpty)
     val attributes = getIcicleAttributesInPython
     s"""
        |        fig = px.icicle(table, path=[$attributes], values='$value',

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ScatterMatrixChart/ScatterMatrixChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ScatterMatrixChart/ScatterMatrixChartOpDesc.scala
@@ -26,7 +26,7 @@ class ScatterMatrixChartOpDesc extends PythonOperatorDescriptor {
   @JsonSchemaTitle("Selected Attributes")
   @JsonPropertyDescription("the axes of each scatter plot in the matrix.")
   @AutofillAttributeNameList
-  var selectedAttributes: List[String] = _
+  var selectedAttributes: List[String] = List()
 
   @JsonProperty(value = "Color", required = true)
   @JsonSchemaTitle("Color Column")
@@ -53,8 +53,6 @@ class ScatterMatrixChartOpDesc extends PythonOperatorDescriptor {
     )
 
   def createPlotlyFigure(): String = {
-    assert(selectedAttributes.nonEmpty)
-
     val list_Attributes = selectedAttributes.map(attribute => s""""$attribute"""").mkString(",")
     s"""
        |        fig = px.scatter_matrix(table, dimensions=[$list_Attributes], color='$color')

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/barChart/BarChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/barChart/BarChartOpDesc.scala
@@ -69,8 +69,6 @@ class BarChartOpDesc extends PythonOperatorDescriptor {
     )
 
   def manipulateTable(): String = {
-    assert(value.nonEmpty)
-    assert(fields.nonEmpty)
     s"""
        |        table = table.dropna(subset = ['$value', '$fields']) #remove missing values
        |""".stripMargin

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxPlot/BoxPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxPlot/BoxPlotOpDesc.scala
@@ -56,7 +56,6 @@ class BoxPlotOpDesc extends PythonOperatorDescriptor {
     )
 
   def manipulateTable(): String = {
-    assert(value.nonEmpty)
 
     s"""
        |        table = table.dropna(subset = ['$value']) #remove missing values

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/bubbleChart/BubbleChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/bubbleChart/BubbleChartOpDesc.scala
@@ -62,7 +62,6 @@ class BubbleChartOpDesc extends PythonOperatorDescriptor {
     )
 
   def manipulateTable(): String = {
-    assert(xValue.nonEmpty && yValue.nonEmpty && zValue.nonEmpty)
     s"""
        |        # drops rows with missing values pertaining to relevant columns
        |        table.dropna(subset=['$xValue', '$yValue', '$zValue'], inplace = True)
@@ -71,7 +70,6 @@ class BubbleChartOpDesc extends PythonOperatorDescriptor {
   }
 
   def createPlotlyFigure(): String = {
-    assert(xValue.nonEmpty && yValue.nonEmpty && zValue.nonEmpty)
     s"""
        |        if '$enableColor' == 'true':
        |            fig = go.Figure(px.scatter(table, x='$xValue', y='$yValue', size='$zValue', size_max=100, color='$colorCategory'))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/continuousErrorBands/ContinuousErrorBandsOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/continuousErrorBands/ContinuousErrorBandsOpDesc.scala
@@ -23,7 +23,7 @@ class ContinuousErrorBandsOpDesc extends PythonOperatorDescriptor {
   var yLabel: String = ""
 
   @JsonProperty(value = "bands", required = true)
-  var bands: util.List[BandConfig] = _
+  var bands: util.List[BandConfig] = new util.ArrayList[BandConfig]()
 
   override def getOutputSchemas(
       inputSchemas: Map[PortIdentity, Schema]

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/figureFactoryTable/FigureFactoryTableOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/figureFactoryTable/FigureFactoryTableOpDesc.scala
@@ -9,17 +9,17 @@ import edu.uci.ics.amber.core.workflow.OutputPort.OutputMode
 import edu.uci.ics.amber.core.workflow.{InputPort, OutputPort, PortIdentity}
 class FigureFactoryTableOpDesc extends PythonOperatorDescriptor {
 
-  @JsonProperty(required = false)
+  @JsonProperty(required = false, defaultValue = "12")
   @JsonSchemaTitle("Font Size")
   @JsonPropertyDescription("Font size of the Figure Factory Table")
   var fontSize: String = "12"
 
-  @JsonProperty(required = false)
+  @JsonProperty(required = false, defaultValue = "#000000")
   @JsonSchemaTitle("Font Color (Hex Code)")
   @JsonPropertyDescription("Font color of the Figure Factory Table")
   var fontColor: String = "#000000"
 
-  @JsonProperty(required = false)
+  @JsonProperty(required = false, defaultValue = "30")
   @JsonSchemaTitle("Row Height")
   @JsonPropertyDescription("Row height of the Figure Factory Table")
   var rowHeight: String = "30"
@@ -32,7 +32,6 @@ class FigureFactoryTableOpDesc extends PythonOperatorDescriptor {
     columns.map(_.attributeName).mkString("'", "','", "'")
 
   def manipulateTable(): String = {
-    assert(columns.nonEmpty)
 
     val attributes = getAttributes
     s"""
@@ -43,8 +42,6 @@ class FigureFactoryTableOpDesc extends PythonOperatorDescriptor {
   }
 
   def createFigureFactoryTablePlotlyFigure(): String = {
-    assert(columns.nonEmpty)
-
     val intFontSize: Option[Double] = fontSize.toDoubleOption
     val intRowHeight: Option[Double] = rowHeight.toDoubleOption
 

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
@@ -65,13 +65,6 @@ class FilledAreaPlotOpDesc extends PythonOperatorDescriptor {
     )
 
   def createPlotlyFigure(): String = {
-    assert(x.nonEmpty)
-    assert(y.nonEmpty)
-
-    if (facetColumn) {
-      assert(lineGroup.nonEmpty)
-    }
-
     val colorArg = if (color.nonEmpty) s""", color="$color"""" else ""
     val facetColumnArg = if (facetColumn) s""", facet_col="$lineGroup"""" else ""
     val lineGroupArg = if (lineGroup.nonEmpty) s""", line_group="$lineGroup"""" else ""

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/funnelPlot/FunnelPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/funnelPlot/FunnelPlotOpDesc.scala
@@ -54,8 +54,6 @@ class FunnelPlotOpDesc extends PythonOperatorDescriptor {
     )
 
   private def createPlotlyFigure(): String = {
-    assert(x.nonEmpty)
-    assert(y.nonEmpty)
     val colorArg = if (color.nonEmpty) s""", color="$color"""" else ""
     s"""
        |        fig = go.Figure(px.funnel(table, x ="$x", y = "$y"$colorArg))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/heatMap/HeatMapOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/heatMap/HeatMapOpDesc.scala
@@ -47,9 +47,6 @@ class HeatMapOpDesc extends PythonOperatorDescriptor {
     )
 
   private def createHeatMap(): String = {
-    assert(x.nonEmpty)
-    assert(y.nonEmpty)
-    assert(value.nonEmpty)
     s"""
        |        heatmap = go.Heatmap(z=table["$value"],x=table["$x"],y=table["$y"])
        |        layout = go.Layout(margin=dict(l=0, r=0, b=0, t=0))

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/hierarchychart/HierarchyChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/hierarchychart/HierarchyChartOpDesc.scala
@@ -59,7 +59,6 @@ class HierarchyChartOpDesc extends PythonOperatorDescriptor {
     hierarchy.map(_.attributeName).mkString("'", "','", "'")
 
   def manipulateTable(): String = {
-    assert(value.nonEmpty)
     val attributes = getHierarchyAttributesInPython
     s"""
        |        table['$value'] = table[table['$value'] > 0]['$value'] # remove non-positive numbers from the data
@@ -68,7 +67,6 @@ class HierarchyChartOpDesc extends PythonOperatorDescriptor {
   }
 
   def createPlotlyFigure(): String = {
-    assert(hierarchy.nonEmpty)
     val attributes = getHierarchyAttributesInPython
     s"""
        |        fig = px.${hierarchyChartType.getPlotlyExpressApiName}(table, path=[$attributes], values='$value',

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/histogram/HistogramChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/histogram/HistogramChartOpDesc.scala
@@ -48,7 +48,6 @@ class HistogramChartOpDesc extends PythonOperatorDescriptor {
     )
 
   def createPlotlyFigure(): String = {
-    assert(value.nonEmpty)
     var colorParam = ""
     var categoryParam = ""
     var marginalParam = ""

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/lineChart/LineChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/lineChart/LineChartOpDesc.scala
@@ -24,7 +24,7 @@ class LineChartOpDesc extends PythonOperatorDescriptor {
   var xLabel: String = ""
 
   @JsonProperty(value = "lines", required = true)
-  var lines: util.List[LineConfig] = _
+  var lines: util.List[LineConfig] = new util.ArrayList[LineConfig]()
 
   override def getOutputSchemas(
       inputSchemas: Map[PortIdentity, Schema]

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/pieChart/PieChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/pieChart/PieChartOpDesc.scala
@@ -52,14 +52,12 @@ class PieChartOpDesc extends PythonOperatorDescriptor {
     )
 
   def manipulateTable(): String = {
-    assert(value.nonEmpty)
     s"""
        |        table.dropna(subset = ['$value', '$name'], inplace = True) #remove missing values
        |""".stripMargin
   }
 
   def createPlotlyFigure(): String = {
-    assert(value.nonEmpty)
     s"""
        |        fig = px.pie(table, names='$name', values='$value')
        |        fig.update_traces(textposition='inside', textinfo='percent+label')

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatter3DChart/Scatter3dChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatter3DChart/Scatter3dChartOpDesc.scala
@@ -53,9 +53,6 @@ class Scatter3dChartOpDesc extends PythonOperatorDescriptor {
     )
 
   private def createPlotlyFigure(): String = {
-    assert(x.nonEmpty)
-    assert(y.nonEmpty)
-    assert(z.nonEmpty)
     s"""
        |        fig = go.Figure(data=[go.Scatter3d(
        |            x=table["$x"],

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatterplot/ScatterplotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatterplot/ScatterplotOpDesc.scala
@@ -79,7 +79,6 @@ class ScatterplotOpDesc extends PythonOperatorDescriptor {
     )
 
   def manipulateTable(): String = {
-    assert(xColumn.nonEmpty && yColumn.nonEmpty)
     val colorColExpr = if (colorColumn.nonEmpty) {
       s"'$colorColumn'"
     } else {
@@ -93,7 +92,6 @@ class ScatterplotOpDesc extends PythonOperatorDescriptor {
   }
 
   def createPlotlyFigure(): String = {
-    assert(xColumn.nonEmpty && yColumn.nonEmpty)
     val colorColExpr = if (colorColumn.nonEmpty) {
       s"color='$colorColumn'"
     } else {

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/tablesChart/TablesPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/tablesChart/TablesPlotOpDesc.scala
@@ -16,7 +16,6 @@ class TablesPlotOpDesc extends PythonOperatorDescriptor {
     includedColumns.map(_.attributeName).mkString("'", "','", "'")
 
   def manipulateTable(): String = {
-    assert(includedColumns.nonEmpty)
     val attributes = getAttributes
     s"""
        |        # drops rows with missing values pertaining to relevant columns
@@ -26,7 +25,6 @@ class TablesPlotOpDesc extends PythonOperatorDescriptor {
   }
 
   def createPlotlyFigure(): String = {
-    assert(includedColumns.nonEmpty)
     val attributes = getAttributes
     s"""
        |

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ternaryPlot/TernaryPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ternaryPlot/TernaryPlotOpDesc.scala
@@ -68,8 +68,6 @@ class TernaryPlotOpDesc extends PythonOperatorDescriptor {
 
   /** Returns a Python string that drops any tuples with missing values */
   def manipulateTable(): String = {
-    // Check for any empty data field names
-    assert(firstVariable.nonEmpty && secondVariable.nonEmpty && thirdVariable.nonEmpty)
     s"""
        |        # Remove any tuples that contain missing values
        |        table.dropna(subset=['$firstVariable', '$secondVariable', '$thirdVariable'], inplace = True)


### PR DESCRIPTION
This PR resolves the issues described in #3191 and addresses all related Python visualization operators. The fix involves removing unnecessary assertions and assigning default values to fields that were previously null.

The root cause of the issue was the early Python code generation during the transformation from a logical plan to a physical plan. This behavior is expected due to the decision to push schema propagation to the physical plan layer.