### PR TITLE
Optimize Runtime Statistics Storage by Managing Metadata and Commit Frequency

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionStatsService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionStatsService.scala
@@ -230,7 +230,6 @@ class ExecutionStatsService(
               )
               writer.putOne(runtimeStats)
           }
-          writer.close()
         } catch {
           case err: Throwable => logger.error("error occurred when storing runtime statistics", err)
         }
@@ -291,5 +290,17 @@ class ExecutionStatsService(
           }
         })
     )
+  }
+
+  override def unsubscribeAll(): Unit = {
+    runtimeStatsWriter.foreach { writer =>
+      try {
+        writer.close()
+      } catch {
+        case err: Throwable =>
+          logger.error("Error occurred when closing runtime statistics writer", err)
+      }
+    }
+    super.unsubscribeAll()
   }
 }

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/util/IcebergUtil.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/util/IcebergUtil.scala
@@ -131,11 +131,24 @@ object IcebergUtil {
       tableSchema: IcebergSchema,
       overrideIfExists: Boolean
   ): Table = {
-    val tableProperties = Map(
+    val MetadataDeleteAfterCommitEnabled = "true"
+    val MetadataPreviousVersionsMax = "1"
+
+    val baseProperties = Map(
       TableProperties.COMMIT_NUM_RETRIES -> StorageConfig.icebergTableCommitNumRetries.toString,
       TableProperties.COMMIT_MAX_RETRY_WAIT_MS -> StorageConfig.icebergTableCommitMaxRetryWaitMs.toString,
       TableProperties.COMMIT_MIN_RETRY_WAIT_MS -> StorageConfig.icebergTableCommitMinRetryWaitMs.toString
     )
+
+    val tableProperties =
+      if (tableNamespace == StorageConfig.icebergTableRuntimeStatisticsNamespace) {
+        baseProperties ++ Map(
+          TableProperties.METADATA_DELETE_AFTER_COMMIT_ENABLED -> MetadataDeleteAfterCommitEnabled,
+          TableProperties.METADATA_PREVIOUS_VERSIONS_MAX -> MetadataPreviousVersionsMax
+        )
+      } else {
+        baseProperties
+      }
     val identifier = TableIdentifier.of(tableNamespace, tableName)
     if (catalog.tableExists(identifier) && overrideIfExists) {
       catalog.dropTable(identifier)


### PR DESCRIPTION
This PR addresses the excessive storage consumption caused by metadata in runtime statistics. In a single workflow execution, metadata accounted for 48MB out of 51MB of total storage.

#### Fixes & Improvements
1. Deleting Old Metadata Files
   - Iceberg tracks table metadata using JSON files, retaining old metadata by default for historical tracking.
   - This PR sets an Iceberg table property to automatically delete old metadata files after each table commit, reducing unnecessary storage usage.

2. Optimizing Commit Frequency
   - Previously, runtime statistics were committed every 0.5 seconds, creating a new snapshot for each interval.
   - This PR adjusts the commit strategy: commits are now triggered when the memory buffer containing runtime statistics is full, significantly reducing the number of snapshots while maintaining efficiency.

#### Related Link
https://iceberg.apache.org/docs/1.7.1/maintenance/