### PR TITLE
Add Reader Port Termination Check Logic for Python Input Manager

### DIFF
--- a/core/amber/src/main/python/core/architecture/packaging/input_manager.py
+++ b/core/amber/src/main/python/core/architecture/packaging/input_manager.py
@@ -83,7 +83,7 @@ class InputManager:
         self._input_queue = input_queue
         self._input_port_mat_reader_runnables: Dict[
             PortIdentity, List[InputPortMaterializationReaderRunnable]
-        ] = dict()
+        ] = dict()  # TODO: Merge this into WorkerPort
 
     def set_up_input_port_mat_reader_threads(
         self, port_id: PortIdentity, uris: List[str], partitionings: List[Partitioning]
@@ -109,13 +109,15 @@ class InputManager:
     def start_input_port_mat_reader_threads(self):
         for port_reader_runnables in self._input_port_mat_reader_runnables.values():
             for reader_runnable in port_reader_runnables:
-                thread_for_reader_runnable = threading.Thread(
-                    target=reader_runnable.run,
-                    daemon=True,
-                    name=f"port_mat_reader_runnable_thread_"
-                    f"{reader_runnable.channel_id}",
-                )
-                thread_for_reader_runnable.start()
+                # A completed reader port should not be started again
+                if not reader_runnable.finished():
+                    thread_for_reader_runnable = threading.Thread(
+                        target=reader_runnable.run,
+                        daemon=True,
+                        name=f"port_mat_reader_runnable_thread_"
+                        f"{reader_runnable.channel_id}",
+                    )
+                    thread_for_reader_runnable.start()
 
     def get_all_channel_ids(self) -> Dict["ChannelIdentity", "Channel"].keys:
         return self._channels.keys()

--- a/core/amber/src/main/python/core/storage/runnables/input_port_materialization_reader_runnable.py
+++ b/core/amber/src/main/python/core/storage/runnables/input_port_materialization_reader_runnable.py
@@ -77,6 +77,7 @@ class InputPortMaterializationReaderRunnable(Runnable, Stoppable):
             from_actor_id, self.worker_actor_id, is_control=False
         )
         self._stopped = False
+        self._finished = False
         self.materialization = None
         self.tuple_schema = None
         self._partitioning_to_partitioner: dict[
@@ -95,6 +96,12 @@ class InputPortMaterializationReaderRunnable(Runnable, Stoppable):
             if partitioner != OneToOnePartitioner
             else partitioner(the_partitioning, self.worker_actor_id)
         )
+
+    def finished(self) -> bool:
+        """
+        :return: Whether this reader thread has finished its logic.
+        """
+        return self._finished
 
     def tuple_to_batch_with_filter(self, tuple_: Tuple) -> typing.Iterator[DataFrame]:
         """
@@ -131,6 +138,7 @@ class InputPortMaterializationReaderRunnable(Runnable, Stoppable):
                 for data_frame in self.tuple_to_batch_with_filter(tup):
                     self.emit_payload(data_frame)
             self.emit_marker(EndOfInputChannel())
+            self._finished = True
         except Exception as err:
             logger.exception(err)
 


### PR DESCRIPTION
#3460 introduced 2-phase execution model for regions. This requires the `InputManager` to check if an input port reader thread is finished before starting it. But #3460 only implemented that logic for Java workers.

This PR adds the same logic on Python workers.