### PR TITLE
moved question mark bubble to right of property window so it doesn't overlap the name edit button

### DIFF
--- a/core/gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.html
+++ b/core/gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.html
@@ -26,7 +26,8 @@
     nzPopoverTitle="Python Lambda Function Instructions"
     nzType="question-circle"
     nzTheme="outline"
-    [nzPopoverContent]="PythonLambdaPopContent"></i>
+    [nzPopoverContent]="PythonLambdaPopContent"
+    class="question-circle-button"></i>
 
   <ng-template #PythonLambdaPopContent>
     You can add a new column by:

--- a/core/gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.scss
+++ b/core/gui/src/app/workspace/component/property-editor/operator-property-edit-frame/operator-property-edit-frame.component.scss
@@ -23,6 +23,13 @@
   color: gray;
 }
 
+.question-circle-button{
+  position: absolute; 
+  right: 0; 
+  top: 50%; 
+  transform: translate(0, -50%);
+}
+
 ::ng-deep {
   // overwrite the color of the Formly error message box
   .property-editor-form {


### PR DESCRIPTION
## Description
This PR moves the question mark (?) tooltip icon to the right side of the property window. Previously, the tooltip icon overlapped with the name edit button, resulting in visual clutter and making the button challenging to interact with.

## Changes:
Added a question-circle-button class and a CSS style to move the question mark to the right and middle of the property window header

## Before:
<img width="839" alt="helpButtonBefore" src="https://github.com/user-attachments/assets/19831415-6bdd-4c54-bae6-6698ed8c8037" />

## After:
<img width="839" alt="helpButtonAfter" src="https://github.com/user-attachments/assets/99c91b3a-d23c-4be0-89b5-4273b656107a" />

