### PR TITLE
Fix Frontend Issue With Compute Unit Termination UI

### DIFF
--- a/core/workflow-computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/resource/WorkflowComputingUnitManagingResource.scala
+++ b/core/workflow-computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/resource/WorkflowComputingUnitManagingResource.scala
@@ -10,6 +10,7 @@ import edu.uci.ics.texera.service.resource.WorkflowComputingUnitManagingResource
   DashboardWorkflowComputingUnit,
   WorkflowComputingUnitCreationParams,
   WorkflowComputingUnitTerminationParams,
+  TerminationResponse,
   context
 }
 import edu.uci.ics.texera.service.util.KubernetesClientService
@@ -39,6 +40,8 @@ object WorkflowComputingUnitManagingResource {
       uri: String,
       status: String
   )
+
+  case class TerminationResponse(message: String, uri: String)
 }
 
 @Produces(Array(MediaType.APPLICATION_JSON))
@@ -131,7 +134,7 @@ class WorkflowComputingUnitManagingResource {
   @Consumes(Array(MediaType.APPLICATION_JSON))
   @Produces(Array(MediaType.APPLICATION_JSON))
   @Path("/terminate")
-  def terminateComputingUnit(param: WorkflowComputingUnitTerminationParams): Response = {
+  def terminateComputingUnit(param: WorkflowComputingUnitTerminationParams): TerminationResponse = {
     // Attempt to delete the pod using the provided URI
     val podURI = param.uri
     KubernetesClientService.deletePod(podURI)
@@ -146,7 +149,6 @@ class WorkflowComputingUnitManagingResource {
       cuDao.update(units)
     }
 
-    Response.ok(s"Successfully terminated compute unit with URI $podURI").build()
-
+    TerminationResponse(s"Successfully terminated compute unit with URI $podURI", podURI)
   }
 }


### PR DESCRIPTION
### PR overview
Previously, when terminating a computing unit, the request would go through and return correctly. However, the UI notification displays incorrect message. The fix was in the "workflow-computing-unit-managing-service" where the response returned in was in json format. 

### Video showing change
https://github.com/user-attachments/assets/05c73672-0f95-4782-a11d-c3dd47abcaf6


