### PR TITLE
Fix email sharing to show actual sharer's email 

### DIFF
--- a/core/gui/src/app/dashboard/component/user/share-access/share-access.component.ts
+++ b/core/gui/src/app/dashboard/component/user/share-access/share-access.component.ts
@@ -44,12 +44,10 @@ export class ShareAccessComponent implements OnInit, OnDestroy {
   readonly type: string = this.nzModalData.type;
   readonly id: number = this.nzModalData.id;
   readonly allOwners: string[] = this.nzModalData.allOwners;
-
   readonly inWorkspace: boolean = this.nzModalData.inWorkspace;
   public validateForm: FormGroup;
   public accessList: ReadonlyArray<ShareAccess> = [];
   public owner: string = "";
-  public sharerName: any = this.userService.getCurrentUser()?.email;
   public filteredOwners: Array<string> = [];
   public ownerSearchValue?: string;
   public emailTags: string[] = [];
@@ -152,8 +150,8 @@ export class ShareAccessComponent implements OnInit, OnDestroy {
             next: () => {
               this.notificationService.success(this.type + " shared with " + email + " successfully.");
               this.gmailService.sendEmail(
-                "Texera: " + this.sharerName + " shared a " + this.type + " with you",
-                this.sharerName +
+                "Texera: " + this.userService.getCurrentUser()?.email + " shared a " + this.type + " with you",
+                this.userService.getCurrentUser()?.email +
                   " shared a " +
                   this.type +
                   " with you, access the workflow at " +

--- a/core/gui/src/app/dashboard/component/user/share-access/share-access.component.ts
+++ b/core/gui/src/app/dashboard/component/user/share-access/share-access.component.ts
@@ -49,6 +49,7 @@ export class ShareAccessComponent implements OnInit, OnDestroy {
   public validateForm: FormGroup;
   public accessList: ReadonlyArray<ShareAccess> = [];
   public owner: string = "";
+  public sharerName: any = this.userService.getCurrentUser()?.email;
   public filteredOwners: Array<string> = [];
   public ownerSearchValue?: string;
   public emailTags: string[] = [];
@@ -151,8 +152,8 @@ export class ShareAccessComponent implements OnInit, OnDestroy {
             next: () => {
               this.notificationService.success(this.type + " shared with " + email + " successfully.");
               this.gmailService.sendEmail(
-                "Texera: " + this.owner + " shared a " + this.type + " with you",
-                this.owner +
+                "Texera: " + this.sharerName + " shared a " + this.type + " with you",
+                this.sharerName +
                   " shared a " +
                   this.type +
                   " with you, access the workflow at " +


### PR DESCRIPTION
This PR ensures that when a workflow is shared, the email correctly reflects the actual sharer instead of the original workflow owner.

Previously, when user A shared a workflow with user B, and user B then shared the same workflow with user C, the email to user C incorrectly displayed user A (owner) as the sharer. 