### PR TITLE
Fix the missing config resolve of AmberConfig  

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberConfig.scala
@@ -16,11 +16,11 @@ object AmberConfig {
   // Perform lazy reload
   private def getConfSource: Config = {
     if (lastModifiedTime == configFile.lastModified()) {
-      conf
+      conf.resolve()
     } else {
       lastModifiedTime = configFile.lastModified()
       conf = ConfigFactory.parseFile(configFile).withFallback(ConfigFactory.load())
-      conf
+      conf.resolve()
     }
   }
 


### PR DESCRIPTION
This PR fixes the config resolving issue by adding the `resolve` function call explicitly. 