### PR TITLE
Prevent MySQL Interaction When user-sys.enabled Is False

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
@@ -5,7 +5,7 @@ import edu.uci.ics.amber.core.workflow.WorkflowContext
 import edu.uci.ics.amber.engine.architecture.controller.{ControllerConfig, Workflow}
 import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.EmptyRequest
 import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState._
-import edu.uci.ics.amber.engine.common.Utils
+import edu.uci.ics.amber.engine.common.{AmberConfig, Utils}
 import edu.uci.ics.amber.engine.common.client.AmberClient
 import edu.uci.ics.amber.engine.common.executionruntimestate.ExecutionMetadataStore
 import edu.uci.ics.texera.dao.jooq.generated.tables.pojos.OperatorExecutions
@@ -108,7 +108,11 @@ class WorkflowExecutionService(
     executionReconfigurationService =
       new ExecutionReconfigurationService(client, executionStateStore, workflow)
     // Create the operatorId to executionId map
-    val operatorIdToExecutionId = createOperatorIdToExecutionIdMap(workflow)
+    val operatorIdToExecutionId: Map[String, ULong] =
+      if (AmberConfig.isUserSystemEnabled)
+        createOperatorIdToExecutionIdMap(workflow)
+      else
+        Map.empty
     executionStatsService =
       new ExecutionStatsService(client, executionStateStore, operatorIdToExecutionId)
     executionRuntimeService = new ExecutionRuntimeService(


### PR DESCRIPTION
This PR addresses an issue where the system interacts with the MySQL database even when `user-sys.enabled` is set to `false`. In such cases, the system should not perform any interactions with the MySQL database. To resolve this, an if statement has been added to remove the logic, ensuring the system behaves as expected.