### PR TITLE
Fix Output Port Writer Thread Termination Logic

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OutputManager.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/messaginglayer/OutputManager.scala
@@ -241,7 +241,7 @@ class OutputManager(
         // Non-blocking call
         writerThread.queue.put(Right(PortStorageWriterTerminateSignal))
         // Blocking call
-        this.outputPortResultWriterThreads.values.foreach(writerThread => writerThread.join())
+        writerThread.join()
       case None =>
     }
 


### PR DESCRIPTION
### Implementation Issue

There is an issue with the current Output Port Materialization Writer Thread's `closeOutputStorageWriterIfNeeded` method where we terminate all the writer threads for all the ports when calling `closeOutputStorageWriterIfNeeded` for only 1 port. 

### Bug

The consequence of this incorrect logic is that an operator with multiple output ports will not terminate all its output ports if there are multiple output ports having materialization reader threads. Before #3460 this issue was not exposed because we have no such use cases. After #3460, A split operator connecting to a training operator will have both its output ports materialized, causing Split operator to misbehave.

### Fix
This PR fixes that issue by letting each output port only terminate its own thread.