### PR TITLE
Fix the issue where the workflow cannot be displayed in the user project.

### DIFF
--- a/core/gui/src/app/dashboard/component/user/user-project/user-project-section/user-project-section.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-project/user-project-section/user-project-section.component.html
@@ -1,4 +1,4 @@
-<div>
+<div class="user-project-container">
   <nz-card>
     <h2 class="project-title">Project : {{name}}</h2>
     <div

--- a/core/gui/src/app/dashboard/component/user/user-project/user-project-section/user-project-section.component.scss
+++ b/core/gui/src/app/dashboard/component/user/user-project/user-project-section/user-project-section.component.scss
@@ -1,3 +1,9 @@
+.user-project-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
 /* project info */
 .description-container {
   padding: 2.5%;
@@ -110,4 +116,8 @@ button {
     display: inline;
     white-space: nowrap;
   }
+}
+
+texera-saved-workflow-section {
+  flex: 1;
 }


### PR DESCRIPTION
### Purpose:
Currently, after adding a workflow to a project, the workflow list cannot be viewed within the project. The issue is caused by the workflow display interface within the project not occupying the full height of the browser window, resulting in the section displaying the workflow being compressed and thus unable to show the workflows in the project.

### Changes:
Modify the styles in the project to make it occupy 100% of the page height and ensure that the workflow results take up the remaining space.

### Demo:
Before:
![image](https://github.com/user-attachments/assets/9a2ce40f-a3f4-4589-82fc-9d1f877c7292)

After:
![image](https://github.com/user-attachments/assets/9d672440-5d7f-48a2-8723-439157e02b41)
