### PR TITLE
Fix Issue with lifecycle removing Incorrect files and losing result content

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResource.scala
@@ -83,6 +83,9 @@ object WorkflowExecutionsResource {
     val executions = context
       .select(WORKFLOW_EXECUTIONS.EID)
       .from(WORKFLOW_EXECUTIONS)
+      .join(WORKFLOW_VERSION)
+      .on(WORKFLOW_EXECUTIONS.VID.eq(WORKFLOW_VERSION.VID))
+      .where(WORKFLOW_VERSION.WID.eq(wid))
       .fetchInto(classOf[UInteger])
       .asScala
       .toList


### PR DESCRIPTION
This PR resolves the issue where storage documents for results randomly disappear. The root cause of this problem lies in the lifecycle fetching the wrong file to remove.

The lifecycle currently retrieves the latest execution ID from the database but does so without considering the workflow ID. This results in the lifecycle incorrectly identifying files for removal, leading to the loss of result content.

With this fix, the lifecycle now ensures that the execution ID is fetched in the context of the corresponding workflow ID.