### PR TITLE
Bring back the dataset downloading feature

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/workflow/WorkflowCompiler.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/workflow/WorkflowCompiler.scala
@@ -4,8 +4,6 @@ import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.core.virtualidentity.OperatorIdentity
 import edu.uci.ics.amber.core.workflow._
 import edu.uci.ics.amber.engine.architecture.controller.Workflow
-import edu.uci.ics.amber.engine.common.AmberConfig
-import edu.uci.ics.amber.operator.SpecialPhysicalOpFactory
 import edu.uci.ics.texera.web.model.websocket.request.LogicalPlanPojo
 
 import scala.collection.mutable

--- a/core/file-service/src/main/scala/edu/uci/ics/texera/service/resource/DatasetResource.scala
+++ b/core/file-service/src/main/scala/edu/uci/ics/texera/service/resource/DatasetResource.scala
@@ -10,12 +10,38 @@ import edu.uci.ics.texera.dao.jooq.generated.tables.User.USER
 import edu.uci.ics.texera.dao.jooq.generated.tables.Dataset.DATASET
 import edu.uci.ics.texera.dao.jooq.generated.tables.DatasetUserAccess.DATASET_USER_ACCESS
 import edu.uci.ics.texera.dao.jooq.generated.tables.DatasetVersion.DATASET_VERSION
-import edu.uci.ics.texera.dao.jooq.generated.tables.daos.{DatasetDao, DatasetUserAccessDao, DatasetVersionDao}
-import edu.uci.ics.texera.dao.jooq.generated.tables.pojos.{Dataset, DatasetUserAccess, DatasetVersion}
+import edu.uci.ics.texera.dao.jooq.generated.tables.daos.{
+  DatasetDao,
+  DatasetUserAccessDao,
+  DatasetVersionDao
+}
+import edu.uci.ics.texera.dao.jooq.generated.tables.pojos.{
+  Dataset,
+  DatasetUserAccess,
+  DatasetVersion
+}
 import edu.uci.ics.texera.service.`type`.DatasetFileNode
 import edu.uci.ics.texera.service.auth.SessionUser
-import edu.uci.ics.texera.service.resource.DatasetAccessResource.{getDatasetUserAccessPrivilege, getOwner, isDatasetPublic, userHasReadAccess, userHasWriteAccess, userOwnDataset}
-import edu.uci.ics.texera.service.resource.DatasetResource.{CreateDatasetRequest, DashboardDataset, DashboardDatasetVersion, DatasetDescriptionModification, DatasetVersionRootFileNodesResponse, Diff, context, getDatasetByID, getDatasetVersionByID, getLatestDatasetVersion}
+import edu.uci.ics.texera.service.resource.DatasetAccessResource.{
+  getDatasetUserAccessPrivilege,
+  getOwner,
+  isDatasetPublic,
+  userHasReadAccess,
+  userHasWriteAccess,
+  userOwnDataset
+}
+import edu.uci.ics.texera.service.resource.DatasetResource.{
+  CreateDatasetRequest,
+  DashboardDataset,
+  DashboardDatasetVersion,
+  DatasetDescriptionModification,
+  DatasetVersionRootFileNodesResponse,
+  Diff,
+  context,
+  getDatasetByID,
+  getDatasetVersionByID,
+  getLatestDatasetVersion
+}
 import edu.uci.ics.texera.service.util.S3StorageClient
 import io.dropwizard.auth.Auth
 import jakarta.annotation.security.RolesAllowed
@@ -840,11 +866,11 @@ class DatasetResource {
   @RolesAllowed(Array("REGULAR", "ADMIN"))
   @Path("/{did}/versionZip")
   def getDatasetVersionZip(
-                            @PathParam("did") did: Integer,
-                            @QueryParam("dvid") dvid: Integer,  // Dataset version ID, nullable
-                            @QueryParam("latest") latest: java.lang.Boolean, // Flag to get latest version, nullable
-                            @Auth user: SessionUser
-                          ): Response = {
+      @PathParam("did") did: Integer,
+      @QueryParam("dvid") dvid: Integer, // Dataset version ID, nullable
+      @QueryParam("latest") latest: java.lang.Boolean, // Flag to get latest version, nullable
+      @Auth user: SessionUser
+  ): Response = {
 
     val uid = user.getUid
 
@@ -904,7 +930,6 @@ class DatasetResource {
         .build()
     }
   }
-
 
   @GET
   @RolesAllowed(Array("REGULAR", "ADMIN"))

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
@@ -180,18 +180,18 @@
                   [nzLabel]="version.name"></nz-option>
               </nz-select>
               <!-- downloading the whole dataset is currently disabled because we switched the backend to LakeFS-->
-              <!--              <button-->
-              <!--                nz-button-->
-              <!--                nz-tooltip="Download Dataset"-->
-              <!--                (click)="onClickDownloadVersionAsZip()"-->
-              <!--                *ngIf="selectedVersion"-->
-              <!--                [disabled]="!isLogin"-->
-              <!--                class="spaced-button">-->
-              <!--                <i-->
-              <!--                  nz-icon-->
-              <!--                  nzType="download"-->
-              <!--                  nzTheme="outline"></i>-->
-              <!--              </button>-->
+              <button
+                nz-button
+                nz-tooltip="Download Dataset"
+                (click)="onClickDownloadVersionAsZip()"
+                *ngIf="selectedVersion"
+                [disabled]="!isLogin"
+                class="spaced-button">
+                <i
+                  nz-icon
+                  nzType="download"
+                  nzTheme="outline"></i>
+              </button>
             </div>
             <div
               *ngIf="selectedVersion"

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.html
@@ -179,7 +179,6 @@
                   [nzValue]="version"
                   [nzLabel]="version.name"></nz-option>
               </nz-select>
-              <!-- downloading the whole dataset is currently disabled because we switched the backend to LakeFS-->
               <button
                 nz-button
                 nz-tooltip="Download Dataset"

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset-explorer/dataset-detail.component.ts
@@ -168,6 +168,15 @@ export class DatasetDetailComponent implements OnInit {
     }
   }
 
+  public onClickDownloadVersionAsZip() {
+    if (this.did && this.selectedVersion && this.selectedVersion.dvid) {
+      this.downloadService
+        .downloadDatasetVersion(this.did, this.selectedVersion.dvid, this.datasetName, this.selectedVersion.name)
+        .pipe(untilDestroyed(this))
+        .subscribe();
+    }
+  }
+
   onPublicStatusChange(checked: boolean): void {
     // Handle the change in dataset public status
     if (this.did) {

--- a/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from "@angular/core";
-import { HttpClient, HttpParams } from "@angular/common/http";
+import { HttpClient, HttpParams, HttpResponse } from "@angular/common/http";
 import { catchError, map, mergeMap, switchMap, tap, toArray } from "rxjs/operators";
 import { Dataset, DatasetVersion } from "../../../../common/type/dataset";
 import { AppSettings } from "../../../../common/app-setting";
@@ -76,21 +76,21 @@ export class DatasetService {
   }
 
   /**
-   * Retrieves a zip file of a dataset or a specific path within a dataset.
-   * @param options An object containing optional parameters:
-   *   - path: A string representing a specific file or directory path within the dataset
-   *   - did: A number representing the dataset ID
-   * @returns An Observable that emits a Blob containing the zip file
+   * Retrieves a zip file of a dataset version.
+   * @param did Dataset ID
+   * @param dvid (Optional) Dataset version ID. If omitted, the latest version is downloaded.
+   * @returns An Observable that emits a Blob containing the zip file.
    */
-  public retrieveDatasetZip(options: { did: number; dvid?: number }): Observable<Blob> {
-    // TODO: finish this
+  public retrieveDatasetVersionZip(did: number, dvid?: number): Observable<Blob> {
     let params = new HttpParams();
-    params = params.set("did", options.did.toString());
-    if (options.dvid) {
-      params = params.set("dvid", options.dvid.toString());
+
+    if (dvid !== undefined && dvid !== null) {
+      params = params.set("dvid", dvid.toString());
+    } else {
+      params = params.set("latest", "true");
     }
 
-    return this.http.get(`${AppSettings.getApiEndpoint()}/${DATASET_BASE_URL}/version-zip`, {
+    return this.http.get(`${AppSettings.getApiEndpoint()}/dataset/${did}/versionZip`, {
       params,
       responseType: "blob",
     });

--- a/core/gui/src/app/dashboard/service/user/download/download.service.spec.ts
+++ b/core/gui/src/app/dashboard/service/user/download/download.service.spec.ts
@@ -86,7 +86,7 @@ describe("DownloadService", () => {
     const datasetName = "TestDataset";
     const mockBlob = new Blob(["dataset content"], { type: "application/zip" });
 
-    datasetServiceSpy.retrieveDatasetZip.and.returnValue(of(mockBlob));
+    datasetServiceSpy.retrieveDatasetVersionZip.and.returnValue(of(mockBlob));
 
     downloadService.downloadDataset(datasetId, datasetName).subscribe({
       next: blob => {
@@ -94,7 +94,7 @@ describe("DownloadService", () => {
         expect(notificationServiceSpy.info).toHaveBeenCalledWith(
           "Starting to download the latest version of the dataset as ZIP"
         );
-        expect(datasetServiceSpy.retrieveDatasetZip).toHaveBeenCalledWith({ did: datasetId });
+        expect(datasetServiceSpy.retrieveDatasetVersionZip).toHaveBeenCalledWith(datasetId);
         expect(fileSaverServiceSpy.saveAs).toHaveBeenCalledWith(mockBlob, "TestDataset.zip");
         expect(notificationServiceSpy.success).toHaveBeenCalledWith(
           "The latest version of the dataset has been downloaded as ZIP"
@@ -112,7 +112,7 @@ describe("DownloadService", () => {
     const datasetName = "TestDataset";
     const errorMessage = "Dataset download failed";
 
-    datasetServiceSpy.retrieveDatasetZip.and.returnValue(throwError(() => new Error(errorMessage)));
+    datasetServiceSpy.retrieveDatasetVersionZip.and.returnValue(throwError(() => new Error(errorMessage)));
 
     downloadService.downloadDataset(datasetId, datasetName).subscribe({
       next: () => {
@@ -123,7 +123,7 @@ describe("DownloadService", () => {
         expect(notificationServiceSpy.info).toHaveBeenCalledWith(
           "Starting to download the latest version of the dataset as ZIP"
         );
-        expect(datasetServiceSpy.retrieveDatasetZip).toHaveBeenCalledWith({ did: datasetId });
+        expect(datasetServiceSpy.retrieveDatasetVersionZip).toHaveBeenCalledWith(datasetId);
         expect(fileSaverServiceSpy.saveAs).not.toHaveBeenCalled();
         expect(notificationServiceSpy.error).toHaveBeenCalledWith(
           "Error downloading the latest version of the dataset as ZIP"
@@ -140,13 +140,13 @@ describe("DownloadService", () => {
     const versionName = "v1.0";
     const mockBlob = new Blob(["version content"], { type: "application/zip" });
 
-    datasetServiceSpy.retrieveDatasetZip.and.returnValue(of(mockBlob));
+    datasetServiceSpy.retrieveDatasetVersionZip.and.returnValue(of(mockBlob));
 
     downloadService.downloadDatasetVersion(datasetId, datasetVersionId, datasetName, versionName).subscribe({
       next: blob => {
         expect(blob).toBe(mockBlob);
         expect(notificationServiceSpy.info).toHaveBeenCalledWith("Starting to download version v1.0 as ZIP");
-        expect(datasetServiceSpy.retrieveDatasetZip).toHaveBeenCalledWith({ did: datasetId, dvid: datasetVersionId });
+        expect(datasetServiceSpy.retrieveDatasetVersionZip).toHaveBeenCalledWith(datasetId, datasetVersionId );
         expect(fileSaverServiceSpy.saveAs).toHaveBeenCalledWith(mockBlob, "TestDataset-v1.0.zip");
         expect(notificationServiceSpy.success).toHaveBeenCalledWith("Version v1.0 has been downloaded as ZIP");
         done();
@@ -164,7 +164,7 @@ describe("DownloadService", () => {
     const versionName = "v1.0";
     const errorMessage = "Dataset version download failed";
 
-    datasetServiceSpy.retrieveDatasetZip.and.returnValue(throwError(() => new Error(errorMessage)));
+    datasetServiceSpy.retrieveDatasetVersionZip.and.returnValue(throwError(() => new Error(errorMessage)));
 
     downloadService.downloadDatasetVersion(datasetId, datasetVersionId, datasetName, versionName).subscribe({
       next: () => {
@@ -173,7 +173,7 @@ describe("DownloadService", () => {
       error: (error: unknown) => {
         expect(error).toBeTruthy();
         expect(notificationServiceSpy.info).toHaveBeenCalledWith("Starting to download version v1.0 as ZIP");
-        expect(datasetServiceSpy.retrieveDatasetZip).toHaveBeenCalledWith({ did: datasetId, dvid: datasetVersionId });
+        expect(datasetServiceSpy.retrieveDatasetVersionZip).toHaveBeenCalledWith(datasetId, datasetVersionId);
         expect(fileSaverServiceSpy.saveAs).not.toHaveBeenCalled();
         expect(notificationServiceSpy.error).toHaveBeenCalledWith("Error downloading version 'v1.0' as ZIP");
         done();

--- a/core/gui/src/app/dashboard/service/user/download/download.service.spec.ts
+++ b/core/gui/src/app/dashboard/service/user/download/download.service.spec.ts
@@ -16,7 +16,7 @@ describe("DownloadService", () => {
   beforeEach(() => {
     const datasetSpy = jasmine.createSpyObj("DatasetService", [
       "retrieveDatasetVersionSingleFile",
-      "retrieveDatasetZip", // Add this method to the spy
+      "retrieveDatasetVersionZip", // Add this method to the spy
     ]);
     const fileSaverSpy = jasmine.createSpyObj("FileSaverService", ["saveAs"]);
     const notificationSpy = jasmine.createSpyObj("NotificationService", ["info", "success", "error"]);

--- a/core/gui/src/app/dashboard/service/user/download/download.service.spec.ts
+++ b/core/gui/src/app/dashboard/service/user/download/download.service.spec.ts
@@ -146,7 +146,7 @@ describe("DownloadService", () => {
       next: blob => {
         expect(blob).toBe(mockBlob);
         expect(notificationServiceSpy.info).toHaveBeenCalledWith("Starting to download version v1.0 as ZIP");
-        expect(datasetServiceSpy.retrieveDatasetVersionZip).toHaveBeenCalledWith(datasetId, datasetVersionId );
+        expect(datasetServiceSpy.retrieveDatasetVersionZip).toHaveBeenCalledWith(datasetId, datasetVersionId);
         expect(fileSaverServiceSpy.saveAs).toHaveBeenCalledWith(mockBlob, "TestDataset-v1.0.zip");
         expect(notificationServiceSpy.success).toHaveBeenCalledWith("Version v1.0 has been downloaded as ZIP");
         done();

--- a/core/gui/src/app/dashboard/service/user/download/download.service.ts
+++ b/core/gui/src/app/dashboard/service/user/download/download.service.ts
@@ -49,7 +49,7 @@ export class DownloadService {
 
   downloadDataset(id: number, name: string): Observable<Blob> {
     return this.downloadWithNotification(
-      () => this.datasetService.retrieveDatasetZip({ did: id }),
+      () => this.datasetService.retrieveDatasetVersionZip(id),
       `${name}.zip`,
       "Starting to download the latest version of the dataset as ZIP",
       "The latest version of the dataset has been downloaded as ZIP",
@@ -64,7 +64,7 @@ export class DownloadService {
     versionName: string
   ): Observable<Blob> {
     return this.downloadWithNotification(
-      () => this.datasetService.retrieveDatasetZip({ did: datasetId, dvid: datasetVersionId }),
+      () => this.datasetService.retrieveDatasetVersionZip(datasetId, datasetVersionId),
       `${datasetName}-${versionName}.zip`,
       `Starting to download version ${versionName} as ZIP`,
       `Version ${versionName} has been downloaded as ZIP`,

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/util/LakeFSStorageClient.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/util/LakeFSStorageClient.scala
@@ -115,6 +115,10 @@ object LakeFSStorageClient {
     objectsApi.uploadObject(repoName, branchName, filePath).content(tempFilePath.toFile).execute()
   }
 
+  def getFileFromRepo(repoName: String, versionHash: String, filePath: String): File = {
+    objectsApi.getObject(repoName, versionHash, filePath).execute()
+  }
+
   /**
     * Removes a file from the repository (similar to Git rm).
     *


### PR DESCRIPTION
This PR re-enables the support of downloading the version of the dataset as a zip file. 

The backend enpoint is implemented by:
1. request all the files of a dataset version
2. read all the files
3. put them in a zip stream

