### PR TITLE
Enhance Visualization Grouping with New Category Hierarchy

### DIFF
--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/metadata/OperatorGroupConstants.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/metadata/OperatorGroupConstants.scala
@@ -12,6 +12,12 @@ object OperatorGroupConstants {
   final val UTILITY_GROUP = "Utilities"
   final val API_GROUP = "External API"
   final val VISUALIZATION_GROUP = "Visualization"
+  final val VISUALIZATION_BASIC = "Basic"
+  final val VISUALIZATION_STATISTICAL = "Statistical"
+  final val VISUALIZATION_SCIENTIFIC = "Scientific"
+  final val VISUALIZATION_FINANCIAL = "Financial"
+  final val VISUALIZATION_MEDIA = "Media"
+  final val VISUALIZATION_ADVANCED = "Advanced"
   final val MACHINE_LEARNING_GROUP = "Machine Learning"
   final val ADVANCED_SKLEARN_GROUP = "Advanced Sklearn"
   final val HUGGINGFACE_GROUP = "Hugging Face"
@@ -47,7 +53,17 @@ object OperatorGroupConstants {
     GroupInfo(UTILITY_GROUP),
     GroupInfo(API_GROUP),
     GroupInfo(UDF_GROUP, List(GroupInfo(PYTHON_GROUP), GroupInfo(JAVA_GROUP), GroupInfo(R_GROUP))),
-    GroupInfo(VISUALIZATION_GROUP),
+    GroupInfo(
+      VISUALIZATION_GROUP,
+      List(
+        GroupInfo(VISUALIZATION_BASIC),
+        GroupInfo(VISUALIZATION_STATISTICAL),
+        GroupInfo(VISUALIZATION_SCIENTIFIC),
+        GroupInfo(VISUALIZATION_FINANCIAL),
+        GroupInfo(VISUALIZATION_MEDIA),
+        GroupInfo(VISUALIZATION_ADVANCED)
+      )
+    ),
     GroupInfo(CONTROL_GROUP)
   )
 }

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/metadata/OperatorGroupConstants.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/metadata/OperatorGroupConstants.scala
@@ -12,12 +12,12 @@ object OperatorGroupConstants {
   final val UTILITY_GROUP = "Utilities"
   final val API_GROUP = "External API"
   final val VISUALIZATION_GROUP = "Visualization"
-  final val VISUALIZATION_BASIC = "Basic"
-  final val VISUALIZATION_STATISTICAL = "Statistical"
-  final val VISUALIZATION_SCIENTIFIC = "Scientific"
-  final val VISUALIZATION_FINANCIAL = "Financial"
-  final val VISUALIZATION_MEDIA = "Media"
-  final val VISUALIZATION_ADVANCED = "Advanced"
+  final val VISUALIZATION_BASIC_GROUP = "Basic"
+  final val VISUALIZATION_STATISTICAL_GROUP = "Statistical"
+  final val VISUALIZATION_SCIENTIFIC_GROUP = "Scientific"
+  final val VISUALIZATION_FINANCIAL_GROUP = "Financial"
+  final val VISUALIZATION_MEDIA_GROUP = "Media"
+  final val VISUALIZATION_ADVANCED_GROUP = "Advanced"
   final val MACHINE_LEARNING_GROUP = "Machine Learning"
   final val ADVANCED_SKLEARN_GROUP = "Advanced Sklearn"
   final val HUGGINGFACE_GROUP = "Hugging Face"
@@ -56,12 +56,12 @@ object OperatorGroupConstants {
     GroupInfo(
       VISUALIZATION_GROUP,
       List(
-        GroupInfo(VISUALIZATION_BASIC),
-        GroupInfo(VISUALIZATION_STATISTICAL),
-        GroupInfo(VISUALIZATION_SCIENTIFIC),
-        GroupInfo(VISUALIZATION_FINANCIAL),
-        GroupInfo(VISUALIZATION_MEDIA),
-        GroupInfo(VISUALIZATION_ADVANCED)
+        GroupInfo(VISUALIZATION_BASIC_GROUP),
+        GroupInfo(VISUALIZATION_STATISTICAL_GROUP),
+        GroupInfo(VISUALIZATION_SCIENTIFIC_GROUP),
+        GroupInfo(VISUALIZATION_FINANCIAL_GROUP),
+        GroupInfo(VISUALIZATION_MEDIA_GROUP),
+        GroupInfo(VISUALIZATION_ADVANCED_GROUP)
       )
     ),
     GroupInfo(CONTROL_GROUP)

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/DotPlot/DotPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/DotPlot/DotPlotOpDesc.scala
@@ -28,9 +28,9 @@ class DotPlotOpDesc extends PythonOperatorDescriptor {
 
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
-      "DotPlot",
+      "Dot Plot",
       "Visualize data using a dot plot",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_BASIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/DotPlot/DotPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/DotPlot/DotPlotOpDesc.scala
@@ -30,7 +30,7 @@ class DotPlotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Dot Plot",
       "Visualize data using a dot plot",
-      OperatorGroupConstants.VISUALIZATION_BASIC,
+      OperatorGroupConstants.VISUALIZATION_BASIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/IcicleChart/IcicleChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/IcicleChart/IcicleChartOpDesc.scala
@@ -47,7 +47,7 @@ class IcicleChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Icicle Chart",
       "Visualize hierarchical data from root to leaves",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_BASIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/IcicleChart/IcicleChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/IcicleChart/IcicleChartOpDesc.scala
@@ -47,7 +47,7 @@ class IcicleChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Icicle Chart",
       "Visualize hierarchical data from root to leaves",
-      OperatorGroupConstants.VISUALIZATION_BASIC,
+      OperatorGroupConstants.VISUALIZATION_BASIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ImageViz/ImageVisualizerOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ImageViz/ImageVisualizerOpDesc.scala
@@ -29,7 +29,7 @@ class ImageVisualizerOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Image Visualizer",
       "visualize image content",
-      OperatorGroupConstants.VISUALIZATION_MEDIA,
+      OperatorGroupConstants.VISUALIZATION_MEDIA_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ImageViz/ImageVisualizerOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ImageViz/ImageVisualizerOpDesc.scala
@@ -29,7 +29,7 @@ class ImageVisualizerOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Image Visualizer",
       "visualize image content",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_MEDIA,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ScatterMatrixChart/ScatterMatrixChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ScatterMatrixChart/ScatterMatrixChartOpDesc.scala
@@ -24,13 +24,13 @@ class ScatterMatrixChartOpDesc extends PythonOperatorDescriptor {
 
   @JsonProperty(value = "Selected Attributes", required = true)
   @JsonSchemaTitle("Selected Attributes")
-  @JsonPropertyDescription("the axes of each scatter plot in the matrix.")
+  @JsonPropertyDescription("The axes of each scatter plot in the matrix.")
   @AutofillAttributeNameList
   var selectedAttributes: List[String] = _
 
   @JsonProperty(value = "Color", required = true)
   @JsonSchemaTitle("Color Column")
-  @JsonPropertyDescription("column to color points")
+  @JsonPropertyDescription("Column to color points")
   @AutofillAttributeName
   var color: String = ""
 
@@ -47,7 +47,7 @@ class ScatterMatrixChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Scatter Matrix Chart",
       "Visualize datasets in a Scatter Matrix",
-      OperatorGroupConstants.VISUALIZATION_STATISTICAL,
+      OperatorGroupConstants.VISUALIZATION_STATISTICAL_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ScatterMatrixChart/ScatterMatrixChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ScatterMatrixChart/ScatterMatrixChartOpDesc.scala
@@ -47,7 +47,7 @@ class ScatterMatrixChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Scatter Matrix Chart",
       "Visualize datasets in a Scatter Matrix",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_STATISTICAL,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/barChart/BarChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/barChart/BarChartOpDesc.scala
@@ -23,7 +23,7 @@ class BarChartOpDesc extends PythonOperatorDescriptor {
 
   @JsonProperty(value = "value", required = true)
   @JsonSchemaTitle("Value Column")
-  @JsonPropertyDescription("the value associated with each category")
+  @JsonPropertyDescription("The value associated with each category")
   @AutofillAttributeName
   var value: String = ""
 
@@ -63,7 +63,7 @@ class BarChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Bar Chart",
       "Visualize data in a Bar Chart",
-      OperatorGroupConstants.VISUALIZATION_BASIC,
+      OperatorGroupConstants.VISUALIZATION_BASIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/barChart/BarChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/barChart/BarChartOpDesc.scala
@@ -63,7 +63,7 @@ class BarChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Bar Chart",
       "Visualize data in a Bar Chart",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_BASIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxViolinPlot/BoxViolinPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxViolinPlot/BoxViolinPlotOpDesc.scala
@@ -55,7 +55,7 @@ class BoxViolinPlotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Box/Violin Plot",
       "Visualize data using either a Box Plot or a Violin Plot. Boxplots are drawn as a box with a vertical line down the middle which is mean value, and has horizontal lines attached to each side (known as “whiskers”). Violin plots are similar to box plots, but with a rotated kernel density plot on each side, providing more insight into the distribution shape.",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_STATISTICAL,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxViolinPlot/BoxViolinPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/boxViolinPlot/BoxViolinPlotOpDesc.scala
@@ -55,7 +55,7 @@ class BoxViolinPlotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Box/Violin Plot",
       "Visualize data using either a Box Plot or a Violin Plot. Boxplots are drawn as a box with a vertical line down the middle which is mean value, and has horizontal lines attached to each side (known as “whiskers”). Violin plots are similar to box plots, but with a rotated kernel density plot on each side, providing more insight into the distribution shape.",
-      OperatorGroupConstants.VISUALIZATION_STATISTICAL,
+      OperatorGroupConstants.VISUALIZATION_STATISTICAL_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/bubbleChart/BubbleChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/bubbleChart/BubbleChartOpDesc.scala
@@ -56,7 +56,7 @@ class BubbleChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Bubble Chart",
       "a 3D Scatter Plot; Bubbles are graphed using x and y labels, and their sizes determined by a z-value.",
-      OperatorGroupConstants.VISUALIZATION_BASIC,
+      OperatorGroupConstants.VISUALIZATION_BASIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/bubbleChart/BubbleChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/bubbleChart/BubbleChartOpDesc.scala
@@ -56,7 +56,7 @@ class BubbleChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Bubble Chart",
       "a 3D Scatter Plot; Bubbles are graphed using x and y labels, and their sizes determined by a z-value.",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_BASIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/candlestickChart/CandlestickChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/candlestickChart/CandlestickChartOpDesc.scala
@@ -54,7 +54,7 @@ class CandlestickChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Candlestick Chart",
       "Visualize data in a Candlestick Chart",
-      OperatorGroupConstants.VISUALIZATION_FINANCIAL,
+      OperatorGroupConstants.VISUALIZATION_FINANCIAL_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/candlestickChart/CandlestickChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/candlestickChart/CandlestickChartOpDesc.scala
@@ -54,7 +54,7 @@ class CandlestickChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Candlestick Chart",
       "Visualize data in a Candlestick Chart",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_FINANCIAL,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/continuousErrorBands/ContinuousErrorBandsOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/continuousErrorBands/ContinuousErrorBandsOpDesc.scala
@@ -38,7 +38,7 @@ class ContinuousErrorBandsOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Continuous Error Bands",
       "Visualize error or uncertainty along a continuous line",
-      OperatorGroupConstants.VISUALIZATION_STATISTICAL,
+      OperatorGroupConstants.VISUALIZATION_STATISTICAL_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/continuousErrorBands/ContinuousErrorBandsOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/continuousErrorBands/ContinuousErrorBandsOpDesc.scala
@@ -38,7 +38,7 @@ class ContinuousErrorBandsOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Continuous Error Bands",
       "Visualize error or uncertainty along a continuous line",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_STATISTICAL,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/contourPlot/ContourPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/contourPlot/ContourPlotOpDesc.scala
@@ -59,7 +59,7 @@ class ContourPlotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Contour Plot",
       "Displays terrain or gradient variations in a Contour Plot",
-      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC,
+      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/contourPlot/ContourPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/contourPlot/ContourPlotOpDesc.scala
@@ -59,7 +59,7 @@ class ContourPlotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Contour Plot",
       "Displays terrain or gradient variations in a Contour Plot",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/dendrogram/DendrogramOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/dendrogram/DendrogramOpDesc.scala
@@ -45,7 +45,7 @@ class DendrogramOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Dendrogram",
       "Visualize data in a Dendrogram",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/dendrogram/DendrogramOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/dendrogram/DendrogramOpDesc.scala
@@ -45,7 +45,7 @@ class DendrogramOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Dendrogram",
       "Visualize data in a Dendrogram",
-      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC,
+      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/dumbbellPlot/DumbbellPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/dumbbellPlot/DumbbellPlotOpDesc.scala
@@ -70,9 +70,9 @@ class DumbbellPlotOpDesc extends PythonOperatorDescriptor {
 
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
-      "DumbbellPlot",
+      "Dumbbell Plot",
       "Visualize data in a Dumbbell Plots. A dumbbell plots (also known as a lollipop chart) is typically used to compare two distinct values or time points for the same entity.",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_BASIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/dumbbellPlot/DumbbellPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/dumbbellPlot/DumbbellPlotOpDesc.scala
@@ -72,7 +72,7 @@ class DumbbellPlotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Dumbbell Plot",
       "Visualize data in a Dumbbell Plots. A dumbbell plots (also known as a lollipop chart) is typically used to compare two distinct values or time points for the same entity.",
-      OperatorGroupConstants.VISUALIZATION_BASIC,
+      OperatorGroupConstants.VISUALIZATION_BASIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/figureFactoryTable/FigureFactoryTableOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/figureFactoryTable/FigureFactoryTableOpDesc.scala
@@ -98,7 +98,7 @@ class FigureFactoryTableOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Figure Factory Table",
       "Visualize data in a figure factory table",
-      OperatorGroupConstants.VISUALIZATION_BASIC,
+      OperatorGroupConstants.VISUALIZATION_BASIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/figureFactoryTable/FigureFactoryTableOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/figureFactoryTable/FigureFactoryTableOpDesc.scala
@@ -96,9 +96,9 @@ class FigureFactoryTableOpDesc extends PythonOperatorDescriptor {
 
   override def operatorInfo: OperatorInfo = {
     OperatorInfo(
-      "FigureFactoryTable",
+      "Figure Factory Table",
       "Visualize data in a figure factory table",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_BASIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
@@ -59,7 +59,7 @@ class FilledAreaPlotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Filled Area Plot",
       "Visualize data in filled area plot",
-      OperatorGroupConstants.VISUALIZATION_BASIC,
+      OperatorGroupConstants.VISUALIZATION_BASIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/filledAreaPlot/FilledAreaPlotOpDesc.scala
@@ -57,9 +57,9 @@ class FilledAreaPlotOpDesc extends PythonOperatorDescriptor {
 
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
-      "FilledAreaPlot",
+      "Filled Area Plot",
       "Visualize data in filled area plot",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_BASIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/funnelPlot/FunnelPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/funnelPlot/FunnelPlotOpDesc.scala
@@ -48,7 +48,7 @@ class FunnelPlotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Funnel Plot",
       "Visualize data in a Funnel Plot",
-      OperatorGroupConstants.VISUALIZATION_FINANCIAL,
+      OperatorGroupConstants.VISUALIZATION_FINANCIAL_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/funnelPlot/FunnelPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/funnelPlot/FunnelPlotOpDesc.scala
@@ -46,9 +46,9 @@ class FunnelPlotOpDesc extends PythonOperatorDescriptor {
 
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
-      "FunnelPlot",
+      "Funnel Plot",
       "Visualize data in a Funnel Plot",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_FINANCIAL,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ganttChart/GanttChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ganttChart/GanttChartOpDesc.scala
@@ -66,7 +66,7 @@ class GanttChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Gantt Chart",
       "A Gantt chart is a type of bar chart that illustrates a project schedule. The chart lists the tasks to be performed on the vertical axis, and time intervals on the horizontal axis. The width of the horizontal bars in the graph shows the duration of each activity.",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_BASIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ganttChart/GanttChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ganttChart/GanttChartOpDesc.scala
@@ -66,7 +66,7 @@ class GanttChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Gantt Chart",
       "A Gantt chart is a type of bar chart that illustrates a project schedule. The chart lists the tasks to be performed on the vertical axis, and time intervals on the horizontal axis. The width of the horizontal bars in the graph shows the duration of each activity.",
-      OperatorGroupConstants.VISUALIZATION_BASIC,
+      OperatorGroupConstants.VISUALIZATION_BASIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/heatMap/HeatMapOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/heatMap/HeatMapOpDesc.scala
@@ -39,9 +39,9 @@ class HeatMapOpDesc extends PythonOperatorDescriptor {
 
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
-      "HeatMap Chart",
+      "Heatmap",
       "Visualize data in a HeatMap Chart",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/heatMap/HeatMapOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/heatMap/HeatMapOpDesc.scala
@@ -41,7 +41,7 @@ class HeatMapOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Heatmap",
       "Visualize data in a HeatMap Chart",
-      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC,
+      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/hierarchychart/HierarchyChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/hierarchychart/HierarchyChartOpDesc.scala
@@ -50,7 +50,7 @@ class HierarchyChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Hierarchy Chart",
       "Visualize data in hierarchy",
-      OperatorGroupConstants.VISUALIZATION_BASIC,
+      OperatorGroupConstants.VISUALIZATION_BASIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/hierarchychart/HierarchyChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/hierarchychart/HierarchyChartOpDesc.scala
@@ -21,19 +21,19 @@ import edu.uci.ics.amber.operator.PythonOperatorDescriptor
 class HierarchyChartOpDesc extends PythonOperatorDescriptor {
   @JsonProperty(required = true)
   @JsonSchemaTitle("Chart Type")
-  @JsonPropertyDescription("treemap or sunburst")
+  @JsonPropertyDescription("Treemap or Sunburst")
   var hierarchyChartType: HierarchyChartType = _
 
   @JsonProperty(required = true)
   @JsonSchemaTitle("Hierarchy Path")
   @JsonPropertyDescription(
-    "hierarchy of attributes from a higher-level category to lower-level category"
+    "Hierarchy of attributes from a higher-level category to lower-level category"
   )
   var hierarchy: List[HierarchySection] = List()
 
   @JsonProperty(value = "value", required = true)
   @JsonSchemaTitle("Value Column")
-  @JsonPropertyDescription("the value associated with the size of each sector in the chart")
+  @JsonPropertyDescription("The value associated with the size of each sector in the chart")
   @AutofillAttributeName
   var value: String = ""
 
@@ -50,7 +50,7 @@ class HierarchyChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Hierarchy Chart",
       "Visualize data in hierarchy",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_BASIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/histogram/HistogramChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/histogram/HistogramChartOpDesc.scala
@@ -42,7 +42,7 @@ class HistogramChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Histogram",
       "Visualize data in a Histogram Chart",
-      OperatorGroupConstants.VISUALIZATION_STATISTICAL,
+      OperatorGroupConstants.VISUALIZATION_STATISTICAL_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/histogram/HistogramChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/histogram/HistogramChartOpDesc.scala
@@ -40,9 +40,9 @@ class HistogramChartOpDesc extends PythonOperatorDescriptor {
 
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
-      "Histogram Chart",
+      "Histogram",
       "Visualize data in a Histogram Chart",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_STATISTICAL,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/htmlviz/HtmlVizOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/htmlviz/HtmlVizOpDesc.scala
@@ -49,7 +49,7 @@ class HtmlVizOpDesc extends LogicalOp {
     OperatorInfo(
       "HTML Visualizer",
       "Render the result of HTML content",
-      OperatorGroupConstants.VISUALIZATION_MEDIA,
+      OperatorGroupConstants.VISUALIZATION_MEDIA_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/htmlviz/HtmlVizOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/htmlviz/HtmlVizOpDesc.scala
@@ -47,9 +47,9 @@ class HtmlVizOpDesc extends LogicalOp {
 
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
-      "HTML visualizer",
+      "HTML Visualizer",
       "Render the result of HTML content",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_MEDIA,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/lineChart/LineChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/lineChart/LineChartOpDesc.scala
@@ -39,7 +39,7 @@ class LineChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Line Chart",
       "View the result in line chart",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_BASIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/lineChart/LineChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/lineChart/LineChartOpDesc.scala
@@ -39,7 +39,7 @@ class LineChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Line Chart",
       "View the result in line chart",
-      OperatorGroupConstants.VISUALIZATION_BASIC,
+      OperatorGroupConstants.VISUALIZATION_BASIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/networkGraph/NetworkGraphOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/networkGraph/NetworkGraphOpDesc.scala
@@ -39,7 +39,7 @@ class NetworkGraphOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Network Graph",
       "Visualize data in a network graph",
-      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC,
+      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/networkGraph/NetworkGraphOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/networkGraph/NetworkGraphOpDesc.scala
@@ -39,7 +39,7 @@ class NetworkGraphOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Network Graph",
       "Visualize data in a network graph",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/pieChart/PieChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/pieChart/PieChartOpDesc.scala
@@ -46,7 +46,7 @@ class PieChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Pie Chart",
       "Visualize data in a Pie Chart",
-      OperatorGroupConstants.VISUALIZATION_BASIC,
+      OperatorGroupConstants.VISUALIZATION_BASIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/pieChart/PieChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/pieChart/PieChartOpDesc.scala
@@ -23,13 +23,13 @@ class PieChartOpDesc extends PythonOperatorDescriptor {
 
   @JsonProperty(value = "value", required = true)
   @JsonSchemaTitle("Value Column")
-  @JsonPropertyDescription("the value associated with slice of pie")
+  @JsonPropertyDescription("The value associated with slice of pie")
   @AutofillAttributeName
   var value: String = ""
 
   @JsonProperty(value = "name", required = true)
   @JsonSchemaTitle("Name Column")
-  @JsonPropertyDescription("the name of the slice of pie")
+  @JsonPropertyDescription("The name of the slice of pie")
   @AutofillAttributeName
   var name: String = ""
 
@@ -44,9 +44,9 @@ class PieChartOpDesc extends PythonOperatorDescriptor {
 
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
-      "PieChart",
+      "Pie Chart",
       "Visualize data in a Pie Chart",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_BASIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/quiverPlot/QuiverPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/quiverPlot/QuiverPlotOpDesc.scala
@@ -24,22 +24,22 @@ class QuiverPlotOpDesc extends PythonOperatorDescriptor {
 
   @JsonProperty(value = "x", required = true)
   @JsonSchemaTitle("x")
-  @JsonPropertyDescription("column for the x-coordinate of the starting point")
+  @JsonPropertyDescription("Column for the x-coordinate of the starting point")
   @AutofillAttributeName var x: String = ""
 
   @JsonProperty(value = "y", required = true)
   @JsonSchemaTitle("y")
-  @JsonPropertyDescription("column for the y-coordinate of the starting point")
+  @JsonPropertyDescription("Column for the y-coordinate of the starting point")
   @AutofillAttributeName var y: String = ""
 
   @JsonProperty(value = "u", required = true)
   @JsonSchemaTitle("u")
-  @JsonPropertyDescription("column for the vector component in the x-direction")
+  @JsonPropertyDescription("Column for the vector component in the x-direction")
   @AutofillAttributeName var u: String = ""
 
   @JsonProperty(value = "v", required = true)
   @JsonSchemaTitle("v")
-  @JsonPropertyDescription("column for the vector component in the y-direction")
+  @JsonPropertyDescription("Column for the vector component in the y-direction")
   @AutofillAttributeName var v: String = ""
 
   override def getOutputSchemas(
@@ -55,7 +55,7 @@ class QuiverPlotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Quiver Plot",
       "Visualize vector data in a Quiver Plot",
-      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC,
+      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/quiverPlot/QuiverPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/quiverPlot/QuiverPlotOpDesc.scala
@@ -55,7 +55,7 @@ class QuiverPlotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Quiver Plot",
       "Visualize vector data in a Quiver Plot",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_SCIENTIFIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/sankeyDiagram/SankeyDiagramOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/sankeyDiagram/SankeyDiagramOpDesc.scala
@@ -42,7 +42,7 @@ class SankeyDiagramOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Sankey Diagram",
       "Visualize data using a Sankey diagram",
-      OperatorGroupConstants.VISUALIZATION_BASIC,
+      OperatorGroupConstants.VISUALIZATION_BASIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/sankeyDiagram/SankeyDiagramOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/sankeyDiagram/SankeyDiagramOpDesc.scala
@@ -13,19 +13,19 @@ class SankeyDiagramOpDesc extends PythonOperatorDescriptor {
 
   @JsonProperty(value = "Source Attribute", required = true)
   @JsonSchemaTitle("Source Attribute")
-  @JsonPropertyDescription("the source node of the Sankey diagram")
+  @JsonPropertyDescription("The source node of the Sankey diagram")
   @AutofillAttributeName
   var sourceAttribute: String = ""
 
   @JsonProperty(value = "Target Attribute", required = true)
   @JsonSchemaTitle("Target Attribute")
-  @JsonPropertyDescription("the target node of the Sankey diagram")
+  @JsonPropertyDescription("The target node of the Sankey diagram")
   @AutofillAttributeName
   var targetAttribute: String = ""
 
   @JsonProperty(value = "Value Attribute", required = true)
   @JsonSchemaTitle("Value Attribute")
-  @JsonPropertyDescription("the value/volume of the flow between source and target")
+  @JsonPropertyDescription("The value/volume of the flow between source and target")
   @AutofillAttributeName
   var valueAttribute: String = ""
 
@@ -42,7 +42,7 @@ class SankeyDiagramOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Sankey Diagram",
       "Visualize data using a Sankey diagram",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_BASIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatter3DChart/Scatter3dChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatter3DChart/Scatter3dChartOpDesc.scala
@@ -47,7 +47,7 @@ class Scatter3dChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Scatter3D Chart",
       "Visualize data in a Scatter3D Plot",
-      OperatorGroupConstants.VISUALIZATION_ADVANCED,
+      OperatorGroupConstants.VISUALIZATION_ADVANCED_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatter3DChart/Scatter3dChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatter3DChart/Scatter3dChartOpDesc.scala
@@ -47,7 +47,7 @@ class Scatter3dChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Scatter3D Chart",
       "Visualize data in a Scatter3D Plot",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_ADVANCED,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatterplot/ScatterplotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatterplot/ScatterplotOpDesc.scala
@@ -46,17 +46,17 @@ class ScatterplotOpDesc extends PythonOperatorDescriptor {
 
   @JsonProperty(required = false, defaultValue = "false")
   @JsonSchemaTitle("log scale X")
-  @JsonPropertyDescription("values in X-column is log-scaled")
+  @JsonPropertyDescription("Values in X-column is log-scaled")
   var xLogScale: Boolean = false
 
   @JsonProperty(required = false, defaultValue = "false")
   @JsonSchemaTitle("log scale Y")
-  @JsonPropertyDescription("values in Y-column is log-scaled")
+  @JsonPropertyDescription("Values in Y-column is log-scaled")
   var yLogScale: Boolean = false
 
   @JsonProperty(required = false)
   @JsonSchemaTitle("Hover column")
-  @JsonPropertyDescription("column value to display when a dot is hovered over")
+  @JsonPropertyDescription("Column value to display when a dot is hovered over")
   @AutofillAttributeName
   var hoverName: String = ""
 
@@ -73,7 +73,7 @@ class ScatterplotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Scatter Plot",
       "View the result in a scatterplot",
-      OperatorGroupConstants.VISUALIZATION_BASIC,
+      OperatorGroupConstants.VISUALIZATION_BASIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatterplot/ScatterplotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/scatterplot/ScatterplotOpDesc.scala
@@ -71,9 +71,9 @@ class ScatterplotOpDesc extends PythonOperatorDescriptor {
 
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
-      "Scatterplot",
+      "Scatter Plot",
       "View the result in a scatterplot",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_BASIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/tablesChart/TablesPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/tablesChart/TablesPlotOpDesc.scala
@@ -74,7 +74,7 @@ class TablesPlotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Tables Plot",
       "Visualize data in a table chart.",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_BASIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/tablesChart/TablesPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/tablesChart/TablesPlotOpDesc.scala
@@ -74,7 +74,7 @@ class TablesPlotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Tables Plot",
       "Visualize data in a table chart.",
-      OperatorGroupConstants.VISUALIZATION_BASIC,
+      OperatorGroupConstants.VISUALIZATION_BASIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ternaryPlot/TernaryPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ternaryPlot/TernaryPlotOpDesc.scala
@@ -52,7 +52,7 @@ class TernaryPlotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       userFriendlyName = "Ternary Plot",
       operatorDescription = "Points are graphed on a Ternary Plot using 3 specified data fields",
-      operatorGroupName = OperatorGroupConstants.VISUALIZATION_SCIENTIFIC,
+      operatorGroupName = OperatorGroupConstants.VISUALIZATION_SCIENTIFIC_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ternaryPlot/TernaryPlotOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/ternaryPlot/TernaryPlotOpDesc.scala
@@ -52,7 +52,7 @@ class TernaryPlotOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       userFriendlyName = "Ternary Plot",
       operatorDescription = "Points are graphed on a Ternary Plot using 3 specified data fields",
-      operatorGroupName = OperatorGroupConstants.VISUALIZATION_GROUP,
+      operatorGroupName = OperatorGroupConstants.VISUALIZATION_SCIENTIFIC,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/urlviz/UrlVizOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/urlviz/UrlVizOpDesc.scala
@@ -60,7 +60,7 @@ class UrlVizOpDesc extends LogicalOp {
     OperatorInfo(
       "URL Visualizer",
       "Render the content of URL",
-      OperatorGroupConstants.VISUALIZATION_MEDIA,
+      OperatorGroupConstants.VISUALIZATION_MEDIA_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/urlviz/UrlVizOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/urlviz/UrlVizOpDesc.scala
@@ -58,9 +58,9 @@ class UrlVizOpDesc extends LogicalOp {
 
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
-      "URL visualizer",
+      "URL Visualizer",
       "Render the content of URL",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_MEDIA,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/waterfallChart/WaterfallChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/waterfallChart/WaterfallChartOpDesc.scala
@@ -36,7 +36,7 @@ class WaterfallChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Waterfall Chart",
       "Visualize data as a waterfall chart",
-      OperatorGroupConstants.VISUALIZATION_FINANCIAL,
+      OperatorGroupConstants.VISUALIZATION_FINANCIAL_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/waterfallChart/WaterfallChartOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/waterfallChart/WaterfallChartOpDesc.scala
@@ -36,7 +36,7 @@ class WaterfallChartOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Waterfall Chart",
       "Visualize data as a waterfall chart",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_FINANCIAL,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/wordCloud/WordCloudOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/wordCloud/WordCloudOpDesc.scala
@@ -36,8 +36,8 @@ class WordCloudOpDesc extends PythonOperatorDescriptor {
   override def operatorInfo: OperatorInfo =
     OperatorInfo(
       "Word Cloud",
-      "Generate word cloud for result texts",
-      OperatorGroupConstants.VISUALIZATION_MEDIA,
+      "Generate word cloud for   texts",
+      OperatorGroupConstants.VISUALIZATION_MEDIA_GROUP,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/wordCloud/WordCloudOpDesc.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/visualization/wordCloud/WordCloudOpDesc.scala
@@ -37,7 +37,7 @@ class WordCloudOpDesc extends PythonOperatorDescriptor {
     OperatorInfo(
       "Word Cloud",
       "Generate word cloud for result texts",
-      OperatorGroupConstants.VISUALIZATION_GROUP,
+      OperatorGroupConstants.VISUALIZATION_MEDIA,
       inputPorts = List(InputPort()),
       outputPorts = List(OutputPort(mode = OutputMode.SINGLE_SNAPSHOT))
     )


### PR DESCRIPTION
### **Purpose:**
This PR reorganizes the visualization operator categories to improve clarity and ease of use in Texera’s visualization suite. By introducing sub-categories (Basic, Statistical, Scientific, Financial, Media, Advanced) under the main "Visualization" group, users will be able to quickly filter and locate the specific types of visualizations they need.

### **Changes:**
_OperatorGroupConstants:_
- Added new sub-category constants (e.g., VISUALIZATION_BASIC_GROUP, VISUALIZATION_STATISTICAL_GROUP, VISUALIZATION_SCIENTIFIC_GROUP, VISUALIZATION_FINANCIAL_GROUP, VISUALIZATION_MEDIA_GROUP, and VISUALIZATION_ADVANCED_GROUP).

_Operator Reassignment:_
- Updated the operatorInfo of each visualization operator to assign it to the appropriate sub-category.
- Renamed some operators to follow a consistent naming rubric, improving readability and ensuring uniformity across the board.

### **Demonstration:**
- Visual Overview:
<img width="258" alt="reorg2" src="https://github.com/user-attachments/assets/63498074-82c0-4284-900c-292af77bcbf1" />
<img width="257" alt="reorg3" src="https://github.com/user-attachments/assets/ab31b3b5-65e8-43ca-8ccc-bf442fbcb5f7" />

- Sub-Category Organization: [[texera_visualization_opeators.xlsx](https://github.com/user-attachments/files/19715165/texera_visualization_opeators.xlsx)]
<img width="875" alt="reorg1" src="https://github.com/user-attachments/assets/bb61d4b1-e8e1-4b3e-bd73-4b1982476305" />

