### PR TITLE
Add flags to the gui to control the displayed pages

### DIFF
--- a/core/gui/src/app/app-routing.module.ts
+++ b/core/gui/src/app/app-routing.module.ts
@@ -19,7 +19,7 @@ import { DatasetDetailComponent } from "./dashboard/component/user/user-dataset/
 import { UserDatasetComponent } from "./dashboard/component/user/user-dataset/user-dataset.component";
 import { HubWorkflowDetailComponent } from "./hub/component/workflow/detail/hub-workflow-detail.component";
 import { LandingPageComponent } from "./hub/component/landing-page/landing-page.component";
-import { DASHBOARD_USER_WORKFLOW } from "./app-routing.constant";
+import { DASHBOARD_USER_WORKFLOW, DASHBOARD_ABOUT } from "./app-routing.constant";
 import { HubSearchResultComponent } from "./hub/component/hub-search-result/hub-search-result.component";
 
 const routes: Routes = [];
@@ -137,7 +137,7 @@ if (environment.userSystemEnabled) {
 
   routes.push({
     path: "",
-    redirectTo: DASHBOARD_USER_WORKFLOW,
+    redirectTo: DASHBOARD_ABOUT,
     pathMatch: "full",
   });
 } else {

--- a/core/gui/src/app/common/service/user/auth-guard.service.ts
+++ b/core/gui/src/app/common/service/user/auth-guard.service.ts
@@ -2,7 +2,7 @@
 import { Router, CanActivate, RouterStateSnapshot, ActivatedRouteSnapshot } from "@angular/router";
 import { UserService } from "./user.service";
 import { environment } from "../../../../environments/environment";
-import { DASHBOARD_HOME } from "../../../app-routing.constant";
+import { DASHBOARD_ABOUT } from "../../../app-routing.constant";
 
 /**
  * AuthGuardService is a service can tell the router whether
@@ -18,7 +18,7 @@ export class AuthGuardService implements CanActivate {
     if (this.userService.isLogin() || !environment.userSystemEnabled) {
       return true;
     } else {
-      this.router.navigate([DASHBOARD_HOME], { queryParams: { returnUrl: state.url === "/" ? null : state.url } });
+      this.router.navigate([DASHBOARD_ABOUT], { queryParams: { returnUrl: state.url === "/" ? null : state.url } });
       return false;
     }
   }

--- a/core/gui/src/app/dashboard/component/dashboard.component.html
+++ b/core/gui/src/app/dashboard/component/dashboard.component.html
@@ -21,6 +21,7 @@
       </li>
 
       <li
+        *ngIf="environment.hubEnabled"
         nz-submenu
         nzTitle="Hub"
         nzIcon="usergroup-add"

--- a/core/gui/src/app/dashboard/component/dashboard.component.html
+++ b/core/gui/src/app/dashboard/component/dashboard.component.html
@@ -37,6 +37,7 @@
         nzOpen="true">
         <ul>
           <li
+            *ngIf="environment.projectEnabled"
             nz-menu-item
             nz-tooltip="Look up the user projects"
             nzMatchRouter="true"
@@ -83,7 +84,7 @@
             <span>Quota</span>
           </li>
           <li
-            *ngIf="displayForum"
+            *ngIf="environment.forumEnabled"
             nz-menu-item
             nz-tooltip="Open the discussion forum"
             nzMatchRouter="true"

--- a/core/gui/src/app/dashboard/component/dashboard.component.ts
+++ b/core/gui/src/app/dashboard/component/dashboard.component.ts
@@ -47,6 +47,7 @@ export class DashboardComponent implements OnInit {
   protected readonly DASHBOARD_ADMIN_USER = DASHBOARD_ADMIN_USER;
   protected readonly DASHBOARD_ADMIN_GMAIL = DASHBOARD_ADMIN_GMAIL;
   protected readonly DASHBOARD_ADMIN_EXECUTION = DASHBOARD_ADMIN_EXECUTION;
+  protected readonly environment = environment;
 
   constructor(
     private userService: UserService,

--- a/core/gui/src/app/dashboard/component/user/user-icon/user-icon.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-icon/user-icon.component.ts
@@ -3,7 +3,7 @@ import { UserService } from "../../../../common/service/user/user.service";
 import { User } from "../../../../common/type/user";
 import { UntilDestroy } from "@ngneat/until-destroy";
 import { Router } from "@angular/router";
-import { DASHBOARD_HOME } from "../../../../app-routing.constant";
+import { DASHBOARD_ABOUT } from "../../../../app-routing.constant";
 
 /**
  * UserIconComponent is used to control user system on the top right corner
@@ -32,6 +32,6 @@ export class UserIconComponent {
   public onClickLogout(): void {
     this.userService.logout();
     document.cookie = "flarum_remember=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;";
-    this.router.navigate([DASHBOARD_HOME]);
+    this.router.navigate([DASHBOARD_ABOUT]);
   }
 }

--- a/core/gui/src/app/hub/component/about/about.component.html
+++ b/core/gui/src/app/hub/component/about/about.component.html
@@ -43,7 +43,7 @@
       </p>
     </div>
     <texera-local-login
-      *ngIf="localLogin"
+      *ngIf="localLogin && !(isLogin$ | async)"
       class="login-container"
       nz-col
       nzFlex="300px"></texera-local-login>

--- a/core/gui/src/app/hub/component/about/about.component.ts
+++ b/core/gui/src/app/hub/component/about/about.component.ts
@@ -1,6 +1,8 @@
 import { UntilDestroy } from "@ngneat/until-destroy";
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { environment } from "../../../../environments/environment";
+import { UserService } from "src/app/common/service/user/user.service";
+import { BehaviorSubject } from "rxjs";
 
 @UntilDestroy()
 @Component({
@@ -8,8 +10,17 @@ import { environment } from "../../../../environments/environment";
   templateUrl: "./about.component.html",
   styleUrls: ["./about.component.scss"],
 })
-export class AboutComponent {
+export class AboutComponent implements OnInit {
   localLogin = environment.localLogin;
+  isLogin$ = new BehaviorSubject<boolean>(false); // control the visibility of the local login component
 
-  constructor() {}
+  constructor(private userService: UserService) {}
+
+  ngOnInit() {
+    this.isLogin$.next(this.userService.isLogin());
+    // Subscribe to user changes
+    this.userService.userChanged().subscribe(user => {
+      this.isLogin$.next(user !== undefined);
+    });
+  }
 }

--- a/core/gui/src/app/hub/component/hub.component.html
+++ b/core/gui/src/app/hub/component/hub.component.html
@@ -1,5 +1,6 @@
 <ul>
   <li
+    *ngIf="environment.hubEnabled"
     nz-menu-item
     nz-tooltip="Home Page"
     nzMatchRouter="true"
@@ -11,6 +12,7 @@
     <span> Home </span>
   </li>
   <li
+    *ngIf="environment.hubEnabled"
     nz-menu-item
     nz-tooltip="Search public workflows"
     nzMatchRouter="true"
@@ -22,6 +24,7 @@
     <span>Workflows</span>
   </li>
   <li
+    *ngIf="environment.hubEnabled"
     nz-menu-item
     nz-tooltip="Search public dataset"
     nzMatchRouter="true"

--- a/core/gui/src/app/hub/component/hub.component.ts
+++ b/core/gui/src/app/hub/component/hub.component.ts
@@ -5,6 +5,7 @@ import {
   DASHBOARD_HUB_DATASET_RESULT,
   DASHBOARD_HUB_WORKFLOW_RESULT,
 } from "../../app-routing.constant";
+import { environment } from "../../../environments/environment";
 
 @Component({
   selector: "texera-hub",
@@ -16,4 +17,5 @@ export class HubComponent {
   protected readonly DASHBOARD_HOME = DASHBOARD_HOME;
   protected readonly DASHBOARD_HUB_WORKFLOW_RESULT = DASHBOARD_HUB_WORKFLOW_RESULT;
   protected readonly DASHBOARD_HUB_DATASET_RESULT = DASHBOARD_HUB_DATASET_RESULT;
+  protected readonly environment = environment;
 }

--- a/core/gui/src/environments/environment.default.ts
+++ b/core/gui/src/environments/environment.default.ts
@@ -114,6 +114,16 @@ export const defaultEnvironment = {
    * whether hub feature is enabled
    */
   hubEnabled: true,
+
+  /**
+   * whether forum feature is enabled
+   */
+  forumEnabled: false,
+
+  /**
+   * whether project feature is enabled
+   */
+  projectEnabled: false,
 };
 
 export type AppEnv = typeof defaultEnvironment;

--- a/core/gui/src/environments/environment.default.ts
+++ b/core/gui/src/environments/environment.default.ts
@@ -109,6 +109,11 @@ export const defaultEnvironment = {
    * whether to send email notification when workflow execution is completed/failed/paused/killed
    */
   workflowEmailNotificationEnabled: false,
+
+  /**
+   * whether hub feature is enabled
+   */
+  hubEnabled: true,
 };
 
 export type AppEnv = typeof defaultEnvironment;


### PR DESCRIPTION
This PR adds three flags to the frontend:

- `hubEnabled`: control whether the hub-related tabs are displayed in the frontend, by default it is true
- `forumEnabled`: control whether the forum feature is enabled in the frontend, by default it is false
- `projectEnabled`: control whether the project feature is enabled in the frontend, by default it is false

Additionally, this PR changes the default landing page to the About page when the user system is enabled. The About page will be displayed when users first visit the application.