### PR TITLE
Fix incorrect wid during the websocket connection with the computing unit

### DIFF
--- a/core/gui/src/app/workspace/component/menu/menu.component.html
+++ b/core/gui/src/app/workspace/component/menu/menu.component.html
@@ -308,10 +308,7 @@
       </button>
 
       <nz-button-group id="execution-buttons">
-        <texera-computing-unit-selection
-          id="texera-compute-unit-selection"
-          [workflowId]="workflowId">
-        </texera-computing-unit-selection>
+        <texera-computing-unit-selection id="texera-compute-unit-selection"> </texera-computing-unit-selection>
         <button
           nz-button
           id="share-button"

--- a/core/gui/src/app/workspace/component/power-button/computing-unit-selection.component.html
+++ b/core/gui/src/app/workspace/component/power-button/computing-unit-selection.component.html
@@ -68,7 +68,7 @@
         id="computing-unit-option"
         [nzDisabled]="cannotSelectUnit(unit)"
         [ngClass]="{ 'unit-selected': isSelectedUnit(unit) }"
-        (click)="selectedComputingUnit = unit; onComputingUnitChange(unit)">
+        (click)="selectedComputingUnit = unit; connectToComputingUnit(unit)">
         <div class="computing-unit-name">
           <nz-badge
             [nzColor]="getBadgeColor(unit.status)"


### PR DESCRIPTION
This PR fixes the #3319 .

The root cause is the `wid=0` in the built websocket connection. During the workspace rendering, the wid is initially 0, and then the actual value. This PR adds the subscription to the wid change to make sure the websocket connection is rebuilt with the actual wid.