### PR TITLE
fix(email): make notification subject lines more informative (#3532)

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
@@ -32,7 +32,7 @@ object EmailTemplate {
     val config = ConfigFactory.load()
     val rawDomain =
       if (config.hasPath("user-sys.domain")) config.getString("user-sys.domain")
-      else "https://hub.texera.io"
+      else ""
     rawDomain.replaceFirst("^https?://", "")
   }
 
@@ -52,7 +52,12 @@ object EmailTemplate {
       toAdmin: Boolean
   ): EmailMessage = {
     if (toAdmin) {
-      val subject = s"New Account Request to $deployment Pending Approval"
+      val subject =
+        if (deployment.nonEmpty)
+          s"New Account Request to $deployment Pending Approval"
+        else
+          "New Account Request Pending Approval"
+
       val content =
         s"""
            |Hello Admin,
@@ -77,7 +82,7 @@ object EmailTemplate {
            |We have received your request and it is currently under review.
            |You will be notified once your account has been approved.
            |
-           |Thank you for your interest in $deployment!
+           |Thank you for your interest in Texera!
            |""".stripMargin
       EmailMessage(subject = subject, content = content, receiver = receiverEmail)
     }
@@ -92,7 +97,12 @@ object EmailTemplate {
     * @return an EmailMessage ready to be sent to the user
     */
   def createRoleChangeTemplate(receiverEmail: String, newRole: UserRoleEnum): EmailMessage = {
-    val subject = s"Your Role Has Been Updated on $deployment"
+    val subject =
+      if (deployment.nonEmpty)
+        s"Your Role Has Been Updated on $deployment"
+      else
+        "Your Role Has Been Updated"
+
     val content =
       s"""
          |Hello,
@@ -101,7 +111,7 @@ object EmailTemplate {
          |
          |If you have any questions, please contact the administrator.
          |
-         |Thank you for using $deployment!
+         |Thank you for using Texera!
          |""".stripMargin
 
     EmailMessage(subject = subject, content = content, receiver = receiverEmail)

--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
@@ -19,6 +19,7 @@
 
 package edu.uci.ics.texera.web.resource
 
+import com.typesafe.config.ConfigFactory
 import edu.uci.ics.texera.dao.jooq.generated.enums.UserRoleEnum
 
 /**
@@ -26,6 +27,14 @@ import edu.uci.ics.texera.dao.jooq.generated.enums.UserRoleEnum
   * for different user notification scenarios.
   */
 object EmailTemplate {
+
+  private val deployment: String = {
+    val config = ConfigFactory.load()
+    val rawDomain =
+      if (config.hasPath("user-sys.domain")) config.getString("user-sys.domain")
+      else "https://hub.texera.io"
+    rawDomain.replaceFirst("^https?://", "")
+  }
 
   /**
     * Creates an email message for user registration notifications.
@@ -43,7 +52,7 @@ object EmailTemplate {
       toAdmin: Boolean
   ): EmailMessage = {
     if (toAdmin) {
-      val subject = "New Account Request Pending Approval"
+      val subject = s"New Account Request to $deployment Pending Approval"
       val content =
         s"""
            |Hello Admin,
@@ -52,6 +61,8 @@ object EmailTemplate {
            |Please review the account request for the following email:
            |
            |${userEmail.getOrElse("Unknown")}
+           |
+           |Visit the admin panel at: $deployment
            |
            |Thanks!
            |""".stripMargin
@@ -64,9 +75,9 @@ object EmailTemplate {
            |
            |Thank you for submitting your account request.
            |We have received your request and it is currently under review.
-           |Please be patient during this process. You will be notified once your account has been approved.
+           |You will be notified once your account has been approved.
            |
-           |Thank you for your interest!
+           |Thank you for your interest in $deployment!
            |""".stripMargin
       EmailMessage(subject = subject, content = content, receiver = receiverEmail)
     }
@@ -81,7 +92,7 @@ object EmailTemplate {
     * @return an EmailMessage ready to be sent to the user
     */
   def createRoleChangeTemplate(receiverEmail: String, newRole: UserRoleEnum): EmailMessage = {
-    val subject = "Your Role Has Been Updated"
+    val subject = s"Your Role Has Been Updated on $deployment"
     val content =
       s"""
          |Hello,
@@ -90,7 +101,7 @@ object EmailTemplate {
          |
          |If you have any questions, please contact the administrator.
          |
-         |Thank you!
+         |Thank you for using $deployment!
          |""".stripMargin
 
     EmailMessage(subject = subject, content = content, receiver = receiverEmail)


### PR DESCRIPTION
Closes #3532 Make the subject of notification emails more informative
Related PR ##3393
### Purpose
Improves email subject clarity by including the deployment domain (e.g., hub.texera.io) in user registration and role update notifications.

### Implementation
Introduced a new deployment variable in EmailTemplate.scala:

- Extracts the user-sys.domain from the config.
- Removes http:// or https:// prefix using .replaceFirst("^https?://", "").

Updated 3 subject lines to incorporate $deployment:

- Admin Notification Subject:
         New Account Request Pending Approval → New Account Request to $deployment Pending Approval
- User Role Update Subject:
         Your Role Has Been Updated → Your Role Has Been Updated on $deployment
- Email body update:
         Added $deployment in the body content for contextual clarity.

### Testing

- Verified manually by simulating Account request (admin and user) and role change event using SMTP.
- Confirmed subject lines and body content are correctly updated with the domain hub.texera.io.











![Untitled design](https://github.com/user-attachments/assets/abf5e433-44c4-4827-a23d-5891a2b89681)
