### PR TITLE
Fix project startup failure on macOS caused by attempting to retrieve the domain name

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberConfig.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/common/AmberConfig.scala
@@ -108,7 +108,7 @@ object AmberConfig {
   val gmail: String = getConfSource.getString("user-sys.google.smtp.gmail")
   val smtpPassword: String = getConfSource.getString("user-sys.google.smtp.password")
   val appDomain: Option[String] = {
-    val domain = conf.getString("user-sys.google.domain").trim
+    val domain = getConfSource.getString("user-sys.google.domain").trim
     if (domain.isEmpty) {
       logger.log(
         Level.WARNING,


### PR DESCRIPTION
### Purpose:
In PR #3440, we added a new `domain` property to `application.conf` to include the domain name in emails sent to users. Previously, the domain was retrieved using `conf.getString`, which worked correctly on Windows. However, this approach caused the project to fail to start on macOS.

### Changes:
Replaced `conf` with the cross-platform compatible `getConfSource` method.