### PR TITLE
Fix unaligned representation of python binary objects

### DIFF
--- a/core/amber/src/main/python/core/models/test_tuple.py
+++ b/core/amber/src/main/python/core/models/test_tuple.py
@@ -284,9 +284,7 @@ class TestTuple:
         # Verify pickle behavior
         assert isinstance(test_tuple2["complex_field"], list)
         assert len(test_tuple2["complex_field"]) > 0
-        assert all(
-            chunk.startswith(b"pickle    ") for chunk in test_tuple2["complex_field"]
-        )
+        assert test_tuple2["complex_field"][0].startswith(b"pickle    ")
 
     def test_schema_validation(self):
         """Test the schema validation logic for different field types."""


### PR DESCRIPTION
In #3331, we changed the binary field representation from a single byte string to a list of byte chunks to support large objects. However, this introduced an inconsistency in how the data is interpreted across operators. On the sender side, the tuple field contains the original Python object, but after transmission, the receiving operator sees the field as a list of byte chunks instead of the original object. This PR fixes the bug by ensuring consistent serialization and deserialization of binary fields across operators.

This PR also fixes a single object being parsed as multiple objects on the receiver side by appending all the chunks together before parsing.
