### PR TITLE
Add fallback function to read file directly from LakeFS when presigned URL is not accessible

### DIFF
--- a/core/scripts/sql/iceberg_postgres_catalog.sql
+++ b/core/scripts/sql/iceberg_postgres_catalog.sql
@@ -1,11 +1,7 @@
--- Replace these with actual values (no \set)
--- Variables can't be used inside DO blocks in this context
--- Instead, write them explicitly
-
 -- Connect to the default postgres database
 \c postgres
 
--- Create the user if it doesn't exist
+-- Create the user `texera` with `password` if it doesn't exist
 DO $$
     BEGIN
         IF NOT EXISTS (

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/util/LakeFSStorageClient.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/util/LakeFSStorageClient.scala
@@ -115,6 +115,14 @@ object LakeFSStorageClient {
     objectsApi.uploadObject(repoName, branchName, filePath).content(tempFilePath.toFile).execute()
   }
 
+  /**
+    * Retrieves a file from a specific repository and commit.
+    *
+    * @param repoName     Repository name.
+    * @param versionHash  Commit hash of the version.
+    * @param filePath     Path to the file in the repository.
+    * @return             The file retrieved from LakeFS.
+    */
   def getFileFromRepo(repoName: String, versionHash: String, filePath: String): File = {
     objectsApi.getObject(repoName, versionHash, filePath).execute()
   }
@@ -170,15 +178,13 @@ object LakeFSStorageClient {
     objectsApi.statObject(repoName, commitHash, filePath).presign(true).execute().getPhysicalAddress
   }
 
-  def getFilePresignedUploadUrl(repoName: String, filePath: String): String = {
-    stagingApi
-      .getPhysicalAddress(repoName, branchName, filePath)
-      .presign(true)
-      .execute()
-      .getPresignedUrl
-  }
-
   /**
+    * Initiates a presigned multipart upload for a file in LakeFS.
+    *
+    * @param repoName     Repository name.
+    * @param filePath     File path within the repository.
+    * @param numberOfParts Number of parts to upload.
+    * @return              Multipart upload information.
     */
   def initiatePresignedMultipartUploads(
       repoName: String,
@@ -192,6 +198,16 @@ object LakeFSStorageClient {
 
   }
 
+  /**
+    * Completes a previously initiated multipart upload.
+    *
+    * @param repoName        Repository name.
+    * @param filePath        File path within the repository.
+    * @param uploadId        Multipart upload ID.
+    * @param partsList       List of (part number, ETag) pairs.
+    * @param physicalAddress Physical location of the file in storage.
+    * @return                Object metadata after completion.
+    */
   def completePresignedMultipartUploads(
       repoName: String,
       filePath: String,
@@ -224,6 +240,14 @@ object LakeFSStorageClient {
       .execute()
   }
 
+  /**
+    * Aborts a multipart upload operation for a given file.
+    *
+    * @param repoName        Repository name.
+    * @param filePath        File path within the repository.
+    * @param uploadId        Multipart upload ID.
+    * @param physicalAddress Physical address of the file.
+    */
   def abortPresignedMultipartUploads(
       repoName: String,
       filePath: String,


### PR DESCRIPTION
A follow-up PR of #3335 .

This PR adds an exception handler for reading file from the presigned url. In some cases when the S3 is not accessible from the network, e.g. single-node architecture where each service is in the docker-compose's own network and cannot access host's network.

If exception happens, this handler will read file from LakeFS by calling LakeFS's API.

This PR also add some comments on LakeFS APIs and remove some redundant comments on a sql file.