### PR TITLE
Enable email notifications to users upon an inactive login attempt

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
@@ -1,5 +1,7 @@
 package edu.uci.ics.texera.web.resource
 
+import edu.uci.ics.texera.dao.jooq.generated.enums.UserRoleEnum
+
 /**
   * EmailTemplate provides factory methods to generate email messages
   * for different user notification scenarios.
@@ -49,5 +51,29 @@ object EmailTemplate {
            |""".stripMargin
       EmailMessage(subject = subject, content = content, receiver = receiverEmail)
     }
+  }
+
+  /**
+    * Creates an email message to notify a user
+    * that their role has been updated.
+    *
+    * @param receiverEmail the user's email address
+    * @param newRole the new role assigned to the user
+    * @return an EmailMessage ready to be sent to the user
+    */
+  def createRoleChangeTemplate(receiverEmail: String, newRole: UserRoleEnum): EmailMessage = {
+    val subject = "Your Role Has Been Updated"
+    val content =
+      s"""
+         |Hello,
+         |
+         |Your user role has been updated to: $newRole.
+         |
+         |If you have any questions, please contact the administrator.
+         |
+         |Thank you!
+         |""".stripMargin
+
+    EmailMessage(subject = subject, content = content, receiver = receiverEmail)
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
@@ -7,48 +7,47 @@ package edu.uci.ics.texera.web.resource
 object EmailTemplate {
 
   /**
-    * Creates an email message to notify the administrator
-    * that a new user account request is pending approval.
+    * Creates an email message for user registration notifications.
+    * Depending on the 'toAdmin' flag, it either notifies an administrator
+    * of a pending account request or acknowledges receipt to the user.
     *
-    * @param receiverEmail the administrator's email address
-    * @param userEmail the email address of the user requesting an account
-    * @return an EmailMessage ready to be sent to the administrator
+    * @param receiverEmail the email address of the receiver (admin or user)
+    * @param userEmail optional; the email address of the user requesting an account (only needed if toAdmin is true)
+    * @param toAdmin flag indicating whether the notification is for the admin (true) or the user (false)
+    * @return an EmailMessage ready to be sent
     */
-  def createAdminNotification(receiverEmail: String, userEmail: String): EmailMessage = {
-    val subject = "New Account Request Pending Approval"
-    val content =
-      s"""
-         |Hello Admin,
-         |
-         |A new user has attempted to log in or register, but their account is not yet approved.
-         |Please review the account request for the following email:
-         |
-         |$userEmail
-         |
-         |Thanks!
-         |""".stripMargin
-    EmailMessage(subject = subject, content = content, receiver = receiverEmail)
-  }
-
-  /**
-    * Creates an email message to notify the user
-    * that their account request has been received and is under review.
-    *
-    * @param receiverEmail the user's email address
-    * @return an EmailMessage ready to be sent to the user
-    */
-  def createUserNotification(receiverEmail: String): EmailMessage = {
-    val subject = "Account Request Received"
-    val content =
-      s"""
-         |Hello,
-         |
-         |Thank you for submitting your account request.
-         |We have received your request and it is currently under review.
-         |Please be patient during this process. You will be notified once your account has been approved.
-         |
-         |Thank you for your interest!
-         |""".stripMargin
-    EmailMessage(subject = subject, content = content, receiver = receiverEmail)
+  def userRegistrationNotification(
+      receiverEmail: String,
+      userEmail: Option[String],
+      toAdmin: Boolean
+  ): EmailMessage = {
+    if (toAdmin) {
+      val subject = "New Account Request Pending Approval"
+      val content =
+        s"""
+           |Hello Admin,
+           |
+           |A new user has attempted to log in or register, but their account is not yet approved.
+           |Please review the account request for the following email:
+           |
+           |${userEmail.getOrElse("Unknown")}
+           |
+           |Thanks!
+           |""".stripMargin
+      EmailMessage(subject = subject, content = content, receiver = receiverEmail)
+    } else {
+      val subject = "Account Request Received"
+      val content =
+        s"""
+           |Hello,
+           |
+           |Thank you for submitting your account request.
+           |We have received your request and it is currently under review.
+           |Please be patient during this process. You will be notified once your account has been approved.
+           |
+           |Thank you for your interest!
+           |""".stripMargin
+      EmailMessage(subject = subject, content = content, receiver = receiverEmail)
+    }
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
@@ -1,6 +1,19 @@
 package edu.uci.ics.texera.web.resource
 
+/**
+  * EmailTemplate provides factory methods to generate email messages
+  * for different user notification scenarios.
+  */
 object EmailTemplate {
+
+  /**
+    * Creates an email message to notify the administrator
+    * that a new user account request is pending approval.
+    *
+    * @param receiverEmail the administrator's email address
+    * @param userEmail the email address of the user requesting an account
+    * @return an EmailMessage ready to be sent to the administrator
+    */
   def createAdminNotification(receiverEmail: String, userEmail: String): EmailMessage = {
     val subject = "New Account Request Pending Approval"
     val content =
@@ -17,6 +30,13 @@ object EmailTemplate {
     EmailMessage(subject = subject, content = content, receiver = receiverEmail)
   }
 
+  /**
+    * Creates an email message to notify the user
+    * that their account request has been received and is under review.
+    *
+    * @param receiverEmail the user's email address
+    * @return an EmailMessage ready to be sent to the user
+    */
   def createUserNotification(receiverEmail: String): EmailMessage = {
     val subject = "Account Request Received"
     val content =

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
@@ -1,0 +1,34 @@
+package edu.uci.ics.texera.web.resource
+
+object EmailTemplate {
+  def createAdminNotification(receiverEmail: String, userEmail: String): EmailMessage = {
+    val subject = "New Account Request Pending Approval"
+    val content =
+      s"""
+         |Hello Admin,
+         |
+         |A new user has attempted to log in or register, but their account is not yet approved.
+         |Please review the account request for the following email:
+         |
+         |$userEmail
+         |
+         |Thanks!
+         |""".stripMargin
+    EmailMessage(subject = subject, content = content, receiver = receiverEmail)
+  }
+
+  def createUserNotification(receiverEmail: String): EmailMessage = {
+    val subject = "Account Request Received"
+    val content =
+      s"""
+         |Hello,
+         |
+         |Thank you for submitting your account request.
+         |We have received your request and it is currently under review.
+         |Please be patient during this process. You will be notified once your account has been approved.
+         |
+         |Thank you for your interest!
+         |""".stripMargin
+    EmailMessage(subject = subject, content = content, receiver = receiverEmail)
+  }
+}

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
@@ -2,12 +2,11 @@ package edu.uci.ics.texera.web.resource
 
 import edu.uci.ics.amber.engine.common.AmberConfig
 import edu.uci.ics.texera.auth.SessionUser
-import edu.uci.ics.texera.web.resource.GmailResource.{
+import edu.uci.ics.texera.web.resource.EmailTemplate.{
   createAdminNotification,
-  createUserNotification,
-  sendEmail,
-  senderGmail
+  createUserNotification
 }
+import edu.uci.ics.texera.web.resource.GmailResource.{sendEmail, senderGmail}
 import io.dropwizard.auth.Auth
 
 import javax.annotation.security.RolesAllowed
@@ -68,37 +67,6 @@ object GmailResource {
       case Failure(exception) => Left(s"Failed to send email: ${exception.getMessage}")
     }
   }
-
-  private def createAdminNotification(userEmail: String): EmailMessage = {
-    val subject = "New Account Request Pending Approval"
-    val content =
-      s"""
-         |Hello Admin,
-         |
-         |A new user has attempted to log in or register, but their account is not yet approved.
-         |Please review the account request for the following email:
-         |
-         |$userEmail
-         |
-         |Thanks!
-         |""".stripMargin
-    EmailMessage(subject = subject, content = content, receiver = senderGmail)
-  }
-
-  private def createUserNotification(userEmail: String): EmailMessage = {
-    val subject = "Account Request Received"
-    val content =
-      s"""
-         |Hello,
-         |
-         |Thank you for submitting your account request.
-         |We have received your request and it is currently under review.
-         |Please be patient during this process. You will be notified once your account has been approved.
-         |
-         |Thank you for your interest!
-         |""".stripMargin
-    EmailMessage(subject = subject, content = content, receiver = userEmail)
-  }
 }
 
 @Path("/gmail")
@@ -119,7 +87,10 @@ class GmailResource {
   @POST
   @Path("/notify-unauthorized")
   def notifyUnauthorizedUser(emailMessage: EmailMessage): Unit = {
-    sendEmail(createAdminNotification(emailMessage.receiver), senderGmail)
-    sendEmail(createUserNotification(emailMessage.receiver), emailMessage.receiver)
+    sendEmail(
+      createAdminNotification(receiverEmail = senderGmail, userEmail = emailMessage.receiver),
+      senderGmail
+    )
+    sendEmail(createUserNotification(receiverEmail = emailMessage.receiver), emailMessage.receiver)
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
@@ -5,18 +5,17 @@ import edu.uci.ics.texera.auth.SessionUser
 import edu.uci.ics.texera.dao.SqlServer
 import edu.uci.ics.texera.dao.jooq.generated.enums.UserRoleEnum
 import edu.uci.ics.texera.dao.jooq.generated.tables.daos.UserDao
-import edu.uci.ics.texera.web.resource.EmailTemplate.{
-  createAdminNotification,
-  createUserNotification
-}
-import edu.uci.ics.texera.web.resource.GmailResource.{sendEmail, senderGmail, userDao}
+import edu.uci.ics.texera.web.resource.EmailTemplate.userRegistrationNotification
+import edu.uci.ics.texera.web.resource.GmailResource.{isValidEmail, sendEmail, senderGmail, userDao}
 import io.dropwizard.auth.Auth
+import org.slf4j.LoggerFactory
 
 import javax.annotation.security.RolesAllowed
 import javax.mail.internet.{InternetAddress, MimeMessage}
 import javax.mail.{Message, PasswordAuthentication, Session, Transport}
 import javax.ws.rs._
 import scala.util.{Failure, Success, Try}
+import jakarta.ws.rs.core.Response
 
 case class EmailMessage(receiver: String, subject: String, content: String)
 
@@ -75,6 +74,23 @@ object GmailResource {
       case Failure(exception) => Left(s"Failed to send email: ${exception.getMessage}")
     }
   }
+
+  /**
+    * Validates whether a given email address has a basic correct format.
+    *
+    * This method uses a regular expression to ensure the email:
+    * - Has a valid local part containing letters, numbers, '+', '_', '.', or '-'
+    * - Contains a single '@' character separating the local part and domain
+    * - Has a valid domain containing letters, numbers, '.' or '-'
+    * - Ends with a domain suffix (e.g., '.com', '.net') that is at least two letters long
+    *
+    * @param email the email address to validate
+    * @return true if the email matches the expected format, false otherwise
+    */
+  private def isValidEmail(email: String): Boolean = {
+    val emailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$".r
+    email != null && emailRegex.matches(email)
+  }
 }
 
 @Path("/gmail")
@@ -95,17 +111,53 @@ class GmailResource {
   @POST
   @Path("/notify-unauthorized")
   def notifyUnauthorizedUser(emailMessage: EmailMessage): Unit = {
+    val logger = LoggerFactory.getLogger(this.getClass)
+
+    if (!isValidEmail(emailMessage.receiver)) {
+      logger.warn(s"Blocked sending notification to invalid user email: ${emailMessage.receiver}")
+      throw new ForbiddenException("Invalid email address.")
+    }
+
     val adminUsers = userDao.fetchByRole(UserRoleEnum.ADMIN)
     val adminUserIterator = adminUsers.iterator()
 
     while (adminUserIterator.hasNext) {
       val admin = adminUserIterator.next()
-      sendEmail(
-        createAdminNotification(receiverEmail = admin.getEmail, userEmail = emailMessage.receiver),
-        admin.getEmail
-      )
+      val adminEmail = admin.getEmail
+
+      if (isValidEmail(adminEmail)) {
+        try {
+          sendEmail(
+            userRegistrationNotification(
+              receiverEmail = adminEmail,
+              userEmail = Some(emailMessage.receiver),
+              toAdmin = true
+            ),
+            adminEmail
+          )
+        } catch {
+          case ex: Exception =>
+            logger.warn(s"Failed to send email to admin: $adminEmail. Error: ${ex.getMessage}")
+        }
+      } else {
+        logger.warn(s"Skipped invalid admin email: $adminEmail")
+      }
     }
 
-    sendEmail(createUserNotification(receiverEmail = emailMessage.receiver), emailMessage.receiver)
+    try {
+      sendEmail(
+        userRegistrationNotification(
+          receiverEmail = emailMessage.receiver,
+          userEmail = None,
+          toAdmin = false
+        ),
+        emailMessage.receiver
+      )
+    } catch {
+      case ex: Exception =>
+        logger.warn(
+          s"Failed to send notification to user: ${emailMessage.receiver}. Error: ${ex.getMessage}"
+        )
+    }
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
@@ -15,7 +15,6 @@ import javax.mail.internet.{InternetAddress, MimeMessage}
 import javax.mail.{Message, PasswordAuthentication, Session, Transport}
 import javax.ws.rs._
 import scala.util.{Failure, Success, Try}
-import jakarta.ws.rs.core.Response
 
 case class EmailMessage(receiver: String, subject: String, content: String)
 


### PR DESCRIPTION
### Purpose:
This PR enables automatic email notifications when an INACTIVE user attempts to log in under inviteOnly mode, including a confirmation email sent to the user acknowledging receipt of their account request.

### Changes:
1. Add `EmailTemplate.scala` to centralize and manage different types of email content.
2. Implement `createAdminNotification` method to generate notification emails for all administrators.
3. Implement `createUserNotification` method to generate confirmation emails for users.
4. Refactor `notifyUnauthorizedUser` to use the email templates from EmailTemplate instead of constructing email content inline; additionally, extend it to send a notification email to the user.

### Demos:
shenghaf@uci.edu is an INACTIVE user
shenghaofu0709@gmail.com and 2318002579@qq.com are administrators:
![image](https://github.com/user-attachments/assets/446b548e-c315-428b-a0e3-fb049b45a131)

An email will be sent to the user when shenghaf@uci.edu attempts to log in:
![image](https://github.com/user-attachments/assets/48200746-8460-454c-8a98-2bfaf36b7366)

Display of User's Email:
![image](https://github.com/user-attachments/assets/d53cf783-3897-4006-8ece-f92016622a40)

Display of Administrators' Emails:
shenghaofu0709@gmail.com:
![image](https://github.com/user-attachments/assets/4854ce04-c94a-49c2-894c-f30cea1ba00d)
2318002579@qq.com:
![image](https://github.com/user-attachments/assets/5395d9cf-ff03-40fa-a752-243a4be3cec0)
