### PR TITLE
Add the pop-up window for notifying users with no account

### DIFF
--- a/core/gui/src/app/common/service/user/auth.service.ts
+++ b/core/gui/src/app/common/service/user/auth.service.ts
@@ -137,7 +137,7 @@ export class AuthService {
 
       this.modal.confirm({
         nzTitle: "You Need Access",
-        nzContent: "Request Access from admin, or switch to an account with access.",
+        nzContent: "Access to the platform is restricted. Please request access from an admin or switch to an account that already has access.",
         nzOkText: "Send Request",
         nzCancelText: "Cancel",
         nzOnOk: () => this.gmailService.notifyUnauthorizedLogin(email),

--- a/core/gui/src/app/common/service/user/auth.service.ts
+++ b/core/gui/src/app/common/service/user/auth.service.ts
@@ -135,7 +135,6 @@ export class AuthService {
     const email = this.jwtHelperService.decodeToken(token).email;
     if (this.config.env.inviteOnly && role == Role.INACTIVE) {
 
-      // THIS IS WHERE I NEED TO MAKE THE UI CHANGE - CHANGE FROM ALERT TO MODAL
       this.modal.confirm({
         nzTitle: "You Need Access",
         nzContent: "Request Access from admin, or switch to an account with access.",

--- a/core/gui/src/app/common/service/user/auth.service.ts
+++ b/core/gui/src/app/common/service/user/auth.service.ts
@@ -28,6 +28,7 @@ import { JwtHelperService } from "@auth0/angular-jwt";
 import { NotificationService } from "../notification/notification.service";
 import { GmailService } from "../gmail/gmail.service";
 import { GuiConfigService } from "../gui-config.service";
+import { NzModalService } from 'ng-zorro-antd/modal';
 
 export const TOKEN_KEY = "access_token";
 export const TOKEN_REFRESH_INTERVAL_IN_MIN = 15;
@@ -55,8 +56,10 @@ export class AuthService {
     private jwtHelperService: JwtHelperService,
     private notificationService: NotificationService,
     private gmailService: GmailService,
-    private config: GuiConfigService
-  ) {}
+    private config: GuiConfigService,
+    private modal: NzModalService
+
+) {}
 
   /**
    * This method will handle the request for user registration.
@@ -131,8 +134,16 @@ export class AuthService {
     const role = this.jwtHelperService.decodeToken(token).role;
     const email = this.jwtHelperService.decodeToken(token).email;
     if (this.config.env.inviteOnly && role == Role.INACTIVE) {
-      alert("The account request of " + email + " is received and pending.");
-      this.gmailService.notifyUnauthorizedLogin(email);
+
+      // THIS IS WHERE I NEED TO MAKE THE UI CHANGE - CHANGE FROM ALERT TO MODAL
+      this.modal.confirm({
+        nzTitle: "You Need Access",
+        nzContent: "Request Access from admin, or switch to an account with access.",
+        nzOkText: "Send Request",
+        nzCancelText: "Cancel",
+        nzOnOk: () => this.gmailService.notifyUnauthorizedLogin(email),
+      })
+
       return this.logout();
     }
 

--- a/core/gui/src/app/common/service/user/auth.service.ts
+++ b/core/gui/src/app/common/service/user/auth.service.ts
@@ -28,7 +28,7 @@ import { JwtHelperService } from "@auth0/angular-jwt";
 import { NotificationService } from "../notification/notification.service";
 import { GmailService } from "../gmail/gmail.service";
 import { GuiConfigService } from "../gui-config.service";
-import { NzModalService } from 'ng-zorro-antd/modal';
+import { NzModalService } from "ng-zorro-antd/modal";
 
 export const TOKEN_KEY = "access_token";
 export const TOKEN_REFRESH_INTERVAL_IN_MIN = 15;
@@ -58,8 +58,7 @@ export class AuthService {
     private gmailService: GmailService,
     private config: GuiConfigService,
     private modal: NzModalService
-
-) {}
+  ) {}
 
   /**
    * This method will handle the request for user registration.
@@ -134,14 +133,14 @@ export class AuthService {
     const role = this.jwtHelperService.decodeToken(token).role;
     const email = this.jwtHelperService.decodeToken(token).email;
     if (this.config.env.inviteOnly && role == Role.INACTIVE) {
-
       this.modal.confirm({
         nzTitle: "You Need Access",
-        nzContent: "Currently the platform is invitation-only. Please request access from the platform admin or switch to an account that already has access.",
+        nzContent:
+          "Currently the platform is invitation-only. Please request access from the platform admin or switch to an account that already has access.",
         nzOkText: "Send request to Admin",
         nzCancelText: "Cancel",
         nzOnOk: () => this.gmailService.notifyUnauthorizedLogin(email),
-      })
+      });
 
       return this.logout();
     }

--- a/core/gui/src/app/common/service/user/auth.service.ts
+++ b/core/gui/src/app/common/service/user/auth.service.ts
@@ -137,8 +137,8 @@ export class AuthService {
 
       this.modal.confirm({
         nzTitle: "You Need Access",
-        nzContent: "Access to the platform is restricted. Please request access from an admin or switch to an account that already has access.",
-        nzOkText: "Send Request",
+        nzContent: "Currently the platform is invitation-only. Please request access from the platform admin or switch to an account that already has access.",
+        nzOkText: "Send request to Admin",
         nzCancelText: "Cancel",
         nzOnOk: () => this.gmailService.notifyUnauthorizedLogin(email),
       })


### PR DESCRIPTION
This PR introduces a pop-up window for inactive users attempting to log in via Google. The pop-up allows users to either request access or cancel the login process. 

<img width="1275" alt="TexeraRequestAccess" src="https://github.com/user-attachments/assets/feb2708b-5500-4727-8f8f-dde8d0363d84" />

 