### PR TITLE
Set `image-pull-policy` when creating the computing unit

### DIFF
--- a/core/computing-unit-managing-service/src/main/resources/kubernetes.conf
+++ b/core/computing-unit-managing-service/src/main/resources/kubernetes.conf
@@ -8,6 +8,9 @@ kubernetes {
   image-name = "bobbai/texera-workflow-computing-unit:dev"
   image-name = ${?KUBERNETES_IMAGE_NAME}
 
+  image-pull-policy = "Always"
+  image-pull-policy = ${?KUBERNETES_IMAGE_PULL_POLICY}
+
   port-num = 8085
 
   # Configuration on how many computing units one user can create

--- a/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/KubernetesConfig.scala
+++ b/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/KubernetesConfig.scala
@@ -10,6 +10,8 @@ object KubernetesConfig {
   val computeUnitServiceName: String = conf.getString("kubernetes.compute-unit-service-name")
   val computeUnitPoolNamespace: String = conf.getString("kubernetes.compute-unit-pool-namespace")
   val computeUnitImageName: String = conf.getString("kubernetes.image-name")
+  val computingUnitImagePullPolicy: String = conf.getString("kubernetes.image-pull-policy")
+
   val computeUnitPortNumber: Int = conf.getInt("kubernetes.port-num")
 
   val maxNumOfRunningComputingUnitsPerUser: Int =

--- a/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/util/KubernetesClient.scala
+++ b/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/util/KubernetesClient.scala
@@ -14,36 +14,11 @@ object KubernetesClient {
   private val namespace: String = KubernetesConfig.computeUnitPoolNamespace
   private val podNamePrefix = "computing-unit"
 
-  def isValidQuantity(q: String): Boolean = {
-    try {
-      new Quantity(q)
-      true
-    } catch {
-      case _: Exception => false
-    }
-  }
-
   def generatePodURI(cuid: Int): String = {
     s"${generatePodName(cuid)}.${KubernetesConfig.computeUnitServiceName}.$namespace.svc.cluster.local"
   }
 
   def generatePodName(cuid: Int): String = s"$podNamePrefix-$cuid"
-
-  def parseCUIDFromURI(uri: String): Int = {
-    val pattern = """computing-unit-(\d+).*""".r
-    uri match {
-      case pattern(cuid) => cuid.toInt
-      case _             => throw new IllegalArgumentException(s"Invalid pod URI: $uri")
-    }
-  }
-
-  def getPodsList(): List[Pod] = {
-    client.pods().inNamespace(namespace).list().getItems.asScala.toList
-  }
-
-  def getPodsList(label: String): List[Pod] = {
-    client.pods().inNamespace(namespace).withLabel(label).list().getItems.asScala.toList
-  }
 
   def getPodByName(podName: String): Option[Pod] = {
     Option(client.pods().inNamespace(namespace).withName(podName).get())
@@ -138,6 +113,7 @@ object KubernetesClient {
       .addNewContainer()
       .withName("computing-unit-master")
       .withImage(KubernetesConfig.computeUnitImageName)
+      .withImagePullPolicy(KubernetesConfig.computingUnitImagePullPolicy)
       .addNewPort()
       .withContainerPort(KubernetesConfig.computeUnitPortNumber)
       .endPort()


### PR DESCRIPTION
This PR sets the `image-pull-policy` when creating the computing unit. The default value is "Always", guarantee that the computing unit's image is up-to-date.