### PR TITLE
Disabling Envoy HTTP Timeout

### DIFF
--- a/deployment/k8s/texera-helmchart/templates/envoy-config.yaml
+++ b/deployment/k8s/texera-helmchart/templates/envoy-config.yaml
@@ -31,11 +31,13 @@ data:
                               route:
                                 cluster: dynamic_service
                                 prefix_rewrite: "/wsapi"
+				timeout: "0s" # disables timeout
                             - match:
                                 prefix: "/api/executions"
                               route:
                                 cluster: dynamic_service
                                 prefix_rewrite: "/api/executions"
+				timeout: "0s"
                     http_filters:
                       - name: envoy.filters.http.lua
                         typed_config:


### PR DESCRIPTION
This PR resolves an issue where downloading large results (>2GB) in the Kubernetes environment was failing. The root cause was identified as Envoy proxy's default HTTP routing timeout of [15 seconds](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-field-config-route-v3-routeaction-timeout). When the download duration exceeded this limit, Envoy closed the connection, resulting in a failed download.

To address this, the HTTP routing timeout has been explicitly disabled, allowing long-running downloads to complete successfully.