### PR TITLE
Fix execution state leak triggered by frequent ExecuteWorkflow requests

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -76,7 +76,13 @@ class WorkflowWebsocketResource extends LazyLogging {
         case workflowExecuteRequest: WorkflowExecuteRequest =>
           workflowStateOpt match {
             case Some(workflow) =>
-              workflow.initExecutionService(workflowExecuteRequest, userOpt, session.getRequestURI)
+              synchronized {
+                workflow.initExecutionService(
+                  workflowExecuteRequest,
+                  userOpt,
+                  session.getRequestURI
+                )
+              }
             case None => throw new IllegalStateException("workflow is not initialized")
           }
         case other =>

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/WorkflowWebsocketResource.scala
@@ -76,6 +76,7 @@ class WorkflowWebsocketResource extends LazyLogging {
         case workflowExecuteRequest: WorkflowExecuteRequest =>
           workflowStateOpt match {
             case Some(workflow) =>
+              sessionState.send(WorkflowStateEvent("Initializing"))
               synchronized {
                 workflow.initExecutionService(
                   workflowExecuteRequest,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
@@ -162,6 +162,7 @@ class WorkflowExecutionService(
     super.unsubscribeAll()
     if (client != null) {
       // runtime created
+      client.shutdown()
       executionRuntimeService.unsubscribeAll()
       executionConsoleService.unsubscribeAll()
       executionStatsService.unsubscribeAll()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -166,6 +166,11 @@ class WorkflowService(
       userOpt: Option[User],
       sessionUri: URI
   ): Unit = {
+
+    if (executionService.hasValue) {
+      executionService.getValue.unsubscribeAll()
+    }
+
     val (uidOpt, userEmailOpt) = userOpt.map(user => (user.getUid, user.getEmail)).unzip
 
     val workflowContext: WorkflowContext = createWorkflowContext()


### PR DESCRIPTION
This PR prevents multiple concurrent workflow executions when the run button is clicked repeatedly (due to slow compilation). It automatically shuts down any ongoing execution when receiving a new request, avoiding resource leaks and infinite iceberg writes.