### PR TITLE
Fix the issue where the left panel in the workspace is covered by the menu

### DIFF
--- a/core/gui/src/app/workspace/component/left-panel/left-panel.component.scss
+++ b/core/gui/src/app/workspace/component/left-panel/left-panel.component.scss
@@ -3,6 +3,7 @@
   width: 100%;
   height: 100%;
   position: fixed;
+  z-index: 3;
 }
 
 #left-container {


### PR DESCRIPTION
### Purpose:
In the workspace, when dragging the left panel, it may be covered by the menu, making it impossible to continue moving. The cause of this issue is that the z-index of the left panel is not defined.

### Changes:
Add a z-index to the left panel

### Demo:
before:
![image](https://github.com/user-attachments/assets/3cbb6cb9-60b1-4876-9fdd-250da3c92dfd)

after:
![image](https://github.com/user-attachments/assets/95691206-9bb9-4c88-92f4-84e91610e5ed)
