### PR TITLE
Replace psycopg2 with pg8000

### DIFF
--- a/core/amber/requirements.txt
+++ b/core/amber/requirements.txt
@@ -31,5 +31,5 @@ pyiceberg==0.8.1
 readerwriterlock==1.0.9
 tenacity==8.5.0
 SQLAlchemy==2.0.37
-psycopg2==2.9.10
+pg8000==1.31.2
 pympler==1.1

--- a/core/amber/src/main/python/core/storage/iceberg/iceberg_utils.py
+++ b/core/amber/src/main/python/core/storage/iceberg/iceberg_utils.py
@@ -36,7 +36,7 @@ def create_postgres_catalog(
     return SqlCatalog(
         catalog_name,
         **{
-            "uri": f"postgresql+psycopg2://{username}:{password}@{uri_without_scheme}",
+            "uri": f"postgresql+pg8000://{username}:{password}@{uri_without_scheme}",
             "warehouse": f"file://{warehouse_path}",
         },
     )


### PR DESCRIPTION
This PR replaces the psycopg2 dependency (LGPL license) using pg8000 (BSD3 license).