### PR TITLE
Fix export single cell

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/ResultResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/ResultResource.scala
@@ -54,7 +54,7 @@ class ResultResource extends LazyLogging {
             return Response
               .status(Response.Status.BAD_REQUEST)
               .`type`(MediaType.APPLICATION_JSON)
-              .entity(Map("error" -> "Local download supports no operator or many.").asJava)
+              .entity(Map("error" -> "Local download does not support no operator.").asJava)
               .build()
           }
           val singleOpId = request.operatorIds.head

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ResultExportService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ResultExportService.scala
@@ -190,6 +190,28 @@ class ResultExportService(workflowIdentity: WorkflowIdentity) {
     }
   }
 
+  /*
+    * Handle streaming a single (row, column) from an operator's result.
+    * This is used for the "data" export type, which exports a single field value.
+   */
+  private def writeData(
+                          out: OutputStream,
+                          request: ResultExportRequest,
+                          results: Iterable[Tuple]
+                       ): Unit = {
+    val rowIndex = request.rowIndex
+    val columnIndex = request.columnIndex
+
+    if (rowIndex >= results.size || columnIndex >= results.head.getFields.length) {
+      -1
+    }
+
+    val selectedRow = results.toSeq(rowIndex)
+    val field: Any = selectedRow.getField(columnIndex)
+    val dataBytes = convertFieldToBytes(field)
+    out.write(dataBytes)
+  }
+
   /**
     * Handle exporting data for a single (row, column) from an operator's result.
     */
@@ -209,7 +231,7 @@ class ResultExportService(workflowIdentity: WorkflowIdentity) {
       }
 
       val selectedRow = results.toSeq(rowIndex)
-      val field = selectedRow.getField(columnIndex)
+      val field: Any = selectedRow.getField(columnIndex)
       val dataBytes: Array[Byte] = convertFieldToBytes(field)
 
       saveToDatasets(
@@ -417,6 +439,7 @@ class ResultExportService(workflowIdentity: WorkflowIdentity) {
         request.exportType match {
           case "csv"   => writeCsv(out, results)
           case "arrow" => writeArrow(out, results)
+          case "data"  => writeData(out, request, results) // handle single cell export
           case _       => writeCsv(out, results) // fallback
         }
       }
@@ -517,6 +540,7 @@ class ResultExportService(workflowIdentity: WorkflowIdentity) {
               request.exportType match {
                 case "csv"   => writeCsv(nonClosingStream, results)
                 case "arrow" => writeArrow(nonClosingStream, results)
+                case "data"  => writeData(nonClosingStream, request, results) // handle single cell export
                 case _       => writeCsv(nonClosingStream, results)
               }
               zipOut.closeEntry()

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ResultExportService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ResultExportService.scala
@@ -191,14 +191,14 @@ class ResultExportService(workflowIdentity: WorkflowIdentity) {
   }
 
   /*
-    * Handle streaming a single (row, column) from an operator's result.
-    * This is used for the "data" export type, which exports a single field value.
+   * Handle streaming a single (row, column) from an operator's result.
+   * This is used for the "data" export type, which exports a single field value.
    */
   private def writeData(
-                          out: OutputStream,
-                          request: ResultExportRequest,
-                          results: Iterable[Tuple]
-                       ): Unit = {
+      out: OutputStream,
+      request: ResultExportRequest,
+      results: Iterable[Tuple]
+  ): Unit = {
     val rowIndex = request.rowIndex
     val columnIndex = request.columnIndex
 
@@ -540,8 +540,9 @@ class ResultExportService(workflowIdentity: WorkflowIdentity) {
               request.exportType match {
                 case "csv"   => writeCsv(nonClosingStream, results)
                 case "arrow" => writeArrow(nonClosingStream, results)
-                case "data"  => writeData(nonClosingStream, request, results) // handle single cell export
-                case _       => writeCsv(nonClosingStream, results)
+                case "data" =>
+                  writeData(nonClosingStream, request, results) // handle single cell export
+                case _ => writeCsv(nonClosingStream, results)
               }
               zipOut.closeEntry()
             }


### PR DESCRIPTION
Fix for issue https://github.com/Texera/texera/issues/3319.
In `ResultExportService.scala` we had a specific case for single cell download. There were two issues with it:
- In export to dataset, the `selectedRow.getField(columnIndex)` return type `T` which caused the following error:
```
Data export failed for operator CSVFileScan-operator-8129ee55-1511-4b8c-870c-078f79afd5f: class java.lang.String cannot be cast to class scala.runtime.Nothing$ (java.lang.String is in module java.base of loader 'bootstrap'; scala.runtime.Nothing$ is in unnamed module of loader 'app')
```
- In export to local, instead of using single cell stream, we returned csvWriter which caused the whole file be downloaded