### PR TITLE
Ignore pgroonga in jooq codegen

### DIFF
--- a/core/dao/src/main/resources/jooq-conf.xml
+++ b/core/dao/src/main/resources/jooq-conf.xml
@@ -31,7 +31,7 @@
             <!-- All elements that are excluded from your schema
                  (A Java regular expression. Use the pipe to separate several expressions).
                  Excludes match before includes, i.e. excludes have a higher priority -->
-            <excludes>(test_.*)|(ignore_.*)</excludes>
+            <excludes>(pgroonga.*)|(test_.*)|(ignore_.*)</excludes>
             <forcedTypes>
                 <forcedType>
                     <name>TIMESTAMP</name>

--- a/core/dao/src/main/scala/edu/uci/ics/texera/dao/JooqCodeGenerator.scala
+++ b/core/dao/src/main/scala/edu/uci/ics/texera/dao/JooqCodeGenerator.scala
@@ -35,7 +35,8 @@ object JooqCodeGenerator {
 
     val jooqJdbcConfig = new Jdbc
     jooqJdbcConfig.setDriver("org.postgresql.Driver")
-    jooqJdbcConfig.setUrl(jdbcConfig.getString("url"))
+    // Skip all the query params, otherwise it will omit the "texera_db." prefix on the field names.
+    jooqJdbcConfig.setUrl(jdbcConfig.getString("url").split('?').head)
     jooqJdbcConfig.setUsername(jdbcConfig.getString("username"))
     jooqJdbcConfig.setPassword(jdbcConfig.getString("password"))
 


### PR DESCRIPTION
This PR updates jooq-conf.xml to skip pgroonga.* tables in jOOQ code generation. It also changes JooqCodeGenerator.scala to remove query parameters from the database URL to make sure the schema prefix is included in the generated code.