### PR TITLE
Replace Apache Commons Compress with JDK Built-in Zip

### DIFF
--- a/core/build.sbt
+++ b/core/build.sbt
@@ -7,7 +7,7 @@ lazy val WorkflowOperator = (project in file("workflow-operator"))
   .dependsOn(WorkflowCore)
   .settings(
     dependencyOverrides ++= Seq(
-      "org.apache.commons" % "commons-compress" % "1.23.0", // because of the dependency introduced by iceberg
+      "org.apache.commons" % "commons-compress" % "1.27.1", // because of the dependency introduced by iceberg
     )
   )
 lazy val WorkflowCompilingService = (project in file("workflow-compiling-service"))

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -3,13 +3,7 @@ lazy val WorkflowCore = (project in file("workflow-core"))
   .dependsOn(DAO)
   .configs(Test)
   .dependsOn(DAO % "test->test") // test scope dependency
-lazy val WorkflowOperator = (project in file("workflow-operator"))
-  .dependsOn(WorkflowCore)
-  .settings(
-    dependencyOverrides ++= Seq(
-      "org.apache.commons" % "commons-compress" % "1.27.1", // because of the dependency introduced by iceberg
-    )
-  )
+lazy val WorkflowOperator = (project in file("workflow-operator")).dependsOn(WorkflowCore)
 lazy val WorkflowCompilingService = (project in file("workflow-compiling-service"))
   .dependsOn(WorkflowOperator)
   .settings(

--- a/core/workflow-operator/build.sbt
+++ b/core/workflow-operator/build.sbt
@@ -92,7 +92,7 @@ libraryDependencies ++= Seq(
   "com.github.tototoshi" %% "scala-csv" % "1.3.10",       // csv parser
   "com.konghq" % "unirest-java" % "3.14.2",
   "commons-io" % "commons-io" % "2.15.1",
-  "org.apache.commons" % "commons-compress" % "1.23.0",
+  "org.apache.commons" % "commons-compress" % "1.27.1",
   "org.tukaani" % "xz" % "1.9",
   "com.univocity" % "univocity-parsers" % "2.9.1",
   "edu.stanford.nlp" % "stanford-corenlp" % "4.5.4",

--- a/core/workflow-operator/build.sbt
+++ b/core/workflow-operator/build.sbt
@@ -92,7 +92,6 @@ libraryDependencies ++= Seq(
   "com.github.tototoshi" %% "scala-csv" % "1.3.10",       // csv parser
   "com.konghq" % "unirest-java" % "3.14.2",
   "commons-io" % "commons-io" % "2.15.1",
-  "org.apache.commons" % "commons-compress" % "1.27.1",
   "org.tukaani" % "xz" % "1.9",
   "com.univocity" % "univocity-parsers" % "2.9.1",
   "edu.stanford.nlp" % "stanford-corenlp" % "4.5.4",

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/source/scan/FileScanSourceOpExec.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/source/scan/FileScanSourceOpExec.scala
@@ -5,11 +5,10 @@ import edu.uci.ics.amber.core.storage.DocumentFactory
 import edu.uci.ics.amber.core.tuple.AttributeTypeUtils.parseField
 import edu.uci.ics.amber.core.tuple.TupleLike
 import edu.uci.ics.amber.util.JSONUtils.objectMapper
-import org.apache.commons.compress.archivers.{ArchiveInputStream, ArchiveStreamFactory}
 import org.apache.commons.io.IOUtils.toByteArray
-
 import java.io._
 import java.net.URI
+import java.util.zip.ZipInputStream
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 
@@ -25,9 +24,7 @@ class FileScanSourceOpExec private[scan] (
     val fileEntries: Iterator[InputStream] = {
       val is = DocumentFactory.openReadonlyDocument(new URI(desc.fileName.get)).asInputStream()
       if (desc.extract) {
-        val inputStream: ArchiveInputStream = new ArchiveStreamFactory().createArchiveInputStream(
-          new BufferedInputStream(is)
-        )
+        val inputStream = new ZipInputStream(new BufferedInputStream(is))
         val (it1, it2) = Iterator
           .continually(inputStream.getNextEntry)
           .takeWhile(_ != null)


### PR DESCRIPTION
Replace Apache Commons Compress because the current version is affected by multiple CVEs, and the latest version has API changes and limitations. The built-in JDK Zip library is sufficient for our needs.