### PR TITLE
Fix the postgres container health check command in the docker-compose file under the `file-service`

### DIFF
--- a/core/file-service/src/main/resources/docker-compose.yml
+++ b/core/file-service/src/main/resources/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - POSTGRES_USER=texera_lakefs_admin
       - POSTGRES_PASSWORD=password
     healthcheck:
-      test: ["CMD", "pg_isready", "-U", "texera_lakefs_admin"]
+      test: ["CMD", "pg_isready", "-U", "texera_lakefs_admin", "-d", "texera_lakefs"]
       interval: 10s
       retries: 5
       start_period: 5s


### PR DESCRIPTION
This PR corrects the health check command of the lakefs's postgres container specified in `core/file-service/src/main/resources/docker-compose.yml`.