### PR TITLE
refactor(amber): move resource allocator into cost estimator

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/CostBasedScheduleGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/CostBasedScheduleGenerator.scala
@@ -29,6 +29,7 @@ import edu.uci.ics.amber.core.workflow.{
   PhysicalPlan,
   WorkflowContext
 }
+import edu.uci.ics.amber.engine.architecture.scheduling.SchedulingUtils.replaceVertex
 import edu.uci.ics.amber.engine.architecture.scheduling.config.{
   IntermediateInputPortConfig,
   OutputPortConfig,
@@ -68,7 +69,11 @@ class CostBasedScheduleGenerator(
   )
 
   private val costEstimator =
-    new DefaultCostEstimator(workflowContext = workflowContext, actorId = actorId)
+    new DefaultCostEstimator(
+      workflowContext = workflowContext,
+      resourceAllocator = resourceAllocator,
+      actorId = actorId
+    )
 
   def generate(): (Schedule, PhysicalPlan) = {
     val startTime = System.nanoTime()
@@ -323,7 +328,6 @@ class CostBasedScheduleGenerator(
     )
 
     val regionDAG = searchResult.regionDAG
-    allocateResource(regionDAG)
     regionDAG
   }
 
@@ -397,10 +401,7 @@ class CostBasedScheduleGenerator(
       def updateOptimumIfApplicable(regionDAG: DirectedAcyclicGraph[Region, RegionLink]): Unit = {
         if (oEarlyStop) schedulableStates.add(currentState)
         // Calculate the current state's cost and update the bestResult if it's lower
-        val cost =
-          evaluate(
-            RegionPlan(regionDAG.vertexSet().asScala.toSet, regionDAG.edgeSet().asScala.toSet)
-          )
+        val cost = allocateResourcesAndEvaluateCost(regionDAG)
         if (cost < bestResult.cost) {
           bestResult = SearchResult(currentState, regionDAG, cost)
         }
@@ -453,12 +454,7 @@ class CostBasedScheduleGenerator(
                 physicalPlan.getBlockingAndDependeeLinks ++ neighborState
               ) match {
                 case Left(regionDAG) =>
-                  evaluate(
-                    RegionPlan(
-                      regionDAG.vertexSet().asScala.toSet,
-                      regionDAG.edgeSet().asScala.toSet
-                    )
-                  )
+                  allocateResourcesAndEvaluateCost(regionDAG)
                 case Right(_) =>
                   Double.MaxValue
               }
@@ -544,10 +540,7 @@ class CostBasedScheduleGenerator(
         */
       def updateOptimumIfApplicable(regionDAG: DirectedAcyclicGraph[Region, RegionLink]): Unit = {
         // Calculate the current state's cost and update the bestResult if it's lower
-        val cost =
-          evaluate(
-            RegionPlan(regionDAG.vertexSet().asScala.toSet, regionDAG.edgeSet().asScala.toSet)
-          )
+        val cost = allocateResourcesAndEvaluateCost(regionDAG)
         if (cost < bestResult.cost) {
           bestResult = SearchResult(currentState, regionDAG, cost)
         }
@@ -577,12 +570,7 @@ class CostBasedScheduleGenerator(
                 physicalPlan.getBlockingAndDependeeLinks ++ neighborState
               ) match {
                 case Left(regionDAG) =>
-                  evaluate(
-                    RegionPlan(
-                      regionDAG.vertexSet().asScala.toSet,
-                      regionDAG.edgeSet().asScala.toSet
-                    )
-                  )
+                  allocateResourcesAndEvaluateCost(regionDAG)
                 case Right(_) =>
                   Double.MaxValue
               }
@@ -601,16 +589,31 @@ class CostBasedScheduleGenerator(
   }
 
   /**
-    * The cost function used by the search. Takes a region plan, generates one or more (to be done in the future)
-    * schedules based on the region plan, and calculates the cost of the schedule(s) using Cost Estimator. Uses the cost
-    * of the best schedule (currently only considers one schedule) as the cost of the region plan.
+    * Takes a region DAG, generates one or more (to be done in the future) schedules based on the region DAG, allocates
+    * resources to each region in the region DAG, and calculates the cost of the schedule(s) using Cost Estimator. Uses
+    * the cost of the best schedule (currently only considers one schedule) as the cost of the region DAG.
     *
     * @return A cost determined by the cost estimator.
     */
-  private def evaluate(regionPlan: RegionPlan): Double = {
+  private def allocateResourcesAndEvaluateCost(
+      regionDAG: DirectedAcyclicGraph[Region, RegionLink]
+  ): Double = {
+    val regionPlan =
+      RegionPlan(regionDAG.vertexSet().asScala.toSet, regionDAG.edgeSet().asScala.toSet)
     val schedule = generateScheduleFromRegionPlan(regionPlan)
     // In the future we may allow multiple regions in a level and split the resources.
-    schedule.map(level => level.map(region => costEstimator.estimate(region, 1)).sum).sum
+    schedule
+      .map(level =>
+        level
+          .map(region => {
+            val (newRegion, regionCost) = costEstimator.allocateResourcesAndEstimateCost(region, 1)
+            // Update the region in the regionDAG to be the new region with resources allocated.
+            replaceVertex(regionDAG, region, newRegion)
+            regionCost
+          })
+          .sum
+      )
+      .sum
   }
 
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyScheduleGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ExpansionGreedyScheduleGenerator.scala
@@ -29,7 +29,7 @@ import edu.uci.ics.amber.core.workflow.{
   PhysicalPlan,
   WorkflowContext
 }
-import edu.uci.ics.amber.engine.architecture.scheduling.ScheduleGenerator.replaceVertex
+import SchedulingUtils.replaceVertex
 import edu.uci.ics.amber.engine.architecture.scheduling.config.{
   IntermediateInputPortConfig,
   OutputPortConfig,
@@ -37,11 +37,12 @@ import edu.uci.ics.amber.engine.architecture.scheduling.config.{
 }
 import org.jgrapht.alg.connectivity.BiconnectivityInspector
 import org.jgrapht.graph.DirectedAcyclicGraph
+import org.jgrapht.traverse.TopologicalOrderIterator
 
 import java.net.URI
 import scala.annotation.tailrec
 import scala.collection.mutable
-import scala.jdk.CollectionConverters.CollectionHasAsScala
+import scala.jdk.CollectionConverters.{CollectionHasAsScala, IteratorHasAsScala}
 
 @deprecated(
   "This greedy schedule generator will be removed in the future. Use CostBasedScheduleGenerator instead."
@@ -359,6 +360,71 @@ class ExpansionGreedyScheduleGenerator(
     val newPhysicalPlan = physicalPlan
       .removeLink(physicalLink)
     newPhysicalPlan
+  }
+
+  private def allocateResource(
+      regionDAG: DirectedAcyclicGraph[Region, RegionLink]
+  ): Unit = {
+    // generate the resource configs
+    new TopologicalOrderIterator(regionDAG).asScala
+      .foreach(region => {
+        val (newRegion, _) = resourceAllocator.allocate(region)
+        replaceVertex(regionDAG, region, newRegion)
+      })
+  }
+
+  private def getRegions(
+      physicalOpId: PhysicalOpIdentity,
+      regionDAG: DirectedAcyclicGraph[Region, RegionLink]
+  ): Set[Region] = {
+    regionDAG
+      .vertexSet()
+      .asScala
+      .filter(region => region.getOperators.map(_.id).contains(physicalOpId))
+      .toSet
+  }
+
+  /**
+    * For a dependee input link, although it connects two regions A->B, we include this link and its toOp in region A
+    * so that the dependee link will be completed first.
+    */
+  private def populateDependeeLinks(
+      regionDAG: DirectedAcyclicGraph[Region, RegionLink]
+  ): Unit = {
+
+    val dependeeLinks = physicalPlan
+      .topologicalIterator()
+      .flatMap { physicalOpId =>
+        val upstreamPhysicalOpIds = physicalPlan.getUpstreamPhysicalOpIds(physicalOpId)
+        upstreamPhysicalOpIds.flatMap { upstreamPhysicalOpId =>
+          physicalPlan
+            .getLinksBetween(upstreamPhysicalOpId, physicalOpId)
+            .filter(link =>
+              physicalPlan
+                .getOperator(physicalOpId)
+                .isInputLinkDependee(link)
+            )
+        }
+      }
+      .toSet
+
+    dependeeLinks
+      .flatMap { link => getRegions(link.fromOpId, regionDAG).map(region => region -> link) }
+      .groupBy(_._1)
+      .view
+      .mapValues(_.map(_._2))
+      .foreach {
+        case (region, links) =>
+          val newRegion = region.copy(
+            physicalLinks = region.physicalLinks ++ links,
+            physicalOps =
+              region.getOperators ++ links.map(_.toOpId).map(id => physicalPlan.getOperator(id)),
+            ports = region.getPorts ++ links.map(dependeeLink =>
+              GlobalPortIdentity(dependeeLink.toOpId, dependeeLink.toPortId, input = true)
+            )
+          )
+          replaceVertex(regionDAG, region, newRegion)
+      }
   }
 
   /**

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ScheduleGenerator.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/ScheduleGenerator.scala
@@ -19,48 +19,10 @@
 
 package edu.uci.ics.amber.engine.architecture.scheduling
 
-import edu.uci.ics.amber.core.virtualidentity.PhysicalOpIdentity
 import edu.uci.ics.amber.core.workflow._
-import edu.uci.ics.amber.engine.architecture.scheduling.ScheduleGenerator.replaceVertex
 import edu.uci.ics.amber.engine.architecture.scheduling.resourcePolicies.{
   DefaultResourceAllocator,
   ExecutionClusterInfo
-}
-import org.jgrapht.graph.DirectedAcyclicGraph
-import org.jgrapht.traverse.TopologicalOrderIterator
-
-import scala.jdk.CollectionConverters.{CollectionHasAsScala, IteratorHasAsScala}
-
-object ScheduleGenerator {
-  def replaceVertex(
-      graph: DirectedAcyclicGraph[Region, RegionLink],
-      oldVertex: Region,
-      newVertex: Region
-  ): Unit = {
-    if (oldVertex.equals(newVertex)) {
-      return
-    }
-    graph.addVertex(newVertex)
-    graph
-      .outgoingEdgesOf(oldVertex)
-      .asScala
-      .toList
-      .foreach(oldEdge => {
-        val dest = graph.getEdgeTarget(oldEdge)
-        graph.removeEdge(oldEdge)
-        graph.addEdge(newVertex, dest, RegionLink(newVertex.id, dest.id))
-      })
-    graph
-      .incomingEdgesOf(oldVertex)
-      .asScala
-      .toList
-      .foreach(oldEdge => {
-        val source = graph.getEdgeSource(oldEdge)
-        graph.removeEdge(oldEdge)
-        graph.addEdge(source, newVertex, RegionLink(source.id, newVertex.id))
-      })
-    graph.removeVertex(oldVertex)
-  }
 }
 
 abstract class ScheduleGenerator(
@@ -68,6 +30,12 @@ abstract class ScheduleGenerator(
     var physicalPlan: PhysicalPlan
 ) {
   private val executionClusterInfo = new ExecutionClusterInfo()
+  val resourceAllocator =
+    new DefaultResourceAllocator(
+      physicalPlan,
+      executionClusterInfo,
+      workflowContext.workflowSettings
+    )
 
   def generate(): (Schedule, PhysicalPlan)
 
@@ -83,77 +51,5 @@ abstract class ScheduleGenerator(
       })
       .toMap
     Schedule.apply(levelSets)
-  }
-
-  def allocateResource(
-      regionDAG: DirectedAcyclicGraph[Region, RegionLink]
-  ): Unit = {
-
-    val resourceAllocator =
-      new DefaultResourceAllocator(
-        physicalPlan,
-        executionClusterInfo,
-        workflowContext.workflowSettings
-      )
-    // generate the resource configs
-    new TopologicalOrderIterator(regionDAG).asScala
-      .foreach(region => {
-        val (newRegion, _) = resourceAllocator.allocate(region)
-        replaceVertex(regionDAG, region, newRegion)
-      })
-  }
-
-  def getRegions(
-      physicalOpId: PhysicalOpIdentity,
-      regionDAG: DirectedAcyclicGraph[Region, RegionLink]
-  ): Set[Region] = {
-    regionDAG
-      .vertexSet()
-      .asScala
-      .filter(region => region.getOperators.map(_.id).contains(physicalOpId))
-      .toSet
-  }
-
-  /**
-    * For a dependee input link, although it connects two regions A->B, we include this link and its toOp in region A
-    * so that the dependee link will be completed first.
-    */
-  def populateDependeeLinks(
-      regionDAG: DirectedAcyclicGraph[Region, RegionLink]
-  ): Unit = {
-
-    val dependeeLinks = physicalPlan
-      .topologicalIterator()
-      .flatMap { physicalOpId =>
-        val upstreamPhysicalOpIds = physicalPlan.getUpstreamPhysicalOpIds(physicalOpId)
-        upstreamPhysicalOpIds.flatMap { upstreamPhysicalOpId =>
-          physicalPlan
-            .getLinksBetween(upstreamPhysicalOpId, physicalOpId)
-            .filter(link =>
-              physicalPlan
-                .getOperator(physicalOpId)
-                .isInputLinkDependee(link)
-            )
-        }
-      }
-      .toSet
-
-    dependeeLinks
-      .flatMap { link => getRegions(link.fromOpId, regionDAG).map(region => region -> link) }
-      .groupBy(_._1)
-      .view
-      .mapValues(_.map(_._2))
-      .foreach {
-        case (region, links) =>
-          val newRegion = region.copy(
-            physicalLinks = region.physicalLinks ++ links,
-            physicalOps =
-              region.getOperators ++ links.map(_.toOpId).map(id => physicalPlan.getOperator(id)),
-            ports = region.getPorts ++ links.map(dependeeLink =>
-              GlobalPortIdentity(dependeeLink.toOpId, dependeeLink.toPortId, input = true)
-            )
-          )
-          replaceVertex(regionDAG, region, newRegion)
-      }
   }
 }

--- a/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/SchedulingUtils.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/amber/engine/architecture/scheduling/SchedulingUtils.scala
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package edu.uci.ics.amber.engine.architecture.scheduling
+
+import org.jgrapht.graph.DirectedAcyclicGraph
+
+import scala.jdk.CollectionConverters.CollectionHasAsScala
+
+object SchedulingUtils {
+
+  def replaceVertex(
+      graph: DirectedAcyclicGraph[Region, RegionLink],
+      oldVertex: Region,
+      newVertex: Region
+  ): Unit = {
+    if (oldVertex.equals(newVertex)) {
+      return
+    }
+    graph.addVertex(newVertex)
+    graph
+      .outgoingEdgesOf(oldVertex)
+      .asScala
+      .toList
+      .foreach(oldEdge => {
+        val dest = graph.getEdgeTarget(oldEdge)
+        graph.removeEdge(oldEdge)
+        graph.addEdge(newVertex, dest, RegionLink(newVertex.id, dest.id))
+      })
+    graph
+      .incomingEdgesOf(oldVertex)
+      .asScala
+      .toList
+      .foreach(oldEdge => {
+        val source = graph.getEdgeSource(oldEdge)
+        graph.removeEdge(oldEdge)
+        graph.addEdge(source, newVertex, RegionLink(source.id, newVertex.id))
+      })
+    graph.removeVertex(oldVertex)
+  }
+}


### PR DESCRIPTION
For the cost-based scheduler in Amber, ideally, the ResourceAllocator should be part of the CostEstimator. However for historical reasons and the fact that the current ResourceAllocator does not This PR 