### PR TITLE
Bring back the dataset size calculation and display

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DatasetSearchQueryBuilder.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DatasetSearchQueryBuilder.scala
@@ -1,5 +1,6 @@
 package edu.uci.ics.texera.web.resource.dashboard
 
+import edu.uci.ics.amber.core.storage.util.LakeFSStorageClient
 import edu.uci.ics.texera.dao.jooq.generated.Tables.{DATASET, DATASET_USER_ACCESS}
 import edu.uci.ics.texera.dao.jooq.generated.enums.PrivilegeEnum
 import edu.uci.ics.texera.dao.jooq.generated.tables.User.USER
@@ -12,7 +13,6 @@ import edu.uci.ics.texera.web.resource.dashboard.FulltextSearchQueryUtils.{
 }
 import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetResource.DashboardDataset
 import org.jooq.impl.DSL
-
 import org.jooq.{Condition, GroupField, Record, TableLike}
 
 import scala.jdk.CollectionConverters.CollectionHasAsScala
@@ -108,7 +108,8 @@ object DatasetSearchQueryBuilder extends SearchQueryBuilder {
           DATASET_USER_ACCESS.PRIVILEGE,
           classOf[PrivilegeEnum]
         ),
-      dataset.getOwnerUid == uid
+      dataset.getOwnerUid == uid,
+      LakeFSStorageClient.retrieveRepositorySize(dataset.getName)
     )
     DashboardClickableFileEntry(
       resourceType = SearchQueryBuilder.DATASET_RESOURCE_TYPE,

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/hub/HubResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/hub/HubResource.scala
@@ -26,6 +26,7 @@ import javax.ws.rs._
 import javax.ws.rs.core.{Context, MediaType}
 import scala.jdk.CollectionConverters._
 import EntityTables._
+import edu.uci.ics.amber.core.storage.util.LakeFSStorageClient
 import edu.uci.ics.texera.dao.jooq.generated.tables.Dataset.DATASET
 import edu.uci.ics.texera.dao.jooq.generated.tables.DatasetUserAccess.DATASET_USER_ACCESS
 import edu.uci.ics.texera.dao.jooq.generated.tables.User.USER
@@ -292,7 +293,8 @@ object HubResource {
         isOwner = if (uid == null) false else dataset.getOwnerUid == uid,
         dataset = dataset,
         accessPrivilege = datasetAccess.getPrivilege,
-        ownerEmail = ownerEmail
+        ownerEmail = ownerEmail,
+        size = LakeFSStorageClient.retrieveRepositorySize(dataset.getName)
       )
     }.toList
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/dataset/DatasetResource.scala
@@ -10,6 +10,7 @@ object DatasetResource {
       dataset: Dataset,
       ownerEmail: String,
       accessPrivilege: EnumType,
-      isOwner: Boolean
+      isOwner: Boolean,
+      size: Long
   )
 }

--- a/core/file-service/src/main/scala/edu/uci/ics/texera/service/resource/DatasetResource.scala
+++ b/core/file-service/src/main/scala/edu/uci/ics/texera/service/resource/DatasetResource.scala
@@ -773,7 +773,7 @@ class DatasetResource {
             dataset = dataset,
             accessPrivilege = PrivilegeEnum.READ,
             ownerEmail = ownerEmail,
-            size = LakeFSStorageClient.retrieveRepositorySize(dataset.getName),
+            size = LakeFSStorageClient.retrieveRepositorySize(dataset.getName)
           )
         })
       publicDatasets.forEach { publicDataset =>

--- a/core/file-service/src/main/scala/edu/uci/ics/texera/service/resource/DatasetResource.scala
+++ b/core/file-service/src/main/scala/edu/uci/ics/texera/service/resource/DatasetResource.scala
@@ -109,7 +109,8 @@ object DatasetResource {
       dataset: Dataset,
       ownerEmail: String,
       accessPrivilege: EnumType,
-      isOwner: Boolean
+      isOwner: Boolean,
+      size: Long
   )
   case class DashboardDatasetVersion(
       datasetVersion: DatasetVersion,
@@ -159,12 +160,12 @@ class DatasetResource {
     }
 
     val userAccessPrivilege = getDatasetUserAccessPrivilege(ctx, did, requesterUid.get)
-
     DashboardDataset(
       targetDataset,
       getOwner(ctx, did).getEmail,
       userAccessPrivilege,
-      targetDataset.getOwnerUid == requesterUid.get
+      targetDataset.getOwnerUid == requesterUid.get,
+      LakeFSStorageClient.retrieveRepositorySize(targetDataset.getName)
     )
   }
 
@@ -232,7 +233,8 @@ class DatasetResource {
         ),
         user.getEmail,
         PrivilegeEnum.WRITE,
-        isOwner = true
+        isOwner = true,
+        0
       )
     }
   }
@@ -746,7 +748,8 @@ class DatasetResource {
               isOwner = dataset.getOwnerUid == uid,
               dataset = dataset,
               accessPrivilege = datasetAccess.getPrivilege,
-              ownerEmail = ownerEmail
+              ownerEmail = ownerEmail,
+              size = 0
             )
           })
           .asScala
@@ -769,7 +772,8 @@ class DatasetResource {
             isOwner = false,
             dataset = dataset,
             accessPrivilege = PrivilegeEnum.READ,
-            ownerEmail = ownerEmail
+            ownerEmail = ownerEmail,
+            size = LakeFSStorageClient.retrieveRepositorySize(dataset.getName),
           )
         })
       publicDatasets.forEach { publicDataset =>
@@ -778,12 +782,12 @@ class DatasetResource {
             isOwner = false,
             dataset = publicDataset.dataset,
             ownerEmail = publicDataset.ownerEmail,
-            accessPrivilege = PrivilegeEnum.READ
+            accessPrivilege = PrivilegeEnum.READ,
+            size = LakeFSStorageClient.retrieveRepositorySize(publicDataset.dataset.getName)
           )
           accessibleDatasets = accessibleDatasets :+ dashboardDataset
         }
       }
-
       accessibleDatasets.toList
     })
   }

--- a/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
+++ b/core/gui/src/app/dashboard/component/user/list-item/list-item.component.html
@@ -116,12 +116,11 @@
       nz-col
       nzFlex="75px"
       class="resource-info">
-      <!-- Disable the Size Display as the backend API of datasets doesn't support it-->
-      <!--      <div-->
-      <!--        *ngIf="entry.type === 'dataset'"-->
-      <!--        class="resource-info">-->
-      <!--        Size: {{ formatSize(entry.size) }}-->
-      <!--      </div>-->
+      <div
+        *ngIf="entry.type === 'dataset'"
+        class="resource-info">
+        Size: {{ formatSize(entry.size) }}
+      </div>
     </div>
 
     <div

--- a/core/gui/src/app/dashboard/type/dashboard-dataset.interface.ts
+++ b/core/gui/src/app/dashboard/type/dashboard-dataset.interface.ts
@@ -6,4 +6,5 @@ export interface DashboardDataset {
   ownerEmail: string;
   dataset: Dataset;
   accessPrivilege: "READ" | "WRITE" | "NONE";
+  size: number;
 }

--- a/core/gui/src/app/dashboard/type/dashboard-entry.ts
+++ b/core/gui/src/app/dashboard/type/dashboard-entry.ts
@@ -76,7 +76,7 @@ export class DashboardEntry {
       this.ownerEmail = value.ownerEmail;
       this.ownerGoogleAvatar = "";
       this.ownerId = value.dataset.ownerUid;
-      this.size = 0; // as we switch to lakeFS dataset implementation, the size is not available anymore
+      this.size = value.size;
     } else {
       throw new Error("Unexpected type in DashboardEntry.");
     }

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/util/LakeFSStorageClient.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/util/LakeFSStorageClient.scala
@@ -258,6 +258,29 @@ object LakeFSStorageClient {
     objectsApi.listObjects(repoName, commitHash).execute().getResults.asScala.toList
   }
 
+  def retrieveRepositorySize(repoName: String, commitHash: String = ""): Long = {
+    val versionHash: String =
+      if (commitHash.isEmpty) {
+        val versionList = retrieveVersionsOfRepository(repoName)
+        if (versionList.isEmpty) {
+          ""
+        } else {
+          versionList.head.getId
+        }
+      } else {
+        commitHash
+      }
+
+    if (versionHash.isEmpty) {
+      0
+    } else {
+      LakeFSStorageClient
+        .retrieveObjectsOfVersion(repoName, versionHash)
+        .map(_.getSizeBytes.longValue())
+        .sum
+    }
+  }
+
   /**
     * Retrieves a list of uncommitted (staged) objects in a repository branch.
     *


### PR DESCRIPTION
This PR adds the functionality on the backend to calculate the size of a dataset, by:
1. call LakeFS api to get the latest version of a dataset
2. call LakeFS api to get the list of metadata of each object in this version
3. Do a sum on the size

This PR also brings the frontend dataset size display back.

<img width="1466" alt="Screenshot 2025-03-12 at 5 57 09 PM" src="https://github.com/user-attachments/assets/4543d7b6-b878-4e81-8f2d-6fde0d8bf521" />


Note that the cost of calculating the size of a dataset is 2 additional http requests. In the future we should consider optimize it.