### PR TITLE
Refactor mapping storage to retain unique mappings for each generated workflow

### DIFF
--- a/core/gui/src/app/app.module.ts
+++ b/core/gui/src/app/app.module.ts
@@ -260,7 +260,7 @@ registerLocaleData(en);
     CodeDebuggerComponent,
     HubSearchResultComponent,
     ComputingUnitSelectionComponent,
-    JupyterNotebookPanelComponent
+    JupyterNotebookPanelComponent,
   ],
   imports: [
     BrowserModule,

--- a/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.html
+++ b/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.html
@@ -1,3 +1,22 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
 <!-- Preview and Upload Dataset Window -->
 <div
   class="modal-content"

--- a/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.scss
+++ b/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.scss
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 .modal-content {
   display: flex;
   justify-content: space-between;

--- a/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.ts
+++ b/core/gui/src/app/dashboard/component/user/user-workflow/notebook-migration-tool/notebook-migration.component.ts
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { Component, Input } from "@angular/core";
 import { HttpClient } from "@angular/common/http";
 import { NzModalService } from "ng-zorro-antd/modal";

--- a/core/gui/src/app/dashboard/type/jupyter-notebook.interface.ts
+++ b/core/gui/src/app/dashboard/type/jupyter-notebook.interface.ts
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 export interface JupyterNotebook {
   cells: JupyterCell[];
   metadata: any;

--- a/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.html
+++ b/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.html
@@ -1,3 +1,22 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements.  See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership.  The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+-->
+
 <div
   class="draggable-panel"
   *ngIf="isVisible"

--- a/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.scss
+++ b/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.scss
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 .draggable-panel {
   position: absolute;
   top: 200px;

--- a/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.ts
+++ b/core/gui/src/app/workspace/component/jupyter-notebook-panel/jupyter-notebook-panel.component.ts
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { Component, ElementRef, OnDestroy, OnInit, ViewChild, AfterViewInit } from "@angular/core";
 import { JupyterPanelService } from "../../service/jupyter-panel/jupyter-panel.service";
 import { Subject } from "rxjs";

--- a/core/gui/src/app/workspace/component/menu/menu.component.ts
+++ b/core/gui/src/app/workspace/component/menu/menu.component.ts
@@ -661,19 +661,18 @@ export class MenuComponent implements OnInit, OnDestroy {
                 .persistWorkflow(workflow)
                 .pipe(untilDestroyed(this))
                 .subscribe((updatedWorkflow: Workflow) => {
-                    const mappingID = "mapping_wid_" + updatedWorkflow.wid;
+                  const mappingID = "mapping_wid_" + updatedWorkflow.wid;
 
-                    mapping[mappingID] = {
-                      cell_to_operator: { ...mappingContent["cell_to_operator"] },
-                      operator_to_cell: { ...mappingContent["operator_to_cell"] }
-                    };
-                    console.log("Added mapping: " + mappingID, mapping)
+                  mapping[mappingID] = {
+                    cell_to_operator: { ...mappingContent["cell_to_operator"] },
+                    operator_to_cell: { ...mappingContent["operator_to_cell"] },
+                  };
+                  console.log("Added mapping: " + mappingID, mapping);
 
-                    this.workflowActionService.reloadWorkflow(updatedWorkflow, true);
-                    this.openJupyterNotebookPanel();
-                    this.notificationService.success("Successfully generated workflow and mapping from notebook.");
-                }
-              );
+                  this.workflowActionService.reloadWorkflow(updatedWorkflow, true);
+                  this.openJupyterNotebookPanel();
+                  this.notificationService.success("Successfully generated workflow and mapping from notebook.");
+                });
             } else {
               console.error("Result is undefined");
             }

--- a/core/gui/src/app/workspace/component/menu/menu.component.ts
+++ b/core/gui/src/app/workspace/component/menu/menu.component.ts
@@ -667,7 +667,6 @@ export class MenuComponent implements OnInit, OnDestroy {
                     cell_to_operator: { ...mappingContent["cell_to_operator"] },
                     operator_to_cell: { ...mappingContent["operator_to_cell"] },
                   };
-                  console.log("Added mapping: " + mappingID, mapping);
 
                   this.workflowActionService.reloadWorkflow(updatedWorkflow, true);
                   this.openJupyterNotebookPanel();

--- a/core/gui/src/app/workspace/service/jupyter-panel/jupyter-panel.service.ts
+++ b/core/gui/src/app/workspace/service/jupyter-panel/jupyter-panel.service.ts
@@ -28,8 +28,8 @@ export class JupyterPanelService {
 
   // Precompute the dictionary for O(1) highlighting
   private precomputeHighlightMapping(): void {
-    const wid = this.workflowActionService.getWorkflow().wid
-    const cellToOperator = mapping[wid != undefined ? "mapping_wid_" + wid : "default"].cell_to_operator
+    const wid = this.workflowActionService.getWorkflow().wid;
+    const cellToOperator = mapping[wid != undefined ? "mapping_wid_" + wid : "default"].cell_to_operator;
     const allLinks: OperatorLink[] = this.workflowActionService.getTexeraGraph().getAllLinks();
 
     if (allLinks.length === 0) {
@@ -77,10 +77,10 @@ export class JupyterPanelService {
   // Close the Jupyter Notebook panel
   closeJupyterNotebookPanel(): void {
     this.jupyterNotebookPanelVisible.next(false);
-    const wid = this.workflowActionService.getWorkflow().wid
+    const wid = this.workflowActionService.getWorkflow().wid;
     if (wid != undefined && "mapping_wid_" + wid in mapping) {
       delete mapping["mapping_wid_" + wid];
-      console.log("Deleted mapping: mapping_wid_" + wid, mapping)
+      console.log("Deleted mapping: mapping_wid_" + wid, mapping);
     }
   }
 
@@ -143,7 +143,7 @@ export class JupyterPanelService {
   // Handle when a Texera component is clicked to trigger the corresponding notebook cell
   onWorkflowComponentClick(cellUUID: string): void {
     if (this.iframeRef && this.iframeRef.contentWindow) {
-      const wid = this.workflowActionService.getWorkflow().wid
+      const wid = this.workflowActionService.getWorkflow().wid;
       const operatorArray = mapping[wid != undefined ? "mapping_wid_" + wid : "default"]["operator_to_cell"][cellUUID];
       if (operatorArray) {
         this.iframeRef.contentWindow.postMessage(

--- a/core/gui/src/app/workspace/service/jupyter-panel/jupyter-panel.service.ts
+++ b/core/gui/src/app/workspace/service/jupyter-panel/jupyter-panel.service.ts
@@ -99,7 +99,6 @@ export class JupyterPanelService {
     const wid = this.workflowActionService.getWorkflow().wid;
     if (wid != undefined && "mapping_wid_" + wid in mapping) {
       delete mapping["mapping_wid_" + wid];
-      console.log("Deleted mapping: mapping_wid_" + wid, mapping);
     }
   }
 

--- a/core/gui/src/app/workspace/service/jupyter-panel/jupyter-panel.service.ts
+++ b/core/gui/src/app/workspace/service/jupyter-panel/jupyter-panel.service.ts
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import { Injectable } from "@angular/core";
 import { BehaviorSubject } from "rxjs";
 import { WorkflowActionService } from "../workflow-graph/model/workflow-action.service";

--- a/core/gui/src/app/workspace/service/jupyter-panel/jupyter-panel.service.ts
+++ b/core/gui/src/app/workspace/service/jupyter-panel/jupyter-panel.service.ts
@@ -48,9 +48,20 @@ export class JupyterPanelService {
   // Precompute the dictionary for O(1) highlighting
   private precomputeHighlightMapping(): void {
     const wid = this.workflowActionService.getWorkflow().wid;
-    const cellToOperator = mapping[wid != undefined ? "mapping_wid_" + wid : "default"].cell_to_operator;
-    const allLinks: OperatorLink[] = this.workflowActionService.getTexeraGraph().getAllLinks();
 
+    if (wid === undefined) {
+      console.warn("Workflow ID is undefined. Cannot compute highlight mapping.");
+      return;
+    }
+    const mappingKey = "mapping_wid_" + wid;
+
+    if (!(mappingKey in mapping)) {
+      console.warn(`Mapping key '${mappingKey}' not found. Cannot compute highlight mapping.`);
+      return;
+    }
+    const cellToOperator = mapping[mappingKey].cell_to_operator;
+
+    const allLinks: OperatorLink[] = this.workflowActionService.getTexeraGraph().getAllLinks();
     if (allLinks.length === 0) {
       console.warn("No links found in the graph during precompute.");
       return;
@@ -76,8 +87,6 @@ export class JupyterPanelService {
 
       this.cellToHighlightMapping[cellUUID] = { components, edges };
     }
-
-    console.log("Precomputed highlight mapping:", this.cellToHighlightMapping);
   }
 
   // Set the iframe reference (from the component's ViewChild)

--- a/core/gui/src/assets/migration_tool/mapping.ts
+++ b/core/gui/src/assets/migration_tool/mapping.ts
@@ -6,8 +6,8 @@ interface MappingContent {
 const mapping: { [key: string]: MappingContent } = {
   default: {
     cell_to_operator: {},
-    operator_to_cell: {}
-  }
+    operator_to_cell: {},
+  },
 };
 
 export default mapping;

--- a/core/gui/src/assets/migration_tool/mapping.ts
+++ b/core/gui/src/assets/migration_tool/mapping.ts
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 interface MappingContent {
   cell_to_operator: { [key: string]: any };
   operator_to_cell: { [key: string]: any };

--- a/core/gui/src/assets/migration_tool/mapping.ts
+++ b/core/gui/src/assets/migration_tool/mapping.ts
@@ -1,6 +1,13 @@
-let mapping = {
-  cell_to_operator: {},
-  operator_to_cell: {},
+interface MappingContent {
+  cell_to_operator: { [key: string]: any };
+  operator_to_cell: { [key: string]: any };
+}
+
+const mapping: { [key: string]: MappingContent } = {
+  default: {
+    cell_to_operator: {},
+    operator_to_cell: {}
+  }
 };
 
 export default mapping;


### PR DESCRIPTION
### Purpose
This PR changes the way mappings (between an AI generated workflow and Jupyter notebook source) are stored in the front-end. Previously, only one mapping was stored and was overwritten each time a new workflow was generated. Now, mappings are stored uniquely using the workflow ID and persist until the user closes the Jupyter notebook.

### Changes
- `mapping.ts` was changed to allow new mappings to be stored in the dictionary using the unique identifier `mapping_wid_<wid>`
- The `onClickImportNotebook` method in `menu.component.ts` was changed to store the mapping using the unique ID
- `jupyter-panel.service.ts` was changed so that whenever the mapping is used, it gets the wid of the current open workflow to fetch the correct mapping
- the mapping is deleted when the user clicks the X button on the Jupyter notebook window

### Demo
(demo starts after the generated workflow has been returned from OpenAI)


https://github.com/user-attachments/assets/45e8e8f2-057d-44e1-bc56-9af0b0e04a90

