### PR TITLE
Enhance full-text search with Pgroonga

### DIFF
--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -64,8 +64,14 @@ jobs:
       JVM_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Prepare ENV
-        run: sudo apt-get install libncurses5
-      - name: Checkout Texera
+        run: |
+          sudo apt-get install libncurses5
+          sudo apt install -y software-properties-common
+          sudo add-apt-repository -y universe
+          sudo add-apt-repository -y ppa:groonga/ppa
+          sudo apt update
+          sudo apt install -y -V postgresql-14-pgroonga
+          sudo apt install -y -V groonga-tokenizer-mecab
         uses: actions/checkout@v2
       - name: Setup Java
         uses: actions/setup-java@v2

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -64,14 +64,7 @@ jobs:
       JVM_OPTS: -Xms2048M -Xmx2048M -Xss6M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Prepare ENV
-        run: |
-          sudo apt-get install libncurses5
-          sudo apt install -y software-properties-common
-          sudo add-apt-repository -y universe
-          sudo add-apt-repository -y ppa:groonga/ppa
-          sudo apt update
-          sudo apt install -y -V postgresql-14-pgroonga
-          sudo apt install -y -V groonga-tokenizer-mecab
+        run: sudo apt-get install libncurses5
       - name: Checkout Texera
         uses: actions/checkout@v2
       - name: Setup Java

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -72,6 +72,7 @@ jobs:
           sudo apt update
           sudo apt install -y -V postgresql-14-pgroonga
           sudo apt install -y -V groonga-tokenizer-mecab
+      - name: Checkout Texera
         uses: actions/checkout@v2
       - name: Setup Java
         uses: actions/setup-java@v2

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/FulltextSearchQueryUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/FulltextSearchQueryUtils.scala
@@ -11,39 +11,29 @@ import scala.jdk.CollectionConverters.CollectionHasAsScala
 object FulltextSearchQueryUtils {
 
   def getFullTextSearchFilter(
-      keywords: Seq[String],
-      fields: List[Field[String]]
-  ): Condition = {
-    if (fields.isEmpty) return noCondition()
-
+                               keywords: Seq[String],
+                               fields: List[Field[String]]
+                             ): Condition = {
+    // If no target columns, skip fulltext search
+    if (fields.isEmpty){
+      return noCondition()
+    }
     // Filter out empty keywords and trim
     val trimmedKeywords = keywords.filter(_.nonEmpty).map(_.trim)
-
-    // Build a SQL expression that concatenates all fields with spaces,
-    // then feeds them into to_tsvector('english', ...).
-    // E.g.: to_tsvector('english', COALESCE(firstName, '') || ' ' || COALESCE(lastName, ''))
-    val combinedFields = fields
-      .map(f => s"COALESCE($f, '')") // handle null -> ''
-      .mkString(" || ' ' || ")
-
-    // Fold each keyword into the final Condition
-    trimmedKeywords.foldLeft(noCondition()) { (acc, keyword) =>
-      // For each "keyword", split it into words
-      val words = keyword.split("\\s+").filter(_.nonEmpty)
-
-      // In Postgres tsquery syntax, an AND search uses '&' between terms
-      // e.g.: apple & banana
-      val tsQuery = words.mkString(" & ")
-
-      // Build the raw SQL string for Postgres FTS
-      // e.g.: to_tsvector('english', COALESCE(firstName, '') || ' ' || COALESCE(lastName, '')) @@ to_tsquery('english', 'apple & banana')
-      val conditionExpr =
-        s"to_tsvector('english', $combinedFields) @@ to_tsquery('english', '$tsQuery')"
-
-      // 'condition(...)' is presumably your helper method that takes a raw SQL string
-      // and an optional binding for debug/logging
-      acc.and(condition(conditionExpr, keyword))
+    // If no keywords, skip fulltext search
+    if (trimmedKeywords.isEmpty){
+      return noCondition()
     }
+    // Concatenate the fields into a single expression.
+    val combinedFields = fields
+      .map(f => s"COALESCE($f, '')") // convert null values to empty string
+      .mkString(" || ' ' || ")
+    // Combine all keywords (AND) into a single PGroonga
+    // fuzzy search condition with a fixed threshold
+    val fuzzySearchCondition =
+      s"($combinedFields) &@~ pgroonga_condition('${trimmedKeywords.mkString(" ")}', fuzzy_max_distance_ratio => 0.34)"
+    // Return the condition
+    condition(fuzzySearchCondition, trimmedKeywords.mkString(" "))
   }
 
   /**

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/FulltextSearchQueryUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/FulltextSearchQueryUtils.scala
@@ -11,17 +11,17 @@ import scala.jdk.CollectionConverters.CollectionHasAsScala
 object FulltextSearchQueryUtils {
 
   def getFullTextSearchFilter(
-                               keywords: Seq[String],
-                               fields: List[Field[String]]
-                             ): Condition = {
+      keywords: Seq[String],
+      fields: List[Field[String]]
+  ): Condition = {
     // If no target columns, skip fulltext search
-    if (fields.isEmpty){
+    if (fields.isEmpty) {
       return noCondition()
     }
     // Filter out empty keywords and trim
     val trimmedKeywords = keywords.filter(_.nonEmpty).map(_.trim)
     // If no keywords, skip fulltext search
-    if (trimmedKeywords.isEmpty){
+    if (trimmedKeywords.isEmpty) {
       return noCondition()
     }
     // Concatenate the fields into a single expression.

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/file/WorkflowResourceSpec.scala
@@ -124,7 +124,7 @@ class WorkflowResourceSpec
 
   override protected def beforeAll(): Unit = {
     initializeDBAndReplaceDSLContext()
-
+    FulltextSearchQueryUtils.usePgroonga = false // disable pgroonga
     // add test user directly
     val userDao = new UserDao(getDSLContext.configuration())
     userDao.insert(testUser)

--- a/core/dao/src/test/scala/edu/uci/ics/texera/dao/MockTexeraDB.scala
+++ b/core/dao/src/test/scala/edu/uci/ics/texera/dao/MockTexeraDB.scala
@@ -80,7 +80,62 @@ trait MockTexeraDB {
         .mkString("\n")
     executeScriptInJDBC(embedded.getPostgresDatabase.getConnection, removeCCommands(parts(0)))
     val texeraDB = embedded.getDatabase(username, database)
-    executeScriptInJDBC(texeraDB.getConnection, removeCCommands(parts(1)))
+    val tablesAndIndexCreation = removeCCommands(parts(1))
+
+    // remove indexes creation for pgroonga because we cannot install the plugin
+    val blockPattern = """(?s)
+                         |-- START Fulltext search index creation \(DO NOT EDIT THIS LINE\)
+                         |.*?
+                         |-- END Fulltext search index creation \(DO NOT EDIT THIS LINE\)\n?
+                         |""".stripMargin.r
+    // replace with native fulltext indexes
+    val replacementText =
+      """CREATE INDEX idx_workflow_name_description_content
+        |    ON workflow
+        |    USING GIN (
+        |    to_tsvector('english',
+        |    COALESCE(name, '') || ' ' ||
+        |    COALESCE(description, '') || ' ' ||
+        |    COALESCE(content, '')
+        |    )
+        |    );
+        |
+        |CREATE INDEX idx_user_name
+        |    ON "user"
+        |    USING GIN (
+        |    to_tsvector('english',
+        |    COALESCE(name, '')
+        |    )
+        |    );
+        |
+        |CREATE INDEX idx_user_project_name_description
+        |    ON project
+        |    USING GIN (
+        |    to_tsvector('english',
+        |    COALESCE(name, '') || ' ' ||
+        |    COALESCE(description, '')
+        |    )
+        |    );
+        |
+        |CREATE INDEX idx_dataset_name_description
+        |    ON dataset
+        |    USING GIN (
+        |    to_tsvector('english',
+        |    COALESCE(name, '') || ' ' ||
+        |    COALESCE(description, '')
+        |    )
+        |    );
+        |
+        |CREATE INDEX idx_dataset_version_name
+        |    ON dataset_version
+        |    USING GIN (
+        |    to_tsvector('english',
+        |    COALESCE(name, '')
+        |    )
+        |    );""".stripMargin
+
+    blockPattern.replaceAllIn(tablesAndIndexCreation, replacementText).trim
+    executeScriptInJDBC(texeraDB.getConnection, tablesAndIndexCreation)
 
     SqlServer.initConnection(embedded.getJdbcUrl(username, database), username, password)
     val sqlServerInstance = SqlServer.getInstance()

--- a/core/scripts/sql/texera_ddl.sql
+++ b/core/scripts/sql/texera_ddl.sql
@@ -301,7 +301,7 @@ CREATE TABLE IF NOT EXISTS dataset_view_count
     FOREIGN KEY (did) REFERENCES dataset(did) ON DELETE CASCADE
     );
 
--- Fulltext search indexes
+-- START Fulltext search index creation (DO NOT EDIT THIS LINE)
 CREATE EXTENSION IF NOT EXISTS pgroonga;
 
 DO $$
@@ -319,7 +319,7 @@ WHERE (indexdef ILIKE '%USING gin%' OR indexdef ILIKE '%USING pgroonga%')
     EXECUTE format('DROP INDEX IF EXISTS %I;', r.indexname);
 END LOOP;
 
-  -- Retrieve PGroonga schema as JSONB
+-- Retrieve PGroonga schema as JSONB
 SELECT (pgroonga_command('schema'::TEXT))::JSONB INTO schema_json;
 
 -- Check if TokenFilterStem exists in the "token_filters" section
@@ -353,3 +353,5 @@ FROM (VALUES ('workflow'), ('user'), ('project'), ('dataset'), ('dataset_version
     );
 END LOOP;
 END $$;
+
+-- END Fulltext search index creation (DO NOT EDIT THIS LINE)

--- a/core/scripts/sql/texera_ddl.sql
+++ b/core/scripts/sql/texera_ddl.sql
@@ -301,52 +301,55 @@ CREATE TABLE IF NOT EXISTS dataset_view_count
     FOREIGN KEY (did) REFERENCES dataset(did) ON DELETE CASCADE
     );
 
--- ============================================
--- 6. Approximate FULLTEXT indexes with GIN
---    to mirror MySQL FULLTEXT
--- ============================================
--- (Requires "pg_trgm" extension for more advanced usage.)
+-- Fulltext search indexes
+CREATE EXTENSION IF NOT EXISTS pgroonga;
 
-CREATE INDEX idx_workflow_name_description_content
-    ON workflow
-    USING GIN (
-    to_tsvector('english',
-    COALESCE(name, '') || ' ' ||
-    COALESCE(description, '') || ' ' ||
-    COALESCE(content, '')
-    )
-    );
+DO $$
+DECLARE
+r RECORD;
+  schema_json JSONB;
+  stem_filter TEXT := '';
+BEGIN
+  -- Drop all GIN and PGroonga indexes
+FOR r IN
+SELECT indexname FROM pg_indexes
+WHERE (indexdef ILIKE '%USING gin%' OR indexdef ILIKE '%USING pgroonga%')
+  AND tablename IN ('workflow', 'user', 'project', 'dataset', 'dataset_version')
+    LOOP
+    EXECUTE format('DROP INDEX IF EXISTS %I;', r.indexname);
+END LOOP;
 
-CREATE INDEX idx_user_name
-    ON "user"
-    USING GIN (
-    to_tsvector('english',
-    COALESCE(name, '')
-    )
-    );
+  -- Retrieve PGroonga schema as JSONB
+SELECT (pgroonga_command('schema'::TEXT))::JSONB INTO schema_json;
 
-CREATE INDEX idx_user_project_name_description
-    ON project
-    USING GIN (
-    to_tsvector('english',
-    COALESCE(name, '') || ' ' ||
-    COALESCE(description, '')
-    )
-    );
+-- Check if TokenFilterStem exists in the "token_filters" section
+IF EXISTS (
+    SELECT 1 FROM jsonb_each(schema_json->'token_filters')
+    WHERE key = 'TokenFilterStem'
+  ) THEN
+    stem_filter := ', plugins=''token_filters/stem'', token_filters=''TokenFilterStem''';
+    RAISE NOTICE 'Using TokenMecab + TokenFilterStem';
+ELSE
+    RAISE NOTICE 'Using TokenMecab only';
+END IF;
 
-CREATE INDEX idx_dataset_name_description
-    ON dataset
-    USING GIN (
-    to_tsvector('english',
-    COALESCE(name, '') || ' ' ||
-    COALESCE(description, '')
-    )
+  -- Create PGroonga indexes dynamically with correct TokenFilterStem usage
+FOR r IN
+SELECT tablename,
+       CASE
+           WHEN tablename = 'workflow' THEN
+               '(COALESCE(name, '''') || '' '' || COALESCE(description, '''') || '' '' || COALESCE(content, ''''))'
+           WHEN tablename IN ('project', 'dataset') THEN
+               '(COALESCE(name, '''') || '' '' || COALESCE(description, ''''))'
+           ELSE
+               'COALESCE(name, '''')'
+           END AS index_column
+FROM (VALUES ('workflow'), ('user'), ('project'), ('dataset'), ('dataset_version')) AS t(tablename)
+    LOOP
+    -- Create PGroonga index with proper TokenFilterStem usage
+    EXECUTE format(
+      'CREATE INDEX idx_%s_pgroonga ON %I USING pgroonga (%s) WITH (tokenizer = ''TokenMecab''%s);',
+      r.tablename, r.tablename, r.index_column, stem_filter
     );
-
-CREATE INDEX idx_dataset_version_name
-    ON dataset_version
-    USING GIN (
-    to_tsvector('english',
-    COALESCE(name, '')
-    )
-    );
+END LOOP;
+END $$;

--- a/core/scripts/sql/updates/02.sql
+++ b/core/scripts/sql/updates/02.sql
@@ -1,0 +1,56 @@
+\c texera_db;
+
+set search_path to texera_db, public;
+
+CREATE EXTENSION IF NOT EXISTS pgroonga;
+
+DO $$
+DECLARE
+r RECORD;
+  schema_json JSONB;
+  stem_filter TEXT := '';
+BEGIN
+  -- Drop all GIN and PGroonga indexes
+FOR r IN
+SELECT indexname FROM pg_indexes
+WHERE (indexdef ILIKE '%USING gin%' OR indexdef ILIKE '%USING pgroonga%')
+  AND tablename IN ('workflow', 'user', 'project', 'dataset', 'dataset_version')
+    LOOP
+    EXECUTE format('DROP INDEX IF EXISTS %I;', r.indexname);
+END LOOP;
+
+  -- Retrieve PGroonga schema as JSONB
+SELECT (pgroonga_command('schema'::TEXT))::JSONB INTO schema_json;
+
+-- Check if TokenFilterStem exists in the "token_filters" section
+IF EXISTS (
+    SELECT 1 FROM jsonb_each(schema_json->'token_filters')
+    WHERE key = 'TokenFilterStem'
+  ) THEN
+    stem_filter := ', plugins=''token_filters/stem'', token_filters=''TokenFilterStem''';
+    RAISE NOTICE 'Using TokenMecab + TokenFilterStem';
+ELSE
+    RAISE NOTICE 'Using TokenMecab only';
+END IF;
+
+  -- Create PGroonga indexes dynamically with correct TokenFilterStem usage
+FOR r IN
+SELECT tablename,
+       CASE
+           WHEN tablename = 'workflow' THEN
+               '(COALESCE(name, '''') || '' '' || COALESCE(description, '''') || '' '' || COALESCE(content, ''''))'
+           WHEN tablename IN ('project', 'dataset') THEN
+               '(COALESCE(name, '''') || '' '' || COALESCE(description, ''''))'
+           ELSE
+               'COALESCE(name, '''')'
+           END AS index_column
+FROM (VALUES ('workflow'), ('user'), ('project'), ('dataset'), ('dataset_version')) AS t(tablename)
+    LOOP
+    -- Create PGroonga index with proper TokenFilterStem usage
+    EXECUTE format(
+      'CREATE INDEX idx_%s_pgroonga ON %I USING pgroonga (%s) WITH (tokenizer = ''TokenMecab''%s);',
+      r.tablename, r.tablename, r.index_column, stem_filter
+    );
+END LOOP;
+END $$;
+

--- a/core/workflow-core/src/main/resources/storage-config.yaml
+++ b/core/workflow-core/src/main/resources/storage-config.yaml
@@ -27,6 +27,6 @@ storage:
           min-wait-ms: 100   # 0.1s
           max-wait-ms: 10000 # 10s
   jdbc:
-    url: "jdbc:postgresql://localhost:5432/texera_db"
+    url: "jdbc:postgresql://localhost:5432/texera_db?currentSchema=texera_db,public"
     username: "postgres"
     password: ""


### PR DESCRIPTION
## Main Changes
We plan to use `Pgroonga` in our postgres database to enhance the full-text search functionality. This PR includes:
1. Dropping the old GIN full-text indexes and creating Pgroonga full-text indexes.
2. Using Pgroonga syntax for the full-text search in the JOOQ query.
3. Updates to the main ddl file to reflect the index changes.
4. Add `schema=texera_db,public` to the connection URL so that JDBC can see Pgroonga by default.

**Note: Since our tests use an embedded PostgreSQL database, we cannot install Pgroonga for testing. As a workaround, we fall back to GIN indexes in the test environment and only check other parts of the search functionality.**

## Pgroonga
Pgroonga is a fast and user-friendly PostgreSQL plugin that enhances full-text search, particularly for Asian languages like Japanese and Chinese. It utilizes MeCab as its tokenizer. Here’s a summary of its capabilities:

1. Tokenization:
    - Japanese: **Very good**
    - Chinese: **Good**
    - Korean: **Poor** (tokenized by spaces)
2. Fuzzy search: Supported and easy to enable.
3. Synonym search: Requires manual dictionary import. Thus we don't do it for now.
4. Stemming: Not supported on macOS but can be enabled on Ubuntu.

We previously evaluated this plugin in detail. For more information, see #1965.

## Migration Guide

1. Install [Pgroonga](https://pgroonga.github.io/install/) on your local dev enviorment. If you are using mac, you can use `brew install pgroonga`.
2. Use `psql` to apply `core/scripts/sql/updates/02.sql` to create pgroonga full-text index.

**Important:**
The PostgreSQL query planner may not automatically use the full-text index if the table is small, which can degrade search quality. To enforce index usage, I inserted 1,000 dummy records into the workflow table.