### PR TITLE
Fix ChannelMarker Partitioning logic on PyAmber

### DIFF
--- a/core/amber/src/main/python/core/architecture/packaging/output_manager.py
+++ b/core/amber/src/main/python/core/architecture/packaging/output_manager.py
@@ -205,21 +205,17 @@ class OutputManager:
         )
 
     def emit_marker_to_channel(
-        self, channel_id: ChannelIdentity, marker: ChannelMarkerPayload
-    ) -> Iterable[typing.Tuple[ActorVirtualIdentity, DataPayload]]:
+        self, to: ActorVirtualIdentity, marker: ChannelMarkerPayload
+    ) -> Iterable[DataPayload]:
         return chain(
             *(
                 (
                     (
-                        receiver,
-                        (
-                            payload
-                            if isinstance(payload, ChannelMarkerPayload)
-                            else self.tuple_to_frame(payload)
-                        ),
+                        payload
+                        if isinstance(payload, ChannelMarkerPayload)
+                        else self.tuple_to_frame(payload)
                     )
-                    for receiver, payload in partitioner.flush(marker)
-                    if receiver == channel_id.to_worker_id
+                    for payload in partitioner.flush(to, marker)
                 )
                 for partitioner in self._partitioners.values()
             )

--- a/core/amber/src/main/python/core/architecture/packaging/output_manager.py
+++ b/core/amber/src/main/python/core/architecture/packaging/output_manager.py
@@ -235,7 +235,7 @@ class OutputManager:
                             else self.tuple_to_frame(payload)
                         ),
                     )
-                    for receiver, payload in partitioner.flush(marker)
+                    for receiver, payload in partitioner.flush_marker(marker)
                 )
                 for partitioner in self._partitioners.values()
             )

--- a/core/amber/src/main/python/core/architecture/sendsemantics/broad_cast_partitioner.py
+++ b/core/amber/src/main/python/core/architecture/sendsemantics/broad_cast_partitioner.py
@@ -52,6 +52,20 @@ class BroadcastPartitioner(Partitioner):
 
     @overrides
     def flush(
+        self, to: ActorVirtualIdentity, marker: Marker
+    ) -> Iterator[typing.Union[Marker, typing.List[Tuple]]]:
+        if len(self.batch) > 0:
+            for receiver in self.receivers:
+                if receiver == to:
+                    yield self.batch
+
+        self.reset()
+        for receiver in self.receivers:
+            if receiver == to:
+                yield marker
+
+    @overrides
+    def flush_marker(
         self, marker: Marker
     ) -> Iterator[
         typing.Tuple[ActorVirtualIdentity, typing.Union[Marker, typing.List[Tuple]]]

--- a/core/amber/src/main/python/core/architecture/sendsemantics/hash_based_shuffle_partitioner.py
+++ b/core/amber/src/main/python/core/architecture/sendsemantics/hash_based_shuffle_partitioner.py
@@ -60,6 +60,16 @@ class HashBasedShufflePartitioner(Partitioner):
 
     @overrides
     def flush(
+        self, to: ActorVirtualIdentity, marker: Marker
+    ) -> Iterator[typing.Union[Marker, typing.List[Tuple]]]:
+        for receiver, batch in self.receivers:
+            if receiver == to:
+                if len(batch) > 0:
+                    yield batch
+                yield marker
+
+    @overrides
+    def flush_marker(
         self, marker: Marker
     ) -> Iterator[
         typing.Tuple[ActorVirtualIdentity, typing.Union[Marker, typing.List[Tuple]]]

--- a/core/amber/src/main/python/core/architecture/sendsemantics/one_to_one_partitioner.py
+++ b/core/amber/src/main/python/core/architecture/sendsemantics/one_to_one_partitioner.py
@@ -51,6 +51,15 @@ class OneToOnePartitioner(Partitioner):
 
     @overrides
     def flush(
+        self, to: ActorVirtualIdentity, marker: Marker
+    ) -> Iterator[typing.Union[Marker, typing.List[Tuple]]]:
+        if len(self.batch) > 0:
+            yield self.batch
+        self.reset()
+        yield marker
+
+    @overrides
+    def flush_marker(
         self, marker: Marker
     ) -> Iterator[
         typing.Tuple[ActorVirtualIdentity, typing.Union[Marker, typing.List[Tuple]]]

--- a/core/amber/src/main/python/core/architecture/sendsemantics/partitioner.py
+++ b/core/amber/src/main/python/core/architecture/sendsemantics/partitioner.py
@@ -38,12 +38,12 @@ class Partitioner(ABC):
         pass
 
     def flush(
-            self, to: ActorVirtualIdentity, marker: Marker
+        self, to: ActorVirtualIdentity, marker: Marker
     ) -> Iterator[typing.Union[Marker, typing.List[Tuple]]]:
         pass
 
-    def flush_maker(
-            self, marker: Marker
+    def flush_marker(
+        self, marker: Marker
     ) -> Iterator[
         typing.Tuple[ActorVirtualIdentity, typing.Union[Marker, typing.List[Tuple]]]
     ]:

--- a/core/amber/src/main/python/core/architecture/sendsemantics/partitioner.py
+++ b/core/amber/src/main/python/core/architecture/sendsemantics/partitioner.py
@@ -38,7 +38,12 @@ class Partitioner(ABC):
         pass
 
     def flush(
-        self, marker: Marker
+            self, to: ActorVirtualIdentity, marker: Marker
+    ) -> Iterator[typing.Union[Marker, typing.List[Tuple]]]:
+        pass
+
+    def flush_maker(
+            self, marker: Marker
     ) -> Iterator[
         typing.Tuple[ActorVirtualIdentity, typing.Union[Marker, typing.List[Tuple]]]
     ]:

--- a/core/amber/src/main/python/core/architecture/sendsemantics/range_based_shuffle_partitioner.py
+++ b/core/amber/src/main/python/core/architecture/sendsemantics/range_based_shuffle_partitioner.py
@@ -74,6 +74,16 @@ class RangeBasedShufflePartitioner(Partitioner):
 
     @overrides
     def flush(
+        self, to: ActorVirtualIdentity, marker: Marker
+    ) -> Iterator[typing.Union[Marker, typing.List[Tuple]]]:
+        for receiver, batch in self.receivers:
+            if receiver == to:
+                if len(batch) > 0:
+                    yield batch
+                yield marker
+
+    @overrides
+    def flush_marker(
         self, marker: Marker
     ) -> Iterator[
         typing.Tuple[ActorVirtualIdentity, typing.Union[Marker, typing.List[Tuple]]]

--- a/core/amber/src/main/python/core/architecture/sendsemantics/round_robin_partitioner.py
+++ b/core/amber/src/main/python/core/architecture/sendsemantics/round_robin_partitioner.py
@@ -54,6 +54,17 @@ class RoundRobinPartitioner(Partitioner):
 
     @overrides
     def flush(
+        self, to: ActorVirtualIdentity, marker: Marker
+    ) -> Iterator[typing.Union[Marker, typing.List[Tuple]]]:
+        for receiver, batch in self.receivers:
+            if receiver == to:
+                if len(batch) > 0:
+                    yield batch
+                    batch.clear()
+                yield marker
+
+    @overrides
+    def flush_marker(
         self, marker: Marker
     ) -> Iterator[
         typing.Tuple[ActorVirtualIdentity, typing.Union[Marker, typing.List[Tuple]]]

--- a/core/amber/src/main/python/core/runnables/main_loop.py
+++ b/core/amber/src/main/python/core/runnables/main_loop.py
@@ -378,12 +378,7 @@ class MainLoop(StoppableQueueBlockingRunnable):
                         for batch in self.context.output_manager.emit_marker_to_channel(
                             active_channel_id.to_worker_id, marker_payload
                         ):
-                            tag = ChannelIdentity(
-                                ActorVirtualIdentity(self.context.worker_id),
-                                active_channel_id.to_worker_id,
-                                False,
-                            )
-
+                            tag = active_channel_id
                             element = (
                                 ChannelMarkerElement(tag=tag, payload=batch)
                                 if isinstance(batch, ChannelMarkerPayload)

--- a/core/amber/src/main/python/core/runnables/main_loop.py
+++ b/core/amber/src/main/python/core/runnables/main_loop.py
@@ -375,15 +375,12 @@ class MainLoop(StoppableQueueBlockingRunnable):
                             f"send marker to {active_channel_id},"
                             f" id = {marker_id}, cmd = {command}"
                         )
-                        for (
-                            to,
-                            batch,
-                        ) in self.context.output_manager.emit_marker_to_channel(
-                            active_channel_id, marker_payload
+                        for batch in self.context.output_manager.emit_marker_to_channel(
+                            active_channel_id.to_worker_id, marker_payload
                         ):
                             tag = ChannelIdentity(
                                 ActorVirtualIdentity(self.context.worker_id),
-                                to,
+                                active_channel_id.to_worker_id,
                                 False,
                             )
 


### PR DESCRIPTION
Problem:
The current ChannelMarker partitioning logic in PyAmber is flawed. When a Python UDF is present in the workflow, only one-to-one partitioning behaves correctly. This issue does not affect the ChannelMarker component itself, but it causes data loss when ChannelMarker sends data to PyAmber. Specifically, due to incorrect partitioning, some data tuples are not routed correctly and are dropped.

Details:
The ChannelMarker framework iterates through each active output channel and, for each one, flushes only the data tuples that belong to both the current output channel and the ChannelMarker. However, in the current implementation, all data tuples—regardless of their target channel—are flushed during the first iteration. Tuples that do not match the current channel are rejected and lost. As a result, when the loop advances to the next channel, there is no data left to flush.

This PR corrects the logic to ensure that data tuples are flushed and delivered only to their intended channels, preserving data integrity in workflows involving Python UDFs.