### PR TITLE
Fixes for BoxViolinPlot Operator (Descriptions, Variables, Functions)

### DIFF
--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxViolinPlot/BoxViolinPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxViolinPlot/BoxViolinPlotOpDesc.scala
@@ -40,7 +40,7 @@ class BoxViolinPlotOpDesc extends PythonOperatorDescriptor {
     required = true,
     defaultValue = "linear"
   )
-  var quertiletype: BoxViolinPlotQuartileFunction = _
+  var quertileType: BoxViolinPlotQuartileFunction = _
 
   override def getOutputSchemas(
       inputSchemas: Map[PortIdentity, Schema]
@@ -83,7 +83,7 @@ class BoxViolinPlotOpDesc extends PythonOperatorDescriptor {
        |                fig = px.box(table, x='$value',boxmode="overlay", points='all')
        |            else:
        |                fig = px.box(table, y='$value',boxmode="overlay", points='all')
-       |        fig.update_traces(quartilemethod="${quertiletype.getQuartiletype}", col=1)
+       |        fig.update_traces(quartilemethod="${quertileType.getQuartiletype}", col=1)
        |        fig.update_layout(margin=dict(t=0, b=0, l=0, r=0))
        |""".stripMargin
   }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxViolinPlot/BoxViolinPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxViolinPlot/BoxViolinPlotOpDesc.scala
@@ -21,26 +21,26 @@ class BoxViolinPlotOpDesc extends PythonOperatorDescriptor {
 
   @JsonProperty(value = "value", required = true)
   @JsonSchemaTitle("Value Column")
-  @JsonPropertyDescription("Data Column for Boxplot")
+  @JsonPropertyDescription("Data column for box plot")
   @AutofillAttributeName
   var value: String = ""
 
   @JsonProperty(defaultValue = "false")
   @JsonSchemaTitle("Horizontal Orientation")
-  @JsonPropertyDescription("Orientation Style")
-  var orientation: Boolean = _
+  @JsonPropertyDescription("Orientation style")
+  var horizontalOrientation: Boolean = _
 
   @JsonProperty(defaultValue = "false")
   @JsonSchemaTitle("Violin Plot")
-  @JsonPropertyDescription("Use Violin Plot")
-  var violinplot: Boolean = _
+  @JsonPropertyDescription("Check this box to overlay a violin plot on the box plot; otherwise, show only the box plot")
+  var violinPlot: Boolean = _
 
   @JsonProperty(
     value = "Quartile Method",
     required = true,
     defaultValue = "linear"
   )
-  var quertiletype: BoxPlotQuartileFunction = _
+  var quertiletype: BoxViolinPlotQuartileFunction = _
 
   override def getOutputSchemas(
       inputSchemas: Map[PortIdentity, Schema]
@@ -54,7 +54,7 @@ class BoxViolinPlotOpDesc extends PythonOperatorDescriptor {
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
       "Box/Violin Plot",
-      "Visualize data using either a Box Plot or a Violin Plot. Boxplots are drawn as a box with a vertical line down the middle which is mean value, and has horizontal lines attached to each side (known as “whiskers”). Violin plots are similar to box plots, but with a rotated kernel density plot on each side, providing more insight into the distribution shape.",
+      "Visualize data using either a Box Plot or a Violin Plot. A violin plot includes a box plot and all data points for reference. Box plots are drawn as a box with a vertical line down the middle which is mean value, and has horizontal lines attached to each side (known as “whiskers”). Violin plots provide more detail by showing a smoothed density curve on each side, and also include a box plot inside for comparison.",
       OperatorGroupConstants.VISUALIZATION_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
@@ -70,8 +70,8 @@ class BoxViolinPlotOpDesc extends PythonOperatorDescriptor {
   }
 
   def createPlotlyFigure(): String = {
-    val horizontal = if (orientation) "True" else "False"
-    val violin = if (violinplot) "True" else "False"
+    val horizontal = if (horizontalOrientation) "True" else "False"
+    val violin = if (violinPlot) "True" else "False"
     s"""
        |        if($violin):
        |            if ($horizontal):
@@ -83,8 +83,7 @@ class BoxViolinPlotOpDesc extends PythonOperatorDescriptor {
        |                fig = px.box(table, x='$value',boxmode="overlay", points='all')
        |            else:
        |                fig = px.box(table, y='$value',boxmode="overlay", points='all')
-       |            fig.update_traces(quartilemethod="${quertiletype.getQuartiletype}", jitter=0, col=1)
-       |
+       |        fig.update_traces(quartilemethod="${quertiletype.getQuartiletype}", col=1)
        |        fig.update_layout(margin=dict(t=0, b=0, l=0, r=0))
        |""".stripMargin
   }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxViolinPlot/BoxViolinPlotQuartileFunction.java
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxViolinPlot/BoxViolinPlotQuartileFunction.java
@@ -2,13 +2,13 @@ package edu.uci.ics.amber.operator.visualization.boxViolinPlot;
 
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum BoxPlotQuartileFunction {
+public enum BoxViolinPlotQuartileFunction {
     LINEAR("linear"),
     INCLUSIVE("inclusive"),
     EXCLUSIVE("exclusive");
     private final String quartiletype;
 
-    BoxPlotQuartileFunction(String quartiletype) {
+    BoxViolinPlotQuartileFunction(String quartiletype) {
         this.quartiletype = quartiletype;
     }
 


### PR DESCRIPTION
This PR fixes a previous PR (#3356), and includes the following updates:

- Renamed variables for better clarity and consistency:
  - orientation → horizontalOrientation
  - violinplot → violinPlot
  - quartiletype → quartileType
- Updated the Violin Plot checkbox description to clarify its behavior
- Revised the operator description to explain that the violin plot overlays the box plot for better visualization
- Modified the createPlotlyFigure() method:
  - Now supports `quartileType` when `box=True` in a violin plot
  - Removed `jitter=0` to allow data points to spread naturally instead of forming a straight line — this shows the distribution shape better
<img width="1439" alt="image" src="https://github.com/user-attachments/assets/b8e96412-aadb-4b96-97fb-16eb6a67179b" />
