### PR TITLE
Fix GitHub Action Build Failure

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           architecture: ${{ matrix.arch }}
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         with:
           path: |
             core/gui/node_modules


### PR DESCRIPTION
This PR updates the github-action-build workflow to resolve the build failure #13522.
<img width="1726" alt="Screenshot 2025-02-11 at 4 59 30 PM" src="https://github.com/user-attachments/assets/037df1a3-46cd-476f-8358-304f3da9a0ca" />
