### PR TITLE
Add ResourceQuota to cap the total resources for computing units

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonProxyClient.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/pythonworker/PythonProxyClient.scala
@@ -21,7 +21,6 @@ package edu.uci.ics.amber.engine.architecture.pythonworker
 
 import com.twitter.util.{Await, Promise}
 import edu.uci.ics.amber.core.WorkflowRuntimeException
-import edu.uci.ics.amber.core.state.State
 import edu.uci.ics.amber.core.tuple.{Schema, Tuple}
 import edu.uci.ics.amber.core.virtualidentity.{ActorVirtualIdentity, ChannelIdentity}
 import edu.uci.ics.amber.engine.architecture.pythonworker.WorkerBatchInternalQueue.{

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/managers/InputPortMaterializationReaderThread.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/worker/managers/InputPortMaterializationReaderThread.scala
@@ -50,7 +50,6 @@ import edu.uci.ics.amber.engine.architecture.worker.WorkflowWorker.{
   DPInputQueueElement,
   FIFOMessageElement
 }
-import edu.uci.ics.amber.engine.common.AmberConfig
 import edu.uci.ics.amber.engine.common.ambermessage.{DataFrame, WorkflowFIFOMessage}
 import edu.uci.ics.amber.util.VirtualIdentityUtils.getFromActorIdForInputPortStorage
 import io.grpc.MethodDescriptor

--- a/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/resource/ComputingUnitManagingResource.scala
+++ b/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/resource/ComputingUnitManagingResource.scala
@@ -421,7 +421,7 @@ class ComputingUnitManagingResource {
 
         } catch {
           case e: KubernetesClientException =>
-            throw new BadRequestException(ComputingUnitManagingServiceException.fromKubernetes(e))
+            throw ComputingUnitManagingServiceException.fromKubernetes(e)
 
           case t: Throwable =>
             throw t

--- a/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/resource/ComputingUnitManagingResource.scala
+++ b/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/resource/ComputingUnitManagingResource.scala
@@ -420,8 +420,8 @@ class ComputingUnitManagingResource {
           )
 
         } catch {
-          case k8sException: KubernetesClientException =>
-            throw ComputingUnitManagingServiceException.fromKubernetes(k8sException)
+          case e: KubernetesClientException =>
+            throw new BadRequestException(ComputingUnitManagingServiceException.fromKubernetes(e))
 
           case t: Throwable =>
             throw t

--- a/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/resource/ComputingUnitManagingResource.scala
+++ b/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/resource/ComputingUnitManagingResource.scala
@@ -36,9 +36,14 @@ import KubernetesConfig.{
 }
 import edu.uci.ics.texera.service.resource.ComputingUnitManagingResource._
 import edu.uci.ics.texera.service.resource.ComputingUnitState._
-import edu.uci.ics.texera.service.util.KubernetesClient
+import edu.uci.ics.texera.service.util.{
+  ComputingUnitManagingServiceException,
+  InsufficientComputingUnitQuota,
+  KubernetesClient
+}
 import io.dropwizard.auth.Auth
 import io.fabric8.kubernetes.api.model.Quantity
+import io.fabric8.kubernetes.client.KubernetesClientException
 import jakarta.annotation.security.RolesAllowed
 import jakarta.ws.rs._
 import jakarta.ws.rs.core.{MediaType, Response}
@@ -333,9 +338,7 @@ class ComputingUnitManagingResource {
       if (
         units.size >= maxNumOfRunningComputingUnitsPerUser && cuType == WorkflowComputingUnitTypeEnum.kubernetes
       ) {
-        throw new BadRequestException(
-          s"You can only have at most ${maxNumOfRunningComputingUnitsPerUser} running at the same time"
-        )
+        throw InsufficientComputingUnitQuota(maxNumOfRunningComputingUnitsPerUser)
       }
 
       val resourceJson: String = cuType match {
@@ -403,17 +406,26 @@ class ComputingUnitManagingResource {
         wcDao.update(insertedUnit)
 
         // 2. Launch the pod as CU
-        KubernetesClient.createPod(
-          cuid,
-          param.cpuLimit,
-          param.memoryLimit,
-          param.gpuLimit,
-          computingUnitEnvironmentVariables ++ Map(
-            EnvironmentalVariable.ENV_USER_JWT_TOKEN -> userToken,
-            EnvironmentalVariable.ENV_JAVA_OPTS -> s"-Xmx${param.jvmMemorySize}"
-          ),
-          Some(param.shmSize)
-        )
+        try {
+          KubernetesClient.createPod(
+            cuid,
+            param.cpuLimit,
+            param.memoryLimit,
+            param.gpuLimit,
+            computingUnitEnvironmentVariables ++ Map(
+              EnvironmentalVariable.ENV_USER_JWT_TOKEN -> userToken,
+              EnvironmentalVariable.ENV_JAVA_OPTS -> s"-Xmx${param.jvmMemorySize}"
+            ),
+            Some(param.shmSize)
+          )
+
+        } catch {
+          case k8sException: KubernetesClientException =>
+            throw ComputingUnitManagingServiceException.fromKubernetes(k8sException)
+
+          case t: Throwable =>
+            throw t
+        }
       }
 
       DashboardWorkflowComputingUnit(

--- a/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/util/ComputingUnitManagingServiceException.scala
+++ b/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/util/ComputingUnitManagingServiceException.scala
@@ -20,12 +20,13 @@
 package edu.uci.ics.texera.service.util
 
 import io.fabric8.kubernetes.client.KubernetesClientException
+import jakarta.ws.rs.WebApplicationException
 
 /**
   * Parent type for every error the CU-managing service can raise.
   */
 sealed abstract class ComputingUnitManagingServiceException(msg: String)
-    extends RuntimeException(msg)
+    extends WebApplicationException(msg)
 
 // Not enough cluster resources for this CU request (CPU / memory / GPU)
 final case class InsufficientComputingResource(resourceType: String)

--- a/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/util/ComputingUnitManagingServiceException.scala
+++ b/core/computing-unit-managing-service/src/main/scala/edu/uci/ics/texera/service/util/ComputingUnitManagingServiceException.scala
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package edu.uci.ics.texera.service.util
+
+import io.fabric8.kubernetes.client.KubernetesClientException
+
+/**
+  * Parent type for every error the CU-managing service can raise.
+  */
+sealed abstract class ComputingUnitManagingServiceException(msg: String)
+    extends RuntimeException(msg)
+
+// Not enough cluster resources for this CU request (CPU / memory / GPU)
+final case class InsufficientComputingResource(resourceType: String)
+    extends ComputingUnitManagingServiceException(
+      s"Insufficient $resourceType available in the server. Please decrease the requested amount or try again later."
+    )
+
+// User has reached the per-user CU-quota (number of running units)
+final case class InsufficientComputingUnitQuota(maxNumberOfComputingUnit: Int)
+    extends ComputingUnitManagingServiceException(
+      s"You may only have $maxNumberOfComputingUnit computing-unit(s) running at the same time"
+    )
+
+// default exception fallback
+final case class InternalError(
+    override val getMessage: String =
+      "The server encountered an internal error while processing your request. " +
+        "Please try again later."
+) extends ComputingUnitManagingServiceException(getMessage)
+
+/**
+  * Companion object with helpers.
+  */
+object ComputingUnitManagingServiceException {
+
+  /**
+    * Translate a KubernetesClientException to one of the service-level exceptions
+    */
+  def fromKubernetes(e: KubernetesClientException): ComputingUnitManagingServiceException = {
+    val message = Option(e.getMessage).map(_.toLowerCase).getOrElse("")
+
+    if (message.contains("exceeded quota")) {
+      if (message.contains("cpu")) InsufficientComputingResource("CPU")
+      else if (message.contains("memory")) InsufficientComputingResource("memory")
+      else if (message.contains("gpu")) InsufficientComputingResource("GPU")
+      else InternalError(e.getMessage)
+    } else {
+      InternalError(e.getMessage)
+    }
+  }
+}

--- a/deployment/k8s/texera-helmchart/templates/workflow-computing-unit-resource-quota.yaml
+++ b/deployment/k8s/texera-helmchart/templates/workflow-computing-unit-resource-quota.yaml
@@ -1,0 +1,31 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+{{- if and .Values.workflowComputingUnitPool.createNamespaces .Values.workflowComputingUnitPool.maxRequestedResources }}
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: {{ .Values.workflowComputingUnitPool.name }}-resource-quota
+  namespace: {{ .Values.workflowComputingUnitPool.namespace }}
+spec:
+  hard:
+    requests.cpu: "{{ .Values.workflowComputingUnitPool.maxRequestedResources.cpu }}"
+    requests.memory: {{ .Values.workflowComputingUnitPool.maxRequestedResources.memory }}
+    {{- if .Values.workflowComputingUnitPool.maxRequestedResources.nvidiaGpu }}
+    requests.nvidia.com/gpu: "{{ .Values.workflowComputingUnitPool.maxRequestedResources.nvidiaGpu }}"
+    {{- end }}
+{{- end }} 

--- a/deployment/k8s/texera-helmchart/values.yaml
+++ b/deployment/k8s/texera-helmchart/values.yaml
@@ -177,6 +177,11 @@ workflowComputingUnitPool:
   name: texera-workflow-computing-unit
   # Note: the namespace of the workflow computing unit pool might conflict when there are multiple texera deployments in the same cluster
   namespace: texera-workflow-computing-unit-pool
+  # Max number of resources allocated for computing units
+  maxRequestedResources:
+    cpu: 100
+    memory: 100Gi
+    nvidiaGpu: 5
   imageName: texera/computing-unit-master:cluster
   service:
     port: 8085


### PR DESCRIPTION
This PR adds the configurations for limiting:
- number of total CPU cores
- number of total memory size
for computing units. The implementation is done by imposing the `ResourceQuota` on the namespace `texera-computing-unit-pool`.