### PR TITLE
Fix the issue where the File Scan operator fails to properly handle compressed files containing multiple files

### DIFF
--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/source/scan/AutoClosingIterator.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/source/scan/AutoClosingIterator.scala
@@ -1,0 +1,26 @@
+package edu.uci.ics.amber.operator.source.scan
+
+/**
+  * A wrapper around an Interator that automatically invokes a cleanup function
+  * when the iterator is fully consumed (i.e. hasNext returns false)
+  *
+  * This is useful for lazily reading resources like InputStreams and ensuring
+  * they are properly closed once no more data is available
+  *
+  * @param iter the underlying iterator to consume
+  * @param onClose a function to call once the iterator is exhausted
+  */
+class AutoClosingIterator[T](iter: Iterator[T], onClose: () => Unit) extends Iterator[T] {
+  private var alreadyClosed = false
+
+  override def hasNext: Boolean = {
+    val hn = iter.hasNext
+    if (!hn && !alreadyClosed) {
+      onClose()
+      alreadyClosed = true
+    }
+    hn
+  }
+
+  override def next(): T = iter.next()
+}

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/source/scan/FileScanSourceOpExec.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/source/scan/FileScanSourceOpExec.scala
@@ -11,7 +11,6 @@ import java.net.URI
 import java.nio.ByteBuffer
 import scala.collection.mutable
 import scala.jdk.CollectionConverters.IteratorHasAsScala
-import scala.util.Using
 import scala.collection.mutable.ArrayBuffer
 import org.apache.commons.compress.archivers.ArchiveStreamFactory
 import org.apache.commons.compress.archivers.zip.ZipArchiveInputStream
@@ -33,80 +32,92 @@ class FileScanSourceOpExec private[scan] (
     * @return a List of ByteBuffers containing the data
     */
   private def readToByteBuffers(input: InputStream): List[ByteBuffer] = {
-    Using.resource(input) { inputStream =>
-      val buffers = ArrayBuffer.empty[ByteBuffer]
-      val buffer = new Array[Byte](BufferSizeBytes)
+    val buffers = ArrayBuffer.empty[ByteBuffer]
+    val buffer = new Array[Byte](BufferSizeBytes)
+    Iterator
+      .continually(input.read(buffer))
+      .takeWhile(_ != -1)
+      .filter(_ > 0)
+      .foreach { bytesRead =>
+        val byteBuffer = ByteBuffer.allocate(bytesRead)
+        byteBuffer.put(buffer, 0, bytesRead)
+        byteBuffer.flip() // Prepare for reading
+        buffers += byteBuffer
+      }
 
-      Iterator
-        .continually(inputStream.read(buffer))
-        .takeWhile(_ != -1)
-        .filter(_ > 0)
-        .foreach { bytesRead =>
-          val byteBuffer = ByteBuffer.allocate(bytesRead)
-          byteBuffer.put(buffer, 0, bytesRead)
-          byteBuffer.flip() // Prepare for reading
-          buffers += byteBuffer
-        }
-
-      buffers.toList
-    }
+    buffers.toList
   }
 
   @throws[IOException]
   override def produceTuple(): Iterator[TupleLike] = {
+    val is: InputStream =
+      DocumentFactory.openReadonlyDocument(new URI(desc.fileName.get)).asInputStream()
+
+    val closeables = mutable.ArrayBuffer.empty[AutoCloseable]
+    var zipIn: ZipArchiveInputStream = null
+    var archiveStream: InputStream = null
+    if (desc.extract) {
+      zipIn = new ArchiveStreamFactory()
+        .createArchiveInputStream(new BufferedInputStream(is))
+        .asInstanceOf[ZipArchiveInputStream]
+      archiveStream = zipIn
+      closeables += zipIn
+    } else {
+      archiveStream = is
+      closeables += is
+    }
+
     var filenameIt: Iterator[String] = Iterator.empty
     val fileEntries: Iterator[InputStream] = {
-      val is = DocumentFactory.openReadonlyDocument(new URI(desc.fileName.get)).asInputStream()
       if (desc.extract) {
-        val inputStream: ZipArchiveInputStream =
-          new ArchiveStreamFactory().createArchiveInputStream(
-            new BufferedInputStream(is)
-          )
         val (it1, it2) = Iterator
-          .continually(inputStream.getNextEntry)
+          .continually(zipIn.getNextEntry)
           .takeWhile(_ != null)
           .filterNot(_.getName.startsWith("__MACOSX"))
           .duplicate
-        filenameIt = it1.map(entry => entry.getName)
-        it2.map(_ => inputStream)
+        filenameIt = it1.map(_.getName)
+        it2.map(_ => zipIn)
       } else {
-        Iterator(is)
+        Iterator(archiveStream)
       }
     }
 
-    if (desc.attributeType.isSingle) {
-      fileEntries.zipAll(filenameIt, null, null).map {
-        case (entry, fileName) =>
-          val fields: mutable.ListBuffer[Any] = mutable.ListBuffer()
-          if (desc.outputFileName) {
-            fields.addOne(fileName)
-          }
-          fields.addOne(desc.attributeType match {
-            case FileAttributeType.SINGLE_STRING =>
-              new String(toByteArray(entry), desc.fileEncoding.getCharset)
-            case _ =>
-              val buffers = readToByteBuffers(entry)
-              parseField(buffers, desc.attributeType.getType)
-          })
-          TupleLike(fields.toSeq: _*)
-      }
-    } else {
-      fileEntries.flatMap(entry =>
-        new BufferedReader(new InputStreamReader(entry, desc.fileEncoding.getCharset))
-          .lines()
-          .iterator()
-          .asScala
-          .slice(
-            desc.fileScanOffset.getOrElse(0),
-            desc.fileScanOffset.getOrElse(0) + desc.fileScanLimit.getOrElse(Int.MaxValue)
-          )
-          .map(line => {
-            TupleLike(desc.attributeType match {
-              case FileAttributeType.SINGLE_STRING => line
-              case _                               => parseField(line, desc.attributeType.getType)
+    val rawIterator: Iterator[TupleLike] =
+      if (desc.attributeType.isSingle) {
+        fileEntries.zipAll(filenameIt, null, null).map {
+          case (entry, fileName) =>
+            val fields: mutable.ListBuffer[Any] = mutable.ListBuffer()
+            if (desc.outputFileName) {
+              fields.addOne(fileName)
+            }
+            fields.addOne(desc.attributeType match {
+              case FileAttributeType.SINGLE_STRING =>
+                new String(toByteArray(entry), desc.fileEncoding.getCharset)
+              case _ =>
+                val buffers = readToByteBuffers(entry)
+                parseField(buffers, desc.attributeType.getType)
             })
-          })
-      )
-    }
+            TupleLike(fields.toSeq: _*)
+        }
+      } else {
+        fileEntries.flatMap(entry =>
+          new BufferedReader(new InputStreamReader(entry, desc.fileEncoding.getCharset))
+            .lines()
+            .iterator()
+            .asScala
+            .slice(
+              desc.fileScanOffset.getOrElse(0),
+              desc.fileScanOffset.getOrElse(0) + desc.fileScanLimit.getOrElse(Int.MaxValue)
+            )
+            .map(line => {
+              TupleLike(desc.attributeType match {
+                case FileAttributeType.SINGLE_STRING => line
+                case _                               => parseField(line, desc.attributeType.getType)
+              })
+            })
+        )
+      }
+
+    new AutoClosingIterator(rawIterator, () => closeables.foreach(_.close()))
   }
 }


### PR DESCRIPTION
### Purpose:
The current File Scan operator can only display the first file in a compressed archive containing multiple files, while the remaining files cannot be read. The root cause lies in the use of `Using.resource` to manage the input stream, which automatically closes the stream after processing the first file. However, ZIP input streams (such as `ZipArchiveInputStream`) rely on continuous access to the underlying stream to read multiple entries. Once the stream is closed, the remaining files become inaccessible. Therefore, the resource should be closed only after all files have been processed, to avoid prematurely releasing the stream before it is fully consumed.
Fix #3384

### Changes:
1. Removed the use of `Using.resource`.  
2. Introduced a custom iterator `AutoClosingIterator` to automatically close the underlying input stream when the iterator is fully consumed.

### Demo:
Before:
![Image](https://github.com/user-attachments/assets/85e72e78-5949-4193-a908-1676bc0ec834)

After:
![image](https://github.com/user-attachments/assets/3f3051d0-ec4e-419f-9252-30f31c7ce6d8)
