### PR TITLE
Enable email notifications to users upon a role change

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
@@ -1,5 +1,7 @@
 package edu.uci.ics.texera.web.resource
 
+import edu.uci.ics.texera.dao.jooq.generated.enums.UserRoleEnum
+
 /**
   * EmailTemplate provides factory methods to generate email messages
   * for different user notification scenarios.
@@ -49,6 +51,30 @@ object EmailTemplate {
          |
          |Thank you for your interest!
          |""".stripMargin
+    EmailMessage(subject = subject, content = content, receiver = receiverEmail)
+  }
+
+  /**
+    * Creates an email message to notify a user
+    * that their role has been updated.
+    *
+    * @param receiverEmail the user's email address
+    * @param newRole the new role assigned to the user
+    * @return an EmailMessage ready to be sent to the user
+    */
+  def createRoleChangeTemplate(receiverEmail: String, newRole: UserRoleEnum): EmailMessage = {
+    val subject = "Your Role Has Been Updated"
+    val content =
+      s"""
+         |Hello,
+         |
+         |Your user role has been updated to: $newRole.
+         |
+         |If you have any questions, please contact the administrator.
+         |
+         |Thank you!
+         |""".stripMargin
+
     EmailMessage(subject = subject, content = content, receiver = receiverEmail)
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
@@ -87,7 +87,7 @@ object GmailResource {
     * @param email the email address to validate
     * @return true if the email matches the expected format, false otherwise
     */
-  private def isValidEmail(email: String): Boolean = {
+  def isValidEmail(email: String): Boolean = {
     val emailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$".r
     email != null && emailRegex.matches(email)
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/GmailResource.scala
@@ -93,7 +93,7 @@ object GmailResource {
     * @param email the email address to validate
     * @return true if the email matches the expected format, false otherwise
     */
-  def isValidEmail(email: String): Boolean = {
+  private def isValidEmail(email: String): Boolean = {
     val emailRegex = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$".r
     email != null && emailRegex.matches(email)
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
@@ -5,7 +5,7 @@ import edu.uci.ics.texera.dao.jooq.generated.enums.UserRoleEnum
 import edu.uci.ics.texera.dao.jooq.generated.tables.daos.UserDao
 import edu.uci.ics.texera.dao.jooq.generated.tables.pojos.User
 import edu.uci.ics.texera.web.resource.EmailTemplate.createRoleChangeTemplate
-import edu.uci.ics.texera.web.resource.GmailResource.sendEmail
+import edu.uci.ics.texera.web.resource.GmailResource.{isValidEmail, sendEmail}
 import edu.uci.ics.texera.web.resource.dashboard.admin.user.AdminUserResource.userDao
 import edu.uci.ics.texera.web.resource.dashboard.user.quota.UserQuotaResource._
 import org.jasypt.util.password.StrongPasswordEncryptor
@@ -53,7 +53,7 @@ class AdminUserResource {
     updatedUser.setComment(user.getComment)
     userDao.update(updatedUser)
 
-    if (roleChanged)
+    if (roleChanged && isValidEmail(updatedUser.getEmail))
       sendEmail(
         createRoleChangeTemplate(receiverEmail = updatedUser.getEmail, newRole = user.getRole),
         updatedUser.getEmail

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/admin/user/AdminUserResource.scala
@@ -5,7 +5,7 @@ import edu.uci.ics.texera.dao.jooq.generated.enums.UserRoleEnum
 import edu.uci.ics.texera.dao.jooq.generated.tables.daos.UserDao
 import edu.uci.ics.texera.dao.jooq.generated.tables.pojos.User
 import edu.uci.ics.texera.web.resource.EmailTemplate.createRoleChangeTemplate
-import edu.uci.ics.texera.web.resource.GmailResource.{isValidEmail, sendEmail}
+import edu.uci.ics.texera.web.resource.GmailResource.sendEmail
 import edu.uci.ics.texera.web.resource.dashboard.admin.user.AdminUserResource.userDao
 import edu.uci.ics.texera.web.resource.dashboard.user.quota.UserQuotaResource._
 import org.jasypt.util.password.StrongPasswordEncryptor
@@ -53,7 +53,7 @@ class AdminUserResource {
     updatedUser.setComment(user.getComment)
     userDao.update(updatedUser)
 
-    if (roleChanged && isValidEmail(updatedUser.getEmail))
+    if (roleChanged)
       sendEmail(
         createRoleChangeTemplate(receiverEmail = updatedUser.getEmail, newRole = user.getRole),
         updatedUser.getEmail


### PR DESCRIPTION
### Purpose:
This PR enables automatic email notifications when a user's role is changed. A notification email will be sent to the user informing them of their updated role.

### Changes:
1. Add a new method `createRoleChangeTemplate` in `EmailTemplate` to generate email content for notifying users about role changes.
2. Send an email notification to the affected user whenever their role is updated.

### Demos:
shenghaf@uci.edu is an INACTIVE user:
![image](https://github.com/user-attachments/assets/4dfe5e8b-2a47-49c4-a05c-5306cb88f506)

Update the role of shenghaf@uci.edu to Regular:
![image](https://github.com/user-attachments/assets/a438aa92-7db4-4dc5-9d26-822bc5cd4a60)

Display of user email:
![image](https://github.com/user-attachments/assets/15c03a11-4d97-42b0-9efa-473d98af6f0d)

Update the role of shenghaf@uci.edu to ADMIN:
![image](https://github.com/user-attachments/assets/e7962079-434f-4192-8589-dce9f44bd349)

Display of user email:
![image](https://github.com/user-attachments/assets/b7e5a2c9-93ea-4671-8446-ec508d4c85d1)