### PR TITLE
Fix Split Operator requires a seed

### DIFF
--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/split/SplitOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/split/SplitOpDesc.scala
@@ -2,23 +2,42 @@ package edu.uci.ics.amber.operator.split
 
 import com.fasterxml.jackson.annotation.{JsonProperty, JsonPropertyDescription}
 import com.google.common.base.Preconditions
+import com.kjetland.jackson.jsonSchema.annotations.{
+  JsonSchemaInject,
+  JsonSchemaString,
+  JsonSchemaTitle
+}
 import edu.uci.ics.amber.core.executor.OpExecWithClassName
 import edu.uci.ics.amber.core.virtualidentity.{ExecutionIdentity, WorkflowIdentity}
 import edu.uci.ics.amber.core.workflow._
 import edu.uci.ics.amber.operator.LogicalOp
+import edu.uci.ics.amber.operator.metadata.annotations.HideAnnotation
 import edu.uci.ics.amber.operator.metadata.{OperatorGroupConstants, OperatorInfo}
 import edu.uci.ics.amber.util.JSONUtils.objectMapper
 
-import scala.util.Random
 class SplitOpDesc extends LogicalOp {
 
-  @JsonProperty(value = "split percentage", required = false, defaultValue = "80")
-  @JsonPropertyDescription("percentage of data going to the upper port (default 80%)")
+  @JsonSchemaTitle("Split Percentage")
+  @JsonProperty(defaultValue = "80")
+  @JsonPropertyDescription("percentage of data going to the upper port")
   var k: Int = 80
 
-  @JsonProperty(value = "random seed", required = false)
-  @JsonPropertyDescription("Random seed for split")
-  var seed: Int = Random.nextInt()
+  @JsonSchemaTitle("Random Shuffle")
+  @JsonPropertyDescription("Shuffle the data based on a random seed")
+  @JsonProperty(defaultValue = "true")
+  var random: Boolean = true
+
+  @JsonSchemaTitle("Seed")
+  @JsonProperty(defaultValue = "1")
+  @JsonPropertyDescription("An int for reproducible output across multiple run")
+  @JsonSchemaInject(
+    strings = Array(
+      new JsonSchemaString(path = HideAnnotation.hideTarget, value = "random"),
+      new JsonSchemaString(path = HideAnnotation.hideType, value = HideAnnotation.Type.equals),
+      new JsonSchemaString(path = HideAnnotation.hideExpectedValue, value = "true")
+    )
+  )
+  var seed: Int = 1
 
   override def getPhysicalOp(
       workflowId: WorkflowIdentity,

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/split/SplitOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/split/SplitOpDesc.scala
@@ -22,7 +22,7 @@ class SplitOpDesc extends LogicalOp {
   @JsonPropertyDescription("percentage of data going to the upper port")
   var k: Int = 80
 
-  @JsonSchemaTitle("Random Shuffle")
+  @JsonSchemaTitle("Auto-Generate Seed")
   @JsonPropertyDescription("Shuffle the data based on a random seed")
   @JsonProperty(defaultValue = "true")
   var random: Boolean = true

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/split/SplitOpExec.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/split/SplitOpExec.scala
@@ -11,7 +11,7 @@ class SplitOpExec(
     descString: String
 ) extends OperatorExecutor {
   val desc: SplitOpDesc = objectMapper.readValue(descString, classOf[SplitOpDesc])
-  lazy val random = new Random(desc.seed)
+  lazy val random: Random = if (desc.random) new Random() else new Random(desc.seed)
 
   override def processTupleMultiPort(
       tuple: Tuple,


### PR DESCRIPTION
Fix the bug where the Split Operator incorrectly requires a seed, even when it's optional.

In this PR, we introduce a "Random Shuffle" checkbox to simplify the user experience and prevent confusion regarding the seed value. For advanced users, the ability to input a seed is still maintained.

After the change:
| | |
|-|-|
| ![image](https://github.com/user-attachments/assets/159ccd0f-610a-4431-a462-8bfa6dc53a55)   | ![image](https://github.com/user-attachments/assets/3f0d9f7f-8059-4c26-a380-b1b98bfdd567)  |




