### PR TITLE
Fix NPE for log writer

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberRuntime.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberRuntime.scala
@@ -14,8 +14,19 @@ import scala.concurrent.duration.FiniteDuration
 
 object AmberRuntime {
 
-  var serde: Serialization = _
+  private var _serde: Serialization = _
   private var _actorSystem: ActorSystem = _
+
+  def serde: Serialization = {
+    if (_serde == null) {
+      if (_actorSystem == null) {
+        _serde = SerializationExtension(ActorSystem("Amber", akkaConfig))
+      } else {
+        _serde = SerializationExtension(_actorSystem)
+      }
+    }
+    _serde
+  }
 
   def actorSystem: ActorSystem = {
     _actorSystem
@@ -85,6 +96,6 @@ object AmberRuntime {
     val deadLetterMonitorActor =
       _actorSystem.actorOf(Props[DeadLetterMonitorActor](), name = "dead-letter-monitor-actor")
     _actorSystem.eventStream.subscribe(deadLetterMonitorActor, classOf[DeadLetter])
-    serde = SerializationExtension(_actorSystem)
+    _serde = SerializationExtension(_actorSystem)
   }
 }

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/architecture/worker/WorkerSpec.scala
@@ -1,7 +1,6 @@
 package edu.uci.ics.amber.engine.architecture.worker
 
 import akka.actor.{ActorRef, ActorSystem, Props}
-import akka.serialization.SerializationExtension
 import akka.testkit.{ImplicitSender, TestActorRef, TestKit}
 import edu.uci.ics.amber.clustering.SingleNodeListener
 import edu.uci.ics.amber.core.executor.{OpExecWithClassName, OperatorExecutor}
@@ -61,7 +60,6 @@ class WorkerSpec
 
   override def beforeAll(): Unit = {
     system.actorOf(Props[SingleNodeListener](), "cluster-info")
-    AmberRuntime.serde = SerializationExtension(system)
   }
 
   override def afterAll(): Unit = {

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/DataProcessingSpec.scala
@@ -1,17 +1,17 @@
 package edu.uci.ics.amber.engine.e2e
 
 import akka.actor.{ActorSystem, Props}
-import akka.serialization.SerializationExtension
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import ch.vorburger.mariadb4j.DB
 import com.twitter.util.{Await, Duration, Promise}
 import edu.uci.ics.amber.clustering.SingleNodeListener
-import edu.uci.ics.amber.core.storage.{DocumentFactory, VFSURIFactory}
 import edu.uci.ics.amber.core.storage.model.VirtualDocument
 import edu.uci.ics.amber.core.storage.result.ExecutionResourcesMapping
+import edu.uci.ics.amber.core.storage.{DocumentFactory, VFSURIFactory}
 import edu.uci.ics.amber.core.tuple.{AttributeType, Tuple}
-import edu.uci.ics.amber.core.workflow.WorkflowContext
+import edu.uci.ics.amber.core.virtualidentity.OperatorIdentity
+import edu.uci.ics.amber.core.workflow.{PortIdentity, WorkflowContext}
 import edu.uci.ics.amber.engine.architecture.controller._
 import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.EmptyRequest
 import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.COMPLETED
@@ -20,11 +20,10 @@ import edu.uci.ics.amber.engine.common.client.AmberClient
 import edu.uci.ics.amber.engine.e2e.TestUtils.buildWorkflow
 import edu.uci.ics.amber.operator.TestOperators
 import edu.uci.ics.amber.operator.aggregate.AggregationFunction
-import edu.uci.ics.amber.core.virtualidentity.OperatorIdentity
-import edu.uci.ics.amber.core.workflow.PortIdentity
 import edu.uci.ics.texera.workflow.LogicalLink
 import org.scalatest.flatspec.AnyFlatSpecLike
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+
 import scala.concurrent.duration.DurationInt
 
 class DataProcessingSpec
@@ -41,7 +40,6 @@ class DataProcessingSpec
 
   override def beforeAll(): Unit = {
     system.actorOf(Props[SingleNodeListener](), "cluster-info")
-    AmberRuntime.serde = SerializationExtension(system)
   }
 
   override def afterAll(): Unit = {

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/PauseSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/e2e/PauseSpec.scala
@@ -1,20 +1,18 @@
 package edu.uci.ics.amber.engine.e2e
 
 import akka.actor.{ActorSystem, Props}
-import akka.serialization.SerializationExtension
 import akka.testkit.{ImplicitSender, TestKit}
 import akka.util.Timeout
 import com.twitter.util.{Await, Promise}
 import com.typesafe.scalalogging.Logger
 import edu.uci.ics.amber.clustering.SingleNodeListener
-import edu.uci.ics.amber.core.workflow.WorkflowContext
+import edu.uci.ics.amber.core.workflow.{PortIdentity, WorkflowContext}
 import edu.uci.ics.amber.engine.architecture.controller.{ControllerConfig, ExecutionStateUpdate}
 import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.EmptyRequest
 import edu.uci.ics.amber.engine.architecture.rpc.controlreturns.WorkflowAggregatedState.COMPLETED
 import edu.uci.ics.amber.engine.common.AmberRuntime
 import edu.uci.ics.amber.engine.common.client.AmberClient
 import edu.uci.ics.amber.operator.{LogicalOp, TestOperators}
-import edu.uci.ics.amber.core.workflow.PortIdentity
 import edu.uci.ics.texera.workflow.LogicalLink
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -33,7 +31,6 @@ class PauseSpec
 
   override def beforeAll(): Unit = {
     system.actorOf(Props[SingleNodeListener](), "cluster-info")
-    AmberRuntime.serde = SerializationExtension(system)
   }
 
   override def afterAll(): Unit = {

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/faulttolerance/CheckpointSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/faulttolerance/CheckpointSpec.scala
@@ -1,9 +1,8 @@
 package edu.uci.ics.amber.engine.faulttolerance
 
 import akka.actor.{ActorSystem, Props}
-import akka.serialization.SerializationExtension
 import edu.uci.ics.amber.clustering.SingleNodeListener
-import edu.uci.ics.amber.core.workflow.WorkflowContext
+import edu.uci.ics.amber.core.workflow.{PortIdentity, WorkflowContext}
 import edu.uci.ics.amber.engine.architecture.controller.{ControllerConfig, ControllerProcessor}
 import edu.uci.ics.amber.engine.architecture.worker.DataProcessor
 import edu.uci.ics.amber.engine.common.SerializedState.{CP_STATE_KEY, DP_STATE_KEY}
@@ -11,7 +10,6 @@ import edu.uci.ics.amber.engine.common.virtualidentity.util.{CONTROLLER, SELF}
 import edu.uci.ics.amber.engine.common.{AmberRuntime, CheckpointState}
 import edu.uci.ics.amber.engine.e2e.TestUtils.buildWorkflow
 import edu.uci.ics.amber.operator.TestOperators
-import edu.uci.ics.amber.core.workflow.PortIdentity
 import edu.uci.ics.texera.workflow.LogicalLink
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.flatspec.AnyFlatSpecLike
@@ -38,7 +36,6 @@ class CheckpointSpec extends AnyFlatSpecLike with BeforeAndAfterAll {
   override def beforeAll(): Unit = {
     system = ActorSystem("CheckpointSpec", AmberRuntime.akkaConfig)
     system.actorOf(Props[SingleNodeListener](), "cluster-info")
-    AmberRuntime.serde = SerializationExtension(system)
   }
 
   "Default controller state" should "be serializable" in {

--- a/core/amber/src/test/scala/edu/uci/ics/amber/engine/faulttolerance/LoggingSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/amber/engine/faulttolerance/LoggingSpec.scala
@@ -1,138 +1,133 @@
-//package edu.uci.ics.amber.engine.faulttolerance
-//
-//import akka.actor.ActorSystem
-//import akka.serialization.SerializationExtension
-//import akka.testkit.{ImplicitSender, TestKit}
-//import edu.uci.ics.amber.core.tuple.{AttributeType, Schema, TupleLike}
-//import edu.uci.ics.amber.core.virtualidentity.{
-//  ActorVirtualIdentity,
-//  ChannelIdentity,
-//  OperatorIdentity,
-//  PhysicalOpIdentity
-//}
-//import edu.uci.ics.amber.core.workflow.{PhysicalLink, PortIdentity}
-//import edu.uci.ics.amber.engine.architecture.logreplay.{ReplayLogManager, ReplayLogRecord}
-//import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.{
-//  AddPartitioningRequest,
-//  AsyncRPCContext,
-//  EmptyRequest
-//}
-//import edu.uci.ics.amber.engine.architecture.rpc.controllerservice.ControllerServiceGrpc.METHOD_WORKER_EXECUTION_COMPLETED
-//import edu.uci.ics.amber.engine.architecture.rpc.workerservice.WorkerServiceGrpc.{
-//  METHOD_ADD_PARTITIONING,
-//  METHOD_PAUSE_WORKER,
-//  METHOD_RESUME_WORKER,
-//  METHOD_START_WORKER
-//}
-//import edu.uci.ics.amber.engine.architecture.sendsemantics.partitionings.OneToOnePartitioning
-//import edu.uci.ics.amber.engine.common.AmberRuntime
-//import edu.uci.ics.amber.engine.common.ambermessage.{
-//  DataFrame,
-//  WorkflowFIFOMessage,
-//  WorkflowFIFOMessagePayload
-//}
-//import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
-//import edu.uci.ics.amber.engine.common.storage.SequentialRecordStorage
-//import edu.uci.ics.amber.engine.common.virtualidentity.util.{CONTROLLER, SELF}
-//import org.scalatest.BeforeAndAfterAll
-//import org.scalatest.concurrent.TimeLimitedTests
-//import org.scalatest.flatspec.AnyFlatSpecLike
-//import org.scalatest.time.Span
-//import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
-//
-//import java.net.URI
-//
-//class LoggingSpec
-//    extends TestKit(ActorSystem("LoggingSpec", AmberRuntime.akkaConfig))
-//    with ImplicitSender
-//    with AnyFlatSpecLike
-//    with BeforeAndAfterAll
-//    with TimeLimitedTests {
-//
-//  override def beforeAll(): Unit = {
-//    AmberRuntime.serde = SerializationExtension(system)
-//  }
-//
-//  private val identifier1 = ActorVirtualIdentity("Worker:WF1-E1-op-layer-1")
-//  private val identifier2 = ActorVirtualIdentity("Worker:WF1-E1-op-layer-2")
-//  private val operatorIdentity = OperatorIdentity("testOperator")
-//  private val physicalOpId1 = PhysicalOpIdentity(operatorIdentity, "1st-layer")
-//  private val physicalOpId2 = PhysicalOpIdentity(operatorIdentity, "2nd-layer")
-//  private val mockLink = PhysicalLink(physicalOpId1, PortIdentity(), physicalOpId2, PortIdentity())
-//
-//  private val mockPolicy =
-//    OneToOnePartitioning(10, Seq(ChannelIdentity(identifier1, identifier2, isControl = false)))
-//  val payloadToLog: Array[WorkflowFIFOMessagePayload] = Array(
-//    ControlInvocation(
-//      METHOD_START_WORKER,
-//      EmptyRequest(),
-//      AsyncRPCContext(CONTROLLER, identifier1),
-//      0
-//    ),
-//    ControlInvocation(
-//      METHOD_ADD_PARTITIONING,
-//      AddPartitioningRequest(mockLink, mockPolicy),
-//      AsyncRPCContext(CONTROLLER, identifier1),
-//      0
-//    ),
-//    ControlInvocation(
-//      METHOD_PAUSE_WORKER,
-//      EmptyRequest(),
-//      AsyncRPCContext(CONTROLLER, identifier1),
-//      0
-//    ),
-//    ControlInvocation(
-//      METHOD_RESUME_WORKER,
-//      EmptyRequest(),
-//      AsyncRPCContext(CONTROLLER, identifier1),
-//      0
-//    ),
-//    DataFrame(
-//      (0 to 400)
-//        .map(i =>
-//          TupleLike(i, i.toString, i.toDouble).enforceSchema(
-//            Schema()
-//              .add("field1", AttributeType.INTEGER)
-//              .add("field2", AttributeType.STRING)
-//              .add("field3", AttributeType.DOUBLE)
-//          )
-//        )
-//        .toArray
-//    ),
-//    ControlInvocation(
-//      METHOD_START_WORKER,
-//      EmptyRequest(),
-//      AsyncRPCContext(CONTROLLER, identifier1),
-//      0
-//    ),
-//    ControlInvocation(
-//      METHOD_WORKER_EXECUTION_COMPLETED,
-//      EmptyRequest(),
-//      AsyncRPCContext(identifier1, CONTROLLER),
-//      0
-//    )
-//  )
-//
-//  "determinant logger" should "log processing steps in local storage" in {
-//    Thread.sleep(1000) // wait for serializer to be registered
-//    val logStorage = SequentialRecordStorage.getStorage[ReplayLogRecord](
-//      Some(new URI("ram:///recovery-logs/tmp"))
-//    )
-//    logStorage.deleteStorage()
-//    val logManager = ReplayLogManager.createLogManager(logStorage, "tmpLog", x => {})
-//    payloadToLog.foreach { payload =>
-//      val channel = ChannelIdentity(CONTROLLER, SELF, isControl = true)
-//      val msgOpt = Some(WorkflowFIFOMessage(channel, 0, payload))
-//      logManager.withFaultTolerant(channel, msgOpt) {
-//        // do nothing
-//      }
-//    }
-//    logManager.sendCommitted(null)
-//    logManager.terminate()
-//    val logRecords = logStorage.getReader("tmpLog").mkRecordIterator().toArray
-//    logStorage.deleteStorage()
-//    assert(logRecords.length == 15)
-//  }
-//
-//  override def timeLimit: Span = 30.seconds
-//}
+package edu.uci.ics.amber.engine.faulttolerance
+
+import akka.actor.ActorSystem
+import akka.testkit.{ImplicitSender, TestKit}
+import edu.uci.ics.amber.core.tuple.{AttributeType, Schema, TupleLike}
+import edu.uci.ics.amber.core.virtualidentity.{
+  ActorVirtualIdentity,
+  ChannelIdentity,
+  OperatorIdentity,
+  PhysicalOpIdentity
+}
+import edu.uci.ics.amber.core.workflow.{PhysicalLink, PortIdentity}
+import edu.uci.ics.amber.engine.architecture.logreplay.{ReplayLogManager, ReplayLogRecord}
+import edu.uci.ics.amber.engine.architecture.rpc.controlcommands.{
+  AddPartitioningRequest,
+  AsyncRPCContext,
+  EmptyRequest
+}
+import edu.uci.ics.amber.engine.architecture.rpc.controllerservice.ControllerServiceGrpc.METHOD_WORKER_EXECUTION_COMPLETED
+import edu.uci.ics.amber.engine.architecture.rpc.workerservice.WorkerServiceGrpc.{
+  METHOD_ADD_PARTITIONING,
+  METHOD_PAUSE_WORKER,
+  METHOD_RESUME_WORKER,
+  METHOD_START_WORKER
+}
+import edu.uci.ics.amber.engine.architecture.sendsemantics.partitionings.OneToOnePartitioning
+import edu.uci.ics.amber.engine.common.AmberRuntime
+import edu.uci.ics.amber.engine.common.ambermessage.{
+  DataFrame,
+  WorkflowFIFOMessage,
+  WorkflowFIFOMessagePayload
+}
+import edu.uci.ics.amber.engine.common.rpc.AsyncRPCClient.ControlInvocation
+import edu.uci.ics.amber.engine.common.storage.SequentialRecordStorage
+import edu.uci.ics.amber.engine.common.virtualidentity.util.{CONTROLLER, SELF}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.concurrent.TimeLimitedTests
+import org.scalatest.flatspec.AnyFlatSpecLike
+import org.scalatest.time.Span
+import org.scalatest.time.SpanSugar.convertIntToGrainOfTime
+
+import java.net.URI
+
+class LoggingSpec
+    extends TestKit(ActorSystem("LoggingSpec", AmberRuntime.akkaConfig))
+    with ImplicitSender
+    with AnyFlatSpecLike
+    with BeforeAndAfterAll
+    with TimeLimitedTests {
+
+  private val identifier1 = ActorVirtualIdentity("Worker:WF1-E1-op-layer-1")
+  private val identifier2 = ActorVirtualIdentity("Worker:WF1-E1-op-layer-2")
+  private val operatorIdentity = OperatorIdentity("testOperator")
+  private val physicalOpId1 = PhysicalOpIdentity(operatorIdentity, "1st-layer")
+  private val physicalOpId2 = PhysicalOpIdentity(operatorIdentity, "2nd-layer")
+  private val mockLink = PhysicalLink(physicalOpId1, PortIdentity(), physicalOpId2, PortIdentity())
+
+  private val mockPolicy =
+    OneToOnePartitioning(10, Seq(ChannelIdentity(identifier1, identifier2, isControl = false)))
+  val payloadToLog: Array[WorkflowFIFOMessagePayload] = Array(
+    ControlInvocation(
+      METHOD_START_WORKER,
+      EmptyRequest(),
+      AsyncRPCContext(CONTROLLER, identifier1),
+      0
+    ),
+    ControlInvocation(
+      METHOD_ADD_PARTITIONING,
+      AddPartitioningRequest(mockLink, mockPolicy),
+      AsyncRPCContext(CONTROLLER, identifier1),
+      0
+    ),
+    ControlInvocation(
+      METHOD_PAUSE_WORKER,
+      EmptyRequest(),
+      AsyncRPCContext(CONTROLLER, identifier1),
+      0
+    ),
+    ControlInvocation(
+      METHOD_RESUME_WORKER,
+      EmptyRequest(),
+      AsyncRPCContext(CONTROLLER, identifier1),
+      0
+    ),
+    DataFrame(
+      (0 to 400)
+        .map(i =>
+          TupleLike(i, i.toString, i.toDouble).enforceSchema(
+            Schema()
+              .add("field1", AttributeType.INTEGER)
+              .add("field2", AttributeType.STRING)
+              .add("field3", AttributeType.DOUBLE)
+          )
+        )
+        .toArray
+    ),
+    ControlInvocation(
+      METHOD_START_WORKER,
+      EmptyRequest(),
+      AsyncRPCContext(CONTROLLER, identifier1),
+      0
+    ),
+    ControlInvocation(
+      METHOD_WORKER_EXECUTION_COMPLETED,
+      EmptyRequest(),
+      AsyncRPCContext(identifier1, CONTROLLER),
+      0
+    )
+  )
+
+  "determinant logger" should "log processing steps in local storage" in {
+    Thread.sleep(1000) // wait for serializer to be registered
+    val logStorage = SequentialRecordStorage.getStorage[ReplayLogRecord](
+      Some(new URI("ram:///recovery-logs/tmp"))
+    )
+    logStorage.deleteStorage()
+    val logManager = ReplayLogManager.createLogManager(logStorage, "tmpLog", x => {})
+    payloadToLog.foreach { payload =>
+      val channel = ChannelIdentity(CONTROLLER, SELF, isControl = true)
+      val msgOpt = Some(WorkflowFIFOMessage(channel, 0, payload))
+      logManager.withFaultTolerant(channel, msgOpt) {
+        // do nothing
+      }
+    }
+    logManager.sendCommitted(null)
+    logManager.terminate()
+    val logRecords = logStorage.getReader("tmpLog").mkRecordIterator().toArray
+    logStorage.deleteStorage()
+    assert(logRecords.length == 15)
+  }
+
+  override def timeLimit: Span = 30.seconds
+}


### PR DESCRIPTION
After #3310, the CI still hangs due to an NPE thrown by the log writer sometimes. I suspect this is caused by a race condition between serializer initialization and the writer thread in certain test cases. However, identifying the exact test case is challenging since the issue is difficult to reproduce locally and the test logs provide little traceability. This PR addresses the issue by deferring initialization until the writer first uses the serializer, ensuring synchronization.