### PR TITLE
Enable email notification to the administrator upon an unauthorized or inactive user login attempt

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
@@ -96,9 +96,9 @@ class GmailResource {
          |Thanks,
          |""".stripMargin
 
-      sendEmail(
-        EmailMessage(subject = subject, content = content, receiver = senderGmail),
-        senderGmail
-      )
+    sendEmail(
+      EmailMessage(subject = subject, content = content, receiver = senderGmail),
+      senderGmail
+    )
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
@@ -79,4 +79,26 @@ class GmailResource {
   @RolesAllowed(Array("ADMIN"))
   @Path("/sender/email")
   def getSenderEmail: String = senderGmail
+
+  @POST
+  @Path("/notify-unauthorized")
+  def notifyUnauthorizedUser(emailMessage: EmailMessage): Unit = {
+    val subject = "New Account Request Pending Approval"
+    val content =
+      s"""
+         |Hello Admin,
+         |
+         |A new user has attempted to log in or register, but their account is not yet approved.
+         |Please review the account request for the following email:
+         |
+         |${emailMessage.receiver}
+         |
+         |Thanks,
+         |""".stripMargin
+
+      sendEmail(
+        EmailMessage(subject = subject, content = content, receiver = senderGmail),
+        senderGmail
+      )
+  }
 }

--- a/core/gui/src/app/common/service/gmail/gmail.service.ts
+++ b/core/gui/src/app/common/service/gmail/gmail.service.ts
@@ -27,4 +27,18 @@ export class GmailService {
         },
       });
   }
+
+  public notifyUnauthorizedLogin(userEmail: string): void {
+    this.http
+      .post(`${AppSettings.getApiEndpoint()}/gmail/notify-unauthorized`, { receiver: userEmail })
+      .subscribe({
+        next: () => this.notificationService.success("Admin has been notified about your account request."),
+        error: (error: unknown) => {
+          if (error instanceof HttpErrorResponse) {
+            this.notificationService.error("Failed to notify admin about your account request.");
+            console.error("Notify error:", error.error);
+          }
+        },
+      });
+  }
 }

--- a/core/gui/src/app/common/service/gmail/gmail.service.ts
+++ b/core/gui/src/app/common/service/gmail/gmail.service.ts
@@ -29,16 +29,14 @@ export class GmailService {
   }
 
   public notifyUnauthorizedLogin(userEmail: string): void {
-    this.http
-      .post(`${AppSettings.getApiEndpoint()}/gmail/notify-unauthorized`, { receiver: userEmail })
-      .subscribe({
-        next: () => this.notificationService.success("Admin has been notified about your account request."),
-        error: (error: unknown) => {
-          if (error instanceof HttpErrorResponse) {
-            this.notificationService.error("Failed to notify admin about your account request.");
-            console.error("Notify error:", error.error);
-          }
-        },
-      });
+    this.http.post(`${AppSettings.getApiEndpoint()}/gmail/notify-unauthorized`, { receiver: userEmail }).subscribe({
+      next: () => this.notificationService.success("Admin has been notified about your account request."),
+      error: (error: unknown) => {
+        if (error instanceof HttpErrorResponse) {
+          this.notificationService.error("Failed to notify admin about your account request.");
+          console.error("Notify error:", error.error);
+        }
+      },
+    });
   }
 }

--- a/core/gui/src/app/common/service/user/auth.service.ts
+++ b/core/gui/src/app/common/service/user/auth.service.ts
@@ -113,7 +113,7 @@ export class AuthService {
     const email = this.jwtHelperService.decodeToken(token).email;
     if (this.inviteOnly && role == Role.INACTIVE) {
       alert("The account request of " + email + " is received and pending.");
-      this.notifyAdminOfInactiveLoginAttempt(email);
+      this.gmailService.notifyUnauthorizedLogin(email);
       return this.logout();
     }
 
@@ -182,20 +182,5 @@ export class AuthService {
 
   static removeAccessToken(): void {
     localStorage.removeItem(TOKEN_KEY);
-  }
-
-  private notifyAdminOfInactiveLoginAttempt(userEmail: string): void {
-    this.gmailService.getSenderEmail().subscribe({
-      next: (adminEmail: string) => {
-        const title = "Pending account login attempt";
-        const content = `User ${userEmail} attempted to login but is still marked as INACTIVE.`;
-        const receiver = adminEmail;
-
-        this.gmailService.sendEmail(title, content, receiver);
-      },
-      error: (err: unknown) => {
-        console.error("Failed to get sender email:", err);
-      },
-    });
   }
 }

--- a/core/gui/src/app/common/service/user/auth.service.ts
+++ b/core/gui/src/app/common/service/user/auth.service.ts
@@ -8,6 +8,7 @@ import { startWith, ignoreElements } from "rxjs/operators";
 import { JwtHelperService } from "@auth0/angular-jwt";
 import { NotificationService } from "../notification/notification.service";
 import { environment } from "../../../../environments/environment";
+import { GmailService } from "../gmail/gmail.service";
 
 export const TOKEN_KEY = "access_token";
 export const TOKEN_REFRESH_INTERVAL_IN_MIN = 15;
@@ -34,7 +35,8 @@ export class AuthService {
   constructor(
     private http: HttpClient,
     private jwtHelperService: JwtHelperService,
-    private notificationService: NotificationService
+    private notificationService: NotificationService,
+    private gmailService: GmailService
   ) {}
 
   /**
@@ -111,6 +113,7 @@ export class AuthService {
     const email = this.jwtHelperService.decodeToken(token).email;
     if (this.inviteOnly && role == Role.INACTIVE) {
       alert("The account request of " + email + " is received and pending.");
+      this.notifyAdminOfInactiveLoginAttempt(email);
       return this.logout();
     }
 
@@ -179,5 +182,20 @@ export class AuthService {
 
   static removeAccessToken(): void {
     localStorage.removeItem(TOKEN_KEY);
+  }
+
+  private notifyAdminOfInactiveLoginAttempt(userEmail: string): void {
+    this.gmailService.getSenderEmail().subscribe({
+      next: (adminEmail: string) => {
+        const title = "Pending account login attempt";
+        const content = `User ${userEmail} attempted to login but is still marked as INACTIVE.`;
+        const receiver = adminEmail;
+
+        this.gmailService.sendEmail(title, content, receiver);
+      },
+      error: (err: unknown) => {
+        console.error("Failed to get sender email:", err);
+      },
+    });
   }
 }


### PR DESCRIPTION
### Purpose:
When the `inviteOnly` flag in `environment.default.ts` is set to **true**, an email will be sent to the administrator when an unauthorized or inactive user attempts to log in.


### Changes:
Added a new backend API endpoint `notify-unauthorized`, which sends an email to the administrator's own address using the admin email credentials. This endpoint is triggered when inviteOnly is set to true and the user attempting to log in has the INACTIVE role.

### Demos:
shenghaf@uci.edu is an INACTIVE user
![image](https://github.com/user-attachments/assets/4dfe5e8b-2a47-49c4-a05c-5306cb88f506)

An email will be sent to the admin when shenghaf@uci.edu attempts to log in
![image](https://github.com/user-attachments/assets/48200746-8460-454c-8a98-2bfaf36b7366)

Display of Administrator Email
![image](https://github.com/user-attachments/assets/48f21bdd-5862-4f0b-bf4c-1ea13e399877)
