### PR TITLE
Fix base image to node:18.17 in the `texera-web-application.dockerfile`

### DIFF
--- a/deployment/texera-web-application.dockerfile
+++ b/deployment/texera-web-application.dockerfile
@@ -1,4 +1,4 @@
-FROM node:18 AS build-gui
+FROM node:18.17 AS build-gui
 
 WORKDIR /gui
 COPY core/gui /gui


### PR DESCRIPTION
As titled, this PR fixes the base image to `node:18.17` instead of `node:18`. Otherwise, the texera web application image cannot be built on arm64 machines.