### PR TITLE
Fix the issue where the public dataset search result page displays public workflows after refreshing

### DIFF
--- a/core/gui/src/app/hub/component/hub-search-result/hub-search-result.component.ts
+++ b/core/gui/src/app/hub/component/hub-search-result/hub-search-result.component.ts
@@ -7,7 +7,7 @@ import { SortMethod } from "../../../dashboard/type/sort-method";
 import { UserService } from "../../../common/service/user/user.service";
 import { SearchService } from "../../../dashboard/service/user/search.service";
 import { isDefined } from "../../../common/util/predicate";
-import { firstValueFrom, filter } from "rxjs";
+import { firstValueFrom } from "rxjs";
 import { DashboardEntry, UserInfo } from "../../../dashboard/type/dashboard-entry";
 
 @UntilDestroy()
@@ -64,7 +64,7 @@ export class HubSearchResultComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
-    const url = this.router.url
+    const url = this.router.url;
     if (url.includes("dataset")) {
       this.searchType = "dataset";
     } else if (url.includes("workflow")) {

--- a/core/gui/src/app/hub/component/hub-search-result/hub-search-result.component.ts
+++ b/core/gui/src/app/hub/component/hub-search-result/hub-search-result.component.ts
@@ -1,4 +1,4 @@
-import { AfterViewInit, Component, Input, ViewChild } from "@angular/core";
+import { AfterViewInit, Component, Input, OnInit, ViewChild } from "@angular/core";
 import { Router, NavigationEnd } from "@angular/router";
 import { SearchResultsComponent } from "../../../dashboard/component/user/search-results/search-results.component";
 import { FiltersComponent } from "../../../dashboard/component/user/filters/filters.component";
@@ -16,7 +16,7 @@ import { DashboardEntry, UserInfo } from "../../../dashboard/type/dashboard-entr
   templateUrl: "./hub-search-result.component.html",
   styleUrls: ["./hub-search-result.component.scss"],
 })
-export class HubSearchResultComponent implements AfterViewInit {
+export class HubSearchResultComponent implements OnInit, AfterViewInit {
   public searchType: "dataset" | "workflow" = "workflow";
   currentUid = this.userService.getCurrentUser()?.uid;
 
@@ -61,20 +61,15 @@ export class HubSearchResultComponent implements AfterViewInit {
       .subscribe(() => {
         this.currentUid = this.userService.getCurrentUser()?.uid;
       });
+  }
 
-    this.router.events
-      .pipe(
-        filter(event => event instanceof NavigationEnd),
-        untilDestroyed(this)
-      )
-      .subscribe((event: any) => {
-        const url = event.urlAfterRedirects.toLowerCase();
-        if (url.includes("dataset")) {
-          this.searchType = "dataset";
-        } else if (url.includes("workflow")) {
-          this.searchType = "workflow";
-        }
-      });
+  ngOnInit() {
+    const url = this.router.url
+    if (url.includes("dataset")) {
+      this.searchType = "dataset";
+    } else if (url.includes("workflow")) {
+      this.searchType = "workflow";
+    }
   }
 
   ngAfterViewInit() {

--- a/core/gui/src/app/hub/component/hub-search-result/hub-search-result.component.ts
+++ b/core/gui/src/app/hub/component/hub-search-result/hub-search-result.component.ts
@@ -1,5 +1,5 @@
 import { AfterViewInit, Component, Input, OnInit, ViewChild } from "@angular/core";
-import { Router, NavigationEnd } from "@angular/router";
+import { Router } from "@angular/router";
 import { SearchResultsComponent } from "../../../dashboard/component/user/search-results/search-results.component";
 import { FiltersComponent } from "../../../dashboard/component/user/filters/filters.component";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";


### PR DESCRIPTION
### Purpose:
Currently, after refreshing the public dataset search result page, public workflow search results appear. The issue occurs because the URL check and type update are only triggered when the `NavigationEnd` event is detected. However, when the page is refreshed, it retains the default type, which is the workflow search results.

### Changes:
Directly check the URL and update the type in OnInit.

### Demos:
Before:
before refreshing:
![image](https://github.com/user-attachments/assets/d604b1e3-06b0-4324-bc57-c16cc05bfa99)

after refreshing:
![image](https://github.com/user-attachments/assets/e9450fa5-71a5-4ac6-9fed-ab7abf4b1516)

After:
before refreshing:
![image](https://github.com/user-attachments/assets/d604b1e3-06b0-4324-bc57-c16cc05bfa99)

after refreshing:
![image](https://github.com/user-attachments/assets/f6010494-f960-41dd-b553-08a64c9e2594)
