### PR TITLE
avoid specifying scala version for lib dependencies

### DIFF
--- a/core/workflow-operator/build.sbt
+++ b/core/workflow-operator/build.sbt
@@ -78,7 +78,7 @@ libraryDependencies ++= Seq(
   "joda-time" % "joda-time" % "2.12.5" % "test",
   "com.fasterxml.jackson.datatype" % "jackson-datatype-joda" % jacksonVersion % "test",
   "com.fasterxml.jackson.module" % "jackson-module-jsonSchema" % jacksonVersion,
-  "com.fasterxml.jackson.module" % "jackson-module-scala_2.13" % jacksonVersion,
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % jacksonVersion,
   // https://mvnrepository.com/artifact/com.fasterxml.jackson.module/jackson-module-no-ctor-deser
   "com.fasterxml.jackson.module" % "jackson-module-no-ctor-deser" % jacksonVersion,
 )


### PR DESCRIPTION
The `%%` operator can be used in to sbt to avoid suffixing the scala version into lib names.