### PR TITLE
Add GPU support for creating the computing unit

### DIFF
--- a/core/computing-unit-managing-service/src/main/resources/kubernetes.conf
+++ b/core/computing-unit-managing-service/src/main/resources/kubernetes.conf
@@ -19,4 +19,12 @@ kubernetes {
 
   computing-unit-memory-limit-options = "1Gi,2Gi,4Gi"
   computing-unit-memory-limit-options = ${?KUBERNETES_COMPUTING_UNIT_MEMORY_LIMIT_OPTIONS}
+
+  # GPU configuration
+  computing-unit-gpu-limit-options = "0,1,2"
+  computing-unit-gpu-limit-options = ${?KUBERNETES_COMPUTING_UNIT_GPU_LIMIT_OPTIONS}
+  
+  # GPU resource key used in Kubernetes (vendor-specific)
+  computing-unit-gpu-resource-key = "nvidia.com/gpu"
+  computing-unit-gpu-resource-key = ${?KUBERNETES_COMPUTING_UNIT_GPU_RESOURCE_KEY}
 }

--- a/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/KubernetesConfig.scala
+++ b/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/KubernetesConfig.scala
@@ -30,4 +30,15 @@ object KubernetesConfig {
       .map(_.trim)
       .filter(_.nonEmpty)
       .toList
+      
+  val gpuLimitOptions: List[String] =
+    conf
+      .getString("kubernetes.computing-unit-gpu-limit-options")
+      .split(",")
+      .map(_.trim)
+      .filter(_.nonEmpty)
+      .toList
+      
+  // GPU resource key used directly in Kubernetes resource specifications
+  val gpuResourceKey: String = conf.getString("kubernetes.computing-unit-gpu-resource-key")
 }

--- a/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/KubernetesConfig.scala
+++ b/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/KubernetesConfig.scala
@@ -30,7 +30,7 @@ object KubernetesConfig {
       .map(_.trim)
       .filter(_.nonEmpty)
       .toList
-      
+
   val gpuLimitOptions: List[String] =
     conf
       .getString("kubernetes.computing-unit-gpu-limit-options")
@@ -38,7 +38,7 @@ object KubernetesConfig {
       .map(_.trim)
       .filter(_.nonEmpty)
       .toList
-      
+
   // GPU resource key used directly in Kubernetes resource specifications
   val gpuResourceKey: String = conf.getString("kubernetes.computing-unit-gpu-resource-key")
 }

--- a/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/resource/ComputingUnitManagingResource.scala
+++ b/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/resource/ComputingUnitManagingResource.scala
@@ -8,7 +8,12 @@ import edu.uci.ics.texera.dao.SqlServer.withTransaction
 import edu.uci.ics.texera.dao.jooq.generated.tables.daos.WorkflowComputingUnitDao
 import edu.uci.ics.texera.dao.jooq.generated.tables.pojos.WorkflowComputingUnit
 import edu.uci.ics.texera.service.KubernetesConfig
-import edu.uci.ics.texera.service.KubernetesConfig.{cpuLimitOptions, gpuLimitOptions, maxNumOfRunningComputingUnitsPerUser, memoryLimitOptions}
+import edu.uci.ics.texera.service.KubernetesConfig.{
+  cpuLimitOptions,
+  gpuLimitOptions,
+  maxNumOfRunningComputingUnitsPerUser,
+  memoryLimitOptions
+}
 import edu.uci.ics.texera.service.resource.ComputingUnitManagingResource._
 import edu.uci.ics.texera.service.util.KubernetesClient
 import io.dropwizard.auth.Auth
@@ -48,8 +53,12 @@ object ComputingUnitManagingResource {
       .get,
     // Variables for amber setting
     // TODO: use AmberConfig for the following items. Currently AmberConfig is only accessible in workflow-executing-service
-    EnvironmentalVariable.ENV_SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR -> true,
-    EnvironmentalVariable.ENV_USER_SYS_ENABLED -> true
+    EnvironmentalVariable.ENV_SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR -> EnvironmentalVariable
+      .get(EnvironmentalVariable.ENV_SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR)
+      .get,
+    EnvironmentalVariable.ENV_USER_SYS_ENABLED -> EnvironmentalVariable
+      .get(EnvironmentalVariable.ENV_USER_SYS_ENABLED)
+      .get
   )
 
   def userOwnComputingUnit(ctx: DSLContext, cuid: Integer, uid: Integer): Boolean = {
@@ -198,7 +207,8 @@ class ComputingUnitManagingResource {
           param.memoryLimit,
           param.gpuLimit,
           computingUnitEnvironmentVariables ++ Map(
-            EnvironmentalVariable.ENV_USER_JWT_TOKEN -> userToken
+            EnvironmentalVariable.ENV_USER_JWT_TOKEN -> userToken,
+            EnvironmentalVariable.ENV_JAVA_OPTS -> "-Xmx2G"
           )
         )
 

--- a/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/util/KubernetesClient.scala
+++ b/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/util/KubernetesClient.scala
@@ -123,9 +123,18 @@ object KubernetesClient {
       .addToLabels("cuid", cuid.toString)
       .addToLabels("name", podName)
 
-    val pod = podBuilder
+    // Start building the pod spec
+    val specBuilder = podBuilder
       .endMetadata()
       .withNewSpec()
+      
+    // Only add runtimeClassName when using NVIDIA GPU
+    if (gpuLimit != "0" && KubernetesConfig.gpuResourceKey.contains("nvidia")) {
+      specBuilder.withRuntimeClassName("nvidia")
+    }
+    
+    // Complete the pod spec
+    val pod = specBuilder
       .addNewContainer()
       .withName("computing-unit-master")
       .withImage(KubernetesConfig.computeUnitImageName)

--- a/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/util/KubernetesClient.scala
+++ b/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/util/KubernetesClient.scala
@@ -70,9 +70,11 @@ object KubernetesClient {
     getPodByName(generatePodName(cuid))
       .flatMap { pod =>
         pod.getSpec.getContainers.asScala.headOption.map { container =>
-          container.getResources.getLimits.asScala.map {
+          val limitsMap = container.getResources.getLimits.asScala.map {
             case (key, value) => key -> value.toString
           }.toMap
+          
+          limitsMap
         }
       }
       .getOrElse(Map.empty[String, String])
@@ -82,6 +84,7 @@ object KubernetesClient {
       cuid: Int,
       cpuLimit: String,
       memoryLimit: String,
+      gpuLimit: String,
       envVars: Map[String, Any]
   ): Pod = {
     val podName = generatePodName(cuid)
@@ -100,14 +103,33 @@ object KubernetesClient {
       .toList
       .asJava
 
-    val pod = new PodBuilder()
+    // Setup the resource requirements
+    val resourceBuilder = new ResourceRequirementsBuilder()
+      .addToLimits("cpu", new Quantity(cpuLimit))
+      .addToLimits("memory", new Quantity(memoryLimit))
+    
+    // Only add GPU resources if the requested amount is greater than 0
+    if (gpuLimit != "0") {
+      // Use the configured GPU resource key directly
+      resourceBuilder.addToLimits(KubernetesConfig.gpuResourceKey, new Quantity(gpuLimit))
+    }
+
+    // Build the pod with metadata
+    val podBuilder = new PodBuilder()
       .withNewMetadata()
       .withName(podName)
       .withNamespace(namespace)
       .addToLabels("type", "computing-unit")
       .addToLabels("cuid", cuid.toString)
       .addToLabels("name", podName)
-      .endMetadata()
+      
+    // Add GPU-specific labels if GPU is requested
+    if (gpuLimit != "0") {
+      podBuilder.addToLabels("gpu-enabled", "true")
+      podBuilder.addToLabels("gpu-resource", KubernetesConfig.gpuResourceKey)
+    }
+      
+    val pod = podBuilder.endMetadata()
       .withNewSpec()
       .addNewContainer()
       .withName("computing-unit-master")
@@ -116,10 +138,7 @@ object KubernetesClient {
       .withContainerPort(KubernetesConfig.computeUnitPortNumber)
       .endPort()
       .withEnv(envList)
-      .withNewResources()
-      .addToLimits("cpu", new Quantity(cpuLimit))
-      .addToLimits("memory", new Quantity(memoryLimit))
-      .endResources()
+      .withResources(resourceBuilder.build())
       .endContainer()
       .withHostname(podName)
       .withSubdomain(KubernetesConfig.computeUnitServiceName)

--- a/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/util/KubernetesClient.scala
+++ b/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/util/KubernetesClient.scala
@@ -127,12 +127,12 @@ object KubernetesClient {
     val specBuilder = podBuilder
       .endMetadata()
       .withNewSpec()
-      
+
     // Only add runtimeClassName when using NVIDIA GPU
     if (gpuLimit != "0" && KubernetesConfig.gpuResourceKey.contains("nvidia")) {
       specBuilder.withRuntimeClassName("nvidia")
     }
-    
+
     // Complete the pod spec
     val pod = specBuilder
       .addNewContainer()

--- a/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/util/KubernetesClient.scala
+++ b/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/util/KubernetesClient.scala
@@ -73,7 +73,7 @@ object KubernetesClient {
           val limitsMap = container.getResources.getLimits.asScala.map {
             case (key, value) => key -> value.toString
           }.toMap
-          
+
           limitsMap
         }
       }
@@ -107,7 +107,7 @@ object KubernetesClient {
     val resourceBuilder = new ResourceRequirementsBuilder()
       .addToLimits("cpu", new Quantity(cpuLimit))
       .addToLimits("memory", new Quantity(memoryLimit))
-    
+
     // Only add GPU resources if the requested amount is greater than 0
     if (gpuLimit != "0") {
       // Use the configured GPU resource key directly
@@ -122,14 +122,9 @@ object KubernetesClient {
       .addToLabels("type", "computing-unit")
       .addToLabels("cuid", cuid.toString)
       .addToLabels("name", podName)
-      
-    // Add GPU-specific labels if GPU is requested
-    if (gpuLimit != "0") {
-      podBuilder.addToLabels("gpu-enabled", "true")
-      podBuilder.addToLabels("gpu-resource", KubernetesConfig.gpuResourceKey)
-    }
-      
-    val pod = podBuilder.endMetadata()
+
+    val pod = podBuilder
+      .endMetadata()
       .withNewSpec()
       .addNewContainer()
       .withName("computing-unit-master")

--- a/core/gui/proxy.config.json
+++ b/core/gui/proxy.config.json
@@ -14,6 +14,11 @@
     "secure": false,
     "changeOrigin": true
   },
+  "/api/computing-unit": {
+    "target": "http://localhost:8888",
+    "secure": false,
+    "changeOrigin": true
+  },
   "/api": {
     "target": "http://localhost:8080",
     "secure": false,

--- a/core/gui/src/app/workspace/component/power-button/computing-unit-selection.component.html
+++ b/core/gui/src/app/workspace/component/power-button/computing-unit-selection.component.html
@@ -187,6 +187,19 @@
           </nz-option>
         </nz-select>
       </div>
+
+      <div class="select-unit">
+        <span>Select #GPU(s)</span>
+        <nz-select
+          class="gpu-selection"
+          [(ngModel)]="selectedGpu">
+          <nz-option
+            *ngFor="let option of gpuOptions"
+            [nzValue]="option"
+            [nzLabel]="option">
+          </nz-option>
+        </nz-select>
+      </div>
     </div>
   </ng-template>
   <ng-template #addComputeUnitModalFooter>
@@ -221,6 +234,12 @@
         {{getMemoryValue() | number:'1.4-4'}}
         <span class="metric-unit">/ {{getMemoryLimit()}} {{getMemoryLimitUnit()}}</span>
         <span class="metric-percentage">({{getMemoryPercentage() | number:'1.1-1'}}%)</span>
+      </p>
+    </div>
+    <div *ngIf="getGpuLimit() !== '0' && getGpuLimit() !== 'N/A'" class="gpu-metric general-metric">
+      <p class="metric-name">GPU</p>
+      <p class="metric-value">
+        {{getGpuLimit()}} GPU(s)
       </p>
     </div>
   </div>

--- a/core/gui/src/app/workspace/component/power-button/computing-unit-selection.component.html
+++ b/core/gui/src/app/workspace/component/power-button/computing-unit-selection.component.html
@@ -188,7 +188,9 @@
         </nz-select>
       </div>
 
-      <div class="select-unit">
+      <div
+        *ngIf="showGpuSelection()"
+        class="select-unit">
         <span>Select #GPU(s)</span>
         <nz-select
           class="gpu-selection"
@@ -236,11 +238,11 @@
         <span class="metric-percentage">({{getMemoryPercentage() | number:'1.1-1'}}%)</span>
       </p>
     </div>
-    <div *ngIf="getGpuLimit() !== '0' && getGpuLimit() !== 'N/A'" class="gpu-metric general-metric">
+    <div
+      *ngIf="getGpuLimit() !== '0' && getGpuLimit() !== 'N/A' && showGpuSelection()"
+      class="gpu-metric general-metric">
       <p class="metric-name">GPU</p>
-      <p class="metric-value">
-        {{getGpuLimit()}} GPU(s)
-      </p>
+      <p class="metric-value">{{getGpuLimit()}} GPU(s)</p>
     </div>
   </div>
 </ng-template>

--- a/core/gui/src/app/workspace/component/power-button/computing-unit-selection.component.scss
+++ b/core/gui/src/app/workspace/component/power-button/computing-unit-selection.component.scss
@@ -150,7 +150,8 @@
 }
 
 .memory-selection,
-.cpu-selection {
+.cpu-selection,
+.gpu-selection {
   width: 100%;
 }
 

--- a/core/gui/src/app/workspace/component/power-button/computing-unit-selection.component.ts
+++ b/core/gui/src/app/workspace/component/power-button/computing-unit-selection.component.ts
@@ -32,10 +32,12 @@ export class ComputingUnitSelectionComponent implements OnInit, OnChanges {
   newComputingUnitName: string = "";
   selectedMemory: string = "";
   selectedCpu: string = "";
+  selectedGpu: string = "0"; // Default to no GPU
 
   // cpu&memory limit options from backend
   cpuOptions: string[] = [];
   memoryOptions: string[] = [];
+  gpuOptions: string[] = []; // Add GPU options array
 
   // Add property to track user-initiated termination
   private isUserTerminatingUnit = false;
@@ -55,16 +57,18 @@ export class ComputingUnitSelectionComponent implements OnInit, OnChanges {
         .getComputingUnitLimitOptions()
         .pipe(untilDestroyed(this))
         .subscribe({
-          next: ({ cpuLimitOptions, memoryLimitOptions }) => {
+          next: ({ cpuLimitOptions, memoryLimitOptions, gpuLimitOptions }) => {
             this.cpuOptions = cpuLimitOptions;
             this.memoryOptions = memoryLimitOptions;
+            this.gpuOptions = gpuLimitOptions;
 
             // fallback defaults
             this.selectedCpu = this.cpuOptions[0] ?? "1";
             this.selectedMemory = this.memoryOptions[0] ?? "1Gi";
+            this.selectedGpu = this.gpuOptions[0] ?? "0";
           },
           error: (err: unknown) =>
-            this.notificationService.error(`Failed to fetch CPU/memory options: ${extractErrorMessage(err)}`),
+            this.notificationService.error(`Failed to fetch resource options: ${extractErrorMessage(err)}`),
         });
     }
 
@@ -226,8 +230,10 @@ export class ComputingUnitSelectionComponent implements OnInit, OnChanges {
     const computeUnitName = this.newComputingUnitName;
     const computeCPU = this.selectedCpu;
     const computeMemory = this.selectedMemory;
+    const computeGPU = this.selectedGpu;
+    
     this.computingUnitService
-      .createComputingUnit(computeUnitName, computeCPU, computeMemory)
+      .createComputingUnit(computeUnitName, computeCPU, computeMemory, computeGPU)
       .pipe(untilDestroyed(this))
       .subscribe({
         next: (unit: DashboardWorkflowComputingUnit) => {
@@ -407,6 +413,10 @@ export class ComputingUnitSelectionComponent implements OnInit, OnChanges {
     return this.selectedComputingUnit ? this.selectedComputingUnit.resourceLimits.memoryLimit : "N/A";
   }
 
+  getCurrentComputingUnitGpuLimit(): string {
+    return this.selectedComputingUnit ? this.selectedComputingUnit.resourceLimits.gpuLimit : "0";
+  }
+
   /**
    * Returns the badge color based on computing unit status
    */
@@ -423,6 +433,10 @@ export class ComputingUnitSelectionComponent implements OnInit, OnChanges {
 
   getCpuLimit(): number {
     return this.parseResourceNumber(this.getCurrentComputingUnitCpuLimit());
+  }
+
+  getGpuLimit(): string {
+    return this.getCurrentComputingUnitGpuLimit();
   }
 
   getCpuLimitUnit(): string {

--- a/core/gui/src/app/workspace/component/power-button/computing-unit-selection.component.ts
+++ b/core/gui/src/app/workspace/component/power-button/computing-unit-selection.component.ts
@@ -191,6 +191,12 @@ export class ComputingUnitSelectionComponent implements OnInit, OnChanges {
     return unit.uri === this.selectedComputingUnit?.uri;
   }
 
+  // Determines if the GPU selection dropdown should be shown
+  showGpuSelection(): boolean {
+    // Don't show GPU selection if there are no options or only "0" option
+    return this.gpuOptions.length > 1 || (this.gpuOptions.length === 1 && this.gpuOptions[0] !== "0");
+  }
+
   showAddComputeUnitModalVisible(): void {
     this.addComputeUnitModalVisible = true;
   }
@@ -231,7 +237,7 @@ export class ComputingUnitSelectionComponent implements OnInit, OnChanges {
     const computeCPU = this.selectedCpu;
     const computeMemory = this.selectedMemory;
     const computeGPU = this.selectedGpu;
-    
+
     this.computingUnitService
       .createComputingUnit(computeUnitName, computeCPU, computeMemory, computeGPU)
       .pipe(untilDestroyed(this))

--- a/core/gui/src/app/workspace/service/workflow-computing-unit/workflow-computing-unit-managing.service.ts
+++ b/core/gui/src/app/workspace/service/workflow-computing-unit/workflow-computing-unit-managing.service.ts
@@ -95,7 +95,7 @@ export class WorkflowComputingUnitManagingService {
         resourceLimits: {
           cpuLimit: "NaN",
           memoryLimit: "NaN",
-          gpuLimit: "0"
+          gpuLimit: "0",
         },
       };
 

--- a/core/gui/src/app/workspace/service/workflow-computing-unit/workflow-computing-unit-managing.service.ts
+++ b/core/gui/src/app/workspace/service/workflow-computing-unit/workflow-computing-unit-managing.service.ts
@@ -21,6 +21,7 @@ export class WorkflowComputingUnitManagingService {
    * @param name The name for the computing unit.
    * @param cpuLimit The cpu resource limit for the computing unit.
    * @param memoryLimit The memory resource limit for the computing unit.
+   * @param gpuLimit The gpu resource limit for the computing unit.
    * @param unitType
    * @returns An Observable of the created WorkflowComputingUnit.
    */
@@ -28,9 +29,10 @@ export class WorkflowComputingUnitManagingService {
     name: string,
     cpuLimit: string,
     memoryLimit: string,
+    gpuLimit: string = "0",
     unitType: string = "k8s_pod"
   ): Observable<DashboardWorkflowComputingUnit> {
-    const body = { name, cpuLimit, memoryLimit, unitType };
+    const body = { name, cpuLimit, memoryLimit, gpuLimit, unitType };
 
     return this.http.post<DashboardWorkflowComputingUnit>(
       `${AppSettings.getApiEndpoint()}/${COMPUTING_UNIT_CREATE_URL}`,
@@ -56,10 +58,12 @@ export class WorkflowComputingUnitManagingService {
   public getComputingUnitLimitOptions(): Observable<{
     cpuLimitOptions: string[];
     memoryLimitOptions: string[];
+    gpuLimitOptions: string[];
   }> {
     return this.http.get<{
       cpuLimitOptions: string[];
       memoryLimitOptions: string[];
+      gpuLimitOptions: string[];
     }>(`${AppSettings.getApiEndpoint()}/${COMPUTING_UNIT_BASE_URL}/limits`);
   }
 
@@ -91,6 +95,7 @@ export class WorkflowComputingUnitManagingService {
         resourceLimits: {
           cpuLimit: "NaN",
           memoryLimit: "NaN",
+          gpuLimit: "0"
         },
       };
 

--- a/core/gui/src/app/workspace/types/workflow-computing-unit.ts
+++ b/core/gui/src/app/workspace/types/workflow-computing-unit.ts
@@ -9,6 +9,7 @@ export interface WorkflowComputingUnit {
 export interface WorkflowComputingUnitResourceLimit {
   cpuLimit: string;
   memoryLimit: string;
+  gpuLimit: string;
 }
 
 export interface WorkflowComputingUnitMetrics {

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/EnvironmentalVariable.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/EnvironmentalVariable.scala
@@ -10,6 +10,11 @@ object EnvironmentalVariable {
   }
 
   /**
+    * JVM related opts
+    */
+  val ENV_JAVA_OPTS = "JAVA_OPTS"
+
+  /**
     * FileService related endpoint
     */
   val ENV_FILE_SERVICE_GET_PRESIGNED_URL_ENDPOINT = "FILE_SERVICE_GET_PRESIGNED_URL_ENDPOINT"

--- a/deployment/k8s/texera-helmchart/values.yaml
+++ b/deployment/k8s/texera-helmchart/values.yaml
@@ -162,6 +162,8 @@ texeraEnvVars:
     value: "1,2"
   - name: KUBERNETES_COMPUTING_UNIT_MEMORY_LIMIT_OPTIONS
     value: "1Gi,2Gi"
+  - name: KUBERNETES_COMPUTING_UNIT_GPU_LIMIT_OPTIONS
+    value: "0"
 
 # Ingress dependency configs
 ingress-nginx:

--- a/deployment/k8s/texera-helmchart/values.yaml
+++ b/deployment/k8s/texera-helmchart/values.yaml
@@ -156,12 +156,14 @@ texeraEnvVars:
     value: postgres
   - name: USER_SYS_ENABLED
     value: "true"
+  - name: SCHEDULE_GENERATOR_ENABLE_COST_BASED_SCHEDULE_GENERATOR
+    value: "true"
   - name: MAX_NUM_OF_RUNNING_COMPUTING_UNITS_PER_USER
     value: "10"
   - name: KUBERNETES_COMPUTING_UNIT_CPU_LIMIT_OPTIONS
-    value: "1,2"
+    value: "2"
   - name: KUBERNETES_COMPUTING_UNIT_MEMORY_LIMIT_OPTIONS
-    value: "1Gi,2Gi"
+    value: "2Gi"
   - name: KUBERNETES_COMPUTING_UNIT_GPU_LIMIT_OPTIONS
     value: "0"
 


### PR DESCRIPTION
This PR adds GPU as one option when creating the computing unit. By changing the configuration in `kubernetes.conf` or passing the environment variable `KUBERNETES_COMPUTING_UNIT_GPU_LIMIT_OPTIONS`, to be list of integers, e.g. `0,1,2`, GPU option will be selectable from the frontend.

Note that this PR will NOT change cluster config, so please make sure the Kubernetes cluster is properly configured with
-  Nvidia GPU driver
- `nvidia` runtimeClass

to enable the usage of GPU for computing units.
