### PR TITLE
fix(auth): handle missing avatar in Google authentication

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/GoogleAuthResource.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/auth/GoogleAuthResource.scala
@@ -71,7 +71,9 @@ class GoogleAuthResource {
       val googleId = payload.getSubject
       val googleName = payload.get("name").asInstanceOf[String]
       val googleEmail = payload.getEmail
-      val googleAvatar = payload.get("picture").asInstanceOf[String].split("/").last
+      val googleAvatar = Option(payload.get("picture").asInstanceOf[String])
+        .flatMap(_.split("/").lastOption)
+        .getOrElse("")
       val user = Option(userDao.fetchOneByGoogleId(googleId)) match {
         case Some(user) =>
           if (user.getName != googleName) {


### PR DESCRIPTION
This PR fixes #3538. When the user has no google avatar, we split their username by `/` and use the last part as their avatar. For user names do not have `/`, this will raise a null exception. This PR fixes it by using `""` as a fall back logic.