### PR TITLE
Replace Terminate Button Icon with Close-Circle

### DIFF
--- a/core/gui/src/app/workspace/component/menu/menu.component.html
+++ b/core/gui/src/app/workspace/component/menu/menu.component.html
@@ -353,7 +353,7 @@
           nzType="primary">
           <i
             nz-icon
-            nzType="exclamation-circle"></i>
+            nzType="close-circle"></i>
         </button>
         <button
           (click)="onClickRunHandler()"


### PR DESCRIPTION
### **Purpose**
This PR updates the "Terminate" action button's icon, replacing the exclamation mark with a cross mark. This change clarifies the button's purpose and aligns it with other actions in the UI.

### **Changes**
- In menu.component.html, updated the terminate (kill) button's icon from "exclamation-circle" to "close-circle".

### **Demonstration**
**Before:**

https://github.com/user-attachments/assets/5575ed2d-9049-421d-810c-661932e2de95

**After:**

https://github.com/user-attachments/assets/5117a113-3c0c-4b88-8314-1a18090ebd3b
