### PR TITLE
Fix metric-resolution for the metric server specified in the helm chart

### DIFF
--- a/deployment/k8s/texera-helmchart/values.yaml
+++ b/deployment/k8s/texera-helmchart/values.yaml
@@ -212,7 +212,7 @@ metrics-server:
   args:
     - --kubelet-insecure-tls
     - --kubelet-preferred-address-types=InternalIP,ExternalIP,Hostname
-    - --metric-resolution=10s
+    - --metric-resolution=15s
   resources:
     requests:
       cpu: 200m


### PR DESCRIPTION
## Error
```
Error: metric-resolution should be larger than kubelet-request-timeout, but metric-resolution value 10s kubelet-request-timeout value 10s provided
```

## Fix
The request timeout on `kubelet` (10sec) should be less than `metric-resolution` parameter for metric server.