### PR TITLE
Fix heap error for exporting zip result

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ResultExportService.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/service/ResultExportService.scala
@@ -533,7 +533,6 @@ class ResultExportService(workflowIdentity: WorkflowIdentity) {
               zipOut.write(msg.getBytes(StandardCharsets.UTF_8))
               zipOut.closeEntry()
             } else {
-              val results = operatorDocument.get().to(Iterable)
               val extension = request.exportType match {
                 case "csv"   => "csv"
                 case "arrow" => "arrow"
@@ -547,8 +546,11 @@ class ResultExportService(workflowIdentity: WorkflowIdentity) {
 
               request.exportType match {
                 case "csv"   => writeCSVLocal(nonClosingStream, operatorDocument)
-                case "arrow" => writeArrowLocal(nonClosingStream, results)
+                case "arrow" =>
+                  val results = operatorDocument.get().to(Iterable)
+                  writeArrowLocal(nonClosingStream, results)
                 case "data" =>
+                  val results = operatorDocument.get().to(Iterable)
                   writeDataLocal(nonClosingStream, request, results) // handle single cell export
                 case _ => writeCSVLocal(nonClosingStream, operatorDocument)
               }


### PR DESCRIPTION
This PR is continuous of previous [fix](https://github.com/Texera/texera/pull/3350) on exporting large CSV result. 
The core logic was implemented in the last PR, here, we just replace the full result forwarded to `ZipOutputStream` with the stream of data to prevent heap error. 