### PR TITLE
Fix Incorrect Channel ID Inclusion Across Workers in ChannelMarker

### DIFF
--- a/core/amber/src/main/python/core/architecture/packaging/output_manager.py
+++ b/core/amber/src/main/python/core/architecture/packaging/output_manager.py
@@ -186,7 +186,11 @@ class OutputManager:
                 channel_id.is_control = False
                 self._channels[channel_id] = Channel()
         partitioner = self._partitioning_to_partitioner[type(the_partitioning)]
-        self._partitioners[tag] = partitioner(the_partitioning, self.worker_id)
+        self._partitioners[tag] = (
+            partitioner(the_partitioning)
+            if partitioner != OneToOnePartitioner
+            else partitioner(the_partitioning, self.worker_id)
+        )
 
     def tuple_to_batch(
         self, tuple_: Tuple


### PR DESCRIPTION
This PR fixes an issue where the output channel IDs used by the ChannelMarker incorrectly include channels belonging to other workers of the same operator.

Problem
Consider a scenario with operator A having 2 workers (A0, A1) and operator B having 1 worker (B0), connected via two channels:

A0 → B0

A1 → B0

From A0's perspective, its output channel should be only A0 → B0. However, because all workers receive the same partitioning information—which includes all channels between the operators—A0 mistakenly includes A1’s channel (A1 → B0) as well.

Fix
This PR introduces a filtering mechanism to ensure that each worker only includes channels that belong to itself when determining output channels. This ensures correct behavior for scenarios involving multiple workers per operator.

