### PR TITLE
Show loading spinner when generating workflow, use nz-icon for close button, and change jupyter cell variable names

### DIFF
--- a/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.html
@@ -16,14 +16,14 @@
           <!-- Markdown Cell -->
           <div
             *ngSwitchCase="'markdown'"
-            class="markdown-cell">
+            class="jupyter-markdown-cell">
             <pre>{{ cell.source.join("") }}</pre>
           </div>
 
           <!-- Code Cell -->
           <div
             *ngSwitchCase="'code'"
-            class="code-cell">
+            class="jupyter-code-cell">
             <pre>{{ cell.source.join("") }}</pre>
             <!-- Safe check for outputs -->
             <div
@@ -37,7 +37,7 @@
           <!-- Raw Cell -->
           <div
             *ngSwitchCase="'raw'"
-            class="raw-cell">
+            class="jupyter-raw-cell">
             <pre>{{ cell.source.join("") }}</pre>
           </div>
         </ng-container>
@@ -87,14 +87,14 @@
             <!-- Markdown Cell -->
             <div
               *ngSwitchCase="'markdown'"
-              class="markdown-cell">
+              class="jupyter-markdown-cell">
               <pre>{{ cell.source.join("") }}</pre>
             </div>
 
             <!-- Code Cell -->
             <div
               *ngSwitchCase="'code'"
-              class="code-cell">
+              class="jupyter-code-cell">
               <pre>{{ cell.source.join("") }}</pre>
               <!-- Safe check for outputs -->
               <div
@@ -108,7 +108,7 @@
             <!-- Raw Cell -->
             <div
               *ngSwitchCase="'raw'"
-              class="raw-cell">
+              class="jupyter-raw-cell">
               <pre>{{ cell.source.join("") }}</pre>
             </div>
           </ng-container>

--- a/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.html
@@ -1,5 +1,7 @@
 <!-- Preview and Upload Dataset Window -->
-<div class="modal-content" *ngIf="popupStage === 0">
+<div
+  class="modal-content"
+  *ngIf="popupStage === 0">
   <!-- Left Column: Jupyter Notebook Preview -->
   <div class="left-column">
     <h2>Upload Successful</h2>
@@ -7,25 +9,35 @@
     <h3>Notebook Preview:</h3>
 
     <div class="notebook-preview">
-      <div *ngFor="let cell of notebookContent?.cells" class="notebook-cell">
+      <div
+        *ngFor="let cell of notebookContent?.cells"
+        class="notebook-cell">
         <ng-container [ngSwitch]="cell.cell_type">
           <!-- Markdown Cell -->
-          <div *ngSwitchCase="'markdown'" class="markdown-cell">
+          <div
+            *ngSwitchCase="'markdown'"
+            class="markdown-cell">
             <pre>{{ cell.source.join("") }}</pre>
           </div>
 
           <!-- Code Cell -->
-          <div *ngSwitchCase="'code'" class="code-cell">
+          <div
+            *ngSwitchCase="'code'"
+            class="code-cell">
             <pre>{{ cell.source.join("") }}</pre>
             <!-- Safe check for outputs -->
-            <div *ngIf="cell.outputs && cell.outputs.length > 0" class="output">
+            <div
+              *ngIf="cell.outputs && cell.outputs.length > 0"
+              class="output">
               <h4>Output:</h4>
               <pre *ngFor="let output of cell.outputs">{{ getOutputText(output) }}</pre>
             </div>
           </div>
 
           <!-- Raw Cell -->
-          <div *ngSwitchCase="'raw'" class="raw-cell">
+          <div
+            *ngSwitchCase="'raw'"
+            class="raw-cell">
             <pre>{{ cell.source.join("") }}</pre>
           </div>
         </ng-container>
@@ -38,16 +50,24 @@
     <h3>Select Datasets for Workflow</h3>
     <p>Add CSV files that will be used as input datasets for the workflow execution:</p>
     <div class="dataset-input">
-      <input type="file" accept=".csv" (change)="onFileChange($event)" multiple />
-      <ul *ngIf="datasets.length > 0" class="dataset-list">
+      <input
+        type="file"
+        accept=".csv"
+        (change)="onFileChange($event)"
+        multiple />
+      <ul
+        *ngIf="datasets.length > 0"
+        class="dataset-list">
         <li *ngFor="let dataset of datasets">{{ dataset.name }}</li>
       </ul>
     </div>
     <!-- Disable button when no datasets are selected -->
-    <button nz-button nzType="primary"
-            (click)="convertToWorkflow()"
-            [disabled]="datasets.length === 0"
-            [nzLoading]="workflowGeneratingInProgress">
+    <button
+      nz-button
+      nzType="primary"
+      (click)="convertToWorkflow()"
+      [disabled]="datasets.length === 0"
+      [nzLoading]="workflowGeneratingInProgress">
       Convert to Texera Workflow
     </button>
   </div>
@@ -60,25 +80,35 @@
     <div class="left-half">
       <h3>Original Notebook</h3>
       <div class="notebook-preview">
-        <div *ngFor="let cell of notebookContent?.cells" class="notebook-cell">
+        <div
+          *ngFor="let cell of notebookContent?.cells"
+          class="notebook-cell">
           <ng-container [ngSwitch]="cell.cell_type">
             <!-- Markdown Cell -->
-            <div *ngSwitchCase="'markdown'" class="markdown-cell">
+            <div
+              *ngSwitchCase="'markdown'"
+              class="markdown-cell">
               <pre>{{ cell.source.join("") }}</pre>
             </div>
 
             <!-- Code Cell -->
-            <div *ngSwitchCase="'code'" class="code-cell">
+            <div
+              *ngSwitchCase="'code'"
+              class="code-cell">
               <pre>{{ cell.source.join("") }}</pre>
               <!-- Safe check for outputs -->
-              <div *ngIf="cell.outputs && cell.outputs.length > 0" class="output">
+              <div
+                *ngIf="cell.outputs && cell.outputs.length > 0"
+                class="output">
                 <h4>Output:</h4>
                 <pre *ngFor="let output of cell.outputs">{{ getOutputText(output) }}</pre>
               </div>
             </div>
 
             <!-- Raw Cell -->
-            <div *ngSwitchCase="'raw'" class="raw-cell">
+            <div
+              *ngSwitchCase="'raw'"
+              class="raw-cell">
               <pre>{{ cell.source.join("") }}</pre>
             </div>
           </ng-container>
@@ -94,7 +124,10 @@
     </div>
   </div>
   <div class="equivalence-check">
-    <button nz-button nzType="primary" (click)="compareOutput()">
+    <button
+      nz-button
+      nzType="primary"
+      (click)="compareOutput()">
       Compare Output
     </button>
   </div>
@@ -119,10 +152,16 @@
     </div>
   </div>
   <div class="equivalence-check">
-    <button nz-button nzType="primary" [style.background-color]="'red'" [style.margin-right]="'10px'">
+    <button
+      nz-button
+      nzType="primary"
+      [style.background-color]="'red'"
+      [style.margin-right]="'10px'">
       Reject Workflow
     </button>
-    <button nz-button nzType="primary">
+    <button
+      nz-button
+      nzType="primary">
       Accept Workflow
     </button>
   </div>

--- a/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.scss
+++ b/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.scss
@@ -27,8 +27,8 @@
 }
 
 .notebook-workflow-side-by-side {
-  display: flex;  /* Use flexbox for the container */
-  flex-direction: row;  /* Arrange children in a row */
+  display: flex; /* Use flexbox for the container */
+  flex-direction: row; /* Arrange children in a row */
   gap: 20px; /* Optional: Adds space between the columns */
 }
 

--- a/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.scss
+++ b/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.scss
@@ -74,7 +74,7 @@
 }
 
 // Markdown Cell Styles
-.markdown-cell {
+.jupyter-markdown-cell {
   padding: 10px;
   background-color: #fbfbfb;
   font-family: "Georgia", "Times", "serif";
@@ -82,7 +82,7 @@
 }
 
 // Code Cell Styles
-.code-cell {
+.jupyter-code-cell {
   background-color: #f7f7f7;
   padding: 10px;
   border-radius: 4px;
@@ -103,7 +103,7 @@
 }
 
 // Raw Cell Styles
-.raw-cell {
+.jupyter-raw-cell {
   padding: 10px;
   background-color: #f1f1f1;
   border: 1px dashed #ddd;

--- a/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.ts
@@ -15,7 +15,10 @@ export class JupyterUploadSuccessComponent {
   workflowGeneratingInProgress: boolean = false;
   workflowJsonContent: any; // variable to store the JSON content
 
-  constructor(private http: HttpClient, private modalService: NzModalService) {}
+  constructor(
+    private http: HttpClient,
+    private modalService: NzModalService
+  ) {}
 
   getOutputText(output: JupyterOutput): string {
     if (output.output_type === "stream") {
@@ -45,9 +48,7 @@ export class JupyterUploadSuccessComponent {
           { id: "1", type: "OperatorA", properties: {} },
           { id: "2", type: "OperatorB", properties: {} },
         ],
-        links: [
-          { source: "1", target: "2" },
-        ],
+        links: [{ source: "1", target: "2" }],
         commentBoxes: [],
         groups: [],
         operatorPositions: {
@@ -59,8 +60,6 @@ export class JupyterUploadSuccessComponent {
       // Process the mock data
       this.workflowJsonContent = mockData; // Assign mock data as workflow content
       this.workflowGeneratingInProgress = false;
-
-
     }, 2000); // Simulate a delay of 2 seconds for processing
   }
 
@@ -69,7 +68,7 @@ export class JupyterUploadSuccessComponent {
    */
   private processDatasets(): void {
     if (this.datasets.length > 0) {
-      this.datasets.forEach((file) => {
+      this.datasets.forEach(file => {
         this.handleFileUploads(file);
       });
     }

--- a/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.html
+++ b/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.html
@@ -9,9 +9,6 @@
     cdkDragHandle>
     <span>Jupyter Notebook</span>
     <button
-      nz-button
-      nzType="text"
-      nzShape="circle"
       class="close-button"
       (click)="closePanel()">
       <i

--- a/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.html
+++ b/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.html
@@ -3,11 +3,17 @@
   *ngIf="isVisible"
   cdkDrag
   cdkDragBoundary="texera-workspace"
-  cdkDragHandle=".panel-header"
->
-  <div class="panel-header" cdkDragHandle>
+  cdkDragHandle=".panel-header">
+  <div
+    class="panel-header"
+    cdkDragHandle>
     <span>Jupyter Notebook</span>
-    <button class="close-button" (click)="closePanel()">X</button> <!-- Close button -->
+    <button
+      class="close-button"
+      (click)="closePanel()">
+      X
+    </button>
+    <!-- Close button -->
   </div>
 
   <div class="iframe-container">
@@ -17,7 +23,6 @@
       src="http://localhost:8888/notebooks/work/example.ipynb?token=mytoken"
       width="100%"
       height="100%"
-      style="border: none"
-    ></iframe>
+      style="border: none"></iframe>
   </div>
 </div>

--- a/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.html
+++ b/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.html
@@ -9,9 +9,15 @@
     cdkDragHandle>
     <span>Jupyter Notebook</span>
     <button
+      nz-button
+      nzType="text"
+      nzShape="circle"
       class="close-button"
       (click)="closePanel()">
-      X
+      <i
+        nz-icon
+        nzType="close"
+        nzTheme="outline"></i>
     </button>
     <!-- Close button -->
   </div>

--- a/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.scss
+++ b/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.scss
@@ -34,7 +34,7 @@
 }
 
 .close-button:hover {
-  color: royalblue;;
+  color: royalblue;
 }
 
 .iframe-container {

--- a/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.ts
+++ b/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.ts
@@ -6,7 +6,7 @@ import { takeUntil } from "rxjs/operators";
 @Component({
   selector: "texera-jupyter-notebook-panel",
   templateUrl: "./jupyter-notebook-panel.component.html",
-  styleUrls: ["./jupyter-notebook-panel.component.scss"]
+  styleUrls: ["./jupyter-notebook-panel.component.scss"],
 })
 export class JupyterNotebookPanelComponent implements OnInit, AfterViewInit, OnDestroy {
   @ViewChild("iframeRef", { static: false }) iframeRef!: ElementRef<HTMLIFrameElement>; // Use static: false

--- a/core/gui/src/app/workspace/component/menu/menu.component.ts
+++ b/core/gui/src/app/workspace/component/menu/menu.component.ts
@@ -606,9 +606,9 @@ export class MenuComponent implements OnInit, OnDestroy {
         await this.sendNotebookToPod(notebookContent);
 
         // Get workflow and mapping from OpenAI
-        console.log("Getting data from OpenAI...")
+        console.log("Getting data from OpenAI...");
         await this.sendToAIGenerateWorkflow()
-          .then((result) => {
+          .then(result => {
             if (result) {
               const { workflowContent, mappingContent } = result;
               console.log("Workflow:", workflowContent);
@@ -648,7 +648,7 @@ export class MenuComponent implements OnInit, OnDestroy {
               console.error("Result is undefined");
             }
           })
-          .catch((error) => {
+          .catch(error => {
             console.error("Error while fetching data from OpenAI:", error);
           })
           .finally(() => {
@@ -678,7 +678,7 @@ export class MenuComponent implements OnInit, OnDestroy {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({})
+        body: JSON.stringify({}),
       });
 
       // Check if the response is OK (status code 200)
@@ -733,9 +733,6 @@ export class MenuComponent implements OnInit, OnDestroy {
       this.notificationService.error("Error sending notebook to JupyterLab: " + error.message);
     }
   }
-
-
-
 
   public onClickImportWorkflow = (file: NzUploadFile): boolean => {
     const reader = new FileReader();

--- a/core/gui/src/app/workspace/component/menu/menu.component.ts
+++ b/core/gui/src/app/workspace/component/menu/menu.component.ts
@@ -572,7 +572,6 @@ export class MenuComponent implements OnInit, OnDestroy {
   }
 
   public onClickImportNotebook = (file: NzUploadFile): boolean => {
-    this.setWaitingForOpenAi.emit(true); // start loading
     const reader = new FileReader();
 
     // Check if the file is a Jupyter notebook based on its extension
@@ -581,6 +580,8 @@ export class MenuComponent implements OnInit, OnDestroy {
       this.notificationService.error("Please upload a valid Jupyter Notebook (.ipynb) file.");
       return false;
     }
+
+    this.setWaitingForOpenAi.emit(true); // start loading
 
     // Read the notebook file as text
     reader.readAsText(file as any);

--- a/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -513,8 +513,8 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
           // else only highlight a single operator or group
           if (this.workflowActionService.getTexeraGraph().hasOperator(elementID)) {
             this.workflowActionService.highlightOperators(<boolean>event[1].shiftKey, elementID);
-          } else if (this.workflowActionService.getOperatorGroup().hasGroup(elementID)) {
-            this.wrapper.highlightGroups(elementID);
+            // } else if (this.workflowActionService.getOperatorGroup().hasGroup(elementID)) {
+            //   this.wrapper.highlightGroups(elementID);
           } else if (this.workflowActionService.getTexeraGraph().hasCommentBox(elementID)) {
             this.wrapper.highlightCommentBoxes(elementID);
           }

--- a/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -513,8 +513,6 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
           // else only highlight a single operator or group
           if (this.workflowActionService.getTexeraGraph().hasOperator(elementID)) {
             this.workflowActionService.highlightOperators(<boolean>event[1].shiftKey, elementID);
-            // } else if (this.workflowActionService.getOperatorGroup().hasGroup(elementID)) {
-            //   this.wrapper.highlightGroups(elementID);
           } else if (this.workflowActionService.getTexeraGraph().hasCommentBox(elementID)) {
             this.wrapper.highlightCommentBoxes(elementID);
           }

--- a/core/gui/src/app/workspace/component/workspace.component.html
+++ b/core/gui/src/app/workspace/component/workspace.component.html
@@ -1,6 +1,6 @@
 <div class="spinner-container">
   <nz-spin
-    [nzSpinning]="isLoading"
+    [nzSpinning]="isLoading || isWaitingForOpenAi"
     [nzSize]="'large'"
     nzTip="Loading workflow..."></nz-spin>
 </div>
@@ -10,7 +10,8 @@
 <texera-workflow-editor></texera-workflow-editor>
 <texera-menu
   [writeAccess]="writeAccess"
-  [pid]="pid">
+  [pid]="pid"
+  (setWaitingForOpenAi)="isWaitingForOpenAi = $event">
 </texera-menu>
 <texera-jupyter-notebook-panel></texera-jupyter-notebook-panel>
 <texera-mini-map class="box"></texera-mini-map>

--- a/core/gui/src/app/workspace/component/workspace.component.scss
+++ b/core/gui/src/app/workspace/component/workspace.component.scss
@@ -12,7 +12,7 @@ texera-menu {
   background-color: white;
 }
 
-texera-jupyter-notebook-panel{
+texera-jupyter-notebook-panel {
   position: absolute;
   top: 0;
   left: 0;

--- a/core/gui/src/app/workspace/component/workspace.component.ts
+++ b/core/gui/src/app/workspace/component/workspace.component.ts
@@ -40,6 +40,8 @@ export class WorkspaceComponent implements AfterViewInit, OnInit, OnDestroy {
   public pid?: number = undefined;
   public writeAccess: boolean = false;
   public isLoading: boolean = false;
+  // variable for track whether we are waiting for AI to finish generating (whether a loading icon should show)
+  public isWaitingForOpenAi = false;
   userSystemEnabled = environment.userSystemEnabled;
   @ViewChild("codeEditor", { read: ViewContainerRef }) codeEditorViewRef!: ViewContainerRef;
   constructor(

--- a/core/gui/src/app/workspace/service/jupyter-panel/jupyter-panel.service.ts
+++ b/core/gui/src/app/workspace/service/jupyter-panel/jupyter-panel.service.ts
@@ -70,10 +70,7 @@ export class JupyterPanelService {
   // Trigger a cell click inside the iframe
   triggerCellClickInsideIframe(cellUUID: string) {
     if (this.iframeRef && this.iframeRef.contentWindow) {
-      this.iframeRef.contentWindow.postMessage(
-        { action: "triggerCellClick", cellUUID },
-        "http://localhost:8888"
-      );
+      this.iframeRef.contentWindow.postMessage({ action: "triggerCellClick", cellUUID }, "http://localhost:8888");
     } else {
       console.error("Iframe reference is null or not loaded.");
     }
@@ -114,10 +111,16 @@ export class JupyterPanelService {
 
     // Unhighlight all operators and links
     this.workflowActionService.unhighlightOperators(
-      ...this.workflowActionService.getTexeraGraph().getAllOperators().map(op => op.operatorID)
+      ...this.workflowActionService
+        .getTexeraGraph()
+        .getAllOperators()
+        .map(op => op.operatorID)
     );
     this.workflowActionService.unhighlightLinks(
-      ...this.workflowActionService.getTexeraGraph().getAllLinks().map(link => link.linkID)
+      ...this.workflowActionService
+        .getTexeraGraph()
+        .getAllLinks()
+        .map(link => link.linkID)
     );
 
     // Highlight components and edges

--- a/core/gui/src/app/workspace/service/jupyter-panel/jupyter-panel.service.ts
+++ b/core/gui/src/app/workspace/service/jupyter-panel/jupyter-panel.service.ts
@@ -67,15 +67,6 @@ export class JupyterPanelService {
     this.iframeRef.onload = () => console.log("Iframe loaded successfully.");
   }
 
-  // Trigger a cell click inside the iframe
-  triggerCellClickInsideIframe(cellUUID: string) {
-    if (this.iframeRef && this.iframeRef.contentWindow) {
-      this.iframeRef.contentWindow.postMessage({ action: "triggerCellClick", cellUUID }, "http://localhost:8888");
-    } else {
-      console.error("Iframe reference is null or not loaded.");
-    }
-  }
-
   // Open the Jupyter Notebook panel
   openPanel(panelName: string): void {
     if (panelName === "JupyterNotebookPanel") {

--- a/core/gui/src/assets/migration_tool/mapping.ts
+++ b/core/gui/src/assets/migration_tool/mapping.ts
@@ -1,39 +1,6 @@
 let mapping = {
-  cell_to_operator: {
-    "b5cc7f69-9128-4876-8ee4-17a17a0e79e9": [],
-    "fe23f9aa-6474-4ac9-8f08-73b132550029": ["CSVFileScan-operator-43e5d7f4-2d3d-498b-a97d-b4d242ee82cf"],
-    "4b172d9c-b974-4f8c-9b30-ed75a35a1b29": [
-      "Distinct-operator-d6a18641-3c29-4835-b8d2-60351b0b8882",
-      "Filter-operator-b46dc58f-8100-478e-80c5-87d93c1f7e04",
-    ],
-    "1177f9a8-a014-43ab-ac3d-71ddabdd6917": [
-      "Aggregate-operator-ba7c3a06-09f8-4ad3-977d-69988789e671",
-      "Aggregate-operator-cd2cbbbf-bad0-46ed-9e13-65ccd1e67c27",
-      "Aggregate-operator-3abc30e7-9ba3-4a97-ac28-937ca950cccf",
-    ],
-    "b5eac814-3c6d-4a62-9530-44475d13fba7": ["BoxPlot-operator-9ffd3dce-29b4-4373-ab38-235487393d72"],
-    "730aa5e5-2b34-4182-8c6b-518d52a03c24": ["PythonUDFV2-operator-1d891fad-a245-4e03-ba40-ad9ffbfa2b6b"],
-    "91cc0423-c670-4982-94d5-522de07057df": ["Split-operator-3e01a035-69bd-487b-bb3c-edf23fb7a64c"],
-    "5db4f799-29bc-43ba-8aba-142f0db829f9": ["SklearnRandomForest-operator-7844ee52-5d28-4421-a537-d267bb52efa8"],
-    "7764cfa5-70a4-48bc-99c8-b70c3db743ae": ["SklearnSVM-operator-7adceacc-b3f9-4af6-8319-cd3c3f96d95d"],
-    "6297d0a8-48dc-4c29-9cc2-e5d5ca517001": ["SklearnDecisionTree-operator-65ea9d8c-9057-4ebc-8a40-a8c01333f948"],
-    "68f22db7-5cd5-4c12-ad4c-3e750d0101b9": ["SklearnLogisticRegression-operator-eca48ee5-d808-4c5d-bb3c-6614d0bfb548"],
-  },
-  operator_to_cell: {
-    "CSVFileScan-operator-43e5d7f4-2d3d-498b-a97d-b4d242ee82cf": ["fe23f9aa-6474-4ac9-8f08-73b132550029"],
-    "Distinct-operator-d6a18641-3c29-4835-b8d2-60351b0b8882": ["4b172d9c-b974-4f8c-9b30-ed75a35a1b29"],
-    "Filter-operator-b46dc58f-8100-478e-80c5-87d93c1f7e04": ["4b172d9c-b974-4f8c-9b30-ed75a35a1b29"],
-    "Aggregate-operator-ba7c3a06-09f8-4ad3-977d-69988789e671": ["1177f9a8-a014-43ab-ac3d-71ddabdd6917"],
-    "Aggregate-operator-cd2cbbbf-bad0-46ed-9e13-65ccd1e67c27": ["1177f9a8-a014-43ab-ac3d-71ddabdd6917"],
-    "Aggregate-operator-3abc30e7-9ba3-4a97-ac28-937ca950cccf": ["1177f9a8-a014-43ab-ac3d-71ddabdd6917"],
-    "BoxPlot-operator-9ffd3dce-29b4-4373-ab38-235487393d72": ["b5eac814-3c6d-4a62-9530-44475d13fba7"],
-    "PythonUDFV2-operator-1d891fad-a245-4e03-ba40-ad9ffbfa2b6b": ["730aa5e5-2b34-4182-8c6b-518d52a03c24"],
-    "Split-operator-3e01a035-69bd-487b-bb3c-edf23fb7a64c": ["91cc0423-c670-4982-94d5-522de07057df"],
-    "SklearnRandomForest-operator-7844ee52-5d28-4421-a537-d267bb52efa8": ["5db4f799-29bc-43ba-8aba-142f0db829f9"],
-    "SklearnSVM-operator-7adceacc-b3f9-4af6-8319-cd3c3f96d95d": ["7764cfa5-70a4-48bc-99c8-b70c3db743ae"],
-    "SklearnDecisionTree-operator-65ea9d8c-9057-4ebc-8a40-a8c01333f948": ["6297d0a8-48dc-4c29-9cc2-e5d5ca517001"],
-    "SklearnLogisticRegression-operator-eca48ee5-d808-4c5d-bb3c-6614d0bfb548": ["68f22db7-5cd5-4c12-ad4c-3e750d0101b9"],
-  },
+  cell_to_operator: {},
+  operator_to_cell: {},
 };
 
 export default mapping;

--- a/core/gui/src/assets/migration_tool/mapping.ts
+++ b/core/gui/src/assets/migration_tool/mapping.ts
@@ -1,81 +1,39 @@
-let mapping =  {
-  "cell_to_operator": {
+let mapping = {
+  cell_to_operator: {
     "b5cc7f69-9128-4876-8ee4-17a17a0e79e9": [],
-    "fe23f9aa-6474-4ac9-8f08-73b132550029": [
-      "CSVFileScan-operator-43e5d7f4-2d3d-498b-a97d-b4d242ee82cf"
-    ],
+    "fe23f9aa-6474-4ac9-8f08-73b132550029": ["CSVFileScan-operator-43e5d7f4-2d3d-498b-a97d-b4d242ee82cf"],
     "4b172d9c-b974-4f8c-9b30-ed75a35a1b29": [
       "Distinct-operator-d6a18641-3c29-4835-b8d2-60351b0b8882",
-      "Filter-operator-b46dc58f-8100-478e-80c5-87d93c1f7e04"
+      "Filter-operator-b46dc58f-8100-478e-80c5-87d93c1f7e04",
     ],
     "1177f9a8-a014-43ab-ac3d-71ddabdd6917": [
       "Aggregate-operator-ba7c3a06-09f8-4ad3-977d-69988789e671",
       "Aggregate-operator-cd2cbbbf-bad0-46ed-9e13-65ccd1e67c27",
-      "Aggregate-operator-3abc30e7-9ba3-4a97-ac28-937ca950cccf"
+      "Aggregate-operator-3abc30e7-9ba3-4a97-ac28-937ca950cccf",
     ],
-    "b5eac814-3c6d-4a62-9530-44475d13fba7": [
-      "BoxPlot-operator-9ffd3dce-29b4-4373-ab38-235487393d72"
-    ],
-    "730aa5e5-2b34-4182-8c6b-518d52a03c24": [
-      "PythonUDFV2-operator-1d891fad-a245-4e03-ba40-ad9ffbfa2b6b"
-    ],
-    "91cc0423-c670-4982-94d5-522de07057df": [
-      "Split-operator-3e01a035-69bd-487b-bb3c-edf23fb7a64c"
-    ],
-    "5db4f799-29bc-43ba-8aba-142f0db829f9": [
-      "SklearnRandomForest-operator-7844ee52-5d28-4421-a537-d267bb52efa8"
-    ],
-    "7764cfa5-70a4-48bc-99c8-b70c3db743ae": [
-      "SklearnSVM-operator-7adceacc-b3f9-4af6-8319-cd3c3f96d95d"
-    ],
-    "6297d0a8-48dc-4c29-9cc2-e5d5ca517001": [
-      "SklearnDecisionTree-operator-65ea9d8c-9057-4ebc-8a40-a8c01333f948"
-    ],
-    "68f22db7-5cd5-4c12-ad4c-3e750d0101b9": [
-      "SklearnLogisticRegression-operator-eca48ee5-d808-4c5d-bb3c-6614d0bfb548"
-    ]
+    "b5eac814-3c6d-4a62-9530-44475d13fba7": ["BoxPlot-operator-9ffd3dce-29b4-4373-ab38-235487393d72"],
+    "730aa5e5-2b34-4182-8c6b-518d52a03c24": ["PythonUDFV2-operator-1d891fad-a245-4e03-ba40-ad9ffbfa2b6b"],
+    "91cc0423-c670-4982-94d5-522de07057df": ["Split-operator-3e01a035-69bd-487b-bb3c-edf23fb7a64c"],
+    "5db4f799-29bc-43ba-8aba-142f0db829f9": ["SklearnRandomForest-operator-7844ee52-5d28-4421-a537-d267bb52efa8"],
+    "7764cfa5-70a4-48bc-99c8-b70c3db743ae": ["SklearnSVM-operator-7adceacc-b3f9-4af6-8319-cd3c3f96d95d"],
+    "6297d0a8-48dc-4c29-9cc2-e5d5ca517001": ["SklearnDecisionTree-operator-65ea9d8c-9057-4ebc-8a40-a8c01333f948"],
+    "68f22db7-5cd5-4c12-ad4c-3e750d0101b9": ["SklearnLogisticRegression-operator-eca48ee5-d808-4c5d-bb3c-6614d0bfb548"],
   },
-  "operator_to_cell": {
-    "CSVFileScan-operator-43e5d7f4-2d3d-498b-a97d-b4d242ee82cf": [
-      "fe23f9aa-6474-4ac9-8f08-73b132550029"
-    ],
-    "Distinct-operator-d6a18641-3c29-4835-b8d2-60351b0b8882": [
-      "4b172d9c-b974-4f8c-9b30-ed75a35a1b29"
-    ],
-    "Filter-operator-b46dc58f-8100-478e-80c5-87d93c1f7e04": [
-      "4b172d9c-b974-4f8c-9b30-ed75a35a1b29"
-    ],
-    "Aggregate-operator-ba7c3a06-09f8-4ad3-977d-69988789e671": [
-      "1177f9a8-a014-43ab-ac3d-71ddabdd6917"
-    ],
-    "Aggregate-operator-cd2cbbbf-bad0-46ed-9e13-65ccd1e67c27": [
-      "1177f9a8-a014-43ab-ac3d-71ddabdd6917"
-    ],
-    "Aggregate-operator-3abc30e7-9ba3-4a97-ac28-937ca950cccf": [
-      "1177f9a8-a014-43ab-ac3d-71ddabdd6917"
-    ],
-    "BoxPlot-operator-9ffd3dce-29b4-4373-ab38-235487393d72": [
-      "b5eac814-3c6d-4a62-9530-44475d13fba7"
-    ],
-    "PythonUDFV2-operator-1d891fad-a245-4e03-ba40-ad9ffbfa2b6b": [
-      "730aa5e5-2b34-4182-8c6b-518d52a03c24"
-    ],
-    "Split-operator-3e01a035-69bd-487b-bb3c-edf23fb7a64c": [
-      "91cc0423-c670-4982-94d5-522de07057df"
-    ],
-    "SklearnRandomForest-operator-7844ee52-5d28-4421-a537-d267bb52efa8": [
-      "5db4f799-29bc-43ba-8aba-142f0db829f9"
-    ],
-    "SklearnSVM-operator-7adceacc-b3f9-4af6-8319-cd3c3f96d95d": [
-      "7764cfa5-70a4-48bc-99c8-b70c3db743ae"
-    ],
-    "SklearnDecisionTree-operator-65ea9d8c-9057-4ebc-8a40-a8c01333f948": [
-      "6297d0a8-48dc-4c29-9cc2-e5d5ca517001"
-    ],
-    "SklearnLogisticRegression-operator-eca48ee5-d808-4c5d-bb3c-6614d0bfb548": [
-      "68f22db7-5cd5-4c12-ad4c-3e750d0101b9"
-    ]
-  }
-}
+  operator_to_cell: {
+    "CSVFileScan-operator-43e5d7f4-2d3d-498b-a97d-b4d242ee82cf": ["fe23f9aa-6474-4ac9-8f08-73b132550029"],
+    "Distinct-operator-d6a18641-3c29-4835-b8d2-60351b0b8882": ["4b172d9c-b974-4f8c-9b30-ed75a35a1b29"],
+    "Filter-operator-b46dc58f-8100-478e-80c5-87d93c1f7e04": ["4b172d9c-b974-4f8c-9b30-ed75a35a1b29"],
+    "Aggregate-operator-ba7c3a06-09f8-4ad3-977d-69988789e671": ["1177f9a8-a014-43ab-ac3d-71ddabdd6917"],
+    "Aggregate-operator-cd2cbbbf-bad0-46ed-9e13-65ccd1e67c27": ["1177f9a8-a014-43ab-ac3d-71ddabdd6917"],
+    "Aggregate-operator-3abc30e7-9ba3-4a97-ac28-937ca950cccf": ["1177f9a8-a014-43ab-ac3d-71ddabdd6917"],
+    "BoxPlot-operator-9ffd3dce-29b4-4373-ab38-235487393d72": ["b5eac814-3c6d-4a62-9530-44475d13fba7"],
+    "PythonUDFV2-operator-1d891fad-a245-4e03-ba40-ad9ffbfa2b6b": ["730aa5e5-2b34-4182-8c6b-518d52a03c24"],
+    "Split-operator-3e01a035-69bd-487b-bb3c-edf23fb7a64c": ["91cc0423-c670-4982-94d5-522de07057df"],
+    "SklearnRandomForest-operator-7844ee52-5d28-4421-a537-d267bb52efa8": ["5db4f799-29bc-43ba-8aba-142f0db829f9"],
+    "SklearnSVM-operator-7adceacc-b3f9-4af6-8319-cd3c3f96d95d": ["7764cfa5-70a4-48bc-99c8-b70c3db743ae"],
+    "SklearnDecisionTree-operator-65ea9d8c-9057-4ebc-8a40-a8c01333f948": ["6297d0a8-48dc-4c29-9cc2-e5d5ca517001"],
+    "SklearnLogisticRegression-operator-eca48ee5-d808-4c5d-bb3c-6614d0bfb548": ["68f22db7-5cd5-4c12-ad4c-3e750d0101b9"],
+  },
+};
 
-export default mapping
+export default mapping;


### PR DESCRIPTION
This PR adds a loading-spinner state so users see a spinner in the workspace while importing a Jupyter notebook and waiting for workflow generation, and also fixes some issues with the close button and some variable names.

## Changes:
1. workspace.component.html
- Updated the main `<nz-spin>` to spin whenever either the existing `isLoading` or the new `isWaitingForOpenAi` flag is true.
- Bound the menu’s `setWaitingForOpenAi` output so that menu emits into the workspace.

2. workspace.component.ts
- Introduced a new public boolean: `public isWaitingForOpenAi = false`.

3. menu.component.ts
- Added an `@Output()` emitter so this component can tell the workspace when AI work starts/ends.
- Marked the `reader.onload` callback as `async`, awaited both `sendNotebookToPod()` and `sendToAIGenerateWorkflow()`.
- Added `this.setWaitingForOpenAi.emit()` calls to start or stop the loading spinner.

4. jupyter-notebook-panel.component.html:
- Changed close button icon from "X" to nz-icon.

5. notebook-migration.component.html:
- Changed `raw-cell`, `code-cell`, and `markdown-cell` to `jupyter-raw-cell`, `jupyter-code-cell`, and `jupyter-markdown-cell` for clarity.

6. Additional changes:
- Made the values of `cell_to_operator` and `operator_to_cell` in the `mapping.ts` temporarily empty for a new design.
- Removed lines with conflicts in `workflow-editor.component.ts`.
- Deleted unused function `triggerCellClickInsideIframe()` in `jupyter-panel.service.ts`.

<img width="1404" alt="image" src="https://github.com/user-attachments/assets/2eaf0b6d-7647-4105-9237-d2896ab76286" />