### PR TITLE
Move the USER_SYS_DOMAIN from config deployment to texeraEnvVars

### DIFF
--- a/deployment/k8s/texera-helmchart/templates/config-service-deployment.yaml
+++ b/deployment/k8s/texera-helmchart/templates/config-service-deployment.yaml
@@ -39,9 +39,6 @@ spec:
           ports:
             - containerPort: {{ .Values.configService.service.port }}
           env:
-            # Texera domain name
-            - name: USER_SYS_DOMAIN
-              value: {{ .Values.minio.customIngress.texeraHostname }}
             # TexeraDB Access
             - name: STORAGE_JDBC_URL
               value: jdbc:postgresql://{{ .Release.Name }}-postgresql:5432/texera_db?currentSchema=texera_db,public

--- a/deployment/k8s/texera-helmchart/values.yaml
+++ b/deployment/k8s/texera-helmchart/values.yaml
@@ -233,6 +233,8 @@ texeraEnvVars:
     value: ""
   - name: USER_SYS_GOOGLE_SMTP_PASSWORD
     value: ""
+  - name: USER_SYS_DOMAIN
+    value: ""
 
 # Ingress dependency configs
 ingress-nginx:


### PR DESCRIPTION
As titled, this PR moves the USER_SYS_DOMAIN variable from the template file of config-service deployment, to the texeraEnvVars. This change fixes the issue that TexeraWebApplication couldn't load this value.