### PR TITLE
Fix Incorrect Version and Execution Order in Backend Queries

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResource.scala
@@ -18,6 +18,7 @@ import edu.uci.ics.texera.web.model.http.request.result.ResultExportRequest
 import edu.uci.ics.texera.web.resource.dashboard.user.workflow.WorkflowExecutionsResource._
 import edu.uci.ics.texera.web.service.{ExecutionsMetadataPersistService, ResultExportService}
 import io.dropwizard.auth.Auth
+import org.jooq.DSLContext
 
 import java.net.URI
 import java.sql.Timestamp
@@ -165,6 +166,33 @@ object WorkflowExecutionsResource {
       ).filter(_.nonEmpty)
         .map(URI.create)
     else None
+
+  def getWorkflowExecutions(wid: Integer, context: DSLContext): List[WorkflowExecutionEntry] = {
+    context
+      .select(
+        WORKFLOW_EXECUTIONS.EID,
+        WORKFLOW_EXECUTIONS.VID,
+        USER.NAME,
+        USER.GOOGLE_AVATAR,
+        WORKFLOW_EXECUTIONS.STATUS,
+        WORKFLOW_EXECUTIONS.RESULT,
+        WORKFLOW_EXECUTIONS.STARTING_TIME,
+        WORKFLOW_EXECUTIONS.LAST_UPDATE_TIME,
+        WORKFLOW_EXECUTIONS.BOOKMARKED,
+        WORKFLOW_EXECUTIONS.NAME,
+        WORKFLOW_EXECUTIONS.LOG_LOCATION
+      )
+      .from(WORKFLOW_EXECUTIONS)
+      .join(WORKFLOW_VERSION)
+      .on(WORKFLOW_VERSION.VID.eq(WORKFLOW_EXECUTIONS.VID))
+      .join(USER)
+      .on(WORKFLOW_EXECUTIONS.UID.eq(USER.UID))
+      .where(WORKFLOW_VERSION.WID.eq(wid))
+      .orderBy(WORKFLOW_EXECUTIONS.EID.desc())
+      .fetchInto(classOf[WorkflowExecutionEntry])
+      .asScala
+      .toList
+  }
 
   def clearUris(eid: ExecutionIdentity): Unit = {
     if (AmberConfig.isUserSystemEnabled) {
@@ -352,30 +380,7 @@ class WorkflowExecutionsResource {
     if (!WorkflowAccessResource.hasReadAccess(wid, user.getUid)) {
       List()
     } else {
-      context
-        .select(
-          WORKFLOW_EXECUTIONS.EID,
-          WORKFLOW_EXECUTIONS.VID,
-          USER.NAME,
-          USER.GOOGLE_AVATAR,
-          WORKFLOW_EXECUTIONS.STATUS,
-          WORKFLOW_EXECUTIONS.RESULT,
-          WORKFLOW_EXECUTIONS.STARTING_TIME,
-          WORKFLOW_EXECUTIONS.LAST_UPDATE_TIME,
-          WORKFLOW_EXECUTIONS.BOOKMARKED,
-          WORKFLOW_EXECUTIONS.NAME,
-          WORKFLOW_EXECUTIONS.LOG_LOCATION
-        )
-        .from(WORKFLOW_EXECUTIONS)
-        .join(WORKFLOW_VERSION)
-        .on(WORKFLOW_VERSION.VID.eq(WORKFLOW_EXECUTIONS.VID))
-        .join(USER)
-        .on(WORKFLOW_EXECUTIONS.UID.eq(USER.UID))
-        .where(WORKFLOW_VERSION.WID.eq(wid))
-        .orderBy(WORKFLOW_EXECUTIONS.EID.desc())
-        .fetchInto(classOf[WorkflowExecutionEntry])
-        .asScala
-        .toList
+      getWorkflowExecutions(wid, context)
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResource.scala
@@ -372,10 +372,10 @@ class WorkflowExecutionsResource {
         .join(USER)
         .on(WORKFLOW_EXECUTIONS.UID.eq(USER.UID))
         .where(WORKFLOW_VERSION.WID.eq(wid))
+        .orderBy(WORKFLOW_EXECUTIONS.EID.desc())
         .fetchInto(classOf[WorkflowExecutionEntry])
         .asScala
         .toList
-        .reverse
     }
   }
 

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResource.scala
@@ -349,13 +349,14 @@ class WorkflowVersionResource {
         .select(WORKFLOW_VERSION.VID, WORKFLOW_VERSION.CREATION_TIME, WORKFLOW_VERSION.CONTENT)
         .from(WORKFLOW_VERSION)
         .where(WORKFLOW_VERSION.WID.eq(wid).and(WORKFLOW_VERSION.VID.ge(vid)))
+        .orderBy(WORKFLOW_VERSION.VID.desc())
         .fetchInto(classOf[WorkflowVersion])
         .asScala
         .toList
       // apply patch
       val currentWorkflow = workflowDao.fetchOneByWid(wid)
       // return particular version of the workflow
-      val res: Workflow = applyPatch(versionEntries.reverse, currentWorkflow)
+      val res: Workflow = applyPatch(versionEntries, currentWorkflow)
       res
     }
   }

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResource.scala
@@ -254,7 +254,7 @@ object WorkflowVersionResource {
     * @param vid starting version ID (inclusive)
     * @return List of workflow versions ordered from latest to earliest
     */
-  def fetchVersionsPrecedingVersion(
+  def fetchSubsequentVersions(
       wid: Integer,
       vid: Integer,
       context: DSLContext
@@ -367,8 +367,8 @@ class WorkflowVersionResource {
     if (!WorkflowAccessResource.hasReadAccess(wid, user.getUid)) {
       throw new ForbiddenException("No sufficient access privilege.")
     } else {
-      // fetch all versions preceding this
-      val versionEntries = fetchVersionsPrecedingVersion(wid, vid, context)
+      // fetch all versions equal to and subsequent to the specified version
+      val versionEntries = fetchSubsequentVersions(wid, vid, context)
       // apply patch
       val currentWorkflow = workflowDao.fetchOneByWid(wid)
       // return particular version of the workflow

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResourceSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowExecutionsResourceSpec.scala
@@ -1,0 +1,158 @@
+package edu.uci.ics.texera.web.resource.dashboard.user.workflow
+
+import edu.uci.ics.texera.dao.MockTexeraDB
+import edu.uci.ics.texera.dao.jooq.generated.Tables._
+import edu.uci.ics.texera.dao.jooq.generated.tables.daos.{
+  UserDao,
+  WorkflowDao,
+  WorkflowVersionDao,
+  WorkflowExecutionsDao
+}
+import edu.uci.ics.texera.dao.jooq.generated.tables.pojos.{
+  User,
+  Workflow,
+  WorkflowVersion,
+  WorkflowExecutions
+}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+
+import java.sql.Timestamp
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import scala.collection.mutable.ArrayBuffer
+
+class WorkflowExecutionsResourceSpec
+    extends AnyFlatSpec
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with MockTexeraDB {
+
+  private val testWorkflowWid = 3000 + scala.util.Random.nextInt(1000)
+  private val testUserId = 1000 + scala.util.Random.nextInt(1000)
+
+  private var testWorkflow: Workflow = _
+  private var testVersion: WorkflowVersion = _
+  private var testUser: User = _
+  private var userDao: UserDao = _
+  private var workflowDao: WorkflowDao = _
+  private var workflowVersionDao: WorkflowVersionDao = _
+  private var workflowExecutionsDao: WorkflowExecutionsDao = _
+
+  override protected def beforeAll(): Unit = {
+    initializeDBAndReplaceDSLContext()
+  }
+
+  override protected def beforeEach(): Unit = {
+    testUser = new User
+    testUser.setUid(testUserId)
+    testUser.setName("test_user")
+    testUser.setEmail("test@example.com")
+    testUser.setPassword("password")
+    testUser.setGoogleAvatar("avatar_url")
+
+    testWorkflow = new Workflow
+    testWorkflow.setWid(testWorkflowWid)
+    testWorkflow.setName("test_workflow_" + UUID.randomUUID().toString.substring(0, 8))
+    testWorkflow.setContent("{}")
+    testWorkflow.setDescription("test description")
+    testWorkflow.setCreationTime(new Timestamp(System.currentTimeMillis()))
+    testWorkflow.setLastModifiedTime(new Timestamp(System.currentTimeMillis()))
+
+    testVersion = new WorkflowVersion
+    testVersion.setWid(testWorkflowWid)
+    testVersion.setContent("{}")
+    testVersion.setCreationTime(new Timestamp(System.currentTimeMillis()))
+
+    workflowDao = new WorkflowDao(getDSLContext.configuration())
+    workflowVersionDao = new WorkflowVersionDao(getDSLContext.configuration())
+    userDao = new UserDao(getDSLContext.configuration())
+    workflowExecutionsDao = new WorkflowExecutionsDao(getDSLContext.configuration())
+
+    cleanupTestData()
+
+    userDao.insert(testUser)
+    workflowDao.insert(testWorkflow)
+    workflowVersionDao.insert(testVersion)
+  }
+
+  override protected def afterEach(): Unit = {
+    cleanupTestData()
+  }
+
+  private def cleanupTestData(): Unit = {
+    getDSLContext
+      .deleteFrom(WORKFLOW_EXECUTIONS)
+      .where(
+        WORKFLOW_EXECUTIONS.VID.in(
+          getDSLContext
+            .select(WORKFLOW_VERSION.VID)
+            .from(WORKFLOW_VERSION)
+            .where(WORKFLOW_VERSION.WID.eq(testWorkflowWid))
+        )
+      )
+      .execute()
+
+    getDSLContext
+      .deleteFrom(WORKFLOW_VERSION)
+      .where(WORKFLOW_VERSION.WID.eq(testWorkflowWid))
+      .execute()
+
+    getDSLContext
+      .deleteFrom(WORKFLOW)
+      .where(WORKFLOW.WID.eq(testWorkflowWid))
+      .execute()
+
+    getDSLContext
+      .deleteFrom(USER)
+      .where(USER.UID.eq(testUserId))
+      .execute()
+  }
+
+  override protected def afterAll(): Unit = {
+    shutdownDB()
+  }
+
+  "WorkflowExecutionsResource.getWorkflowExecutions" should "return executions with EIDs in descending order" in {
+    val numExecutions = 10
+    val executionIds = ArrayBuffer.empty[Integer]
+
+    for (i <- 1 to numExecutions) {
+      val execution = new WorkflowExecutions
+      execution.setVid(testVersion.getVid)
+      execution.setUid(testUser.getUid)
+      execution.setStatus(0.toByte)
+      execution.setResult("")
+      execution.setStartingTime(
+        new Timestamp(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(numExecutions - i))
+      )
+      execution.setBookmarked(false)
+      execution.setName(s"Execution ${i}")
+      execution.setEnvironmentVersion("test-env-1.0")
+
+      workflowExecutionsDao.insert(execution)
+      executionIds.append(execution.getEid)
+    }
+
+    val result = WorkflowExecutionsResource.getWorkflowExecutions(testWorkflowWid, getDSLContext)
+
+    assert(result.nonEmpty, "Result should not be empty")
+    assert(
+      result.size == numExecutions,
+      s"Expected $numExecutions executions, but got ${result.size}"
+    )
+
+    for (i <- 0 until result.size - 1) {
+      assert(
+        result(i).eId > result(i + 1).eId,
+        s"Executions are not in descending order: ${result(i).eId} should be > ${result(i + 1).eId}"
+      )
+    }
+
+    val returnedIds = result.map(_.eId).toSet
+    assert(
+      executionIds.toSet.subsetOf(returnedIds),
+      "All inserted execution IDs should be returned"
+    )
+  }
+}

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
@@ -1,0 +1,143 @@
+package edu.uci.ics.texera.web.resource.dashboard.user.workflow
+
+import edu.uci.ics.texera.dao.MockTexeraDB
+import edu.uci.ics.texera.auth.SessionUser
+import edu.uci.ics.texera.dao.jooq.generated.enums.UserRoleEnum
+import edu.uci.ics.texera.dao.jooq.generated.tables.daos.{UserDao, WorkflowDao, WorkflowVersionDao}
+import edu.uci.ics.texera.dao.jooq.generated.tables.pojos.{User, Workflow, WorkflowVersion}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
+import edu.uci.ics.amber.engine.common.Utils.objectMapper
+
+import scala.jdk.CollectionConverters._
+
+class WorkflowVersionResourceSpec
+    extends AnyFlatSpec
+    with BeforeAndAfterAll
+    with BeforeAndAfterEach
+    with MockTexeraDB {
+
+  private val testUser: User = {
+    val user = new User
+    user.setUid(Integer.valueOf(1))
+    user.setName("test_user")
+    user.setRole(UserRoleEnum.ADMIN)
+    user.setPassword("123")
+    user
+  }
+
+  private val sessionUser: SessionUser = {
+    new SessionUser(testUser)
+  }
+
+  private val workflowVersionResource: WorkflowVersionResource = {
+    new WorkflowVersionResource()
+  }
+
+  private val workflowDao: WorkflowDao = new WorkflowDao(getDSLContext.configuration())
+  private val workflowVersionDao: WorkflowVersionDao = new WorkflowVersionDao(
+    getDSLContext.configuration()
+  )
+  private val userDao: UserDao = new UserDao(getDSLContext.configuration())
+
+  // Helper method to create a test workflow
+  private def createTestWorkflow(name: String, content: String): Workflow = {
+    val workflow = new Workflow()
+    workflow.setName(name)
+    workflow.setDescription("Test description")
+    workflow.setContent(content)
+    workflow
+  }
+
+  // Helper method to create a version of a workflow
+  private def createWorkflowVersion(wid: Integer, content: String): WorkflowVersion = {
+    val version = new WorkflowVersion()
+    version.setWid(wid)
+    version.setContent(content)
+    workflowVersionDao.insert(version)
+    version
+  }
+
+  override protected def beforeAll(): Unit = {
+    initializeDBAndReplaceDSLContext()
+    userDao.insert(testUser)
+  }
+
+  override protected def afterEach(): Unit = {
+    // Clean up all workflow versions
+    val allVersions = workflowVersionDao.findAll().asScala
+    allVersions.foreach(version => workflowVersionDao.delete(version))
+
+    // Clean up all workflows
+    val allWorkflows = workflowDao.findAll().asScala
+    allWorkflows.foreach(workflow => workflowDao.delete(workflow))
+  }
+
+  override protected def afterAll(): Unit = {
+    shutdownDB()
+  }
+
+  // Test case to verify that retrieveWorkflowVersion correctly applies patches in the right order
+  "retrieveWorkflowVersion" should "correctly apply patches in chronological order" in {
+    // Create a workflow with initial content
+    val initialContent = """{"operators": {"op1": {"id": "op1", "value": 1}}}"""
+    val workflow = createTestWorkflow("Test Workflow", initialContent)
+    workflowDao.insert(workflow)
+    val wid = workflow.getWid
+
+    // Create a series of versions with different patches
+    // Version 1: Initial version (automatically created by the system)
+    WorkflowVersionResource.insertNewVersion(wid)
+    Thread.sleep(100) // ensure different timestamps
+
+    // Version 2: Change op1 value from 1 to 2
+    val patchContent2 = """[{"op":"replace","path":"/operators/op1/value","value":2}]"""
+    createWorkflowVersion(wid, patchContent2)
+    Thread.sleep(100)
+
+    // Version 3: Change op1 value from 2 to 3
+    val patchContent3 = """[{"op":"replace","path":"/operators/op1/value","value":3}]"""
+    createWorkflowVersion(wid, patchContent3)
+    Thread.sleep(100)
+
+    // Version 4: Change op1 value from 3 to 4
+    val patchContent4 = """[{"op":"replace","path":"/operators/op1/value","value":4}]"""
+    val v4 = createWorkflowVersion(wid, patchContent4)
+    val vid = v4.getVid
+
+    // Retrieve versions to get the original workflow
+    val restoredWorkflow = workflowVersionResource.retrieveWorkflowVersion(wid, vid, sessionUser)
+
+    // Parse the JSON content to verify the value
+    val jsonNode = objectMapper.readTree(restoredWorkflow.getContent)
+    val op1Value = jsonNode.path("operators").path("op1").path("value").asInt()
+
+    // The value should be 1 because we're applying patches from vid to the latest version
+    // Each patch reverts one change, going backwards from 4 to 3 to 2 to 1
+    assert(op1Value === 1)
+  }
+
+  // Test case to verify that retrieveWorkflowVersion with the latest vid returns the current workflow
+  "retrieveWorkflowVersion" should "return the current workflow when using the latest vid" in {
+    // Create a workflow with initial content
+    val initialContent = """{"operators": {"op1": {"id": "op1", "value": 1}}}"""
+    val workflow = createTestWorkflow("Test Workflow", initialContent)
+    workflowDao.insert(workflow)
+    val wid = workflow.getWid
+
+    // Update the workflow content
+    val updatedContent = """{"operators": {"op1": {"id": "op1", "value": 99}}}"""
+    workflow.setContent(updatedContent)
+    workflowDao.update(workflow)
+
+    // Create a version (this happens automatically in the real system)
+    val version = WorkflowVersionResource.insertNewVersion(wid)
+    val vid = version.getVid
+
+    // Retrieve the latest version
+    val retrievedWorkflow = workflowVersionResource.retrieveWorkflowVersion(wid, vid, sessionUser)
+
+    // Verify the content is the same as the current workflow
+    assert(retrievedWorkflow.getContent === updatedContent)
+  }
+}

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
@@ -1,11 +1,18 @@
 package edu.uci.ics.texera.web.resource.dashboard.user.workflow
 
+import edu.uci.ics.amber.engine.common.Utils.objectMapper
 import edu.uci.ics.texera.dao.MockTexeraDB
+import edu.uci.ics.texera.dao.jooq.generated.Tables
 import edu.uci.ics.texera.dao.jooq.generated.tables.daos.{WorkflowDao, WorkflowVersionDao}
 import edu.uci.ics.texera.dao.jooq.generated.tables.pojos.{Workflow, WorkflowVersion}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
-import edu.uci.ics.amber.engine.common.Utils.objectMapper
+import org.jooq.impl.DSL
+
+import java.sql.Timestamp
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import scala.collection.mutable.ArrayBuffer
 
 class WorkflowVersionResourceSpec
     extends AnyFlatSpec
@@ -13,185 +20,157 @@ class WorkflowVersionResourceSpec
     with BeforeAndAfterEach
     with MockTexeraDB {
 
+  private val testWorkflowWid = 2000 + scala.util.Random.nextInt(1000)
+
+  private var testWorkflow: Workflow = _
   private var workflowDao: WorkflowDao = _
   private var workflowVersionDao: WorkflowVersionDao = _
-  // Test workflow for the first test
-  private var testWorkflow1: Workflow = _
-  private var testWorkflow1Versions: List[WorkflowVersion] = List()
-  private var lastVersionId1: Integer = _
 
-  // Test workflow for the second test
-  private var testWorkflow2: Workflow = _
-  private var testWorkflow2Versions: List[WorkflowVersion] = List()
-  private var lastVersionId2: Integer = _
+  private val capturedVersions = ArrayBuffer.empty[Integer]
 
-  // Test workflow for the third test
-  private var testWorkflow3: Workflow = _
-  private var testWorkflow3Version: WorkflowVersion = _
+  override protected def beforeAll(): Unit = {
+    initializeDBAndReplaceDSLContext()
+  }
 
   override protected def beforeEach(): Unit = {
-    // Initialize database and create DAOs before each test
-    initializeDBAndReplaceDSLContext()
+    testWorkflow = new Workflow
+    testWorkflow.setWid(Integer.valueOf(testWorkflowWid))
+    testWorkflow.setName("test_workflow_" + UUID.randomUUID().toString.substring(0, 8))
+    testWorkflow.setContent(createWorkflowContent("initial"))
+    testWorkflow.setDescription("test description")
+
     workflowDao = new WorkflowDao(getDSLContext.configuration())
     workflowVersionDao = new WorkflowVersionDao(getDSLContext.configuration())
+
+    cleanupTestData()
+    workflowDao.insert(testWorkflow)
+    capturedVersions.clear()
   }
 
   override protected def afterEach(): Unit = {
+    cleanupTestData()
+  }
+
+  private def cleanupTestData(): Unit = {
+    getDSLContext
+      .deleteFrom(Tables.WORKFLOW_VERSION)
+      .where(Tables.WORKFLOW_VERSION.WID.eq(testWorkflowWid))
+      .execute()
+
+    getDSLContext
+      .deleteFrom(Tables.WORKFLOW)
+      .where(Tables.WORKFLOW.WID.eq(testWorkflowWid))
+      .execute()
+  }
+
+  override protected def afterAll(): Unit = {
     shutdownDB()
   }
 
-  private def createTestWorkflow(name: String, content: String): Workflow = {
-    val workflow = new Workflow()
-    workflow.setName(name)
-    workflow.setDescription("Test description")
-    workflow.setContent(content)
-    workflowDao.insert(workflow)
-    workflow
+  private def createWorkflowContent(value: String): String = {
+    val jsonNode = objectMapper.createObjectNode()
+    jsonNode.put("value", value)
+    jsonNode.toString
   }
 
-  private def createVersionForWorkflow(wid: Integer, content: String): WorkflowVersion = {
-    val version = new WorkflowVersion()
-    version.setWid(wid)
-    version.setContent(content)
-    workflowVersionDao.insert(version)
-    version
+  private def createVersionDiff(oldValue: String, newValue: String): String = {
+    val oldJson = objectMapper.createObjectNode()
+    oldJson.put("value", oldValue)
+
+    val newJson = objectMapper.createObjectNode()
+    newJson.put("value", newValue)
+
+    val patch = com.flipkart.zjsonpatch.JsonDiff.asJson(
+      oldJson,
+      newJson
+    )
+    patch.toString
   }
 
-  // Test case to verify that fetchWorkflowVersion correctly applies patches
-  "fetchWorkflowVersion" should "return the workflow at the specified version" in {
-    // Create a workflow with initial content
-    val initialContent = """{"operators": {"op1": {"id": "op1", "value": 1}}}"""
-    val workflow = createTestWorkflow("Test Workflow 1", initialContent)
-    val wid = workflow.getWid
+  "WorkflowVersionResource" should "return versions in descending order from fetchVersionsPrecedingVersion and apply patches correctly" in {
+    var currentContent = "initial"
+    for (i <- 1 to 10) {
+      val newContent = s"version_$i"
+      val diffContent = createVersionDiff(currentContent, newContent)
 
-    // Create initial version
-    val initialVersion = WorkflowVersionResource.insertNewVersion(wid)
-    Thread.sleep(50)
+      val version = new WorkflowVersion
+      version.setWid(testWorkflow.getWid)
+      version.setContent(diffContent)
+      version.setCreationTime(
+        new Timestamp(System.currentTimeMillis() - TimeUnit.MINUTES.toMillis(10 - i))
+      )
+      workflowVersionDao.insert(version)
 
-    // Create 10 versions with incrementing values
-    var versionMap = Map[Integer, Int]()
-    var lastVersion: WorkflowVersion = null
-    for (i <- 2 to 11) {
-      val patchContent = s"""[{"op":"replace","path":"/operators/op1/value","value":$i}]"""
-      lastVersion = createVersionForWorkflow(wid, patchContent)
-      versionMap += (lastVersion.getVid -> i)
-      Thread.sleep(50)
+      currentContent = newContent
     }
-    val vid = lastVersion.getVid
 
-    // Retrieve the last version (should have value 11)
-    val lastVersionWorkflow = WorkflowVersionResource.fetchWorkflowVersion(wid, vid)
+    testWorkflow.setContent(createWorkflowContent(currentContent))
+    workflowDao.update(testWorkflow)
 
-    // Parse the JSON content to verify the value
-    val jsonNode = objectMapper.readTree(lastVersionWorkflow.getContent)
-    val op1Value = jsonNode.path("operators").path("op1").path("value").asInt()
-
-    // The value should be 11 at the latest version
-    assert(op1Value === 11)
-
-    // Check a middle version (e.g., the 5th version)
-    val midVersionId = versionMap.keys.toList.sorted.apply(4) // 5th version
-    val midVersion = WorkflowVersionResource.fetchWorkflowVersion(wid, midVersionId)
-    val midJsonNode = objectMapper.readTree(midVersion.getContent)
-    val midValue = midJsonNode.path("operators").path("op1").path("value").asInt()
-
-    // Value should match what we set for this version
-    assert(midValue === versionMap(midVersionId))
-
-    // Check the first version (should still be 1)
-    val firstVersionWorkflow =
-      WorkflowVersionResource.fetchWorkflowVersion(wid, initialVersion.getVid)
-    val firstJsonNode = objectMapper.readTree(firstVersionWorkflow.getContent)
-    val firstValue = firstJsonNode.path("operators").path("op1").path("value").asInt()
-
-    // The value should be 1 at the first version
-    assert(firstValue === 1)
-  }
-
-  // Additional test case with different types of changes
-  "fetchWorkflowVersion" should "correctly handle a mix of different patch operations" in {
-    // Create a workflow with initial content
-    val initialContent = """{"operators": {"op1": {"id": "op1", "value": 1, "config": {}}}}"""
-    val workflow = createTestWorkflow("Test Workflow 2", initialContent)
-    val wid = workflow.getWid
-
-    // Create initial version
-    val initialVersion = WorkflowVersionResource.insertNewVersion(wid)
-    Thread.sleep(50)
-
-    // Add different types of changes
-    val changes = List(
-      """[{"op":"replace","path":"/operators/op1/value","value":2}]""",
-      """[{"op":"add","path":"/operators/op1/name","value":"Operator 1"}]""",
-      """[{"op":"add","path":"/operators/op1/config/size","value":10}]""",
-      """[{"op":"replace","path":"/operators/op1/config/size","value":20}]""",
-      """[{"op":"add","path":"/operators/op2","value":{"id":"op2","value":5}}]""",
-      """[{"op":"remove","path":"/operators/op1/name"}]""",
-      """[{"op":"replace","path":"/operators/op1/config","value":{"color":"blue"}}]""",
-      """[{"op":"replace","path":"/operators/op2/value","value":10}]""",
-      """[{"op":"add","path":"/links","value":[{"source":"op1","target":"op2"}]}]"""
+    val midVersionId = 5
+    val versions = WorkflowVersionResource.fetchVersionsPrecedingVersion(
+      testWorkflow.getWid,
+      midVersionId,
+      getDSLContext
     )
 
-    var versions: List[WorkflowVersion] = List()
-    for (change <- changes) {
-      val version = createVersionForWorkflow(wid, change)
-      versions = versions :+ version
-      Thread.sleep(50)
+    assert(versions.nonEmpty, "No versions were returned")
+
+    for (i <- 0 until versions.length - 1) {
+      assert(
+        versions(i).getVid > versions(i + 1).getVid,
+        s"Versions not in descending order: ${versions(i).getVid} should be > ${versions(i + 1).getVid}"
+      )
     }
 
-    // Check the state at the final version (should have all changes applied)
-    val finalVersion = WorkflowVersionResource.fetchWorkflowVersion(wid, versions.last.getVid)
-    val finalJson = objectMapper.readTree(finalVersion.getContent)
+    val highestVersionId = getDSLContext
+      .select(DSL.max(Tables.WORKFLOW_VERSION.VID))
+      .from(Tables.WORKFLOW_VERSION)
+      .where(Tables.WORKFLOW_VERSION.WID.eq(testWorkflowWid))
+      .fetchOneInto(classOf[Integer])
 
-    // Verify final state has all changes applied
-    assert(finalJson.path("operators").path("op1").path("value").asInt() === 2)
-    assert(!finalJson.path("operators").path("op1").has("name")) // was removed in version 6
-    assert(finalJson.path("operators").has("op2"))
-    assert(finalJson.path("operators").path("op2").path("value").asInt() === 10)
-    assert(finalJson.has("links"))
-    assert(finalJson.path("operators").path("op1").path("config").has("color"))
-    assert(finalJson.path("operators").path("op1").path("config").path("color").asText() === "blue")
+    assert(versions.head.getVid === highestVersionId, "First version should have the highest VID")
 
-    // Check the initial version (should be the original content)
-    val firstVersion = WorkflowVersionResource.fetchWorkflowVersion(wid, initialVersion.getVid)
-    val firstJson = objectMapper.readTree(firstVersion.getContent)
+    capturedVersions.clear()
+    versions.foreach(v => capturedVersions.append(v.getVid))
 
-    assert(firstJson.path("operators").path("op1").path("value").asInt() === 1)
-    assert(!firstJson.path("operators").path("op1").has("name"))
-    assert(!firstJson.path("operators").has("op2"))
-    assert(!firstJson.has("links"))
-    assert(firstJson.path("operators").path("op1").path("config").isObject)
-    assert(firstJson.path("operators").path("op1").path("config").isEmpty)
-  }
+    val workflowFromDb = workflowDao.fetchOneByWid(testWorkflow.getWid)
 
-  // Test case to verify that fetchWorkflowVersion with the latest vid returns the current workflow
-  "fetchWorkflowVersion" should "return the current workflow when using the latest vid" in {
-    // Create a workflow with initial content
-    val initialContent = """{"operators": {"op1": {"id": "op1", "value": 1}}}"""
-    val updatedContent = """{"operators": {"op1": {"id": "op1", "value": 99}}}"""
-    val workflow = createTestWorkflow("Test Workflow 3", initialContent)
-    val wid = workflow.getWid
+    val workflowVersionDirect = WorkflowVersionResource.applyPatch(versions, workflowFromDb)
+    val directVersionContent =
+      objectMapper.readTree(workflowVersionDirect.getContent).get("value").asText()
 
-    // Create initial version
-    val initialVersion = WorkflowVersionResource.insertNewVersion(wid)
+    assert(
+      directVersionContent === s"version_$midVersionId",
+      s"Workflow content from direct applyPatch should be 'version_$midVersionId' but was '$directVersionContent'"
+    )
 
-    // Update the workflow content
-    workflow.setContent(updatedContent)
-    workflowDao.update(workflow)
+    val combinedVersions = WorkflowVersionResource.fetchVersionsPrecedingVersion(
+      testWorkflow.getWid,
+      midVersionId,
+      getDSLContext
+    )
+    val currentWorkflowForCombined = workflowDao.fetchOneByWid(testWorkflow.getWid)
+    val workflowVersion =
+      WorkflowVersionResource.applyPatch(combinedVersions, currentWorkflowForCombined)
 
-    // Create another version after the update
-    val updatedVersion = WorkflowVersionResource.insertNewVersion(wid)
+    assert(capturedVersions.nonEmpty, "No versions were captured")
+    assert(
+      capturedVersions.length === versions.length,
+      "Captured versions length doesn't match fetched versions"
+    )
 
-    // Retrieve the latest version
-    val retrievedWorkflow = WorkflowVersionResource.fetchWorkflowVersion(wid, updatedVersion.getVid)
+    for (i <- versions.indices) {
+      assert(
+        capturedVersions(i) === versions(i).getVid,
+        s"Captured version ${capturedVersions(i)} doesn't match fetched version ${versions(i).getVid} at index $i"
+      )
+    }
 
-    // Verify the content is the same as the current workflow
-    assert(retrievedWorkflow.getContent === updatedContent)
-
-    // Retrieve the initial version
-    val initialWorkflow = WorkflowVersionResource.fetchWorkflowVersion(wid, initialVersion.getVid)
-
-    // Verify the content is the original content
-    assert(initialWorkflow.getContent === initialContent)
+    val midVersionContent = objectMapper.readTree(workflowVersion.getContent).get("value").asText()
+    assert(
+      midVersionContent === s"version_$midVersionId",
+      s"Workflow content should be 'version_$midVersionId' but was '$midVersionContent'"
+    )
   }
 }

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
@@ -19,7 +19,6 @@ import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import edu.uci.ics.amber.engine.common.Utils.objectMapper
 
-
 class WorkflowVersionResourceSpec
     extends AnyFlatSpec
     with BeforeAndAfterAll

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
@@ -1,14 +1,8 @@
 package edu.uci.ics.texera.web.resource.dashboard.user.workflow
 
 import edu.uci.ics.texera.dao.MockTexeraDB
-import edu.uci.ics.texera.dao.jooq.generated.tables.daos.{
-  WorkflowDao,
-  WorkflowVersionDao
-}
-import edu.uci.ics.texera.dao.jooq.generated.tables.pojos.{
-  Workflow,
-  WorkflowVersion
-}
+import edu.uci.ics.texera.dao.jooq.generated.tables.daos.{WorkflowDao, WorkflowVersionDao}
+import edu.uci.ics.texera.dao.jooq.generated.tables.pojos.{Workflow, WorkflowVersion}
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach}
 import edu.uci.ics.amber.engine.common.Utils.objectMapper

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
@@ -87,7 +87,7 @@ class WorkflowVersionResourceSpec
     patch.toString
   }
 
-  "WorkflowVersionResource" should "return versions in descending order from fetchSubsequentVersions  and apply patches correctly" in {
+  "WorkflowVersionResource" should "return versions in descending order from fetchSubsequentVersions and apply patches correctly" in {
     var currentContent = "initial"
     for (i <- 1 to 10) {
       val newContent = s"version_$i"

--- a/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
+++ b/core/amber/src/test/scala/edu/uci/ics/texera/web/resource/dashboard/user/workflow/WorkflowVersionResourceSpec.scala
@@ -87,7 +87,7 @@ class WorkflowVersionResourceSpec
     patch.toString
   }
 
-  "WorkflowVersionResource" should "return versions in descending order from fetchVersionsPrecedingVersion and apply patches correctly" in {
+  "WorkflowVersionResource" should "return versions in descending order from fetchSubsequentVersions  and apply patches correctly" in {
     var currentContent = "initial"
     for (i <- 1 to 10) {
       val newContent = s"version_$i"
@@ -108,7 +108,7 @@ class WorkflowVersionResourceSpec
     workflowDao.update(testWorkflow)
 
     val midVersionId = 5
-    val versions = WorkflowVersionResource.fetchVersionsPrecedingVersion(
+    val versions = WorkflowVersionResource.fetchSubsequentVersions(
       testWorkflow.getWid,
       midVersionId,
       getDSLContext
@@ -145,7 +145,7 @@ class WorkflowVersionResourceSpec
       s"Workflow content from direct applyPatch should be 'version_$midVersionId' but was '$directVersionContent'"
     )
 
-    val combinedVersions = WorkflowVersionResource.fetchVersionsPrecedingVersion(
+    val combinedVersions = WorkflowVersionResource.fetchSubsequentVersions(
       testWorkflow.getWid,
       midVersionId,
       getDSLContext


### PR DESCRIPTION
This PR resolves a version control issue where older workflow versions (e.g., version diff > 7) are not displayed in the frontend, and a backend error is thrown during retrieval. The error observed is:

`JsonPatchApplicationException: Array index 4 out of bounds`.

This occurs because the JSON Patch logic expects versions to be applied in reverse order of their IDs. However, the JOOQ query retrieving version history did not guarantee the ordering of version IDs, leading to an incorrect patch sequence.

This issue occurred after migrating from MySQL to PostgreSQL. MySQL often returns rows in primary key order by default, while PostgreSQL does not guarantee any specific ordering unless explicitly specified.

### Fixes:
- Added an `ORDER BY` clause to the version query to ensure consistent descending order of version IDs.
- Similarly, fixed an unrelated but similar issue in the execution history query where execution IDs were not returned in descending order.

These changes ensure proper version patching and accurate display of both version history and execution history.

### [Before the Change]
<img width="1044" alt="Screenshot 2025-04-30 at 4 32 01 PM" src="https://github.com/user-attachments/assets/389a2656-bfe2-467b-bd64-29c687b6dae3" />
<img width="1158" alt="Screenshot 2025-04-30 at 4 31 39 PM" src="https://github.com/user-attachments/assets/beb0ce8a-521e-4423-9b95-c73d786ab08c" />

### [After the Change]
<img width="749" alt="Screenshot 2025-04-30 at 4 33 12 PM" src="https://github.com/user-attachments/assets/a93fae9a-d28e-48c1-8a03-0b5d2628c72b" />
<img width="1203" alt="Screenshot 2025-04-30 at 4 33 22 PM" src="https://github.com/user-attachments/assets/6b7e81c1-607f-41eb-a389-f111f709419c" />
