### PR TITLE
Migrate config storage (logos & tabs) to database and enable sidebar customization

### DIFF
--- a/core/config/src/main/resources/defaults.conf
+++ b/core/config/src/main/resources/defaults.conf
@@ -1,0 +1,66 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This file is used to configure the default appearance and features of the Texera web GUI.
+# These defaults are loaded into the database at startup or when resetting settings, and can be
+# overridden at runtime by site administrators via the Admin Settings page.
+
+logo      = "gui/src/assets/logos/logo.png"
+mini_logo = "gui/src/assets/logos/full_logo_small.png"
+favicon   = "gui/src/assets/logos/favicon-32x32.png"
+
+sidebar_tabs = [
+  {
+    group = "Hub"
+    icon = "usergroup-add"
+    enabled = true
+    children = [
+      { label = "Home", route = "/dashboard/home", icon = "home", enabled = true }
+      { label = "Workflow", route = "/dashboard/hub/workflow", icon = "project", enabled = true }
+      { label = "Dataset", route = "/dashboard/hub/dataset", icon = "database", enabled = true }
+    ]
+  },
+  {
+    group = "Your Work"
+    icon = "user"
+    enabled = true
+    children = [
+      { label = "Projects", route = "/dashboard/user/project", icon = "container", enabled = false, tooltip = "Look up the user projects" }
+      { label = "Workflows", route = "/dashboard/user/workflow", icon = "project", enabled = true, tooltip = "Open the saved workflows" }
+      { label = "Datasets", route = "/dashboard/user/dataset", icon = "database", enabled = true, tooltip = "Look up for datasets" }
+      { label = "Quota", route = "/dashboard/user/quota", icon = "dashboard", enabled = true, tooltip = "Quota information" }
+      { label = "Forum", route = "/dashboard/user/discussion", icon = "comment", enabled = false, tooltip = "Open the discussion forum" }
+    ]
+  },
+  {
+    group = "Admin"
+    icon = "tool"
+    enabled = true
+    children = [
+      { label = "Users", route = "/dashboard/admin/user", icon = "user", enabled = true, tooltip = "Look up the users" }
+      { label = "Executions", route = "/dashboard/admin/execution", icon = "setting", enabled = true, tooltip = "View statistics" }
+      { label = "Gmail", route = "/dashboard/admin/gmail", icon = "mail", enabled = true, tooltip = "Setup Gmail" }
+      { label = "Settings", route = "/dashboard/admin/settings", icon = "edit", enabled = true, tooltip = "Site-wide settings" }
+    ]
+  },
+  {
+    group = "About"
+    route = "/dashboard/about"
+    icon = "info-circle"
+    enabled = true
+  }
+]

--- a/core/config/src/main/scala/edu/uci/ics/texera/config/DefaultsConfig.scala
+++ b/core/config/src/main/scala/edu/uci/ics/texera/config/DefaultsConfig.scala
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package edu.uci.ics.texera.config
+
+import com.typesafe.config.{Config, ConfigFactory, ConfigRenderOptions, ConfigValueType}
+import edu.uci.ics.amber.util.PathUtils
+import java.nio.file.Files
+import java.util.Base64
+import scala.jdk.CollectionConverters.MapHasAsScala
+
+object DefaultsConfig {
+  private val conf: Config = ConfigFactory
+    .parseResources("defaults.conf")
+    .resolve()
+
+  val allDefaults: Map[String, String] = conf
+    .root()
+    .asScala
+    .map {
+      case (k, v) =>
+        val raw = v.valueType() match {
+          case ConfigValueType.STRING | ConfigValueType.NUMBER | ConfigValueType.BOOLEAN =>
+            v.unwrapped().toString
+          case _ =>
+            v.render(ConfigRenderOptions.concise())
+        }
+
+        // For image paths, load resource and encode
+        val finalValue =
+          if (Set("logo", "mini_logo", "favicon").contains(k)) {
+            val asset = PathUtils.corePath.resolve(raw)
+            if (!Files.exists(asset)) {
+              throw new RuntimeException(s"Not found：$asset")
+            }
+            val bytes = Files.readAllBytes(asset)
+            val rawBase64 = Base64.getEncoder.encodeToString(bytes)
+            s"data:image/png;base64,$rawBase64"
+          } else raw
+
+        k -> finalValue
+    }
+    .toMap
+}

--- a/core/gui/src/app/dashboard/component/admin/settings/admin-settings.component.html
+++ b/core/gui/src/app/dashboard/component/admin/settings/admin-settings.component.html
@@ -21,7 +21,7 @@
   <h2 class="page-title">General Settings</h2>
 </nz-card>
 
-<nz-card>
+<nz-card nzTitle="Branding">
   <div class="upload-row">
     <span>Logo:</span>
     <button
@@ -99,8 +99,45 @@
     <button
       nz-button
       nzType="default"
-      (click)="resetToDefault()">
-      Default
+      (click)="resetBranding()">
+      Reset Branding
+    </button>
+  </div>
+</nz-card>
+
+<nz-card nzTitle="Sidebar Tabs">
+  <div class="sidebar-tabs-container">
+    <ng-container *ngFor="let g of sidebarTabs">
+      <div
+        *ngIf="g.group !== 'Admin'"
+        class="group-card">
+        <div class="group-header">
+          <nz-switch
+            [(ngModel)]="g.enabled"
+            (ngModelChange)="saveTabs()"></nz-switch>
+          <span class="group-label">{{ g.group }}</span>
+        </div>
+        <div
+          class="group-children"
+          *ngIf="g.enabled">
+          <div
+            *ngFor="let t of g.children"
+            class="child-item">
+            <nz-switch
+              [(ngModel)]="t.enabled"
+              (ngModelChange)="saveTabs()"></nz-switch>
+            <span class="child-label">{{ t.label }}</span>
+          </div>
+        </div>
+      </div>
+    </ng-container>
+  </div>
+  <div class="button-row">
+    <button
+      nz-button
+      nzType="default"
+      (click)="resetTabs()">
+      Reset Tabs
     </button>
   </div>
 </nz-card>

--- a/core/gui/src/app/dashboard/component/admin/settings/admin-settings.component.scss
+++ b/core/gui/src/app/dashboard/component/admin/settings/admin-settings.component.scss
@@ -41,10 +41,40 @@
   margin-left: 88px;
   font-size: 12px;
   color: #888;
-  margin-bottom: 24px;
+  margin-bottom: 20px;
 }
 
 .button-row {
   display: flex;
   gap: 14px;
+  margin-top: 16px;
+}
+
+.sidebar-tabs-container {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1rem;
+  max-width: 500px;
+  padding: 1rem;
+  border: 1px solid #efeeee;
+  background: #fbfbfb;
+}
+
+.group-card {
+  box-shadow: 0 2px 6px #d8d6d6;
+  padding: 0.5rem;
+}
+
+.group-header {
+  margin-bottom: 0.5rem;
+  font-weight: 500;
+}
+
+.child-item {
+  margin-bottom: 0.25rem;
+}
+
+.group-label,
+.child-label {
+  margin-left: 0.5rem;
 }

--- a/core/gui/src/app/dashboard/component/admin/settings/admin-settings.component.ts
+++ b/core/gui/src/app/dashboard/component/admin/settings/admin-settings.component.ts
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-import { Component } from "@angular/core";
+import { Component, OnInit } from "@angular/core";
 import { AdminSettingsService } from "../../../service/admin/settings/admin-settings.service";
 import { NzMessageService } from "ng-zorro-antd/message";
 import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
@@ -28,15 +28,45 @@ import { UntilDestroy, untilDestroyed } from "@ngneat/until-destroy";
   templateUrl: "./admin-settings.component.html",
   styleUrls: ["./admin-settings.component.scss"],
 })
-export class AdminSettingsComponent {
+export class AdminSettingsComponent implements OnInit {
   logoData: string | null = null;
   miniLogoData: string | null = null;
   faviconData: string | null = null;
+  sidebarTabs: Array<{
+    route: string;
+    group: string;
+    icon: string;
+    enabled: boolean;
+    tooltip?: string;
+    children: Array<{
+      label: string;
+      route: string;
+      icon: string;
+      enabled: boolean;
+      tooltip?: string;
+    }>;
+  }> = [];
 
   constructor(
     private adminSettingsService: AdminSettingsService,
     private message: NzMessageService
   ) {}
+  ngOnInit(): void {
+    this.loadTabs();
+  }
+
+  private loadTabs(): void {
+    this.adminSettingsService
+      .getSetting("sidebar_tabs")
+      .pipe(untilDestroyed(this))
+      .subscribe(json => {
+        try {
+          this.sidebarTabs = JSON.parse(json);
+        } catch {
+          this.sidebarTabs = [];
+        }
+      });
+  }
 
   onFileChange(type: "logo" | "mini_logo" | "favicon", event: Event): void {
     const file = (event.target as HTMLInputElement).files?.[0];
@@ -94,9 +124,9 @@ export class AdminSettingsComponent {
     }
   }
 
-  resetToDefault(): void {
+  resetBranding(): void {
     this.adminSettingsService
-      .deleteSetting("logo")
+      .resetSetting("logo")
       .pipe(untilDestroyed(this))
       .subscribe({
         next: () => {
@@ -107,7 +137,7 @@ export class AdminSettingsComponent {
       });
 
     this.adminSettingsService
-      .deleteSetting("mini_logo")
+      .resetSetting("mini_logo")
       .pipe(untilDestroyed(this))
       .subscribe({
         next: () => {
@@ -118,7 +148,7 @@ export class AdminSettingsComponent {
       });
 
     this.adminSettingsService
-      .deleteSetting("favicon")
+      .resetSetting("favicon")
       .pipe(untilDestroyed(this))
       .subscribe({
         next: () => {
@@ -129,5 +159,34 @@ export class AdminSettingsComponent {
       });
 
     setTimeout(() => window.location.reload(), 500);
+  }
+
+  saveTabs(): void {
+    const payload = JSON.stringify(this.sidebarTabs);
+    this.adminSettingsService
+      .updateSetting("sidebar_tabs", payload)
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: () => this.message.success("Tabs saved successfully."),
+        error: () => this.message.error("Failed to save."),
+      });
+  }
+
+  resetTabs(): void {
+    this.adminSettingsService
+      .resetSetting("sidebar_tabs")
+      .pipe(untilDestroyed(this))
+      .subscribe({
+        next: () => {
+          this.message.success("Sidebar tabs reset to default.");
+          this.loadTabs();
+        },
+        error: () => this.message.error("Failed to reset sidebar tabs."),
+      });
+  }
+
+  resetAllToDefault(): void {
+    this.resetBranding();
+    this.resetTabs();
   }
 }

--- a/core/gui/src/app/dashboard/component/dashboard.component.html
+++ b/core/gui/src/app/dashboard/component/dashboard.component.html
@@ -41,145 +41,59 @@
       </li>
 
       <li
-        *ngIf="config.env.hubEnabled"
+        *ngIf="isHubEnabled"
         nz-submenu
         nzTitle="Hub"
         nzIcon="usergroup-add"
-        nzOpen="true">
+        nzOpen="true"
+        [class.ant-menu-submenu-selected]="isHubRoute()">
         <texera-hub [isLogin]="isLogin"></texera-hub>
       </li>
 
-      <li
-        *ngIf="isLogin"
-        nz-submenu
-        nzTitle="Your Work"
-        nzIcon="user"
-        nzOpen="true">
-        <ul>
+      <ng-container *ngFor="let group of sidebarTabs">
+        <ng-container
+          *ngIf="group.enabled && group.group !== 'Hub'&&
+    (group.group !== 'Your Work' || isLogin) &&
+    (group.group !== 'Admin' || isAdmin)">
           <li
-            *ngIf="config.env.projectEnabled"
-            nz-menu-item
-            nz-tooltip="Look up the user projects"
-            nzMatchRouter="true"
-            nzTooltipPlacement="right"
-            [routerLink]="DASHBOARD_USER_PROJECT">
-            <span
-              nz-icon
-              nzType="container"></span>
-            <span>Projects</span>
-          </li>
-
-          <li
-            nz-menu-item
-            nz-tooltip="Open the saved workflows"
-            nzMatchRouter="true"
-            nzTooltipPlacement="right"
-            [routerLink]="DASHBOARD_USER_WORKFLOW">
-            <span
-              nz-icon
-              nzType="project"></span>
-            <span>Workflows</span>
-          </li>
-
-          <li
-            nz-menu-item
-            nz-tooltip="Look up for datasets"
-            nzMatchRouter="true"
-            nzTooltipPlacement="right"
-            [routerLink]="DASHBOARD_USER_DATASET">
-            <span
-              nz-icon
-              nzType="database"></span>
-            <span>Datasets</span>
-          </li>
-          <li
-            nz-menu-item
-            nz-tooltip="Quota information"
-            nzMatchRouter="true"
-            nzTooltipPlacement="right"
-            [routerLink]="DASHBOARD_USER_QUOTA">
-            <span
-              nz-icon
-              nzType="dashboard"></span>
-            <span>Quota</span>
-          </li>
-          <li
-            *ngIf="config.env.forumEnabled"
-            nz-menu-item
-            nz-tooltip="Open the discussion forum"
-            nzMatchRouter="true"
-            nzTooltipPlacement="right"
-            [routerLink]="DASHBOARD_USER_DISCUSSION">
-            <span
-              nz-icon
-              nzType="comment"></span>
-            <span>Forum</span>
-          </li>
-          <li
-            *ngIf="isAdmin"
+            *ngIf="group.children && group.children.length > 0;"
             nz-submenu
-            nzTitle="Admin"
-            nzIcon="tool">
+            [nzTitle]="group.group"
+            [nzIcon]="group.icon"
+            nzOpen="true">
             <ul>
-              <li
-                nz-menu-item
-                nz-tooltip="Look up the users"
-                nzMatchRouter="true"
-                nzTooltipPlacement="right"
-                [routerLink]="DASHBOARD_ADMIN_USER">
-                <span
-                  nz-icon
-                  nzType="user"></span>
-                <span>Users</span>
-              </li>
-              <li
-                nz-menu-item
-                nz-tooltip="View statistics"
-                nzMatchRouter="true"
-                nzTooltipPlacement="right"
-                [routerLink]="DASHBOARD_ADMIN_EXECUTION">
-                <span
-                  nz-icon
-                  nzType="setting"></span>
-                <span>Executions</span>
-              </li>
-              <li
-                nz-menu-item
-                nz-tooltip="Setup gmail"
-                nzMatchRouter="true"
-                nzTooltipPlacement="right"
-                [routerLink]="DASHBOARD_ADMIN_GMAIL">
-                <span
-                  nz-icon
-                  nzType="mail"></span>
-                <span>Gmail</span>
-              </li>
-              <li
-                nz-menu-item
-                nz-tooltip="Settings"
-                nzMatchRouter="true"
-                nzTooltipPlacement="right"
-                [routerLink]="DASHBOARD_ADMIN_SETTINGS">
-                <span
-                  nz-icon
-                  nzType="edit"></span>
-                <span>Settings</span>
-              </li>
+              <ng-container *ngFor="let t of group.children">
+                <li
+                  *ngIf="t.enabled"
+                  nz-menu-item
+                  nzMatchRouter="true"
+                  [routerLink]="t.route"
+                  nz-tooltip
+                  [nzTooltipTitle]="t.tooltip"
+                  nzTooltipPlacement="right">
+                  <span
+                    nz-icon
+                    [nzType]="t.icon"></span>
+                  <span>{{ t.label }}</span>
+                </li>
+              </ng-container>
             </ul>
           </li>
-        </ul>
-      </li>
-
-      <li
-        nz-menu-item
-        nz-tooltip
-        nzTooltipPlacement="right"
-        [routerLink]="DASHBOARD_ABOUT">
-        <span
-          nz-icon
-          nzType="info-circle"></span>
-        <span>About</span>
-      </li>
+          <li
+            *ngIf="!group.children || group.children.length === 0"
+            nz-menu-item
+            nzMatchRouter="true"
+            [routerLink]="group.route"
+            nz-tooltip
+            [nzTooltipTitle]="group.tooltip"
+            nzTooltipPlacement="right">
+            <span
+              nz-icon
+              [nzType]="group.icon"></span>
+            <span>{{ group.group }}</span>
+          </li>
+        </ng-container>
+      </ng-container>
     </ul>
     <span id="git-commit-id">Git hash: {{ gitCommitHash }}</span>
   </nz-sider>

--- a/core/gui/src/app/dashboard/service/admin/settings/admin-settings.service.ts
+++ b/core/gui/src/app/dashboard/service/admin/settings/admin-settings.service.ts
@@ -32,10 +32,6 @@ import { map } from "rxjs/operators";
 })
 export class AdminSettingsService {
   private readonly BASE_URL = "/api/admin/settings";
-  private readonly DEFAULT_LOGO_PATH = "assets/logos/logo.png";
-  private readonly DEFAULT_MINI_LOGO_PATH = "assets/logos/full_logo_small.png";
-  private readonly DEFAULT_FAVICON_PATH = "assets/logos/favicon-32x32.png";
-
   constructor(private http: HttpClient) {}
 
   getSetting(key: string): Observable<string> {
@@ -44,29 +40,11 @@ export class AdminSettingsService {
       .pipe(map(resp => resp?.value ?? null));
   }
 
-  getLogoPath(): Observable<string> {
-    return this.getSetting("logo").pipe(map(url => url || this.DEFAULT_LOGO_PATH));
-  }
-
-  getMiniLogoPath(): Observable<string> {
-    return this.getSetting("mini_logo").pipe(map(url => url || this.DEFAULT_MINI_LOGO_PATH));
-  }
-
-  getFaviconPath(): Observable<string> {
-    return this.getSetting("favicon").pipe(
-      map(url => {
-        const path = url || this.DEFAULT_FAVICON_PATH;
-        document.querySelectorAll("link[rel*='icon']").forEach(link => ((link as HTMLLinkElement).href = path));
-        return path;
-      })
-    );
-  }
-
   updateSetting(key: string, value: string): Observable<void> {
     return this.http.put<void>(`${this.BASE_URL}/${key}`, { value }, { withCredentials: true });
   }
 
-  deleteSetting(key: string): Observable<void> {
-    return this.http.post<void>(`${this.BASE_URL}/delete/${key}`, {});
+  resetSetting(key: string): Observable<void> {
+    return this.http.post<void>(`${this.BASE_URL}/reset/${key}`, {});
   }
 }


### PR DESCRIPTION
### **Purpose:**
This PR migrates the configuration storage of UI elements, currently only logos and sidebar tabs from static files to the database. It enables admins to customize these settings at runtime through a web UI without requiring service restarts. Future updates will support other config elements.
Additionally, this PR fixes issue [#3490](https://github.com/Texera/texera/issues/3490), where certain selected page tabs were not highlighted correctly.

### **Design Proposal:**
[doc...]
**Related PRs:**
#3453
#3480
#3489 

### **Changes (updated):**
- gui/../admin/settings/admin-setting.component.ts/html/scss: add sidebar tabs management and branding upload features.
- gui/..component/dashboard.component.html.ts: dashboard sidebar updated to load tabs from database dynamically and fix the highlights issue.
- gui/.../service/admin/settings/admin-settings.service.ts: API service for admin settings CRUD
- config-service/.../ConfigService.scala: connect to database and preload defaults into database on startup
- amber/../dashboard/admin/settings/AdminSettingsResource.scala: REST endpoints for config CRUD

### **Changes (new)**
- config/../resource/defaults.conf: default config values for logos, tabs, and (future)other UI elements
- config/../scala/DefaultsConfig.scala: logic to load defaults and encode image assets

### **Demonstration:**
Sidebar tabs customization:
<img width="1684" alt="tabs_before" src="https://github.com/user-attachments/assets/79c3999f-47b6-4b1a-ac7b-6d23607531eb" />
After updating:
<img width="1692" alt="tabs_after" src="https://github.com/user-attachments/assets/effa0728-38b1-44a6-ae72-9c1b3a48b8e9" />

Correct highlighting of selected page tabs:
<img width="1568" alt="hub-highlight" src="https://github.com/user-attachments/assets/3f83b0b1-7993-40e8-91bf-ab5671ca5d2d" />
<img width="1494" alt="about-highlight" src="https://github.com/user-attachments/assets/61400ef6-31c4-4ad8-b20b-6be1a6bff9ab" />