### PR TITLE
fix(operator): fixed typo in PythonUDF

### DIFF
--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/DualInputPortsPythonUDFOpDescV2.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/DualInputPortsPythonUDFOpDescV2.scala
@@ -63,7 +63,7 @@ class DualInputPortsPythonUDFOpDescV2 extends LogicalOp {
 
   @JsonProperty(required = true, defaultValue = "1")
   @JsonSchemaTitle("Worker count")
-  @JsonPropertyDescription("Specify how many parallel workers to lunch")
+  @JsonPropertyDescription("Specify how many parallel workers to launch")
   var workers: Int = Int.box(1)
 
   @JsonProperty(required = true, defaultValue = "true")

--- a/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/PythonUDFOpDescV2.scala
+++ b/core/workflow-operator/src/main/scala/edu/uci/ics/amber/operator/udf/python/PythonUDFOpDescV2.scala
@@ -64,7 +64,7 @@ class PythonUDFOpDescV2 extends LogicalOp {
 
   @JsonProperty(required = true, defaultValue = "1")
   @JsonSchemaTitle("Worker count")
-  @JsonPropertyDescription("Specify how many parallel workers to lunch")
+  @JsonPropertyDescription("Specify how many parallel workers to launch")
   var workers: Int = Int.box(1)
 
   @JsonProperty(required = true, defaultValue = "true")


### PR DESCRIPTION
**Purpose:**
Currently, there is a typo in operators `PythonUDF` and `Dual Input PythonUDF`.

<img width="266" alt="Screenshot 2025-07-08 at 1 42 51 PM" src="https://github.com/user-attachments/assets/8b79846c-7a31-413c-8df3-8dd23cb0dae6" />


**Changes:**
Modified  `PythonUDF` and `Dual Input PythonUDF`

<img width="263" alt="Screenshot 2025-07-08 at 2 33 16 PM" src="https://github.com/user-attachments/assets/6c842d26-cbb9-4b20-8b2e-2d9b48b98d1e" />

