### PR TITLE
Handle mismatched datasets on displaying dashboard

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DashboardResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DashboardResource.scala
@@ -45,7 +45,11 @@ object DashboardResource {
 
   case class UserInfo(userId: Integer, userName: String, googleAvatar: Option[String])
 
-  case class DashboardSearchResult(results: List[DashboardClickableFileEntry], more: Boolean, hasMismatch: Boolean = false)
+  case class DashboardSearchResult(
+      results: List[DashboardClickableFileEntry],
+      more: Boolean,
+      hasMismatch: Boolean = false
+  )
 
   /*
    The following class describe the available params from the frontend for full text search.
@@ -131,7 +135,11 @@ object DashboardResource {
           false
       }
 
-    DashboardSearchResult(results = entries, more = queryResult.size() > params.count, hasMismatch = hasMismatch)
+    DashboardSearchResult(
+      results = entries,
+      more = queryResult.size() > params.count,
+      hasMismatch = hasMismatch
+    )
   }
 
   def getOrderFields(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DashboardResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DashboardResource.scala
@@ -45,7 +45,7 @@ object DashboardResource {
 
   case class UserInfo(userId: Integer, userName: String, googleAvatar: Option[String])
 
-  case class DashboardSearchResult(results: List[DashboardClickableFileEntry], more: Boolean)
+  case class DashboardSearchResult(results: List[DashboardClickableFileEntry], more: Boolean, hasMismatch: Boolean = false)
 
   /*
    The following class describe the available params from the frontend for full text search.
@@ -108,7 +108,7 @@ object DashboardResource {
       query.orderBy(getOrderFields(params): _*).offset(params.offset).limit(params.count + 1)
     val queryResult = finalQuery.fetch()
 
-    val entries = queryResult.asScala.toList
+    val allEntries = queryResult.asScala.toList
       .take(params.count)
       .map(record => {
         val resourceType = record.get("resourceType", classOf[String])
@@ -122,7 +122,16 @@ object DashboardResource {
         }
       })
 
-    DashboardSearchResult(results = entries, more = queryResult.size() > params.count)
+    val entries = allEntries.filter(_ != null)
+    val hasMismatch =
+      params.resourceType match {
+        case SearchQueryBuilder.DATASET_RESOURCE_TYPE | SearchQueryBuilder.ALL_RESOURCE_TYPE =>
+          allEntries.exists(_ == null)
+        case _ =>
+          false
+      }
+
+    DashboardSearchResult(results = entries, more = queryResult.size() > params.count, hasMismatch = hasMismatch)
   }
 
   def getOrderFields(

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DatasetSearchQueryBuilder.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DatasetSearchQueryBuilder.scala
@@ -33,11 +33,10 @@ import edu.uci.ics.texera.web.resource.dashboard.FulltextSearchQueryUtils.{
 import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetResource.DashboardDataset
 import org.jooq.impl.DSL
 import org.jooq.{Condition, GroupField, Record, TableLike}
-import org.slf4j.LoggerFactory
-
+import com.typesafe.scalalogging.LazyLogging
 import scala.jdk.CollectionConverters.CollectionHasAsScala
 
-object DatasetSearchQueryBuilder extends SearchQueryBuilder {
+object DatasetSearchQueryBuilder extends SearchQueryBuilder with LazyLogging {
   override protected val mappedResourceSchema: UnifiedResourceSchema = UnifiedResourceSchema(
     resourceType = DSL.inline(SearchQueryBuilder.DATASET_RESOURCE_TYPE),
     name = DATASET.NAME,
@@ -114,7 +113,6 @@ object DatasetSearchQueryBuilder extends SearchQueryBuilder {
     Seq.empty
   }
 
-  private val logger = LoggerFactory.getLogger(getClass)
   override protected def toEntryImpl(
       uid: Integer,
       record: Record

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DatasetSearchQueryBuilder.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/dashboard/DatasetSearchQueryBuilder.scala
@@ -25,7 +25,11 @@ import edu.uci.ics.texera.dao.jooq.generated.enums.PrivilegeEnum
 import edu.uci.ics.texera.dao.jooq.generated.tables.User.USER
 import edu.uci.ics.texera.dao.jooq.generated.tables.pojos.{Dataset, User}
 import edu.uci.ics.texera.web.resource.dashboard.DashboardResource.DashboardClickableFileEntry
-import edu.uci.ics.texera.web.resource.dashboard.FulltextSearchQueryUtils.{getContainsFilter, getDateFilter, getFullTextSearchFilter}
+import edu.uci.ics.texera.web.resource.dashboard.FulltextSearchQueryUtils.{
+  getContainsFilter,
+  getDateFilter,
+  getFullTextSearchFilter
+}
 import edu.uci.ics.texera.web.resource.dashboard.user.dataset.DatasetResource.DashboardDataset
 import org.jooq.impl.DSL
 import org.jooq.{Condition, GroupField, Record, TableLike}

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
@@ -146,7 +146,7 @@ export class UserDatasetComponent implements AfterViewInit {
       this.hasMismatch = results.hasMismatch ?? false;
       const filteredResults = results.results.filter(i => i !== null && i.dataset != null);
 
-      if (this.hasMismatch){
+      if (this.hasMismatch) {
         this.message.warning(
           "There is a mismatch between some datasets in the database and LakeFS. Only matched datasets are displayed.",
           { nzDuration: 4000 }

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
@@ -34,7 +34,7 @@ import { FileSelectionComponent } from "../../../../workspace/component/file-sel
 import { DatasetFileNode, getFullPathFromDatasetFileNode } from "../../../../common/type/datasetVersionFileTree";
 import { UserDatasetVersionCreatorComponent } from "./user-dataset-explorer/user-dataset-version-creator/user-dataset-version-creator.component";
 import { DashboardDataset } from "../../../type/dashboard-dataset.interface";
-import { NzMessageService } from 'ng-zorro-antd/message';
+import { NzMessageService } from "ng-zorro-antd/message";
 
 @UntilDestroy()
 @Component({
@@ -150,10 +150,7 @@ export class UserDatasetComponent implements AfterViewInit {
       this.hasMismatch = results.hasMismatch ?? false;
       const filteredResults = results.results.filter(i => i !== null && i.dataset != null);
 
-      if (
-        this.hasMismatch &&
-        !this.mismatchToastShown
-      ) {
+      if (this.hasMismatch && !this.mismatchToastShown) {
         this.mismatchToastShown = true;
         this.message.warning(
           "There is a mismatch between some datasets in the database and LakeFS. Only matched datasets are displayed.",

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
@@ -77,6 +77,8 @@ export class UserDatasetComponent implements AfterViewInit {
   }
 
   private masterFilterList: ReadonlyArray<string> | null = null;
+
+  // Prevents showing duplicate mismatch notification toasts
   private mismatchToastShown = false;
 
   constructor(

--- a/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-dataset/user-dataset.component.ts
@@ -47,9 +47,7 @@ export class UserDatasetComponent implements AfterViewInit {
   lastSortMethod: SortMethod | null = null;
   public isLogin = this.userService.isLogin();
   public currentUid = this.userService.getCurrentUser()?.uid;
-
-  // Display warning when there are mismatched datasets
-  public hasMismatch = false;
+  public hasMismatch = false; // Display warning when there are mismatched datasets
 
   private _searchResultsComponent?: SearchResultsComponent;
   @ViewChild(SearchResultsComponent) get searchResultsComponent(): SearchResultsComponent {
@@ -77,10 +75,6 @@ export class UserDatasetComponent implements AfterViewInit {
   }
 
   private masterFilterList: ReadonlyArray<string> | null = null;
-
-  // Prevents showing duplicate mismatch notification toasts
-  private mismatchToastShown = false;
-
   constructor(
     private modalService: NzModalService,
     private userService: UserService,
@@ -152,17 +146,11 @@ export class UserDatasetComponent implements AfterViewInit {
       this.hasMismatch = results.hasMismatch ?? false;
       const filteredResults = results.results.filter(i => i !== null && i.dataset != null);
 
-      if (this.hasMismatch && !this.mismatchToastShown) {
-        this.mismatchToastShown = true;
+      if (this.hasMismatch){
         this.message.warning(
           "There is a mismatch between some datasets in the database and LakeFS. Only matched datasets are displayed.",
           { nzDuration: 4000 }
         );
-        setTimeout(() => {
-          this.mismatchToastShown = false;
-        }, 4000);
-      } else if (!this.hasMismatch) {
-        this.mismatchToastShown = false;
       }
 
       const userIds = new Set<number>();

--- a/core/gui/src/app/dashboard/type/search-result.ts
+++ b/core/gui/src/app/dashboard/type/search-result.ts
@@ -33,4 +33,5 @@ export interface SearchResultItem {
 export interface SearchResult {
   results: SearchResultItem[];
   more: boolean;
+  hasMismatch?: boolean; // Indicates whether there are mismatched datasets (added for dashboard notification)
 }


### PR DESCRIPTION
### **Purpose:**
Fixes issue [#3428]( https://github.com/Texera/texera/issues/3428) where mismatched datasets (e.g., datasets whose LakeFS repository is missing or being deleted) would previously cause the dashboard to display empty results by error. This update ensures that such “mismatched” datasets are filtered out, and users receive a clear notification, rather than encountering unexplained empty results or server errors.

### **Changes:**
In DatasetSearchQueryBuilder.scala:

- Catch LakeFS API exceptions (404 for missing repository, 500 for "repository in deletion", and any fatal error).
- Return null for mismatched datasets so they are excluded from results.

In DashboardResource.scala:

- Update the resource search logic to filter out null results (mismatched datasets).
- Set the hasMismatch flag if any mismatched dataset is detected.

In user-dataset.component.ts:

- Update the front-end to display a warning notification if mismatched datasets are detected.
- The notification message is:
"There is a mismatch between some datasets in the database and LakeFS. Only matched datasets are displayed."

In search-result.ts:

- Ensure the dataset search result type includes the hasMismatch flag, supporting the new front-end warning logic.

### **Demonstration:**
**If one or more datasets are missing or being deleted in LakeFS:**

The dashboard shows all valid (matched) datasets  with a warning notification:

<img width="1230" alt="mismatch-display" src="https://github.com/user-attachments/assets/2fb1d817-aa4d-4b17-b397-e1d2d105dbfc" />

Mismatched datasets:
<img width="600" alt="mismatch" src="https://github.com/user-attachments/assets/8b1e15a7-c109-49f0-bea6-96859d32ceae" />

**When all datasets are present in LakeFS, the list displays as normal and no warning appears:**

<img width="1139" alt="noerror" src="https://github.com/user-attachments/assets/0173efdb-880f-405d-9ff0-14abeaf15ec6" />

Matched datasets:

<img width="1088" alt="match" src="https://github.com/user-attachments/assets/9890b575-40a0-4f4d-a197-4a620cf444ee" />
