### PR TITLE
Fix Visualization Rendering Issue Caused by String Truncation Logic in Backend

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ExecutionResultService.scala
@@ -55,9 +55,13 @@ object ExecutionResultService {
     * NULL values are converted to the string "NULL".
     *
     * @param tuples The collection of Tuples to convert
+    * @param isVisualization Whether this is for visualization rendering (affects string truncation)
     * @return A List of ObjectNodes containing the JSON representation of the tuples
     */
-  def convertTuplesToJson(tuples: Iterable[Tuple]): List[ObjectNode] = {
+  def convertTuplesToJson(
+      tuples: Iterable[Tuple],
+      isVisualization: Boolean = false
+  ): List[ObjectNode] = {
     val maxStringLength = 100
 
     tuples.map { tuple =>
@@ -107,7 +111,7 @@ object ExecutionResultService {
                     }
                   case AttributeType.STRING =>
                     val stringValue = value.asInstanceOf[String]
-                    if (stringValue.length > maxStringLength)
+                    if (stringValue.length > maxStringLength && !isVisualization)
                       stringValue.take(maxStringLength) + "..."
                     else
                       stringValue
@@ -153,7 +157,7 @@ object ExecutionResultService {
       mode: WebOutputMode,
       table: List[Tuple]
   ): WebDataUpdate = {
-    val tableInJson = convertTuplesToJson(table)
+    val tableInJson = convertTuplesToJson(table, mode == SetSnapshotMode())
     WebDataUpdate(mode, tableInJson)
   }
 


### PR DESCRIPTION
This PR addresses a regression introduced in PR #3331, which prevented the visualization operator's result from being displayed correctly.

Cause:
PR #3331 moved the string truncation logic from the backend to the frontend to improve memory efficiency. However, the backend continued to truncate all string results, without checking whether the result was an HTML-based visualization or a standard table. Since visualizations are represented as HTML strings, truncating them led to broken outputs on the frontend.

Fix:
The backend now differentiates between visualization and table results before applying string truncation. This ensures that visualization outputs are no longer truncated and are rendered properly on the frontend.