### PR TITLE
Fix issue where table statistics are not displayed correctly on the frontend

### DIFF
--- a/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
+++ b/core/gui/src/app/workspace/component/result-panel/result-table-frame/result-table-frame.component.html
@@ -32,7 +32,7 @@
           </th>
         </tr>
         <tr
-          *ngIf="tableStats && prevTableStats && sinkStorageMode === 'mongodb'"
+          *ngIf="tableStats && prevTableStats"
           #statsRow
           class="custom-stats-row">
           <th *ngFor="let column of currentColumns">
@@ -47,20 +47,20 @@
                 </div>
               </ng-container>
               <ng-container
-                *ngIf="tableStats[column.header] && prevTableStats[column.header] && tableStats[column.header]['mean'] !== undefined">
-                <div class="statsLine">
-                  <h5 class="leftAlign">Average</h5>
-                  <h5 class="rightAlign">
-                    <span [innerHTML]="compare(column.header, 'mean')"></span>
-                  </h5>
-                </div>
-              </ng-container>
-              <ng-container
                 *ngIf="tableStats[column.header] && prevTableStats[column.header] && tableStats[column.header]['max'] !== undefined">
                 <div class="statsLine">
                   <h5 class="leftAlign">Max</h5>
                   <h5 class="rightAlign">
                     <span [innerHTML]="compare(column.header, 'max')"></span>
+                  </h5>
+                </div>
+              </ng-container>
+              <ng-container
+                *ngIf="tableStats[column.header] && prevTableStats[column.header] && tableStats[column.header]['not_null_count'] !== undefined">
+                <div class="statsLine">
+                  <h5 class="leftAlign">Non-Null Count</h5>
+                  <h5 class="rightAlign">
+                    <span [innerHTML]="compare(column.header, 'not_null_count')"></span>
                   </h5>
                 </div>
               </ng-container>


### PR DESCRIPTION
This PR fixes the issue where table statistics were not correctly displayed on the frontend. Since we migrated our statistics storage from MongoDB to Iceberg, the types of statistics provided have changed. This PR updates the frontend to properly display the statistics based on the new Iceberg format.
<img width="924" alt="image" src="https://github.com/user-attachments/assets/f55d34db-3e45-4176-8520-045645307e9c" />
<img width="913" alt="image" src="https://github.com/user-attachments/assets/9720e961-45f4-4966-bf63-2f31d798cf5c" />
