### PR TITLE
Fix Iceberg Catalog on Window Machines

### DIFF
--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/util/IcebergUtil.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/util/IcebergUtil.scala
@@ -102,7 +102,10 @@ object IcebergUtil {
     catalog.initialize(
       catalogName,
       Map(
-        "warehouse" -> warehouse.toString.replace(":", ""), //warehouse path is C:/xxx/xxx in Windows, but PyArrow on the Python side cannot parse it. The acceptable format for PyArrow is C/xxx/xxx.
+        "warehouse" -> warehouse.toString.replace(
+          ":",
+          ""
+        ), //warehouse path is C:/xxx/xxx in Windows, but PyArrow on the Python side cannot parse it. The acceptable format for PyArrow is C/xxx/xxx.
         CatalogProperties.FILE_IO_IMPL -> classOf[HadoopFileIO].getName,
         CatalogProperties.URI -> s"jdbc:postgresql://${StorageConfig.icebergPostgresCatalogUriWithoutScheme}",
         JdbcCatalog.PROPERTY_PREFIX + "user" -> StorageConfig.icebergPostgresCatalogUsername,

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/util/IcebergUtil.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/util/IcebergUtil.scala
@@ -102,7 +102,7 @@ object IcebergUtil {
     catalog.initialize(
       catalogName,
       Map(
-        "warehouse" -> warehouse.toString.replace(":", ""),
+        "warehouse" -> warehouse.toString.replace(":", ""), //warehouse path is C:/xxx/xxx in Windows, but PyArrow on the Python side cannot parse it. The acceptable format for PyArrow is C/xxx/xxx.
         CatalogProperties.FILE_IO_IMPL -> classOf[HadoopFileIO].getName,
         CatalogProperties.URI -> s"jdbc:postgresql://${StorageConfig.icebergPostgresCatalogUriWithoutScheme}",
         JdbcCatalog.PROPERTY_PREFIX + "user" -> StorageConfig.icebergPostgresCatalogUsername,

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/util/IcebergUtil.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/util/IcebergUtil.scala
@@ -102,7 +102,7 @@ object IcebergUtil {
     catalog.initialize(
       catalogName,
       Map(
-        "warehouse" -> warehouse.toString,
+        "warehouse" -> warehouse.toString.replace(":", ""),
         CatalogProperties.FILE_IO_IMPL -> classOf[HadoopFileIO].getName,
         CatalogProperties.URI -> s"jdbc:postgresql://${StorageConfig.icebergPostgresCatalogUriWithoutScheme}",
         JdbcCatalog.PROPERTY_PREFIX + "user" -> StorageConfig.icebergPostgresCatalogUsername,
@@ -148,6 +148,7 @@ object IcebergUtil {
       PartitionSpec.unpartitioned,
       tableProperties.asJava
     )
+
   }
 
   /**


### PR DESCRIPTION
Fix the bug where the workflow throws a No storage is found for the given URI error when a Python UDF is present, and the workflow is running on a Windows machine.

The root cause is that the Java side writes the path as C:/Users/texera/core to the Iceberg Catalog in the database, but PyArrow on the Python side cannot parse it. The acceptable format for PyArrow is C/Users/texera/core.

@Xiao-zhen-Liu please test on Macos.
@bobbai00 please test on Window.