### PR TITLE
Fix hard-coded values and wrong configurations in Helm

### DIFF
--- a/deployment/k8s/texera-helmchart/templates/envoy-config.yaml
+++ b/deployment/k8s/texera-helmchart/templates/envoy-config.yaml
@@ -40,7 +40,7 @@ data:
                                 local uri = request_handle:headers():get(":path")
                                 local cuid = string.match(uri, "cuid=(%d+)")
                                 if cuid then
-                                  local new_host = "computing-unit-" .. cuid .. ".workflow-computing-unit-svc.workflow-computing-unit-pool.svc.cluster.local:8085"
+                                  local new_host = "computing-unit-" .. cuid .. ".{{ .Values.workflowComputingUnitPool.name }}-svc.{{ .Values.workflowComputingUnitPool.namespace }}.svc.cluster.local:{{ .Values.workflowComputingUnitPool.service.port }}"
                                   request_handle:headers():replace(":authority", new_host)
                                 end
                               end

--- a/deployment/k8s/texera-helmchart/templates/external-names.yaml
+++ b/deployment/k8s/texera-helmchart/templates/external-names.yaml
@@ -18,7 +18,7 @@ spec:
 
 {{/* Define namespace variables for better readability */}}
 {{- $namespace := .Release.Namespace }}
-{{- $workflowNamespace := .Values.workflowComputingUnitPool.namespace }}
+{{- $workflowComputingUnitPoolNamespace := .Values.workflowComputingUnitPool.namespace }}
 
 {{/* 
 Create ExternalName services in the workflow namespace to allow compute units
@@ -28,7 +28,7 @@ to access services in the main namespace using the same service names.
 {{/* File service ExternalName */}}
 {{- include "external-name-service" (dict 
   "name" (printf "%s-svc" .Values.fileService.name)
-  "namespace" $workflowNamespace
+  "namespace" $workflowComputingUnitPoolNamespace
   "externalName" (printf "%s-svc.%s.svc.cluster.local" .Values.fileService.name $namespace)
 ) | nindent 0 }}
 
@@ -36,7 +36,7 @@ to access services in the main namespace using the same service names.
 {{/* PostgreSQL ExternalName */}}
 {{- include "external-name-service" (dict 
   "name" (printf "%s-postgresql" .Release.Name)
-  "namespace" $workflowNamespace
+  "namespace" $workflowComputingUnitPoolNamespace
   "externalName" (printf "%s-postgresql.%s.svc.cluster.local" .Release.Name $namespace)
 ) | nindent 0 }}
 
@@ -44,7 +44,7 @@ to access services in the main namespace using the same service names.
 {{/* Webserver ExternalName */}}
 {{- include "external-name-service" (dict 
   "name" (printf "%s-svc" .Values.webserver.name)
-  "namespace" $workflowNamespace
+  "namespace" $workflowComputingUnitPoolNamespace
   "externalName" (printf "%s-svc.%s.svc.cluster.local" .Values.webserver.name $namespace)
 ) | nindent 0 }}
 

--- a/deployment/k8s/texera-helmchart/templates/minio-ingress.yaml
+++ b/deployment/k8s/texera-helmchart/templates/minio-ingress.yaml
@@ -3,9 +3,10 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: texera-minio-api-ingress
-  namespace: texera
+  namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.minio.customIngress.ingressClassName }}
+    cert-manager.io/issuer: {{ .Values.minio.customIngress.issuer }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/cors-allow-origin: "http://{{ .Values.minio.customIngress.texeraHostname }}"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, PUT, POST, DELETE, OPTIONS"

--- a/deployment/k8s/texera-helmchart/templates/minio-ingress.yaml
+++ b/deployment/k8s/texera-helmchart/templates/minio-ingress.yaml
@@ -6,9 +6,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.minio.customIngress.ingressClassName }}
+    {{- if .Values.minio.customIngress.issuer }}
     cert-manager.io/issuer: {{ .Values.minio.customIngress.issuer }}
+    {{- end }}
     nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/cors-allow-origin: "http://{{ .Values.minio.customIngress.texeraHostname }}"
+    nginx.ingress.kubernetes.io/cors-allow-origin: "{{ .Values.minio.customIngress.texeraHostname }}"
     nginx.ingress.kubernetes.io/cors-allow-methods: "GET, PUT, POST, DELETE, OPTIONS"
     nginx.ingress.kubernetes.io/cors-allow-headers: "*"
     nginx.ingress.kubernetes.io/cors-expose-headers: "ETag, x-amz-meta-custom-header"
@@ -21,19 +23,26 @@ metadata:
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/x-forwarded-proto: "https"
     nginx.ingress.kubernetes.io/backend-protocol: "HTTP"
+    {{- if or .Values.ingressPaths.tlsSecretName .Values.ingressPaths.issuer }}
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    {{- end }}
 spec:
   ingressClassName: {{ .Values.minio.customIngress.ingressClassName }}
+  {{- if or .Values.ingressPaths.tlsSecretName .Values.ingressPaths.issuer }}
+  tls:
+    - hosts:
+        - {{ .Values.minio.customIngress.minioHostname }}
+      secretName: {{ .Values.ingressPaths.tlsSecretName | default (printf "%s-minio-tls" .Release.Name) }}
+  {{- end }}
   rules:
-    {{- if .Values.minio.customIngress.minioHostname }}
     - host: {{ .Values.minio.customIngress.minioHostname }}
-    {{- end}}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: texera-minio
+                name: {{ .Release.Name }}-minio
                 port:
                   number: 9000
 {{- end }}

--- a/deployment/k8s/texera-helmchart/templates/minio-ingress.yaml
+++ b/deployment/k8s/texera-helmchart/templates/minio-ingress.yaml
@@ -27,7 +27,7 @@ spec:
     {{- if .Values.minio.customIngress.minioHostname }}
     - host: {{ .Values.minio.customIngress.minioHostname }}
     {{- end}}
-    - http:
+      http:
         paths:
           - path: /
             pathType: Prefix

--- a/deployment/k8s/texera-helmchart/templates/postgresql-init-script-config.yaml
+++ b/deployment/k8s/texera-helmchart/templates/postgresql-init-script-config.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Release.Name }}-postgresql-init-script
+  name: {{ .Values.postgresql.primary.initdb.scriptsConfigMap }}
   namespace: {{ .Release.Namespace }}
   labels:
     app: {{ .Release.Name }}

--- a/deployment/k8s/texera-helmchart/values.yaml
+++ b/deployment/k8s/texera-helmchart/values.yaml
@@ -37,22 +37,23 @@ minio:
   mode: standalone
   customIngress:
     enabled: false
-    ingressClassName: ""
-    texeraHostname: ""
-    minioHostname: ""
+    ingressClassName: "" # e.g., "nginx"
+    texeraHostname: "" # the url for the texera
+    minioHostname: "" # the url for the minio
     issuer: "" # e.g., "letsencrypt-prod"
   auth:
     rootUser: texera_minio
     rootPassword: password
   service:
-    type: ClusterIP
-    #  type: NodePort
-    #  nodePorts:
-    #   api: 31000
+    # In production, use ClusterIP to avoid exposing the minio to the internet
+    # type: ClusterIP
+    type: NodePort
+    nodePorts:
+      api: 31000
   persistence:
     enabled: true
     size: 20Gi
-    storageClass: local-path # change to specific storageClass if needed.
+    storageClass: local-path
     existingClaim: "minio-data-pvc"
 
 lakefs:
@@ -97,9 +98,8 @@ webserver:
   numOfPods: 1  # Number of pods for the Texera deployment
   imageName: texera/texera-web-application:cluster # image name of the texera
   service:
-    type: NodePort
-    port: 8080 # port of the pod
-    nodePort: 30081 # exposed port
+    type: ClusterIP
+    port: 8080
 
 workflowComputingUnitManager:
   name: workflow-computing-unit-manager
@@ -107,27 +107,24 @@ workflowComputingUnitManager:
   serviceAccountName: workflow-computing-unit-manager-service-account
   imageName: texera/workflow-computing-unit-managing-service:cluster
   service:
-    type: NodePort
-    port: 8888 # port of the pod
-    nodePort: 30082 # exposed port
+    type: ClusterIP
+    port: 8888
 
 workflowCompilingService:
   name: workflow-compiling-service
   numOfPods: 1
   imageName: texera/workflow-compiling-service:cluster
   service:
-    type: NodePort
+    type: ClusterIP
     port: 9090
-    nodePort: 30083 # exposed port
 
 fileService:
   name: file-service
   numOfPods: 1
   imageName: texera/file-service:cluster
   service:
-    type: NodePort
+    type: ClusterIP
     port: 9092
-    nodePort: 30084 # exposed port
 
 # Configs of the envoy proxy, used to routerequests to the computing units
 envoy:
@@ -139,9 +136,8 @@ envoy:
     10000
   debug: false
   service:
-    type: NodePort
+    type: ClusterIP
     port: 10000
-    nodePort: 30085
 
 # headless service for the access of computing units
 workflowComputingUnitPool:
@@ -169,7 +165,7 @@ texeraEnvVars:
 
 # Ingress dependency configs
 ingress-nginx:
-  enabled: true # set to true if nginx is not installed.
+  enabled: true # set to true if nginx is not installed, should be false in production
   controller:
     replicaCount: 1
     service:
@@ -207,10 +203,8 @@ pythonLanguageServer:
       memory: "100Mi"
 
 # Metrics Server configuration
-# IMPORTANT: If metrics-server is not installed in your cluster, set enabled: true
-# If metrics-server is already installed, set enabled: false to avoid conflicts
 metrics-server:
-  enabled: false
+  enabled: true # set to false if metrics-server is already installed
   args:
     - --kubelet-insecure-tls
     - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname

--- a/deployment/k8s/texera-helmchart/values.yaml
+++ b/deployment/k8s/texera-helmchart/values.yaml
@@ -38,7 +38,7 @@ minio:
   customIngress:
     enabled: false
     ingressClassName: "" # e.g., "nginx"
-    texeraHostname: "" # the url for the texera
+    texeraHostname: "" # the url for the texera WITH http or https, e.g., "https://texera.example.com"
     minioHostname: "" # the url for the minio
     issuer: "" # e.g., "letsencrypt-prod"
   auth:

--- a/deployment/k8s/texera-helmchart/values.yaml
+++ b/deployment/k8s/texera-helmchart/values.yaml
@@ -9,7 +9,7 @@ global:
 #   - true: PVCs will be deleted when helm uninstalls the chart
 #   - false: PVCs will remain after uninstall to preserve the data
 persistence:
-  removeAfterUninstall: false
+  removeAfterUninstall: true
 
 # Part 1: the configuration of Postgres, Minio and LakeFS
 postgresql:
@@ -31,7 +31,7 @@ postgresql:
       existingClaim: "postgresql-data-pvc"
 
     initdb:
-      scriptsConfigMap: texera-postgresql-init-script
+      scriptsConfigMap: "postgresql-init-script"
 
 minio:
   mode: standalone
@@ -40,13 +40,15 @@ minio:
     ingressClassName: ""
     texeraHostname: ""
     minioHostname: ""
+    issuer: "" # e.g., "letsencrypt-prod"
   auth:
     rootUser: texera_minio
     rootPassword: password
   service:
-    type: NodePort
-    nodePorts:
-      api: 31000
+    type: ClusterIP
+    #  type: NodePort
+    #  nodePorts:
+    #   api: 31000
   persistence:
     enabled: true
     size: 20Gi
@@ -95,8 +97,9 @@ webserver:
   numOfPods: 1  # Number of pods for the Texera deployment
   imageName: texera/texera-web-application:cluster # image name of the texera
   service:
-    type: ClusterIP
+    type: NodePort
     port: 8080 # port of the pod
+    nodePort: 30081 # exposed port
 
 workflowComputingUnitManager:
   name: workflow-computing-unit-manager
@@ -104,24 +107,27 @@ workflowComputingUnitManager:
   serviceAccountName: workflow-computing-unit-manager-service-account
   imageName: texera/workflow-computing-unit-managing-service:cluster
   service:
-    type: ClusterIP
+    type: NodePort
     port: 8888 # port of the pod
+    nodePort: 30082 # exposed port
 
 workflowCompilingService:
   name: workflow-compiling-service
   numOfPods: 1
   imageName: texera/workflow-compiling-service:cluster
   service:
-    type: ClusterIP
+    type: NodePort
     port: 9090
+    nodePort: 30083 # exposed port
 
 fileService:
   name: file-service
   numOfPods: 1
   imageName: texera/file-service:cluster
   service:
-    type: ClusterIP
+    type: NodePort
     port: 9092
+    nodePort: 30084 # exposed port
 
 # Configs of the envoy proxy, used to routerequests to the computing units
 envoy:
@@ -133,14 +139,17 @@ envoy:
     10000
   debug: false
   service:
-    type: ClusterIP
+    type: NodePort
     port: 10000
+    nodePort: 30085
 
 # headless service for the access of computing units
 workflowComputingUnitPool:
   createNamespaces: true
-  name: workflow-computing-unit
-  namespace: workflow-computing-unit-pool
+  # The name of the workflow computing unit pool
+  name: texera-workflow-computing-unit
+  # Note: the namespace of the workflow computing unit pool might conflict when there are multiple texera deployments in the same cluster
+  namespace: texera-workflow-computing-unit-pool
   imageName: texera/computing-unit-master:cluster
   service:
     port: 8085
@@ -201,7 +210,7 @@ pythonLanguageServer:
 # IMPORTANT: If metrics-server is not installed in your cluster, set enabled: true
 # If metrics-server is already installed, set enabled: false to avoid conflicts
 metrics-server:
-  enabled: true
+  enabled: false
   args:
     - --kubelet-insecure-tls
     - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
@@ -218,7 +227,7 @@ metrics-server:
 
 # Custom Ingress resource configs
 ingressPaths:
-  enabled: false
+  enabled: true
   hostname: "localhost"
   # Optional TLS secret (manually created)
   tlsSecretName: ""  # e.g., "texera-tls"


### PR DESCRIPTION
As titled, this PR fixes:
- some hard-coded values
- wrong configurations for ingress

With this fix, multiple releases **with `texera` as the release name** in different namespaces can co-exist.