### PR TITLE
Temporary Fix for Python Partitioner Index Issues

### DIFF
--- a/core/amber/src/main/python/core/architecture/sendsemantics/hash_based_shuffle_partitioner.py
+++ b/core/amber/src/main/python/core/architecture/sendsemantics/hash_based_shuffle_partitioner.py
@@ -36,9 +36,17 @@ class HashBasedShufflePartitioner(Partitioner):
         super().__init__(set_one_of(Partitioning, partitioning))
         logger.debug(f"got {partitioning}")
         self.batch_size = partitioning.batch_size
+        # Partitioning contains an ordered list of downstream worker ids.
+        # Currently we are using the index of such an order to choose
+        # a downstream worker to send tuples to.
+        # Must use dict.fromkeys to ensure the order of receiver workers
+        # from partitioning is preserved (using `{}` to create a set
+        # does not preserve order and will not work correctly.)
         self.receivers = [
-            (receiver, [])
-            for receiver in {channel.to_worker_id for channel in partitioning.channels}
+            (rid, [])
+            for rid in dict.fromkeys(
+                channel.to_worker_id for channel in partitioning.channels
+            )
         ]
         self.hash_attribute_names = partitioning.hash_attribute_names
 

--- a/core/amber/src/main/python/core/architecture/sendsemantics/range_based_shuffle_partitioner.py
+++ b/core/amber/src/main/python/core/architecture/sendsemantics/range_based_shuffle_partitioner.py
@@ -37,9 +37,17 @@ class RangeBasedShufflePartitioner(Partitioner):
         super().__init__(set_one_of(Partitioning, partitioning))
         logger.info(f"got {partitioning}")
         self.batch_size = partitioning.batch_size
+        # Partitioning contains an ordered list of downstream worker ids.
+        # Currently we are using the index of such an order to choose
+        # a downstream worker to send tuples to.
+        # Must use dict.fromkeys to ensure the order of receiver workers
+        # from partitioning is preserved (using `{}` to create a set
+        # does not preserve order and will not work correctly.)
         self.receivers = [
-            (receiver, [])
-            for receiver in {channel.to_worker_id for channel in partitioning.channels}
+            (rid, [])
+            for rid in dict.fromkeys(
+                channel.to_worker_id for channel in partitioning.channels
+            )
         ]
         self.range_attribute_names = partitioning.range_attribute_names
         self.range_min = partitioning.range_min


### PR DESCRIPTION
### Problem

Currently some Python partitioners are not working properly:

- Partitioning information is sent from Java controller to Python workers as a (ordered) List of Channels .
- When extracting a list of receivers from Channels  in Python, currently we are using an intermediate `{}` (set), which removes the ordered nature of the list.
- As Hash and Range partitioners are currently using the index of the list of receivers for their partitioning logic, and the index do not correspond correctly to the downstream workers, these two partitioners do not work correctly currently.

### Fix

The fix is to simply avoid using set in these two partitioners.

### TODO

Ideally, we should use a Map for all these implementations as List is fragile and prune to such issues. We need another PR to update the `Partitioning` information to be a map.