### PR TITLE
Move Email Notification Logic to ExecutionRuntimeService

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/EmailNotificationService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/EmailNotificationService.scala
@@ -15,7 +15,7 @@ class EmailNotificationService(emailNotifier: EmailNotifier) {
   private val executorService: ExecutorService = Executors.newSingleThreadExecutor()
   private implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(executorService)
 
-  def sendEmailNotification(
+  def processEmailNotificationIfNeeded(
       workflowState: WorkflowAggregatedState
   ): Future[Unit] = {
     Future {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/EmailNotificationService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/EmailNotificationService.scala
@@ -6,7 +6,7 @@ import java.util.concurrent.{ExecutorService, Executors}
 import scala.concurrent.{ExecutionContext, Future}
 
 trait EmailNotifier {
-  def shouldSendEmail(oldState: WorkflowAggregatedState, newState: WorkflowAggregatedState): Boolean
+  def shouldSendEmail(workflowState: WorkflowAggregatedState): Boolean
 
   def sendStatusEmail(state: WorkflowAggregatedState): Unit
 }
@@ -16,12 +16,11 @@ class EmailNotificationService(emailNotifier: EmailNotifier) {
   private implicit val ec: ExecutionContext = ExecutionContext.fromExecutor(executorService)
 
   def sendEmailNotification(
-      oldState: WorkflowAggregatedState,
-      newState: WorkflowAggregatedState
+      workflowState: WorkflowAggregatedState
   ): Future[Unit] = {
     Future {
-      if (emailNotifier.shouldSendEmail(oldState, newState)) {
-        emailNotifier.sendStatusEmail(newState)
+      if (emailNotifier.shouldSendEmail(workflowState)) {
+        emailNotifier.sendStatusEmail(workflowState)
       }
     }.recover {
       case e: Exception =>

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowEmailNotifier.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowEmailNotifier.scala
@@ -25,10 +25,9 @@ class WorkflowEmailNotifier(
   )
 
   override def shouldSendEmail(
-      oldState: WorkflowAggregatedState,
-      newState: WorkflowAggregatedState
+      workflowState: WorkflowAggregatedState
   ): Boolean = {
-    oldState == RUNNING && CompletedPausedOrTerminatedStates.contains(newState)
+    CompletedPausedOrTerminatedStates.contains(workflowState)
   }
 
   override def sendStatusEmail(state: WorkflowAggregatedState): Unit = {

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowEmailNotifier.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowEmailNotifier.scala
@@ -1,5 +1,6 @@
 package edu.uci.ics.texera.web.service
 
+import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState
 import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState._
 import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowResource
@@ -14,25 +15,24 @@ class WorkflowEmailNotifier(
     workflowId: Long,
     userEmail: String,
     sessionUri: URI
-) extends EmailNotifier {
+) extends EmailNotifier
+    with LazyLogging {
   private val workflowName = WorkflowResource.getWorkflowName(workflowId.toInt)
   private val emailValidator = new EmailValidator()
-  private val CompletedPausedOrTerminatedStates: Set[WorkflowAggregatedState] = Set(
+
+  private val TerminalStates: Set[WorkflowAggregatedState] = Set(
     COMPLETED,
     PAUSED,
     FAILED,
     KILLED
   )
 
-  override def shouldSendEmail(
-      workflowState: WorkflowAggregatedState
-  ): Boolean = {
-    CompletedPausedOrTerminatedStates.contains(workflowState)
-  }
+  override def shouldSendEmail(workflowState: WorkflowAggregatedState): Boolean =
+    TerminalStates.contains(workflowState)
 
   override def sendStatusEmail(state: WorkflowAggregatedState): Unit = {
     if (!isValidEmail(userEmail)) {
-      println(s"Invalid email address: $userEmail")
+      logger.warn(s"Invalid email address: $userEmail")
       return
     }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
@@ -20,7 +20,7 @@ import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowExecution
 import edu.uci.ics.texera.web.storage.ExecutionStateStore
 import edu.uci.ics.texera.web.storage.ExecutionStateStore.updateWorkflowState
 import edu.uci.ics.texera.web.{ComputingUnitMaster, SubscriptionManager, WebsocketInput}
-import edu.uci.ics.texera.workflow.{LogicalPlan, WorkflowCompiler}
+import edu.uci.ics.texera.workflow.WorkflowCompiler
 
 import java.net.URI
 import scala.collection.mutable

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowExecutionService.scala
@@ -43,7 +43,6 @@ class WorkflowExecutionService(
     request: WorkflowExecuteRequest,
     val executionStateStore: ExecutionStateStore,
     errorHandler: Throwable => Unit,
-    lastCompletedLogicalPlan: Option[LogicalPlan],
     userEmailOpt: Option[String],
     sessionUri: URI
 ) extends SubscriptionManager
@@ -52,26 +51,12 @@ class WorkflowExecutionService(
   workflowContext.workflowSettings = request.workflowSettings
   val wsInput = new WebsocketInput(errorHandler)
 
-  private val emailNotificationService = userEmailOpt.map(email =>
-    new EmailNotificationService(
-      new WorkflowEmailNotifier(
-        workflowContext.workflowId.id,
-        email,
-        sessionUri
-      )
-    )
-  )
-
   addSubscription(
     executionStateStore.metadataStore.registerDiffHandler((oldState, newState) => {
       val outputEvents = new mutable.ArrayBuffer[TexeraWebSocketEvent]()
 
       if (newState.state != oldState.state || newState.isRecovering != oldState.isRecovering) {
         outputEvents.append(createStateEvent(newState))
-
-        if (request.emailNotificationEnabled && emailNotificationService.nonEmpty) {
-          emailNotificationService.get.sendEmailNotification(oldState.state, newState.state)
-        }
       }
 
       if (newState.fatalErrors != oldState.fatalErrors) {
@@ -123,7 +108,11 @@ class WorkflowExecutionService(
       executionStateStore,
       wsInput,
       executionReconfigurationService,
-      controllerConfig.faultToleranceConfOpt
+      controllerConfig.faultToleranceConfOpt,
+      workflowContext.workflowId.id,
+      request.emailNotificationEnabled,
+      userEmailOpt,
+      sessionUri
     )
     executionConsoleService =
       new ExecutionConsoleService(client, executionStateStore, wsInput, workflowContext)
@@ -167,9 +156,6 @@ class WorkflowExecutionService(
       executionConsoleService.unsubscribeAll()
       executionStatsService.unsubscribeAll()
       executionReconfigurationService.unsubscribeAll()
-    }
-    if (emailNotificationService.nonEmpty) {
-      emailNotificationService.get.shutdown()
     }
 
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/WorkflowService.scala
@@ -274,7 +274,6 @@ class WorkflowService(
         req,
         executionStateStore,
         errorHandler,
-        lastCompletedLogicalPlan,
         userEmailOpt,
         sessionUri
       )


### PR DESCRIPTION
This PR moves the email notification logic by moving it to the ExecutionRuntimeService. This change ensures that when multiple users access the same workspace, the email notification is sent only once, preventing redundant notifications.


https://github.com/user-attachments/assets/7347ad06-734f-475f-a7b4-2252ca8bd825

