### PR TITLE
Disable User System in front end config by default

### DIFF
--- a/core/gui/src/environments/environment.default.ts
+++ b/core/gui/src/environments/environment.default.ts
@@ -26,7 +26,7 @@ export const defaultEnvironment = {
   /**
    * whether user system is enabled
    */
-  userSystemEnabled: true,
+  userSystemEnabled: false,
 
   /**
    * whether local login is enabled


### PR DESCRIPTION
### Purpose:
Fix a mistake due to a misunderstanding. userSystemEnabled flag should be set to false by default.
