### PR TITLE
Prevent Duplicate Sink Operator Generation for Shared Storage URIs

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ScheduleGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ScheduleGenerator.scala
@@ -1,5 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.scheduling
 
+import edu.uci.ics.amber.core.executor.OpExecSink
 import edu.uci.ics.amber.core.storage.{DocumentFactory, VFSURIFactory}
 import edu.uci.ics.amber.core.workflow.{PhysicalOp, PhysicalPlan, WorkflowContext}
 import edu.uci.ics.amber.engine.architecture.scheduling.ScheduleGenerator.replaceVertex
@@ -151,7 +152,6 @@ abstract class ScheduleGenerator(
     var newPhysicalPlan = physicalPlan
       .removeLink(physicalLink)
 
-    // create cache writer and link
     // create the uri of the materialization storage
     val storageUri = VFSURIFactory.createMaterializedResultURI(
       workflowContext.workflowId,
@@ -166,32 +166,44 @@ abstract class ScheduleGenerator(
       storageUri,
       fromPortOutputMode
     )
-    val sourceToWriterLink =
-      PhysicalLink(
-        fromOp.id,
-        fromPortId,
-        matWriterPhysicalOp.id,
-        matWriterPhysicalOp.inputPorts.keys.head
-      )
-    newPhysicalPlan = newPhysicalPlan
-      .addOperator(matWriterPhysicalOp)
-      .addLink(sourceToWriterLink)
 
-    // sink has exactly one input port and one output port
-    val schema = newPhysicalPlan
-      .getOperator(matWriterPhysicalOp.id)
-      .outputPorts(matWriterPhysicalOp.outputPorts.keys.head)
-      ._3
-      .toOption
-      .get
-    // create the document
-    DocumentFactory.createDocument(storageUri, schema)
-    WorkflowExecutionsResource.insertOperatorPortResultUri(
-      workflowContext.executionId,
-      physicalLink.fromOpId.logicalOpId,
-      physicalLink.fromPortId,
-      storageUri
-    )
+    // Check if an operator with the same storageUri already exists
+    val existingOperator = newPhysicalPlan.operators.find {
+      case op if op.opExecInitInfo.isInstanceOf[OpExecSink] =>
+        val OpExecSink(uri, _, _) = op.opExecInitInfo
+        uri == storageUri.toString
+      case _ => false
+    }
+
+    if (existingOperator.isEmpty) {
+      // create cache writer and link
+      val sourceToWriterLink =
+        PhysicalLink(
+          fromOp.id,
+          fromPortId,
+          matWriterPhysicalOp.id,
+          matWriterPhysicalOp.inputPorts.keys.head
+        )
+      newPhysicalPlan = newPhysicalPlan
+        .addOperator(matWriterPhysicalOp)
+        .addLink(sourceToWriterLink)
+
+      // sink has exactly one input port and one output port
+      val schema = newPhysicalPlan
+        .getOperator(matWriterPhysicalOp.id)
+        .outputPorts(matWriterPhysicalOp.outputPorts.keys.head)
+        ._3
+        .toOption
+        .get
+      // create the document
+      DocumentFactory.createDocument(storageUri, schema)
+      WorkflowExecutionsResource.insertOperatorPortResultUri(
+        workflowContext.executionId,
+        physicalLink.fromOpId.logicalOpId,
+        physicalLink.fromPortId,
+        storageUri
+      )
+    }
 
     // create cache reader and link
     val matReaderPhysicalOp: PhysicalOp = SpecialPhysicalOpFactory.newSourcePhysicalOp(
@@ -207,7 +219,8 @@ abstract class ScheduleGenerator(
         toPortId
       )
     // add the pair to the map for later adding edges between 2 regions.
-    writerReaderPairs(matWriterPhysicalOp.id) = matReaderPhysicalOp.id
+    writerReaderPairs(existingOperator.map(_.id).getOrElse(matWriterPhysicalOp.id)) =
+      matReaderPhysicalOp.id
     newPhysicalPlan
       .addOperator(matReaderPhysicalOp)
       .addLink(readerToDestLink)

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ScheduleGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ScheduleGenerator.scala
@@ -219,8 +219,7 @@ abstract class ScheduleGenerator(
         toPortId
       )
     // add the pair to the map for later adding edges between 2 regions.
-    writerReaderPairs(existingOperator.map(_.id).getOrElse(matWriterPhysicalOp.id)) =
-      matReaderPhysicalOp.id
+    writerReaderPairs(matWriterPhysicalOp.id) = matReaderPhysicalOp.id
     newPhysicalPlan
       .addOperator(matReaderPhysicalOp)
       .addLink(readerToDestLink)


### PR DESCRIPTION
This PR addresses an issue in the workflow scheduler where duplicate sink operators are generated when multiple blocking downstream operators cause the split operator to produce multiple sinks with the same storage URI. With these changes, an additional check is added during the physical plan construction. If a sink operator with the given URI already exists, the scheduler will skip generating another one, thereby preventing redundancy.

The PR will fix the issue #3263.
<img width="1528" alt="Screenshot 2025-02-13 at 4 22 20 PM" src="https://github.com/user-attachments/assets/c8061e3a-50a7-4acf-a518-04cde6af9090" />
