### PR TITLE
Add admin account in the configuration file and make local-sign-up accounts `restricted`

### DIFF
--- a/core/amber/src/main/resources/application.conf
+++ b/core/amber/src/main/resources/application.conf
@@ -50,6 +50,9 @@ user-sys {
     enabled = false
     enabled = ${?USER_SYS_ENABLED}
 
+    username-password-registration-enabled = true
+    username-password-registration-enabled = ${?USER_SYS_USERNAME_PASSWORD_REGISTRATION_ENABLED}
+
     google {
         clientId = ""
         clientId = ${?USER_SYS_GOOGLE_CLIENT_ID}

--- a/core/amber/src/main/resources/application.conf
+++ b/core/amber/src/main/resources/application.conf
@@ -50,8 +50,11 @@ user-sys {
     enabled = false
     enabled = ${?USER_SYS_ENABLED}
 
-    username-password-registration-enabled = true
-    username-password-registration-enabled = ${?USER_SYS_USERNAME_PASSWORD_REGISTRATION_ENABLED}
+    admin-username = "texera"
+    admin-username = ${?USER_SYS_ADMIN_USERNAME}
+
+    admin-password = "texera"
+    admin-password = ${?USER_SYS_ADMIN_PASSWORD}
 
     google {
         clientId = ""

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberConfig.scala
@@ -80,6 +80,7 @@ object AmberConfig {
 
   // User system
   val isUserSystemEnabled: Boolean = getConfSource.getBoolean("user-sys.enabled")
+  val usernamePasswordRegistrationEnabled: Boolean = getConfSource.getBoolean("user-sys.username-password-registration-enabled")
   val googleClientId: String = getConfSource.getString("user-sys.google.clientId")
   val gmail: String = getConfSource.getString("user-sys.google.smtp.gmail")
   val smtpPassword: String = getConfSource.getString("user-sys.google.smtp.password")

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberConfig.scala
@@ -80,7 +80,8 @@ object AmberConfig {
 
   // User system
   val isUserSystemEnabled: Boolean = getConfSource.getBoolean("user-sys.enabled")
-  val usernamePasswordRegistrationEnabled: Boolean = getConfSource.getBoolean("user-sys.username-password-registration-enabled")
+  val adminUsername: String = getConfSource.getString("user-sys.admin-username")
+  val adminPassword: String = getConfSource.getString("user-sys.admin-password")
   val googleClientId: String = getConfSource.getString("user-sys.google.clientId")
   val gmail: String = getConfSource.getString("user-sys.google.smtp.gmail")
   val smtpPassword: String = getConfSource.getString("user-sys.google.smtp.password")

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWebApplication.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWebApplication.scala
@@ -14,9 +14,18 @@ import edu.uci.ics.texera.web.resource.dashboard.DashboardResource
 import edu.uci.ics.texera.web.resource.dashboard.admin.execution.AdminExecutionResource
 import edu.uci.ics.texera.web.resource.dashboard.admin.user.AdminUserResource
 import edu.uci.ics.texera.web.resource.dashboard.hub.HubResource
-import edu.uci.ics.texera.web.resource.dashboard.user.project.{ProjectAccessResource, ProjectResource, PublicProjectResource}
+import edu.uci.ics.texera.web.resource.dashboard.user.project.{
+  ProjectAccessResource,
+  ProjectResource,
+  PublicProjectResource
+}
 import edu.uci.ics.texera.web.resource.dashboard.user.quota.UserQuotaResource
-import edu.uci.ics.texera.web.resource.dashboard.user.workflow.{WorkflowAccessResource, WorkflowExecutionsResource, WorkflowResource, WorkflowVersionResource}
+import edu.uci.ics.texera.web.resource.dashboard.user.workflow.{
+  WorkflowAccessResource,
+  WorkflowExecutionsResource,
+  WorkflowResource,
+  WorkflowVersionResource
+}
 import io.dropwizard.auth.AuthValueFactoryProvider
 import io.dropwizard.setup.{Bootstrap, Environment}
 import io.dropwizard.websockets.WebsocketBundle

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWebApplication.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/TexeraWebApplication.scala
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.github.dirkraft.dropwizard.fileassets.FileAssetsBundle
 import com.typesafe.scalalogging.LazyLogging
 import edu.uci.ics.amber.core.storage.StorageConfig
-import edu.uci.ics.amber.engine.common.Utils
+import edu.uci.ics.amber.engine.common.{AmberConfig, Utils}
 import edu.uci.ics.texera.auth.SessionUser
 import edu.uci.ics.texera.dao.SqlServer
 import edu.uci.ics.texera.web.auth.JwtAuth.setupJwtAuth
@@ -14,18 +14,9 @@ import edu.uci.ics.texera.web.resource.dashboard.DashboardResource
 import edu.uci.ics.texera.web.resource.dashboard.admin.execution.AdminExecutionResource
 import edu.uci.ics.texera.web.resource.dashboard.admin.user.AdminUserResource
 import edu.uci.ics.texera.web.resource.dashboard.hub.HubResource
-import edu.uci.ics.texera.web.resource.dashboard.user.project.{
-  ProjectAccessResource,
-  ProjectResource,
-  PublicProjectResource
-}
+import edu.uci.ics.texera.web.resource.dashboard.user.project.{ProjectAccessResource, ProjectResource, PublicProjectResource}
 import edu.uci.ics.texera.web.resource.dashboard.user.quota.UserQuotaResource
-import edu.uci.ics.texera.web.resource.dashboard.user.workflow.{
-  WorkflowAccessResource,
-  WorkflowExecutionsResource,
-  WorkflowResource,
-  WorkflowVersionResource
-}
+import edu.uci.ics.texera.web.resource.dashboard.user.workflow.{WorkflowAccessResource, WorkflowExecutionsResource, WorkflowResource, WorkflowVersionResource}
 import io.dropwizard.auth.AuthValueFactoryProvider
 import io.dropwizard.setup.{Bootstrap, Environment}
 import io.dropwizard.websockets.WebsocketBundle
@@ -127,5 +118,8 @@ class TexeraWebApplication
     environment.jersey.register(classOf[UserQuotaResource])
     environment.jersey.register(classOf[AIAssistantResource])
 
+    if (AmberConfig.isUserSystemEnabled) {
+      AuthResource.createAdminUser()
+    }
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/AuthResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/AuthResource.scala
@@ -85,6 +85,8 @@ class AuthResource {
   def register(request: UserRegistrationRequest): TokenIssueResponse = {
     if (!AmberConfig.isUserSystemEnabled)
       throw new NotAcceptableException("User System is disabled on the backend!")
+    if (!AmberConfig.usernamePasswordRegistrationEnabled)
+      throw new NotAcceptableException("Username-Password Registration is disabled on the backend!")
     val username = request.username
     if (username == null) throw new NotAcceptableException("Username cannot be null.")
     if (username.trim.isEmpty) throw new NotAcceptableException("Username cannot be empty.")

--- a/core/gui/src/app/hub/component/about/local-login/local-login.component.ts
+++ b/core/gui/src/app/hub/component/about/local-login/local-login.component.ts
@@ -123,7 +123,9 @@ export class LocalLoginComponent implements OnInit {
         untilDestroyed(this)
       )
       .subscribe(() =>
-        this.router.navigateByUrl(this.route.snapshot.queryParams["returnUrl"] || DASHBOARD_USER_WORKFLOW)
+        this.notificationService.success(
+          "Your account has been created. Please contact the Texera administrator to activate your account."
+        )
       );
   }
 }

--- a/deployment/k8s/texera-helmchart/values.yaml
+++ b/deployment/k8s/texera-helmchart/values.yaml
@@ -156,6 +156,10 @@ workflowComputingUnitPool:
     targetPort: 8085
 
 texeraEnvVars:
+  - name: USER_SYS_ADMIN_USERNAME
+    value: "texera"
+  - name: USER_SYS_ADMIN_PASSWORD
+    value: "texera"
   - name: STORAGE_JDBC_USERNAME
     value: postgres
   - name: USER_SYS_ENABLED


### PR DESCRIPTION
This PR:
- adds two new configuration items in the `application.conf`, describing the admin account that will be automatically registered.
- make users who sign up via local-login `Restricted`, instead of `Admin`

A demo gif for sign up:
![2025-04-22 09 06 58](https://github.com/user-attachments/assets/1f015292-24f5-4a60-af49-3afb35236ed5)
