### PR TITLE
Fix the compilation of Python Lambda Operator

### DIFF
--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/LambdaAttributeUnit.java
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/LambdaAttributeUnit.java
@@ -19,6 +19,7 @@
 
 package edu.uci.ics.amber.operator.udf.python;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaBool;
 import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject;
@@ -56,13 +57,16 @@ public class LambdaAttributeUnit {
     @JsonSchemaTitle("Expression")
     public String expression;
 
-    public LambdaAttributeUnit() {}
-
-    LambdaAttributeUnit(String attributeName, String expression, String newAttributeName, AttributeType newAttributeType) {
+    @JsonCreator
+    public LambdaAttributeUnit(
+            @JsonProperty("attributeName") String attributeName,
+            @JsonProperty("expression") String expression,
+            @JsonProperty("newAttributeName") String newAttributeName,
+            @JsonProperty("attributeType") AttributeType attributeType) {
         this.attributeName = attributeName;
         this.expression = expression;
         this.newAttributeName = newAttributeName;
-        this.attributeType = newAttributeType;
+        this.attributeType = attributeType;
     }
 
     @Override

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/LambdaAttributeUnit.java
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/LambdaAttributeUnit.java
@@ -56,6 +56,8 @@ public class LambdaAttributeUnit {
     @JsonSchemaTitle("Expression")
     public String expression;
 
+    public LambdaAttributeUnit() {}
+
     LambdaAttributeUnit(String attributeName, String expression, String newAttributeName, AttributeType newAttributeType) {
         this.attributeName = attributeName;
         this.expression = expression;


### PR DESCRIPTION
As titled, this PR fixes the compilation error when the python lambda operator is presented in the workflow.

The fix is done by adding the @JsonCreator annotation, the same fix in https://github.com/Texera/texera/pull/3132