### PR TITLE
Enable Independent Configuration of Dashboard Logo, Collapsed Icon, and Favicon

### DIFF
--- a/core/gui/src/app/dashboard/component/admin/settings/admin-settings.component.html
+++ b/core/gui/src/app/dashboard/component/admin/settings/admin-settings.component.html
@@ -44,6 +44,29 @@
   <div class="help-text">The logo will appear in the expanded sidebar. Recommend: use a square image.</div>
 
   <div class="upload-row">
+    <span>Mini logo:</span>
+    <button
+      nz-button
+      (click)="minilogoInput.click()">
+      Choose a Mini Logo
+    </button>
+    <input
+      #minilogoInput
+      type="file"
+      accept="image/*"
+      hidden
+      (change)="onFileChange('mini_logo', $event)" />
+    <img
+      *ngIf="miniLogoData"
+      [src]="miniLogoData"
+      alt="Mini Logo Preview"
+      class="preview-img" />
+  </div>
+  <div class="help-text">
+    The mini logo will appear in the collapsed sidebar as a small icon. Recommended: use a square image.
+  </div>
+
+  <div class="upload-row">
     <span>Favicon:</span>
     <button
       nz-button
@@ -63,7 +86,7 @@
       class="preview-img" />
   </div>
   <div class="help-text">
-    The favicon (mini logo) will appear in the collapsed sidebar as a small icon. Recommend: use a square image.
+    This image will be used as your browser tab icon. Recommend: use a square image (16×16 or 32×32).
   </div>
 
   <div class="button-row">

--- a/core/gui/src/app/dashboard/component/admin/settings/admin-settings.component.ts
+++ b/core/gui/src/app/dashboard/component/admin/settings/admin-settings.component.ts
@@ -30,6 +30,7 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
 })
 export class AdminSettingsComponent {
   logoData: string | null = null;
+  miniLogoData: string | null = null;
   faviconData: string | null = null;
 
   constructor(
@@ -37,7 +38,7 @@ export class AdminSettingsComponent {
     private message: NzMessageService
   ) {}
 
-  onFileChange(type: "logo" | "favicon", event: Event): void {
+  onFileChange(type: "logo" | "mini_logo" | "favicon", event: Event): void {
     const file = (event.target as HTMLInputElement).files?.[0];
     if (file && file.type.startsWith("image/")) {
       const reader = new FileReader();
@@ -45,6 +46,8 @@ export class AdminSettingsComponent {
         const result = typeof e.target?.result === "string" ? e.target.result : null;
         if (type === "logo") {
           this.logoData = result;
+        } else if (type === "mini_logo") {
+          this.miniLogoData = result;
         } else {
           this.faviconData = result;
         }
@@ -65,6 +68,15 @@ export class AdminSettingsComponent {
           error: () => this.message.error("Failed to save logo."),
         });
     }
+    if (this.miniLogoData) {
+      this.adminSettingsService
+        .updateSetting("mini_logo", this.miniLogoData)
+        .pipe(untilDestroyed(this))
+        .subscribe({
+          next: () => this.message.success("Mini logo saved successfully."),
+          error: () => this.message.error("Failed to save favicon."),
+        });
+    }
     if (this.faviconData) {
       this.adminSettingsService
         .updateSetting("favicon", this.faviconData)
@@ -74,7 +86,7 @@ export class AdminSettingsComponent {
           error: () => this.message.error("Failed to save favicon."),
         });
     }
-    if (this.logoData || this.faviconData) {
+    if (this.logoData || this.miniLogoData || this.faviconData) {
       setTimeout(() => window.location.reload(), 500);
     }
   }
@@ -89,6 +101,17 @@ export class AdminSettingsComponent {
           this.message.success("Logo reset to default.");
         },
         error: () => this.message.error("Failed to reset logo."),
+      });
+
+    this.adminSettingsService
+      .deleteSetting("mini_logo")
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: () => {
+          this.miniLogoData = null;
+          this.message.success("Mini logo reset to default.");
+        },
+        error: () => this.message.error("Failed to reset mini logo."),
       });
 
     this.adminSettingsService

--- a/core/gui/src/app/dashboard/component/dashboard.component.html
+++ b/core/gui/src/app/dashboard/component/dashboard.component.html
@@ -31,7 +31,7 @@
         <img
           *ngIf="isCollapsed"
           alt="mini-logo"
-          [src]="favicon"
+          [src]="miniLogo"
           class="collapsed-logo" />
         <img
           *ngIf="!isCollapsed"

--- a/core/gui/src/app/dashboard/component/dashboard.component.ts
+++ b/core/gui/src/app/dashboard/component/dashboard.component.ts
@@ -59,8 +59,9 @@ export class DashboardComponent implements OnInit {
   isCollapsed: boolean = false;
   routesWithoutNavbar: string[] = ["/workspace"];
   showLinks: boolean = false;
-  logo: string = "assets/logos/logo.png";
-  favicon: string = "assets/logos/full_logo_small.png";
+  logo: string = ""; //assets/logos/logo.png
+  miniLogo: string = ""; //assets/logos/full_logo_small.png
+  favicon: string = ""; // assets/logos/favicon-32x32.png
 
   protected readonly DASHBOARD_USER_PROJECT = DASHBOARD_USER_PROJECT;
   protected readonly DASHBOARD_USER_WORKFLOW = DASHBOARD_USER_WORKFLOW;
@@ -126,26 +127,19 @@ export class DashboardComponent implements OnInit {
 
   loadLogos(): void {
     this.adminSettingsService
-      .getSetting("logo")
+      .getLogoPath()
       .pipe(untilDestroyed(this))
-      .subscribe(logoUrl => {
-        if (logoUrl) {
-          this.logo = logoUrl;
-        }
-      });
+      .subscribe(path => (this.logo = path));
 
     this.adminSettingsService
-      .getSetting("favicon")
+      .getMiniLogoPath()
       .pipe(untilDestroyed(this))
-      .subscribe(faviconUrl => {
-        if (faviconUrl) {
-          this.favicon = faviconUrl;
-          const links = document.querySelectorAll("link[rel*='icon']");
-          links.forEach(link => {
-            (link as HTMLLinkElement).setAttribute("href", faviconUrl);
-          });
-        }
-      });
+      .subscribe(path => (this.miniLogo = path));
+
+    this.adminSettingsService
+      .getFaviconPath()
+      .pipe(untilDestroyed(this))
+      .subscribe(path => (this.favicon = path));
   }
 
   forumLogin() {

--- a/core/gui/src/app/dashboard/service/admin/settings/admin-settings.service.ts
+++ b/core/gui/src/app/dashboard/service/admin/settings/admin-settings.service.ts
@@ -32,12 +32,34 @@ import { map } from "rxjs/operators";
 })
 export class AdminSettingsService {
   private readonly BASE_URL = "/api/admin/settings";
+  private readonly DEFAULT_LOGO_PATH = "assets/logos/logo.png";
+  private readonly DEFAULT_MINI_LOGO_PATH = "assets/logos/full_logo_small.png";
+  private readonly DEFAULT_FAVICON_PATH = "assets/logos/favicon-32x32.png";
+
   constructor(private http: HttpClient) {}
 
   getSetting(key: string): Observable<string> {
     return this.http
       .get<{ key: string; value: string }>(`${this.BASE_URL}/${key}`)
       .pipe(map(resp => resp?.value ?? null));
+  }
+
+  getLogoPath(): Observable<string> {
+    return this.getSetting("logo").pipe(map(url => url || this.DEFAULT_LOGO_PATH));
+  }
+
+  getMiniLogoPath(): Observable<string> {
+    return this.getSetting("mini_logo").pipe(map(url => url || this.DEFAULT_MINI_LOGO_PATH));
+  }
+
+  getFaviconPath(): Observable<string> {
+    return this.getSetting("favicon").pipe(
+      map(url => {
+        const path = url || this.DEFAULT_FAVICON_PATH;
+        document.querySelectorAll("link[rel*='icon']").forEach(link => ((link as HTMLLinkElement).href = path));
+        return path;
+      })
+    );
   }
 
   updateSetting(key: string, value: string): Observable<void> {


### PR DESCRIPTION
### **Purpose:**
- Introduce three independent site‐wide settings—logo, mini_logo, and favicon—to allow separate customization of the expanded sidebar banner, the collapsed sidebar icon, and the browser tab icon.
- Simplify service API by providing strongly-typed updateLogo, updateMiniLogo, and updateFavicon methods.
- Ensure each asset has a default fallback and can be reset independently.

### **Changes**

### **Demo**
