### PR TITLE
Fix zombie websocket sessions 

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -142,17 +142,18 @@ class WorkflowService(
   }
 
   def connectToExecution(onNext: TexeraWebSocketEvent => Unit): Disposable = {
-    var localDisposable = Disposable.empty()
-    executionService.subscribe { executionService: WorkflowExecutionService =>
-      localDisposable.dispose()
-      val subscriptions = executionService.executionStateStore.getAllStores
+    val localDisposable = new CompositeDisposable()
+    val disposable = executionService.subscribe { execService: WorkflowExecutionService =>
+      localDisposable.clear() // Clears previous subscriptions safely
+      val subscriptions = execService.executionStateStore.getAllStores
         .map(_.getWebsocketEventObservable)
         .map(evtPub =>
           evtPub.subscribe { events: Iterable[TexeraWebSocketEvent] => events.foreach(onNext) }
         )
         .toSeq
-      localDisposable = new CompositeDisposable(subscriptions: _*)
+      localDisposable.addAll(subscriptions: _*)
     }
+    new CompositeDisposable(localDisposable, disposable)
   }
 
   def disconnect(): Unit = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -153,7 +153,8 @@ class WorkflowService(
         .toSeq
       localDisposable.addAll(subscriptions: _*)
     }
-    new CompositeDisposable(localDisposable, disposable)
+    localDisposable.add(disposable)
+    localDisposable
   }
 
   def disconnect(): Unit = {


### PR DESCRIPTION
This PR resolves an issue where refreshing the workflow webpage multiple times leaves previous WebSocket sessions active in the backend. As a result, duplicate WebSocket events are sent to multiple outdated sessions, even though only the latest session is active and capable of receiving messages.

To fix this, the PR ensures proper management of subscriptions by correctly disposing of stale ones when a user reconnects, preventing event duplication.