### PR TITLE
Add minimizing and restoring features for Jupyter Notebook panel

### DIFF
--- a/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.html
+++ b/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.html
@@ -5,18 +5,28 @@
   cdkDragBoundary="texera-workspace"
   cdkDragHandle=".panel-header">
   <div
-    class="panel-header"
-    cdkDragHandle>
+    class="panel-header" cdkDragHandle>
     <span>Jupyter Notebook</span>
-    <button
-      class="close-button"
-      (click)="closePanel()">
-      <i
-        nz-icon
-        nzType="close"
-        nzTheme="outline"></i>
-    </button>
-    <!-- Close button -->
+    <div class="panel-buttons">
+      <!-- Minimize button -->
+      <button
+        class="minimize-button"
+        (click)="minimizePanel()">
+        <i
+          nz-icon
+          nzType="minus"
+          nzTheme="outline"></i>
+      </button>
+      <!-- Close button -->
+      <button
+        class="close-button"
+        (click)="closePanel()">
+        <i
+          nz-icon
+          nzType="close"
+          nzTheme="outline"></i>
+      </button>
+    </div>
   </div>
 
   <div class="iframe-container">

--- a/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.html
+++ b/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.html
@@ -5,7 +5,8 @@
   cdkDragBoundary="texera-workspace"
   cdkDragHandle=".panel-header">
   <div
-    class="panel-header" cdkDragHandle>
+    class="panel-header"
+    cdkDragHandle>
     <span>Jupyter Notebook</span>
     <div class="panel-buttons">
       <!-- Minimize button -->

--- a/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.scss
+++ b/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.scss
@@ -25,12 +25,23 @@
   cursor: move;
 }
 
+.panel-buttons {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.minimize-button,
 .close-button {
   background: none;
   border: none;
   color: white;
   font-size: 16px;
   cursor: pointer;
+}
+
+.minimize-button:hover {
+  color: royalblue;
 }
 
 .close-button:hover {

--- a/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.ts
+++ b/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.ts
@@ -57,4 +57,10 @@ export class JupyterNotebookPanelComponent implements OnInit, AfterViewInit, OnD
   closePanel(): void {
     this.jupyterPanelService.closeJupyterNotebookPanel();
   }
+
+  // Minimize the jupyter notebook by invoking the service method
+  minimizePanel(): void {
+    this.isVisible = false;
+    this.jupyterPanelService.minimizeJupyterNotebookPanel();
+  }
 }

--- a/core/gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.html
+++ b/core/gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.html
@@ -39,7 +39,10 @@
     (click)="onClickExpandJupyterNotebookPanel()"
     nz-button
     title="Expand Jupyter Notebook">
-    <i nz-icon nzType="expand-alt" nzTheme="outline"></i>
+    <i
+      nz-icon
+      nzType="expand-alt"
+      nzTheme="outline"></i>
   </button>
   <div
     [hidden]="hidden"

--- a/core/gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.html
+++ b/core/gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.html
@@ -34,6 +34,13 @@
       nz-icon
       nzType="zoom-in"></i>
   </button>
+  <button
+    id="minimap-expand-jupyter-button"
+    (click)="onClickExpandJupyterNotebookPanel()"
+    nz-button
+    title="Expand Jupyter Notebook">
+    <i nz-icon nzType="expand-alt" nzTheme="outline"></i>
+  </button>
   <div
     [hidden]="hidden"
     id="mini-map-container">

--- a/core/gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.scss
+++ b/core/gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.scss
@@ -26,6 +26,13 @@
   z-index: 4;
 }
 
+#minimap-expand-jupyter-button {
+  position: absolute;
+  bottom: 0;
+  right: 120px;
+  z-index: 4;
+}
+
 #mini-map-container {
   position: relative;
   overflow: hidden;

--- a/core/gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/mini-map/mini-map.component.ts
@@ -6,6 +6,7 @@ import * as joint from "jointjs";
 import { JointGraphWrapper } from "../../../service/workflow-graph/model/joint-graph-wrapper";
 import { PanelService } from "../../../service/panel/panel.service";
 import { CdkDrag } from "@angular/cdk/drag-drop";
+import { JupyterPanelService } from "../../../service/jupyter-panel/jupyter-panel.service";
 
 @UntilDestroy()
 @Component({
@@ -23,7 +24,8 @@ export class MiniMapComponent implements AfterViewInit, OnDestroy {
 
   constructor(
     private workflowActionService: WorkflowActionService,
-    private panelService: PanelService
+    private panelService: PanelService,
+    private jupyterPanelService: JupyterPanelService
   ) {}
 
   ngAfterViewInit() {
@@ -120,6 +122,13 @@ export class MiniMapComponent implements AfterViewInit, OnDestroy {
       .setZoomProperty(
         this.workflowActionService.getJointGraphWrapper().getZoomRatio() + JointGraphWrapper.ZOOM_CLICK_DIFF
       );
+  }
+
+  /**
+   * This method will expand and redisplay the jupyter notebook.
+   */
+  public onClickExpandJupyterNotebookPanel(): void {
+    this.jupyterPanelService.openJupyterNotebookPanel();
   }
 
   public triggerCenter(): void {

--- a/core/gui/src/app/workspace/service/jupyter-panel/jupyter-panel.service.ts
+++ b/core/gui/src/app/workspace/service/jupyter-panel/jupyter-panel.service.ts
@@ -79,6 +79,16 @@ export class JupyterPanelService {
     this.jupyterNotebookPanelVisible.next(false);
   }
 
+  // Minimize the Jupyter Notebook panel
+  public minimizeJupyterNotebookPanel(): void {
+    this.jupyterNotebookPanelVisible.next(false);
+  }
+
+  // Expand the Jupyter Notebook panel
+  public openJupyterNotebookPanel(): void {
+    this.jupyterNotebookPanelVisible.next(true);
+  }
+
   // Handle messages from the Jupyter notebook iframe
   private handleNotebookMessage = (event: MessageEvent) => {
     const allowedOrigins = ["http://localhost:4200", "http://localhost:8888"];


### PR DESCRIPTION
This PR adds a feature that allows users to minimize the Jupyter Notebook by clicking the "minus" button and restore it using an "expand-alt" button in the bottom right corner.

## Changes:
- Added a "minus" icon button next to the existing close button. When clicked, the panel is hidden but not closed completely.
- Added an "expand-alt" icon in the bottom UI controls. Clicking the icon restores the minimized Jupyter panel.
- Added `minimizePanel()` and `onClickExpandJupyterNotebookPanel()` to trigger panel minimization and restoration via service calls.
- Added methods `minimizeJupyterNotebookPanel()` and `openJupyterNotebookPanel()` in `jupyter-panel.service.ts` to manage the panel’s minimized state.

![minimize](https://github.com/user-attachments/assets/ca87f743-9f21-4920-9bfc-999bba1e6fc1)
