### PR TITLE
Fix lambda serialization for remote actors

### DIFF
--- a/core/amber/build.sbt
+++ b/core/amber/build.sbt
@@ -218,7 +218,8 @@ libraryDependencies += "org.jooq" % "jooq" % "3.14.16"
 // https://mvnrepository.com/artifact/org.jgrapht/jgrapht-core
 libraryDependencies += "org.jgrapht" % "jgrapht-core" % "1.4.0"
 
-libraryDependencies += "io.altoo" %% "akka-kryo-serialization" % "2.5.0"
+// https://mvnrepository.com/artifact/io.altoo/akka-kryo-serialization
+libraryDependencies += "io.altoo" %% "akka-kryo-serialization" % "2.5.2"
 
 // https://mvnrepository.com/artifact/com.twitter/util-core
 libraryDependencies += "com.twitter" %% "util-core" % "22.12.0"

--- a/core/amber/src/main/resources/cluster.conf
+++ b/core/amber/src/main/resources/cluster.conf
@@ -58,3 +58,5 @@ akka {
         }
     }
 }
+
+akka-kryo-serialization.kryo-initializer = "edu.uci.ics.amber.engine.common.AmberKryoInitializer"

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberKryoInitializer.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberKryoInitializer.scala
@@ -1,0 +1,16 @@
+package edu.uci.ics.amber.engine.common
+
+import akka.actor.ExtendedActorSystem
+import com.esotericsoftware.kryo.serializers.ClosureSerializer
+import com.esotericsoftware.kryo.serializers.ClosureSerializer.Closure
+import io.altoo.akka.serialization.kryo.DefaultKryoInitializer
+import io.altoo.akka.serialization.kryo.serializer.scala.ScalaKryo
+
+import java.lang.invoke.SerializedLambda
+
+class AmberKryoInitializer extends DefaultKryoInitializer {
+  override def preInit(kryo: ScalaKryo, system: ExtendedActorSystem): Unit = {
+    kryo.register(classOf[SerializedLambda])
+    kryo.register(classOf[Closure], new ClosureSerializer())
+  }
+}

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberRuntime.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberRuntime.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration.FiniteDuration
 
 object AmberRuntime {
 
-  var serde: Serialization = _
+  @volatile var serde: Serialization = _
   private var _actorSystem: ActorSystem = _
 
   def actorSystem: ActorSystem = {

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberRuntime.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberRuntime.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration.FiniteDuration
 
 object AmberRuntime {
 
-  @volatile var serde: Serialization = _
+  var serde: Serialization = _
   private var _actorSystem: ActorSystem = _
 
   def actorSystem: ActorSystem = {

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/faulttolerance/LoggingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/faulttolerance/LoggingSpec.scala
@@ -4,6 +4,13 @@ import akka.actor.ActorSystem
 import akka.serialization.SerializationExtension
 import akka.testkit.{ImplicitSender, TestKit}
 import edu.uci.ics.amber.core.tuple.{AttributeType, Schema, TupleLike}
+import edu.uci.ics.amber.core.virtualidentity.{
+  ActorVirtualIdentity,
+  ChannelIdentity,
+  OperatorIdentity,
+  PhysicalOpIdentity
+}
+import edu.uci.ics.amber.core.workflow.{PhysicalLink, PortIdentity}
 import edu.uci.ics.amber.engine.architecture.logreplay.{ReplayLogManager, ReplayLogRecord}
 import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.{
   AddPartitioningRequest,
@@ -18,6 +25,7 @@ import edu.uci.ics.amber.engine.architecture.rpc.workerservice.WorkerServiceGrpc
   METHOD_START_WORKER
 }
 import edu.uci.ics.amber.engine.architecture.sendsemantics.partitionings.OneToOnePartitioning
+import edu.uci.ics.amber.engine.common.AmberRuntime
 import edu.uci.ics.amber.engine.common.ambermessage.{
   DataFrame,
   WorkflowFIFOMessage,
@@ -26,16 +34,8 @@ import edu.uci.ics.amber.engine.common.ambermessage.{
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
 import edu.uci.ics.amber.engine.common.storage.SequentialRecordStorage
 import edu.uci.ics.amber.engine.common.virtualidentity.util.{CONTROLLER, SELF}
-import edu.uci.ics.amber.core.virtualidentity.{
-  ActorVirtualIdentity,
-  ChannelIdentity,
-  OperatorIdentity,
-  PhysicalOpIdentity
-}
-import edu.uci.ics.amber.core.workflow.{PhysicalLink, PortIdentity}
-import edu.uci.ics.amber.engine.common.AmberRuntime
 import org.scalatest.BeforeAndAfterAll
-import org.scalatest.concurrent.AsyncTimeLimitedTests
+import org.scalatest.concurrent.TimeLimitedTests
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.time.Span
 import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
@@ -47,7 +47,7 @@ class LoggingSpec
     with ImplicitSender
     with AnyFlatSpecLike
     with BeforeAndAfterAll
-    with AsyncTimeLimitedTests {
+    with TimeLimitedTests {
 
   override def beforeAll(): Unit = {
     AmberRuntime.serde = SerializationExtension(system)

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/faulttolerance/LoggingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/faulttolerance/LoggingSpec.scala
@@ -5,15 +5,33 @@ import akka.serialization.SerializationExtension
 import akka.testkit.{ImplicitSender, TestKit}
 import edu.uci.ics.amber.core.tuple.{AttributeType, Schema, TupleLike}
 import edu.uci.ics.amber.engine.architecture.logreplay.{ReplayLogManager, ReplayLogRecord}
-import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.{AddPartitioningRequest, AsyncRPCContext, EmptyRequest}
+import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.{
+  AddPartitioningRequest,
+  AsyncRPCContext,
+  EmptyRequest
+}
 import edu.uci.ics.amber.engine.architecture.rpc.controllerservice.ControllerServiceGrpc.METHOD_WORKER_EXECUTION_COMPLETED
-import edu.uci.ics.amber.engine.architecture.rpc.workerservice.WorkerServiceGrpc.{METHOD_ADD_PARTITIONING, METHOD_PAUSE_WORKER, METHOD_RESUME_WORKER, METHOD_START_WORKER}
+import edu.uci.ics.amber.engine.architecture.rpc.workerservice.WorkerServiceGrpc.{
+  METHOD_ADD_PARTITIONING,
+  METHOD_PAUSE_WORKER,
+  METHOD_RESUME_WORKER,
+  METHOD_START_WORKER
+}
 import edu.uci.ics.amber.engine.architecture.sendsemantics.partitionings.OneToOnePartitioning
-import edu.uci.ics.amber.engine.common.ambermessage.{DataFrame, WorkflowFIFOMessage, WorkflowFIFOMessagePayload}
+import edu.uci.ics.amber.engine.common.ambermessage.{
+  DataFrame,
+  WorkflowFIFOMessage,
+  WorkflowFIFOMessagePayload
+}
 import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
 import edu.uci.ics.amber.engine.common.storage.SequentialRecordStorage
 import edu.uci.ics.amber.engine.common.virtualidentity.util.{CONTROLLER, SELF}
-import edu.uci.ics.amber.core.virtualidentity.{ActorVirtualIdentity, ChannelIdentity, OperatorIdentity, PhysicalOpIdentity}
+import edu.uci.ics.amber.core.virtualidentity.{
+  ActorVirtualIdentity,
+  ChannelIdentity,
+  OperatorIdentity,
+  PhysicalOpIdentity
+}
 import edu.uci.ics.amber.core.workflow.{PhysicalLink, PortIdentity}
 import edu.uci.ics.amber.engine.common.AmberRuntime
 import org.scalatest.BeforeAndAfterAll
@@ -28,7 +46,8 @@ class LoggingSpec
     extends TestKit(ActorSystem("LoggingSpec", AmberRuntime.akkaConfig))
     with ImplicitSender
     with AnyFlatSpecLike
-    with BeforeAndAfterAll with AsyncTimeLimitedTests {
+    with BeforeAndAfterAll
+    with AsyncTimeLimitedTests {
 
   override def beforeAll(): Unit = {
     AmberRuntime.serde = SerializationExtension(system)


### PR DESCRIPTION
After #3285, we replaced chill with the akka-kryo-serialization library. However, the new library does not automatically register lambdas in the serializer. As a result, remote actor creation fails because Akka sends a lambda to the remote JVM with captured worker arguments. This PR introduces a customized Kryo initializer to register lambdas and their serializer.