### PR TITLE
Improve `single-node` deployment script

### DIFF
--- a/deployment/computing-unit-master.dockerfile
+++ b/deployment/computing-unit-master.dockerfile
@@ -26,23 +26,51 @@ FROM eclipse-temurin:11-jre-jammy AS runtime
 
 WORKDIR /core/amber
 
+COPY --from=build /core/amber/r-requirements.txt /tmp/r-requirements.txt
 COPY --from=build /core/amber/requirements.txt /tmp/requirements.txt
 COPY --from=build /core/amber/operator-requirements.txt /tmp/operator-requirements.txt
 
-# Install Python runtime and dependencies
+# Install Python & R runtime dependencies
 RUN apt-get update && apt-get install -y \
     python3-pip \
     python3-dev \
     libpq-dev \
+    gfortran \
+    curl \
+    build-essential \
+    libreadline-dev \
+    libncurses-dev \
+    libssl-dev \
+    libxml2-dev \
+    xorg-dev \
+    libbz2-dev \
+    liblzma-dev \
+    libpcre++-dev \
+    libpango1.0-dev \
+     libcurl4-openssl-dev \
+    unzip \
     && apt-get clean
 
-RUN pip3 install --upgrade pip setuptools wheel
-RUN pip3 install python-lsp-server python-lsp-server[websockets]
-
-# Install requirements with a fallback for wordcloud
-RUN pip3 install -r /tmp/requirements.txt
-RUN pip3 install --no-cache-dir --find-links https://pypi.org/simple/ -r /tmp/operator-requirements.txt || \
-    pip3 install --no-cache-dir wordcloud==1.9.2
+# Install R and needed libraries
+ENV R_VERSION=4.3.3
+RUN curl -O https://cran.r-project.org/src/base/R-4/R-${R_VERSION}.tar.gz && \
+    tar -xf R-${R_VERSION}.tar.gz && \
+    cd R-${R_VERSION} && \
+    ./configure --prefix=/usr/local \
+                --enable-R-shlib \
+                --with-blas \
+                --with-lapack && \
+    make -j 4 && \
+    make install && \
+    cd .. && \
+    rm -rf R-${R_VERSION}* && R --version && pip3 install --upgrade pip setuptools wheel&& \
+    pip3 install -r /tmp/requirements.txt && \
+    pip3 install -r /tmp/operator-requirements.txt && \
+    pip3 install -r /tmp/r-requirements.txt
+RUN Rscript -e "options(repos = c(CRAN = 'https://cran.r-project.org')); \
+                install.packages(c('coro', 'arrow'), \
+                                 Ncpus = parallel::detectCores())"
+ENV LD_LIBRARY_PATH=/usr/local/lib/R/lib:$LD_LIBRARY_PATH
 
 # Copy the built texera binary from the build phase
 COPY --from=build /core/amber/target/texera-0.1-SNAPSHOT /core/amber
@@ -50,7 +78,7 @@ COPY --from=build /core/amber/target/texera-0.1-SNAPSHOT /core/amber
 COPY --from=build /core/amber/src/main/resources /core/amber/src/main/resources
 COPY --from=build /core/workflow-core/src/main/resources /core/workflow-core/src/main/resources
 COPY --from=build /core/file-service/src/main/resources /core/file-service/src/main/resources
-# Copy code for python UDF
+# Copy code for python & R UDF
 COPY --from=build /core/amber/src/main/python /core/amber/src/main/python
 
 CMD ["bin/computing-unit-master"]

--- a/deployment/single-node/.env
+++ b/deployment/single-node/.env
@@ -14,6 +14,7 @@ STORAGE_JDBC_URL=jdbc:postgresql://texera-postgres:5432/texera_db?currentSchema=
 STORAGE_JDBC_USERNAME=texera
 STORAGE_JDBC_PASSWORD=password
 FILE_SERVICE_GET_PRESIGNED_URL_ENDPOINT=http://texera-file-service:9092/api/dataset/presign-download
+FILE_SERVICE_UPLOAD_ONE_FILE_TO_DATASET_ENDPOINT=http://texera-file-service:9092/api/dataset/did/upload
 USER_SYS_ENABLED=true
 STORAGE_ICEBERG_CATALOG_TYPE=postgres
 STORAGE_ICEBERG_CATALOG_POSTGRES_URI_WITHOUT_SCHEME=texera-postgres:5432/texera_iceberg_catalog

--- a/deployment/single-node/docker-compose.yml
+++ b/deployment/single-node/docker-compose.yml
@@ -1,5 +1,7 @@
 name: texera-single-node
 services:
+  # Part1: Specification of the storage services used by Texera
+  # MinIO is an S3-compatible object storage used to store datasets and files.
   minio:
     image: minio/minio:RELEASE.2025-02-28T09-55-16Z
     container_name: texera-minio
@@ -8,11 +10,11 @@ services:
     env_file:
       - .env
     volumes:
-      #Uncomment the below line instead if you want to mount the minio data to a certain directory on your machine
-      #- /path/to/the/local/folder:/data
       - minio_data:/data
     command: server --console-address ":9001" /data
 
+  # PostgreSQL with PGroonga extension for full-text search.
+  # Used by lakeFS and Texera's metadata storage.
   postgres:
     image: groonga/pgroonga:4.0.1-debian-15
     container_name: texera-postgres
@@ -25,12 +27,11 @@ services:
       retries: 5
       start_period: 5s
     volumes:
-      # Uncomment the below line if you want to mount the postgres data to a certain directory on your machine
-      #- /path/to/the/local/folder:/var/lib/postgresql/data
       - postgres_data:/var/lib/postgresql/data
       # mount the sql files for initializing the postgres
       - ../../core/scripts/sql:/docker-entrypoint-initdb.d
 
+  # lakeFS is the underlying storage of Texera's dataset service
   lakefs:
     image: treeverse/lakefs:1.51
     container_name: texera-lakefs
@@ -72,6 +73,8 @@ services:
       timeout: 5s
       retries: 10
 
+  # Part2: Specification of Texera's micro-services
+  # FileService provides endpoints for Texera's dataset management
   file-service:
     image: texera/file-service:test
     container_name: texera-file-service
@@ -84,6 +87,7 @@ services:
     env_file:
       - .env
 
+  # WorkflowCompilingService provides endpoints for sanity check and schema propagation while workflows are being edited
   workflow-compiling-service:
     image: texera/workflow-compiling-service:test
     container_name: texera-workflow-compiling-service
@@ -94,6 +98,7 @@ services:
     env_file:
       - .env
 
+  # TexeraWebApplication provides endpoints for hub resource management.
   texera-web-application:
     image: texera/texera-web-application:test
     container_name: texera-web-application
@@ -101,9 +106,12 @@ services:
     depends_on:
       file-service:
         condition: service_started
+      workflow-compiling-service:
+        condition: service_started
     env_file:
       - .env
-  
+
+  # ComputingUnitMaster provides endpoints for executing workflows and interactions during executions.
   computing-unit-master:
     image: texera/computing-unit-master:test
     container_name: texera-computing-unit-master
@@ -114,10 +122,9 @@ services:
     env_file:
       - .env
     volumes:
-      #Uncomment the below line instead if you want to mount the workflow result data to a certain directory on your machine
-      #- /path/to/the/local/folder:/core/amber/user-resources
       - computing_unit_data:/core/amber/user-resources
 
+  # Part 3: reverse proxy service for Texera's micro services
   nginx:
     image: nginx:alpine
     container_name: texera-nginx
@@ -130,10 +137,21 @@ services:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
     ports:
       - "8080:8080"
+
+# This section creates the named volumes for postgres, minio and workflow results, making sure data of these three
+#   services are persisted across containers terminations
 volumes:
   postgres_data:
   minio_data:
   computing_unit_data:
+  # By default, Docker assigns host locations for the above volumes.
+  # To bind them to specific local folders, configure each volume like below:
+  #   postgres_data:
+  #     driver: local
+  #     driver_opts:
+  #       type: none
+  #       o: bind
+  #       device: /absolute/path/to/your/local/folder
 
 networks:
   default:


### PR DESCRIPTION
This PR improves the `single-node` deployment scripts by:
1. add more instructions in `docker-compose.yml`
2. add R building phase in the dockerfile of computing-unit-master
3. add one more env var for export result