### PR TITLE
Use `MultipartUpload` to implement the upload-one-file endpoint of the FileService 

### DIFF
--- a/core/file-service/src/main/scala/edu/uci/ics/texera/service/util/S3StorageClient.scala
+++ b/core/file-service/src/main/scala/edu/uci/ics/texera/service/util/S3StorageClient.scala
@@ -15,6 +15,9 @@ import scala.jdk.CollectionConverters._
   * - Supports object upload, download, listing, and deletion.
   */
 object S3StorageClient {
+  val MINIMUM_NUM_OF_MULTIPART_S3_PART: Long = 5L * 1024 * 1024 // 5 MiB
+  val MAXIMUM_NUM_OF_MULTIPART_S3_PARTS = 10_000
+
   // Initialize MinIO-compatible S3 Client
   private lazy val s3Client: S3Client = {
     val credentials = AwsBasicCredentials.create(StorageConfig.s3Username, StorageConfig.s3Password)

--- a/core/gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
+++ b/core/gui/src/app/workspace/service/workflow-result-export/workflow-result-export.service.ts
@@ -93,6 +93,7 @@ export class WorkflowResultExportService {
 
     const workflowId = this.workflowActionService.getWorkflow().wid;
     if (!workflowId) {
+      this.notificationService.error("Cannot export result: workflow ID is not available");
       return;
     }
 

--- a/core/workflow-core/src/main/resources/storage.conf
+++ b/core/workflow-core/src/main/resources/storage.conf
@@ -101,6 +101,11 @@ storage {
         region = "us-west-2"
         region = ${?STORAGE_S3_REGION}
 
+        multipart {
+            part-size = "16MB"
+            part-size = ${?STORAGE_S3_MULTIPART_PART_SIZE}
+        }
+
         auth {
             username = "texera_minio"
             username = ${?STORAGE_S3_AUTH_USERNAME}

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/StorageConfig.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/StorageConfig.scala
@@ -1,6 +1,7 @@
 package edu.uci.ics.amber.core.storage
 
 import com.typesafe.config.{Config, ConfigFactory}
+import edu.uci.ics.amber.core.storage.util.ConfigParserUtil.parseS3MultipartPartSize
 import edu.uci.ics.amber.util.PathUtils.corePath
 
 import java.nio.file.Path
@@ -63,6 +64,7 @@ object StorageConfig {
   val s3Region: String = conf.getString("storage.s3.region")
   val s3Username: String = conf.getString("storage.s3.auth.username")
   val s3Password: String = conf.getString("storage.s3.auth.password")
+  val s3partSize: Long = parseS3MultipartPartSize(conf.getString("storage.s3.multipart.part-size"))
 
   // File storage configurations
   val fileStorageDirectoryPath: Path =

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/StorageConfig.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/StorageConfig.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.amber.core.storage
 
 import com.typesafe.config.{Config, ConfigFactory}
-import edu.uci.ics.amber.core.storage.util.ConfigParserUtil.parseS3MultipartPartSize
+import edu.uci.ics.amber.core.storage.util.ConfigParserUtil.parseSizeStringToBytes
 import edu.uci.ics.amber.util.PathUtils.corePath
 
 import java.nio.file.Path
@@ -64,7 +64,9 @@ object StorageConfig {
   val s3Region: String = conf.getString("storage.s3.region")
   val s3Username: String = conf.getString("storage.s3.auth.username")
   val s3Password: String = conf.getString("storage.s3.auth.password")
-  val s3partSize: Long = parseS3MultipartPartSize(conf.getString("storage.s3.multipart.part-size"))
+  val s3MultipartUploadPartSize: Long = parseSizeStringToBytes(
+    conf.getString("storage.s3.multipart.part-size")
+  )
 
   // File storage configurations
   val fileStorageDirectoryPath: Path =

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/util/ConfigParserUtil.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/util/ConfigParserUtil.scala
@@ -1,0 +1,20 @@
+package edu.uci.ics.amber.core.storage.util
+
+object ConfigParserUtil {
+  def parseS3MultipartPartSize(size: String): Long = {
+    val sizePattern = """(\d+)([KMG]B)""".r
+    size match {
+      case sizePattern(value, unit) =>
+        val multiplier = unit match {
+          case "KB" => 1024L
+          case "MB" => 1024L * 1024
+          case "GB" => 1024L * 1024 * 1024
+        }
+        value.toLong * multiplier
+      case _ =>
+        throw new IllegalArgumentException(
+          s"Invalid s3 multipart part-size format in StorageConfig.scala with value $size"
+        )
+    }
+  }
+}

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/util/ConfigParserUtil.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/util/ConfigParserUtil.scala
@@ -1,7 +1,7 @@
 package edu.uci.ics.amber.core.storage.util
 
 object ConfigParserUtil {
-  def parseS3MultipartPartSize(size: String): Long = {
+  def parseSizeStringToBytes(size: String): Long = {
     val sizePattern = """(\d+)([KMG]B)""".r
     size match {
       case sizePattern(value, unit) =>


### PR DESCRIPTION
## Issue
When trying to export large result (>2GB) from Iceberg to Dataset (LakeFS), it fails due to 2 issues:
- Writing the result on a file in `file-service`
- Sending the written file at once

## Solution
We define two variables `MAXIMUM_NUM_OF_MULTIPART_S3_PARTS` and `MINIMUM_NUM_OF_MULTIPART_S3_PART`, then we request for a presigned URL with maximum number of parts allowed (10,000) because we do not know the exact size of the result (it is coming as stream from Iceberg) and we create an intermediate buffer to store minimum part size and then send to LakeFS as a new part. We stack incoming input stream until we reach the minimum part size (5MB), now if the input stream finish, it means our result was <= `MAXIMUM_NUM_OF_MULTIPART_S3_PARTS` so we just save that in MinIO, however, if the input stream has data still, we start to buffer them in parts.
The minimum part size is defined in `core/workflow-core/src/main/resources/storage.conf` (by default is 16MB). In this regard, `file-service` stack up to the part size from input buffer and upload to MinIO.

### Reference
MinIO explicitly removes unused parts periodically (2 weeks in this [link](https://github.com/minio/minio/issues/6913))