### PR TITLE
Fix export in cluster mode

### DIFF
--- a/core/gui/src/app/dashboard/service/user/download/download.service.ts
+++ b/core/gui/src/app/dashboard/service/user/download/download.service.ts
@@ -10,6 +10,7 @@ import { Workflow } from "../../../../common/type/workflow";
 import { AppSettings } from "../../../../common/app-setting";
 import { HttpClient, HttpResponse } from "@angular/common/http";
 import { WORKFLOW_EXECUTIONS_API_BASE_URL } from "../workflow-executions/workflow-executions.service";
+import { DashboardWorkflowComputingUnit } from "../../../../workspace/types/workflow-computing-unit";
 var contentDisposition = require("content-disposition");
 
 export const EXPORT_BASE_URL = "result/export";
@@ -108,7 +109,8 @@ export class DownloadService {
     rowIndex: number,
     columnIndex: number,
     filename: string,
-    destination: "local" | "dataset" = "dataset" // "local" or "dataset" => default to "dataset"
+    destination: "local" | "dataset" = "dataset", // "local" or "dataset" => default to "dataset"
+    unit: DashboardWorkflowComputingUnit | null = null // computing unit for cluster setting
   ): Observable<HttpResponse<Blob> | HttpResponse<ExportWorkflowJsonResponse>> {
     const requestBody = {
       exportType,
@@ -121,8 +123,10 @@ export class DownloadService {
       filename,
       destination,
     };
+    console.log("received cui from exportWorkflowResult", unit);
+    const urlPath = (unit && unit.computingUnit?.cuid) ? `${WORKFLOW_EXECUTIONS_API_BASE_URL}/${EXPORT_BASE_URL}?cuid=${unit.computingUnit.cuid}` : `${WORKFLOW_EXECUTIONS_API_BASE_URL}/${EXPORT_BASE_URL}`;
     if (destination === "local") {
-      return this.http.post(`${WORKFLOW_EXECUTIONS_API_BASE_URL}/${EXPORT_BASE_URL}`, requestBody, {
+      return this.http.post(urlPath, requestBody, {
         responseType: "blob",
         observe: "response",
         headers: {
@@ -133,7 +137,7 @@ export class DownloadService {
     } else {
       // dataset => return JSON
       return this.http.post<ExportWorkflowJsonResponse>(
-        `${WORKFLOW_EXECUTIONS_API_BASE_URL}/${EXPORT_BASE_URL}`,
+        urlPath,
         requestBody,
         {
           responseType: "json",

--- a/core/gui/src/app/dashboard/service/user/download/download.service.ts
+++ b/core/gui/src/app/dashboard/service/user/download/download.service.ts
@@ -124,7 +124,10 @@ export class DownloadService {
       destination,
     };
     console.log("received cui from exportWorkflowResult", unit);
-    const urlPath = (unit && unit.computingUnit?.cuid) ? `${WORKFLOW_EXECUTIONS_API_BASE_URL}/${EXPORT_BASE_URL}?cuid=${unit.computingUnit.cuid}` : `${WORKFLOW_EXECUTIONS_API_BASE_URL}/${EXPORT_BASE_URL}`;
+    const urlPath =
+      unit && unit.computingUnit?.cuid
+        ? `${WORKFLOW_EXECUTIONS_API_BASE_URL}/${EXPORT_BASE_URL}?cuid=${unit.computingUnit.cuid}`
+        : `${WORKFLOW_EXECUTIONS_API_BASE_URL}/${EXPORT_BASE_URL}`;
     if (destination === "local") {
       return this.http.post(urlPath, requestBody, {
         responseType: "blob",
@@ -136,18 +139,14 @@ export class DownloadService {
       });
     } else {
       // dataset => return JSON
-      return this.http.post<ExportWorkflowJsonResponse>(
-        urlPath,
-        requestBody,
-        {
-          responseType: "json",
-          observe: "response",
-          headers: {
-            "Content-Type": "application/json",
-            Accept: "application/json",
-          },
-        }
-      );
+      return this.http.post<ExportWorkflowJsonResponse>(urlPath, requestBody, {
+        responseType: "json",
+        observe: "response",
+        headers: {
+          "Content-Type": "application/json",
+          Accept: "application/json",
+        },
+      });
     }
   }
 

--- a/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.ts
+++ b/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.ts
@@ -6,6 +6,8 @@ import { DatasetService } from "../../../dashboard/service/user/dataset/dataset.
 import { NZ_MODAL_DATA, NzModalRef } from "ng-zorro-antd/modal";
 import { WorkflowActionService } from "../../service/workflow-graph/model/workflow-action.service";
 import { WorkflowResultService } from "../../service/workflow-result/workflow-result.service";
+import { ComputingUnitStatusService } from "../../service/computing-unit-status/computing-unit-status.service";
+import { DashboardWorkflowComputingUnit } from "../../types/workflow-computing-unit";
 
 @UntilDestroy()
 @Component({
@@ -29,6 +31,7 @@ export class ResultExportationComponent implements OnInit {
   isVisualizationOutput: boolean = false;
   containsBinaryData: boolean = false;
   inputDatasetName = "";
+  selectedComputingUnit: DashboardWorkflowComputingUnit | null = null;
 
   userAccessibleDatasets: DashboardDataset[] = [];
   filteredUserAccessibleDatasets: DashboardDataset[] = [];
@@ -38,7 +41,8 @@ export class ResultExportationComponent implements OnInit {
     private modalRef: NzModalRef,
     private datasetService: DatasetService,
     private workflowActionService: WorkflowActionService,
-    private workflowResultService: WorkflowResultService
+    private workflowResultService: WorkflowResultService,
+    private computingUnitStatusService: ComputingUnitStatusService
   ) {}
 
   ngOnInit(): void {
@@ -50,6 +54,13 @@ export class ResultExportationComponent implements OnInit {
         this.filteredUserAccessibleDatasets = [...this.userAccessibleDatasets];
       });
     this.updateOutputType();
+
+    this.computingUnitStatusService
+      .getSelectedComputingUnit()
+      .pipe(untilDestroyed(this))
+      .subscribe(unit => {
+        this.selectedComputingUnit = unit;
+      })
   }
 
   updateOutputType(): void {
@@ -123,7 +134,8 @@ export class ResultExportationComponent implements OnInit {
       this.columnIndex,
       this.inputFileName,
       this.sourceTriggered === "menu",
-      destination
+      destination,
+      this.selectedComputingUnit
     );
     this.modalRef.close();
   }

--- a/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.ts
+++ b/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.ts
@@ -60,7 +60,7 @@ export class ResultExportationComponent implements OnInit {
       .pipe(untilDestroyed(this))
       .subscribe(unit => {
         this.selectedComputingUnit = unit;
-      })
+      });
   }
 
   updateOutputType(): void {

--- a/core/gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
+++ b/core/gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
@@ -13,6 +13,7 @@ import { OperatorResultService, WorkflowResultService } from "../workflow-result
 import { DownloadService } from "../../../dashboard/service/user/download/download.service";
 import { HttpResponse } from "@angular/common/http";
 import { ExportWorkflowJsonResponse } from "../../../dashboard/service/user/download/download.service";
+import { DashboardWorkflowComputingUnit } from "../../types/workflow-computing-unit";
 
 @Injectable({
   providedIn: "root",
@@ -83,7 +84,8 @@ export class WorkflowResultExportService {
     exportAll: boolean = false, // if the user click export button on the top bar (a.k.a menu),
     // we should export all operators, otherwise, only highlighted ones
     // which means export button is selected from context-menu
-    destination: "dataset" | "local" = "dataset" // default to dataset
+    destination: "dataset" | "local" = "dataset", // default to dataset
+    unit: DashboardWorkflowComputingUnit | null = null // computing unit for cluster setting
   ): void {
     if (!environment.exportExecutionResultEnabled) {
       return;
@@ -120,7 +122,8 @@ export class WorkflowResultExportService {
         rowIndex,
         columnIndex,
         filename,
-        destination
+        destination,
+        unit
       )
       .subscribe({
         next: response => {

--- a/core/gui/src/environments/environment.default.ts
+++ b/core/gui/src/environments/environment.default.ts
@@ -15,7 +15,7 @@ export const defaultEnvironment = {
   /**
    * whether export execution result is supported
    */
-  exportExecutionResultEnabled: true,
+  exportExecutionResultEnabled: false,
 
   /**
    * whether automatically correcting attribute name on change is enabled
@@ -26,12 +26,12 @@ export const defaultEnvironment = {
   /**
    * whether user system is enabled
    */
-  userSystemEnabled: true,
+  userSystemEnabled: false,
 
   /**
    * whether workflow computing unit manager is enabled (requires k8s)
    */
-  computingUnitManagerEnabled: true,
+  computingUnitManagerEnabled: false,
 
   /**
    * whether selecting files from datasets instead of the local file system.
@@ -61,7 +61,7 @@ export const defaultEnvironment = {
   /**
    * whether workflow executions tracking feature is enabled
    */
-  workflowExecutionsTrackingEnabled: true,
+  workflowExecutionsTrackingEnabled: false,
 
   /**
    * whether linkBreakpoint is supported
@@ -87,7 +87,7 @@ export const defaultEnvironment = {
   /**
    * the file size limit for dataset upload
    */
-  singleFileUploadMaximumSizeMB: 2000000,
+  singleFileUploadMaximumSizeMB: 20,
 
   /**
    * the maximum number of file chunks that can be held in the memory;
@@ -129,7 +129,7 @@ export const defaultEnvironment = {
    * Can be configured as { username: "texera", password: "password" }
    * If configured, this will be automatically filled into the local login input box
    */
-  defaultLocalUser: { username: "texera", password: "texera" },
+  defaultLocalUser: {} as { username?: string; password?: string },
 
   /**
    * maximum number of console messages to store per operator

--- a/core/gui/src/environments/environment.default.ts
+++ b/core/gui/src/environments/environment.default.ts
@@ -15,7 +15,7 @@ export const defaultEnvironment = {
   /**
    * whether export execution result is supported
    */
-  exportExecutionResultEnabled: false,
+  exportExecutionResultEnabled: true,
 
   /**
    * whether automatically correcting attribute name on change is enabled
@@ -26,12 +26,12 @@ export const defaultEnvironment = {
   /**
    * whether user system is enabled
    */
-  userSystemEnabled: false,
+  userSystemEnabled: true,
 
   /**
    * whether workflow computing unit manager is enabled (requires k8s)
    */
-  computingUnitManagerEnabled: false,
+  computingUnitManagerEnabled: true,
 
   /**
    * whether selecting files from datasets instead of the local file system.
@@ -61,7 +61,7 @@ export const defaultEnvironment = {
   /**
    * whether workflow executions tracking feature is enabled
    */
-  workflowExecutionsTrackingEnabled: false,
+  workflowExecutionsTrackingEnabled: true,
 
   /**
    * whether linkBreakpoint is supported
@@ -87,7 +87,7 @@ export const defaultEnvironment = {
   /**
    * the file size limit for dataset upload
    */
-  singleFileUploadMaximumSizeMB: 20,
+  singleFileUploadMaximumSizeMB: 2000000,
 
   /**
    * the maximum number of file chunks that can be held in the memory;
@@ -129,7 +129,7 @@ export const defaultEnvironment = {
    * Can be configured as { username: "texera", password: "password" }
    * If configured, this will be automatically filled into the local login input box
    */
-  defaultLocalUser: {} as { username?: string; password?: string },
+  defaultLocalUser: { username: "texera", password: "texera" },
 
   /**
    * maximum number of console messages to store per operator

--- a/deployment/k8s/texera-helmchart/templates/envoy-config.yaml
+++ b/deployment/k8s/texera-helmchart/templates/envoy-config.yaml
@@ -31,6 +31,11 @@ data:
                               route:
                                 cluster: dynamic_service
                                 prefix_rewrite: "/wsapi"
+                            - match:
+                                prefix: "/api/executions"
+                              route:
+                                cluster: dynamic_service
+                                prefix_rewrite: "/api/executions"
                     http_filters:
                       - name: envoy.filters.http.lua
                         typed_config:

--- a/deployment/k8s/texera-helmchart/values.yaml
+++ b/deployment/k8s/texera-helmchart/values.yaml
@@ -247,6 +247,9 @@ ingressPaths:
     - path: /wsapi/workflow-websocket
       serviceName: envoy-svc
       servicePort: 10000
+    - path: /api/executions
+      serviceName: envoy-svc
+      servicePort: 10000
     - path: /api
       serviceName: webserver-svc
       servicePort: 8080


### PR DESCRIPTION
## Issue
In cluster setting, computing units are distributed and export request should be sent to the corresponding computing unit. Currently, we use generic `execution` endpoint which works on single node (or local) deployment but does not work with cluster setting.

## Fix
We need to incorporate `cuid` attribute in export request so `envoy` service forward the request to the correct computing unit.
We replicated `computing-unit-selection.component.ts` logic to receive `selectedComputingUnit` in `result-exportation.component.ts` and pass it to `download.service` and finally put it as a parameter in the URL.
![Screenshot from 2025-04-14 14-21-53](https://github.com/user-attachments/assets/bff429ab-8958-4f88-bbbe-6f73f36b76c4)

