### PR TITLE
Add PostgreSQL Catalog in Java Iceberg Implementation

### DIFF
--- a/core/amber/src/main/python/core/storage/iceberg/iceberg_catalog_instance.py
+++ b/core/amber/src/main/python/core/storage/iceberg/iceberg_catalog_instance.py
@@ -28,6 +28,7 @@ class IcebergCatalogInstance:
             cls._instance = create_postgres_catalog(
                 "texera_iceberg",
                 StorageConfig.ICEBERG_FILE_STORAGE_DIRECTORY_PATH,
+                StorageConfig.ICEBERG_POSTGRES_CATALOG_URI_WITHOUT_SCHEME,
                 StorageConfig.ICEBERG_POSTGRES_CATALOG_USERNAME,
                 StorageConfig.ICEBERG_POSTGRES_CATALOG_PASSWORD,
             )

--- a/core/amber/src/main/python/core/storage/iceberg/iceberg_utils.py
+++ b/core/amber/src/main/python/core/storage/iceberg/iceberg_utils.py
@@ -14,7 +14,11 @@ from core.models import ArrowTableTupleProvider, Tuple
 
 
 def create_postgres_catalog(
-    catalog_name: str, warehouse_path: str, username: str, password: str
+    catalog_name: str,
+    warehouse_path: str,
+    uri_without_scheme: str,
+    username: str,
+    password: str,
 ) -> SqlCatalog:
     """
     Creates a Postgres SQL catalog instance by connecting to the database named
@@ -23,6 +27,8 @@ def create_postgres_catalog(
     can connect to the database, it will handle the initializations.
     :param catalog_name: the name of the catalog.
     :param warehouse_path: the root path for the warehouse where the tables are stored.
+    :param uri_without_scheme: the uri of the postgres database but without
+            the scheme prefix since java and python use different schemes.
     :param username: the username of the postgres database.
     :param password: the password of the postgres database.
     :return: a SQLCatalog instance.
@@ -30,8 +36,7 @@ def create_postgres_catalog(
     return SqlCatalog(
         catalog_name,
         **{
-            "uri": f"postgresql+psycopg2://{username}:"
-            f"{password}@localhost/texera_iceberg_catalog",
+            "uri": f"postgresql+psycopg2://{username}:{password}@{uri_without_scheme}",
             "warehouse": f"file://{warehouse_path}",
         },
     )

--- a/core/amber/src/main/python/core/storage/iceberg/test_iceberg_document.py
+++ b/core/amber/src/main/python/core/storage/iceberg/test_iceberg_document.py
@@ -19,6 +19,7 @@ from proto.edu.uci.ics.amber.core import (
 
 # Hardcoded storage config only for test purposes.
 StorageConfig.initialize(
+    postgres_uri_without_scheme="localhost:5432/texera_iceberg_catalog",
     postgres_username="texera_iceberg_admin",
     postgres_password="password",
     table_namespace="operator-port-result",

--- a/core/amber/src/main/python/core/storage/storage_config.py
+++ b/core/amber/src/main/python/core/storage/storage_config.py
@@ -7,6 +7,7 @@ class StorageConfig:
 
     _initialized = False
 
+    ICEBERG_POSTGRES_CATALOG_URI_WITHOUT_SCHEME = None
     ICEBERG_POSTGRES_CATALOG_USERNAME = None
     ICEBERG_POSTGRES_CATALOG_PASSWORD = None
     ICEBERG_TABLE_NAMESPACE = None
@@ -16,6 +17,7 @@ class StorageConfig:
     @classmethod
     def initialize(
         cls,
+        postgres_uri_without_scheme,
         postgres_username,
         postgres_password,
         table_namespace,
@@ -27,6 +29,7 @@ class StorageConfig:
                 "Storage config has already been initialized" "and cannot be modified."
             )
 
+        cls.ICEBERG_POSTGRES_CATALOG_URI_WITHOUT_SCHEME = postgres_uri_without_scheme
         cls.ICEBERG_POSTGRES_CATALOG_USERNAME = postgres_username
         cls.ICEBERG_POSTGRES_CATALOG_PASSWORD = postgres_password
         cls.ICEBERG_TABLE_NAMESPACE = table_namespace

--- a/core/workflow-core/build.sbt
+++ b/core/workflow-core/build.sbt
@@ -157,6 +157,7 @@ libraryDependencies ++= Seq(
     excludeJackson,
     excludeJacksonModule
   ),
+  "org.postgresql" % "postgresql" % "42.7.3"
 )
 
 /////////////////////////////////////////////////////////////////////////////

--- a/core/workflow-core/src/main/resources/storage-config.yaml
+++ b/core/workflow-core/src/main/resources/storage-config.yaml
@@ -6,13 +6,13 @@ storage:
     commit-batch-size: 1000
   iceberg:
     catalog:
-      type: hadoop # either hadoop, rest, or postgres
+      type: postgres # either hadoop, rest, or postgres
       rest-uri: "" # the uri of the rest catalog, not needed unless using REST catalog
       postgres:
         # do not include scheme in the uri as Python and Java use different schemes
         uri-without-scheme: "localhost:5432/texera_iceberg_catalog"
-        username: "" # replace with actual username
-        password: "" # replace with actual password
+        username: "texera_iceberg_admin" # replace with actual username
+        password: "password" # replace with actual password
     table:
       namespace: "operator-port-result"
       commit:

--- a/core/workflow-core/src/main/resources/storage-config.yaml
+++ b/core/workflow-core/src/main/resources/storage-config.yaml
@@ -6,7 +6,7 @@ storage:
     commit-batch-size: 1000
   iceberg:
     catalog:
-      type: postgres # either hadoop, rest, or postgres
+      type: hadoop # either hadoop, rest, or postgres
       rest-uri: "" # the uri of the rest catalog, not needed unless using REST catalog
       postgres:
         # do not include scheme in the uri as Python and Java use different schemes

--- a/core/workflow-core/src/main/resources/storage-config.yaml
+++ b/core/workflow-core/src/main/resources/storage-config.yaml
@@ -6,10 +6,15 @@ storage:
     commit-batch-size: 1000
   iceberg:
     catalog:
-      type: hadoop # either hadoop or rest
-      uri: http://localhost:8181 # the uri of the rest catalog
+      type: hadoop # either hadoop, rest, or postgres
+      rest-uri: "" # the uri of the rest catalog, not needed unless using REST catalog
+      postgres:
+        # do not include scheme in the uri as Python and Java use different schemes
+        uri-without-scheme: "localhost:5432/texera_iceberg_catalog"
+        username: "" # replace with actual username
+        password: "" # replace with actual password
     table:
-      namespace: "operator-result"
+      namespace: "operator-port-result"
       commit:
         batch-size: 4096 # decide the buffer size of our IcebergTableWriter
         retry:

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/IcebergCatalogInstance.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/IcebergCatalogInstance.scala
@@ -34,6 +34,11 @@ object IcebergCatalogInstance {
               "texera_iceberg",
               StorageConfig.fileStorageDirectoryPath
             )
+          case "postgres" =>
+            IcebergUtil.createPostgresCatalog(
+              "texera_iceberg",
+              StorageConfig.fileStorageDirectoryPath
+            )
           case unsupported =>
             throw new IllegalArgumentException(s"Unsupported catalog type: $unsupported")
         }

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/StorageConfig.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/StorageConfig.scala
@@ -17,7 +17,8 @@ object StorageConfig {
     val mongodbMap = storageMap("mongodb").asInstanceOf[JMap[String, Any]].asScala.toMap
     val icebergMap = storageMap("iceberg").asInstanceOf[JMap[String, Any]].asScala.toMap
     val icebergCatalogMap = icebergMap("catalog").asInstanceOf[JMap[String, Any]].asScala.toMap
-    val icebergPostgresMap = icebergCatalogMap("postgres").asInstanceOf[JMap[String, Any]].asScala.toMap
+    val icebergPostgresMap =
+      icebergCatalogMap("postgres").asInstanceOf[JMap[String, Any]].asScala.toMap
     val icebergTableMap = icebergMap("table").asInstanceOf[JMap[String, Any]].asScala.toMap
     val icebergCommitMap = icebergTableMap("commit").asInstanceOf[JMap[String, Any]].asScala.toMap
     val icebergRetryMap = icebergCommitMap("retry").asInstanceOf[JMap[String, Any]].asScala.toMap

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/StorageConfig.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/StorageConfig.scala
@@ -17,6 +17,7 @@ object StorageConfig {
     val mongodbMap = storageMap("mongodb").asInstanceOf[JMap[String, Any]].asScala.toMap
     val icebergMap = storageMap("iceberg").asInstanceOf[JMap[String, Any]].asScala.toMap
     val icebergCatalogMap = icebergMap("catalog").asInstanceOf[JMap[String, Any]].asScala.toMap
+    val icebergPostgresMap = icebergCatalogMap("postgres").asInstanceOf[JMap[String, Any]].asScala.toMap
     val icebergTableMap = icebergMap("table").asInstanceOf[JMap[String, Any]].asScala.toMap
     val icebergCommitMap = icebergTableMap("commit").asInstanceOf[JMap[String, Any]].asScala.toMap
     val icebergRetryMap = icebergCommitMap("retry").asInstanceOf[JMap[String, Any]].asScala.toMap
@@ -36,7 +37,10 @@ object StorageConfig {
                 icebergCommitMap.updated("retry", icebergRetryMap)
               )
             )
-            .updated("catalog", icebergCatalogMap)
+            .updated(
+              "catalog",
+              icebergCatalogMap.updated("postgres", icebergPostgresMap)
+            )
         )
         .updated("jdbc", jdbcMap)
     )
@@ -106,10 +110,31 @@ object StorageConfig {
     .asInstanceOf[Map[String, Any]]("type")
     .asInstanceOf[String]
 
-  val icebergCatalogUri: String = conf("storage")
+  val icebergRESTCatalogUri: String = conf("storage")
     .asInstanceOf[Map[String, Any]]("iceberg")
     .asInstanceOf[Map[String, Any]]("catalog")
-    .asInstanceOf[Map[String, Any]]("uri")
+    .asInstanceOf[Map[String, Any]]("rest-uri")
+    .asInstanceOf[String]
+
+  val icebergPostgresCatalogUriWithoutScheme: String = conf("storage")
+    .asInstanceOf[Map[String, Any]]("iceberg")
+    .asInstanceOf[Map[String, Any]]("catalog")
+    .asInstanceOf[Map[String, Any]]("postgres")
+    .asInstanceOf[Map[String, Any]]("uri-without-scheme")
+    .asInstanceOf[String]
+
+  val icebergPostgresCatalogUsername: String = conf("storage")
+    .asInstanceOf[Map[String, Any]]("iceberg")
+    .asInstanceOf[Map[String, Any]]("catalog")
+    .asInstanceOf[Map[String, Any]]("postgres")
+    .asInstanceOf[Map[String, Any]]("username")
+    .asInstanceOf[String]
+
+  val icebergPostgresCatalogPassword: String = conf("storage")
+    .asInstanceOf[Map[String, Any]]("iceberg")
+    .asInstanceOf[Map[String, Any]]("catalog")
+    .asInstanceOf[Map[String, Any]]("postgres")
+    .asInstanceOf[Map[String, Any]]("password")
     .asInstanceOf[String]
 
   // JDBC configurations

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/util/IcebergUtil.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/util/IcebergUtil.scala
@@ -9,17 +9,11 @@ import org.apache.iceberg.types.Types
 import org.apache.iceberg.data.{GenericRecord, Record}
 import org.apache.iceberg.hadoop.{HadoopCatalog, HadoopFileIO}
 import org.apache.iceberg.io.{CloseableIterable, InputFile}
+import org.apache.iceberg.jdbc.JdbcCatalog
 import org.apache.iceberg.parquet.{Parquet, ParquetValueReader}
 import org.apache.iceberg.rest.RESTCatalog
 import org.apache.iceberg.types.Type.PrimitiveType
-import org.apache.iceberg.{
-  CatalogProperties,
-  DataFile,
-  PartitionSpec,
-  Table,
-  TableProperties,
-  Schema => IcebergSchema
-}
+import org.apache.iceberg.{CatalogProperties, DataFile, PartitionSpec, Table, TableProperties, Schema => IcebergSchema}
 
 import java.nio.ByteBuffer
 import java.nio.file.Path
@@ -86,8 +80,27 @@ object IcebergUtil {
       catalogName,
       Map(
         "warehouse" -> warehouse.toString,
-        CatalogProperties.URI -> StorageConfig.icebergCatalogUri,
+        CatalogProperties.URI -> StorageConfig.icebergRESTCatalogUri,
         CatalogProperties.FILE_IO_IMPL -> classOf[HadoopFileIO].getName
+      ).asJava
+    )
+    catalog
+  }
+
+
+  def createPostgresCatalog(
+                             catalogName: String,
+                             warehouse: Path
+                           ): JdbcCatalog = {
+    val catalog = new JdbcCatalog()
+    catalog.initialize(
+      catalogName,
+      Map(
+        "warehouse" -> warehouse.toString,
+        CatalogProperties.FILE_IO_IMPL -> classOf[HadoopFileIO].getName,
+        CatalogProperties.URI ->  s"jdbc:postgresql://${StorageConfig.icebergPostgresCatalogUriWithoutScheme}",
+        JdbcCatalog.PROPERTY_PREFIX + "user" -> StorageConfig.icebergPostgresCatalogUsername,
+        JdbcCatalog.PROPERTY_PREFIX + "password" -> StorageConfig.icebergPostgresCatalogPassword
       ).asJava
     )
     catalog

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/util/IcebergUtil.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/util/IcebergUtil.scala
@@ -13,7 +13,14 @@ import org.apache.iceberg.jdbc.JdbcCatalog
 import org.apache.iceberg.parquet.{Parquet, ParquetValueReader}
 import org.apache.iceberg.rest.RESTCatalog
 import org.apache.iceberg.types.Type.PrimitiveType
-import org.apache.iceberg.{CatalogProperties, DataFile, PartitionSpec, Table, TableProperties, Schema => IcebergSchema}
+import org.apache.iceberg.{
+  CatalogProperties,
+  DataFile,
+  PartitionSpec,
+  Table,
+  TableProperties,
+  Schema => IcebergSchema
+}
 
 import java.nio.ByteBuffer
 import java.nio.file.Path
@@ -87,18 +94,17 @@ object IcebergUtil {
     catalog
   }
 
-
   def createPostgresCatalog(
-                             catalogName: String,
-                             warehouse: Path
-                           ): JdbcCatalog = {
+      catalogName: String,
+      warehouse: Path
+  ): JdbcCatalog = {
     val catalog = new JdbcCatalog()
     catalog.initialize(
       catalogName,
       Map(
         "warehouse" -> warehouse.toString,
         CatalogProperties.FILE_IO_IMPL -> classOf[HadoopFileIO].getName,
-        CatalogProperties.URI ->  s"jdbc:postgresql://${StorageConfig.icebergPostgresCatalogUriWithoutScheme}",
+        CatalogProperties.URI -> s"jdbc:postgresql://${StorageConfig.icebergPostgresCatalogUriWithoutScheme}",
         JdbcCatalog.PROPERTY_PREFIX + "user" -> StorageConfig.icebergPostgresCatalogUsername,
         JdbcCatalog.PROPERTY_PREFIX + "password" -> StorageConfig.icebergPostgresCatalogPassword
       ).asJava


### PR DESCRIPTION
This PR unifies the Java and Python catalog implementations by doing the following:
- Add postgresql catalog in Java's Iceberg storage implementation as an option
- Rename default table namespace from "`operator-result`" to "`operator-port-result`"
- Separate uri scheme from the rest of the uri for postgres uri config because Java and Python use different schemes ("`jdbc:postgresql://`" vs. "`postgresql+psycopg2://`")
- Remove default REST catalog URI since we are not using REST catalog right now; in the future we might use it.

**Since we will use PostgreSQL catalog as the default soon, it is strongly recommended for developers to set it up now.**

## Steps to enable Postgres catalog:
1. Ensure PostgreSQL is installed locally and the PostgresSQL service is running.
2. Go to `core/workflow-core/src/main/resources/storage-config.yaml` and configure the "`iceberg.catalog.type`" field to be "`postgres`".
3. (Optional for local dev, **required for prod**) Configure username and password for the new postgres database that will be used for iceberg catalog:
    1.  Go to `core/scripts/sql/iceberg_postgres_catalog.sql` and Replace the "db_user" and "db_password" fields with your own username/password.
    2. Go to `core/workflow-core/src/main/resources/storage-config.yaml` and configure the "`iceberg.catalog.postgres.username`" and "`iceberg.catalog.postgres.password`" fields accordingly.
4. Execute the postgres iceberg catalog database creation script using `postgres` or any other postgres superuser account.
    - One way you can execute the script is by using the command line `psql -f core/scripts/sql/iceberg_postgres_catalog.sql` plus any additional credential paramenters, e.g., `-U postgres`. 
    - Another way is to use a GUI tool like pgadmin. Make sure you use an account with superuser privileges.
5. If the script executes successfully, the catalog database should be correctly set up. It is an empty database currently, but iceberg will initialize the database once it is used in the backend. Note the only thing needed from PostgreSQL is that there is an empty database named "`texera_iceberg_cataglog`" and the configs in`core/workflow-core/src/main/resources/storage-config.yaml` can point to that database correctly, so if for any reason the script fails, you can create the database manually.