### PR TITLE
Improve the compilation of visualization operators by suppressing the exception to codes 

### DIFF
--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/PythonOperatorDescriptor.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/PythonOperatorDescriptor.scala
@@ -10,19 +10,26 @@ trait PythonOperatorDescriptor extends LogicalOp {
       workflowId: WorkflowIdentity,
       executionId: ExecutionIdentity
   ): PhysicalOp = {
+    // TODO: make python code be the error reporting code
+    val pythonCode = try {
+      generatePythonCode()
+    } catch {
+      case ex: Throwable =>
+        "" // Proceed with an empty string if an exception occurs
+    }
     val physicalOp = if (asSource()) {
       PhysicalOp.sourcePhysicalOp(
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecWithCode(generatePythonCode(), "python")
+        OpExecWithCode(pythonCode, "python")
       )
     } else {
       PhysicalOp.oneToOnePhysicalOp(
         workflowId,
         executionId,
         operatorIdentifier,
-        OpExecWithCode(generatePythonCode(), "python")
+        OpExecWithCode(pythonCode, "python")
       )
     }
 


### PR DESCRIPTION

This PR tries to improve the workflow editing experience with visualization operators.

### Before the changes

When users drag a visualization operator out, the compilation is likely to fail because users have not configured the properties yet and in the compiler `generatePythonCode` is called and lots of assertion fail the calling. This often breaks the schema propagation which is quite unfriendly to the user.

### How the changes are done

This PR adds a try-catch around `generatePythonCode` function. If there is any exception happen during the python code generation, it will be caught. The exception will be reflected in the generated python code.