### PR TITLE
Add `Parquet` option in export workflow result types

### DIFF
--- a/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.html
+++ b/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.html
@@ -42,6 +42,9 @@
                   *ngIf="isVisualizationOutput"
                   nzValue="html"
                   nzLabel="Web Page (.html)"></nz-option>
+                <nz-option
+                  nzValue="parquet"
+                  nzLabel="Parquet (.parquet)"></nz-option>
               </nz-select>
             </nz-form-control>
           </nz-form-item>

--- a/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.ts
+++ b/core/gui/src/app/workspace/component/result-exportation/result-exportation.component.ts
@@ -85,8 +85,7 @@ export class ResultExportationComponent implements OnInit {
   updateOutputType(): void {
     // Determine if the caller of this component is menu or context menu
     // if its menu then we need to export all operators else we need to export only highlighted operators
-    // TODO: currently, user need to set `view result` to true in order to export result but
-    //  we should allow user to export result without setting `view result` to true
+
     let operatorIds: readonly string[];
     if (this.sourceTriggered === "menu") {
       operatorIds = this.workflowActionService

--- a/core/gui/src/app/workspace/service/workflow-result/workflow-result.service.ts
+++ b/core/gui/src/app/workspace/service/workflow-result/workflow-result.service.ts
@@ -211,7 +211,8 @@ export class WorkflowResultService {
   }
 
   public determineOutputExtension(operatorId: string, defaultExtension: string = "csv"): string {
-    if (defaultExtension === "data") return "data";
+
+    if (defaultExtension === "data" || defaultExtension == "parquet") return defaultExtension;
     var outputType = this.determineOutputTypes(operatorId);
 
     if (outputType.isVisualizationOutput) return "html";

--- a/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/model/VirtualDocument.scala
+++ b/core/workflow-core/src/main/scala/edu/uci/ics/amber/core/storage/model/VirtualDocument.scala
@@ -138,4 +138,14 @@ abstract class VirtualDocument[T] extends ReadonlyVirtualDocument[T] {
 
   def getTotalFileSize: Long =
     throw new NotImplementedError("getTotalFileSize method is not implemented")
+
+  /**
+   * The following two methods are used to directly access files in the underlying storage system.
+   * For example, in Iceberg, it provides direct access to Parquet files.
+   */
+  def getUnderlyingFileCount: Int = 0
+
+  def getUnderlyingFileData(index: Int): java.io.InputStream = {
+    throw new UnsupportedOperationException("getUnderlyingFileData is not implemented")
+  }
 }


### PR DESCRIPTION
## New feature
Users may need to export result of one or multiple operators as Parquet format. This includes exporting to local or dataset.

## How implemented
In `VirtualDocument` we added two new functions. They are meant to provide access to the underlying files of the documents:
- `getUnderlyingFileCount`: This function should return number of files saved by the service
- `getUnderlyingFileData`: This function should stream the file specified by its index
By implementing these two functions in `IcebergDocument`, we are now able to directly access the files stored by storage service. In our case, since we need Parquet format, we can directly stream back the files saved by Iceberg without need to convert and consume extra computation.

## Feature behavior
As shown in the picture, now users can select Parquet as export type. If the underlying Iceberg service has stored only one Parquet file, it will be streamed back directly, otherwise, multiple Parquet files will be zipped and sent back.

![Screenshot from 2025-06-18 10-50-54](https://github.com/user-attachments/assets/4db1f6b2-42f5-4ae9-86c9-3170ea03e793)
