### PR TITLE
Remove sub-string matching from search query

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DatasetSearchQueryBuilder.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DatasetSearchQueryBuilder.scala
@@ -8,8 +8,7 @@ import edu.uci.ics.texera.web.resource.dashboard.DashboardResource.DashboardClic
 import edu.uci.ics.texera.web.resource.dashboard.FulltextSearchQueryUtils.{
   getContainsFilter,
   getDateFilter,
-  getFullTextSearchFilter,
-  getSubstringSearchFilter
+  getFullTextSearchFilter
 }
 import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetResource
 import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetResource.DashboardDataset
@@ -89,12 +88,6 @@ object DatasetSearchQueryBuilder extends SearchQueryBuilder {
       .and(getContainsFilter(params.datasetIds, DATASET.DID))
       .and(
         getFullTextSearchFilter(splitKeywords, List(DATASET.NAME, DATASET.DESCRIPTION))
-          .or(
-            getSubstringSearchFilter(
-              splitKeywords,
-              List(DATASET.NAME, DATASET.DESCRIPTION)
-            )
-          )
       )
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/ProjectSearchQueryBuilder.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/ProjectSearchQueryBuilder.scala
@@ -6,8 +6,7 @@ import edu.uci.ics.texera.web.resource.dashboard.DashboardResource.DashboardClic
 import edu.uci.ics.texera.web.resource.dashboard.FulltextSearchQueryUtils.{
   getContainsFilter,
   getDateFilter,
-  getFullTextSearchFilter,
-  getSubstringSearchFilter
+  getFullTextSearchFilter
 }
 import org.jooq.impl.DSL
 
@@ -56,12 +55,6 @@ object ProjectSearchQueryBuilder extends SearchQueryBuilder {
       .and(getContainsFilter(params.projectIds, PROJECT.PID))
       .and(
         getFullTextSearchFilter(splitKeywords, List(PROJECT.NAME, PROJECT.DESCRIPTION))
-          .or(
-            getSubstringSearchFilter(
-              splitKeywords,
-              List(PROJECT.NAME, PROJECT.DESCRIPTION)
-            )
-          )
       )
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/WorkflowSearchQueryBuilder.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/WorkflowSearchQueryBuilder.scala
@@ -96,11 +96,6 @@ object WorkflowSearchQueryBuilder extends SearchQueryBuilder {
         getFullTextSearchFilter(
           splitKeywords,
           List(WORKFLOW.NAME, WORKFLOW.DESCRIPTION, WORKFLOW.CONTENT)
-        ).or(
-          getSubstringSearchFilter(
-            splitKeywords,
-            List(WORKFLOW.NAME, WORKFLOW.DESCRIPTION, WORKFLOW.CONTENT)
-          )
         )
       )
   }

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
@@ -330,25 +330,6 @@ class WorkflowResourceSpec
     test(sessionUser2, testWorkflow2)
   }
 
-  it should "search for keywords containing special characters" in {
-    // testWorkflow1: {name: test_name, description: test_description, content: "key@gmail.com"}
-    // search "key@gmail.com" should return testWorkflow1
-    workflowResource.persistWorkflow(testWorkflowWithSpecialCharacters, sessionUser1)
-    workflowResource.persistWorkflow(testWorkflow3, sessionUser1)
-    val DashboardWorkflowEntryList =
-      dashboardResource
-        .searchAllResourcesCall(
-          sessionUser1,
-          SearchQueryParams(getKeywordsArray(exampleEmailAddress))
-        )
-        .results
-    assert(DashboardWorkflowEntryList.size == 1)
-    assertSameWorkflow(
-      testWorkflowWithSpecialCharacters,
-      DashboardWorkflowEntryList.head.workflow.get
-    )
-  }
-
   it should "return a proper condition for a single owner" in {
     val ownerList = new java.util.ArrayList[String](util.Arrays.asList("owner1"))
     val ownerFilter: Condition =


### PR DESCRIPTION
Previously, we combined full-text search with substring matching to improve the search quality on MySQL due to it's limited support for full-text search. However, sub-string matching can lead to a bad performance. Since we migrated our database to postgres which has a better full-text search support, this PR removes the sub-string matching part from the search query for a better performance.