### PR TITLE
Fix ChannelMarker sending on PyAmber

### DIFF
--- a/core/amber/src/main/python/core/architecture/packaging/output_manager.py
+++ b/core/amber/src/main/python/core/architecture/packaging/output_manager.py
@@ -179,6 +179,7 @@ class OutputManager:
         the_partitioning = get_one_of(partitioning)
         logger.debug(f"adding {the_partitioning}")
         for channel_id in the_partitioning.channels:
+            channel_id.is_control = False
             self._channels[channel_id] = Channel()
         partitioner = self._partitioning_to_partitioner[type(the_partitioning)]
         self._partitioners[tag] = (

--- a/core/amber/src/main/python/core/architecture/packaging/output_manager.py
+++ b/core/amber/src/main/python/core/architecture/packaging/output_manager.py
@@ -179,6 +179,9 @@ class OutputManager:
         the_partitioning = get_one_of(partitioning)
         logger.debug(f"adding {the_partitioning}")
         for channel_id in the_partitioning.channels:
+            # Explicitly set is_control to trigger lazy computation.
+            # If not set, it may be computed at different times,
+            # causing hash inconsistencies.
             channel_id.is_control = False
             self._channels[channel_id] = Channel()
         partitioner = self._partitioning_to_partitioner[type(the_partitioning)]

--- a/core/amber/src/main/python/core/runnables/main_loop.py
+++ b/core/amber/src/main/python/core/runnables/main_loop.py
@@ -362,7 +362,7 @@ class MainLoop(StoppableQueueBlockingRunnable):
                 self._async_rpc_server.receive(channel_id, command)
 
             downstream_channels_in_scope = {
-                (scope.from_worker_id, scope.to_worker_id)
+                scope
                 for scope in marker_payload.scope
                 if scope.from_worker_id == ActorVirtualIdentity(self.context.worker_id)
             }
@@ -370,10 +370,7 @@ class MainLoop(StoppableQueueBlockingRunnable):
                 for (
                     active_channel_id
                 ) in self.context.output_manager.get_output_channel_ids():
-                    if (
-                        active_channel_id.from_worker_id,
-                        active_channel_id.to_worker_id,
-                    ) in downstream_channels_in_scope:
+                    if active_channel_id in downstream_channels_in_scope:
                         logger.info(
                             f"send marker to {active_channel_id},"
                             f" id = {marker_id}, cmd = {command}"

--- a/core/amber/src/main/python/core/runnables/main_loop.py
+++ b/core/amber/src/main/python/core/runnables/main_loop.py
@@ -72,10 +72,10 @@ from proto.edu.uci.ics.amber.core import (
 
 class MainLoop(StoppableQueueBlockingRunnable):
     def __init__(
-            self,
-            worker_id: str,
-            input_queue: InternalQueue,
-            output_queue: InternalQueue,
+        self,
+        worker_id: str,
+        input_queue: InternalQueue,
+        output_queue: InternalQueue,
     ):
         super().__init__(self.__class__.__name__, queue=input_queue)
         self._input_queue: InternalQueue = input_queue
@@ -370,7 +370,10 @@ class MainLoop(StoppableQueueBlockingRunnable):
                 for (
                     active_channel_id
                 ) in self.context.output_manager.get_output_channel_ids():
-                    if (active_channel_id.from_worker_id, active_channel_id.to_worker_id) in downstream_channels_in_scope:
+                    if (
+                        active_channel_id.from_worker_id,
+                        active_channel_id.to_worker_id,
+                    ) in downstream_channels_in_scope:
                         logger.info(
                             f"send marker to {active_channel_id},"
                             f" id = {marker_id}, cmd = {command}"

--- a/core/amber/src/main/python/core/runnables/main_loop.py
+++ b/core/amber/src/main/python/core/runnables/main_loop.py
@@ -72,10 +72,10 @@ from proto.edu.uci.ics.amber.core import (
 
 class MainLoop(StoppableQueueBlockingRunnable):
     def __init__(
-        self,
-        worker_id: str,
-        input_queue: InternalQueue,
-        output_queue: InternalQueue,
+            self,
+            worker_id: str,
+            input_queue: InternalQueue,
+            output_queue: InternalQueue,
     ):
         super().__init__(self.__class__.__name__, queue=input_queue)
         self._input_queue: InternalQueue = input_queue
@@ -362,7 +362,7 @@ class MainLoop(StoppableQueueBlockingRunnable):
                 self._async_rpc_server.receive(channel_id, command)
 
             downstream_channels_in_scope = {
-                scope
+                (scope.from_worker_id, scope.to_worker_id)
                 for scope in marker_payload.scope
                 if scope.from_worker_id == ActorVirtualIdentity(self.context.worker_id)
             }
@@ -370,7 +370,7 @@ class MainLoop(StoppableQueueBlockingRunnable):
                 for (
                     active_channel_id
                 ) in self.context.output_manager.get_output_channel_ids():
-                    if active_channel_id in downstream_channels_in_scope:
+                    if (active_channel_id.from_worker_id, active_channel_id.to_worker_id) in downstream_channels_in_scope:
                         logger.info(
                             f"send marker to {active_channel_id},"
                             f" id = {marker_id}, cmd = {command}"


### PR DESCRIPTION
Before sending a ChannelMarker, we must verify whether the active channel falls within the marker's scope. In Python, this check always returns False, and as a result, the ChannelMarker is never sent downstream. This occurs because ChannelIdentity instances on the Python side lack the is_control field, and their hash values are inconsistent — as noted in PR #3245.