### PR TITLE
Fix File Scan Operator Extract Function

### DIFF
--- a/core/workflow-operator/build.sbt
+++ b/core/workflow-operator/build.sbt
@@ -92,6 +92,7 @@ libraryDependencies ++= Seq(
   "com.github.tototoshi" %% "scala-csv" % "1.3.10",       // csv parser
   "com.konghq" % "unirest-java" % "3.14.2",
   "commons-io" % "commons-io" % "2.15.1",
+  "org.apache.commons" % "commons-compress" % "1.27.1",
   "org.tukaani" % "xz" % "1.9",
   "com.univocity" % "univocity-parsers" % "2.9.1",
   "org.apache.lucene" % "lucene-analyzers-common" % "8.11.4",

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/source/scan/FileScanSourceOpExec.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/source/scan/FileScanSourceOpExec.scala
@@ -9,11 +9,12 @@ import org.apache.commons.io.IOUtils.toByteArray
 import java.io._
 import java.net.URI
 import java.nio.ByteBuffer
-import java.util.zip.ZipInputStream
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.IteratorHasAsScala
 import scala.util.Using
 import scala.collection.mutable.ArrayBuffer
+import org.apache.commons.compress.archivers.ArchiveStreamFactory
+import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream
 
 class FileScanSourceOpExec private[scan] (
     descString: String
@@ -57,7 +58,10 @@ class FileScanSourceOpExec private[scan] (
     val fileEntries: Iterator[InputStream] = {
       val is = DocumentFactory.openReadonlyDocument(new URI(desc.fileName.get)).asInputStream()
       if (desc.extract) {
-        val inputStream = new ZipInputStream(new BufferedInputStream(is))
+        val inputStream: ZipArchiveInputStream =
+          new ArchiveStreamFactory().createArchiveInputStream(
+            new BufferedInputStream(is)
+          )
         val (it1, it2) = Iterator
           .continually(inputStream.getNextEntry)
           .takeWhile(_ != null)


### PR DESCRIPTION
Fix the bug that File Scan Operator cannot extract zip files by reverting the changes we made in #3290 and using the latest version of apache commons compress