### PR TITLE
Add if statement on catch error for `uploadOneFileToDataset`

### DIFF
--- a/core/file-service/src/main/scala/edu/uci/ics/texera/service/resource/DatasetResource.scala
+++ b/core/file-service/src/main/scala/edu/uci/ics/texera/service/resource/DatasetResource.scala
@@ -518,12 +518,14 @@ class DatasetResource {
       }
     } catch {
       case e: Exception =>
-        LakeFSStorageClient.abortPresignedMultipartUploads(
-          repoName,
-          filePath,
-          uploadId,
-          physicalAddress
-        )
+        if (repoName != null && filePath != null && uploadId != null && physicalAddress != null) {
+          LakeFSStorageClient.abortPresignedMultipartUploads(
+            repoName,
+            filePath,
+            uploadId,
+            physicalAddress
+          )
+        }
         throw new WebApplicationException(
           s"Failed to upload file to dataset: ${e.getMessage}",
           e


### PR DESCRIPTION
## Issue
Following the previous [PR](https://github.com/Texera/texera/pull/3396), we were calling `abortPresignedMultipartUploads` unconditionally, so if for any reason, the export has not started at all (due to unexpected issues), then the `catch` part would fail itself.

## Solution
Add `if` statement to make sure the variables are defined, i.e. the upload has not even started so no need to abort it.