### PR TITLE
fix(ui): temporarily disable frontend undo and redo

### DIFF
--- a/core/gui/src/app/workspace/component/menu/menu.component.html
+++ b/core/gui/src/app/workspace/component/menu/menu.component.html
@@ -291,22 +291,22 @@
               nzType="database"
               nzTheme="twotone"></i>
           </button>
-          <button
-            (click)="undoRedoService.undoAction()"
-            [disabled]="displayParticularWorkflowVersion || !undoRedoService.canUndo()"
-            nz-button>
-            <i
-              nz-icon
-              nzType="undo"></i>
-          </button>
-          <button
-            (click)="undoRedoService.redoAction()"
-            [disabled]="displayParticularWorkflowVersion || !undoRedoService.canRedo()"
-            nz-button>
-            <i
-              nz-icon
-              nzType="redo"></i>
-          </button>
+          <!--          <button-->
+          <!--            (click)="undoRedoService.undoAction()"-->
+          <!--            [disabled]="displayParticularWorkflowVersion || !undoRedoService.canUndo()"-->
+          <!--            nz-button>-->
+          <!--            <i-->
+          <!--              nz-icon-->
+          <!--              nzType="undo"></i>-->
+          <!--          </button>-->
+          <!--          <button-->
+          <!--            (click)="undoRedoService.redoAction()"-->
+          <!--            [disabled]="displayParticularWorkflowVersion || !undoRedoService.canRedo()"-->
+          <!--            nz-button>-->
+          <!--            <i-->
+          <!--              nz-icon-->
+          <!--              nzType="redo"></i>-->
+          <!--          </button>-->
         </nz-button-group>
       </ng-template>
       <nz-dropdown-menu #menu="nzDropdownMenu">

--- a/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.spec.ts
@@ -897,54 +897,56 @@ describe("WorkflowEditorComponent", () => {
       expect(jointGraphWrapper.getCurrentHighlightedOperatorIDs()).toContain(mockResultPredicate.operatorID);
     });
 
-    //undo
-    it("should undo action when user presses command + Z or control + Z", () => {
-      spyOn(workflowVersionService, "getDisplayParticularVersionStream").and.returnValue(of(false));
-      spyOn(undoRedoService, "canUndo").and.returnValue(true);
-      let undoSpy = spyOn(undoRedoService, "undoAction");
-      fixture.detectChanges();
-      const commandZEvent = new KeyboardEvent("keydown", { key: "Z", metaKey: true, shiftKey: false });
-      (document.activeElement as HTMLElement)?.blur();
-      document.dispatchEvent(commandZEvent);
-      fixture.detectChanges();
-      expect(undoSpy).toHaveBeenCalledTimes(1);
-
-      const controlZEvent = new KeyboardEvent("keydown", { key: "Z", ctrlKey: true, shiftKey: false });
-      (document.activeElement as HTMLElement)?.blur();
-      document.dispatchEvent(controlZEvent);
-      fixture.detectChanges();
-      expect(undoSpy).toHaveBeenCalledTimes(2);
-    });
-
-    //redo
-    it("should redo action when user presses command/control + Y or command/control + shift + Z", () => {
-      spyOn(workflowVersionService, "getDisplayParticularVersionStream").and.returnValue(of(false));
-      spyOn(undoRedoService, "canRedo").and.returnValue(true);
-      let redoSpy = spyOn(undoRedoService, "redoAction");
-      fixture.detectChanges();
-      const commandYEvent = new KeyboardEvent("keydown", { key: "y", metaKey: true, shiftKey: false });
-      (document.activeElement as HTMLElement)?.blur();
-      document.dispatchEvent(commandYEvent);
-      fixture.detectChanges();
-      expect(redoSpy).toHaveBeenCalledTimes(1);
-
-      const controlYEvent = new KeyboardEvent("keydown", { key: "y", ctrlKey: true, shiftKey: false });
-      (document.activeElement as HTMLElement)?.blur();
-      document.dispatchEvent(controlYEvent);
-      fixture.detectChanges();
-      expect(redoSpy).toHaveBeenCalledTimes(2);
-
-      const commandShitZEvent = new KeyboardEvent("keydown", { key: "z", metaKey: true, shiftKey: true });
-      (document.activeElement as HTMLElement)?.blur();
-      document.dispatchEvent(commandShitZEvent);
-      fixture.detectChanges();
-      expect(redoSpy).toHaveBeenCalledTimes(3);
-
-      const controlShitZEvent = new KeyboardEvent("keydown", { key: "z", ctrlKey: true, shiftKey: true });
-      (document.activeElement as HTMLElement)?.blur();
-      document.dispatchEvent(controlShitZEvent);
-      fixture.detectChanges();
-      expect(redoSpy).toHaveBeenCalledTimes(4);
-    });
+    // Temporarily disabling undo-redo because of a bug that can cause invalid workflow structures.
+    // TODO: enable after fixing the bug.
+    // //undo
+    // it("should undo action when user presses command + Z or control + Z", () => {
+    //   spyOn(workflowVersionService, "getDisplayParticularVersionStream").and.returnValue(of(false));
+    //   spyOn(undoRedoService, "canUndo").and.returnValue(true);
+    //   let undoSpy = spyOn(undoRedoService, "undoAction");
+    //   fixture.detectChanges();
+    //   const commandZEvent = new KeyboardEvent("keydown", { key: "Z", metaKey: true, shiftKey: false });
+    //   (document.activeElement as HTMLElement)?.blur();
+    //   document.dispatchEvent(commandZEvent);
+    //   fixture.detectChanges();
+    //   expect(undoSpy).toHaveBeenCalledTimes(1);
+    //
+    //   const controlZEvent = new KeyboardEvent("keydown", { key: "Z", ctrlKey: true, shiftKey: false });
+    //   (document.activeElement as HTMLElement)?.blur();
+    //   document.dispatchEvent(controlZEvent);
+    //   fixture.detectChanges();
+    //   expect(undoSpy).toHaveBeenCalledTimes(2);
+    // });
+    //
+    // //redo
+    // it("should redo action when user presses command/control + Y or command/control + shift + Z", () => {
+    //   spyOn(workflowVersionService, "getDisplayParticularVersionStream").and.returnValue(of(false));
+    //   spyOn(undoRedoService, "canRedo").and.returnValue(true);
+    //   let redoSpy = spyOn(undoRedoService, "redoAction");
+    //   fixture.detectChanges();
+    //   const commandYEvent = new KeyboardEvent("keydown", { key: "y", metaKey: true, shiftKey: false });
+    //   (document.activeElement as HTMLElement)?.blur();
+    //   document.dispatchEvent(commandYEvent);
+    //   fixture.detectChanges();
+    //   expect(redoSpy).toHaveBeenCalledTimes(1);
+    //
+    //   const controlYEvent = new KeyboardEvent("keydown", { key: "y", ctrlKey: true, shiftKey: false });
+    //   (document.activeElement as HTMLElement)?.blur();
+    //   document.dispatchEvent(controlYEvent);
+    //   fixture.detectChanges();
+    //   expect(redoSpy).toHaveBeenCalledTimes(2);
+    //
+    //   const commandShitZEvent = new KeyboardEvent("keydown", { key: "z", metaKey: true, shiftKey: true });
+    //   (document.activeElement as HTMLElement)?.blur();
+    //   document.dispatchEvent(commandShitZEvent);
+    //   fixture.detectChanges();
+    //   expect(redoSpy).toHaveBeenCalledTimes(3);
+    //
+    //   const controlShitZEvent = new KeyboardEvent("keydown", { key: "z", ctrlKey: true, shiftKey: true });
+    //   (document.activeElement as HTMLElement)?.blur();
+    //   document.dispatchEvent(controlShitZEvent);
+    //   fixture.detectChanges();
+    //   expect(redoSpy).toHaveBeenCalledTimes(4);
+    // });
   });
 });

--- a/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -182,23 +182,23 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
       .pipe(takeUntil(this._onProcessKeyboardActionObservable))
       .subscribe(displayParticularWorkflowVersion => {
         if (!displayParticularWorkflowVersion) {
-          // cmd/ctrl+z undo ; ctrl+y or cmd/ctrl + shift+z for redo
-          if ((event.metaKey || event.ctrlKey) && !event.shiftKey && event.key.toLowerCase() === "z") {
-            // UNDO
-            if (this.undoRedoService.canUndo()) {
-              // Temporarily disabling undo-redo because of a bug that can cause invalid workflow structures.
-              // TODO: enable after fixing the bug.
-              // this.undoRedoService.undoAction();
-            }
-          } else if (
-            ((event.metaKey || event.ctrlKey) && !event.shiftKey && event.key.toLowerCase() === "y") ||
-            ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === "z")
-          ) {
-            // redo
-            if (this.undoRedoService.canRedo()) {
-              // this.undoRedoService.redoAction();
-            }
-          }
+          // Temporarily disabling undo-redo because of a bug that can cause invalid workflow structures.
+          // TODO: enable after fixing the bug.
+          // // cmd/ctrl+z undo ; ctrl+y or cmd/ctrl + shift+z for redo
+          // if ((event.metaKey || event.ctrlKey) && !event.shiftKey && event.key.toLowerCase() === "z") {
+          //   // UNDO
+          //   if (this.undoRedoService.canUndo()) {
+          //     this.undoRedoService.undoAction();
+          //   }
+          // } else if (
+          //   ((event.metaKey || event.ctrlKey) && !event.shiftKey && event.key.toLowerCase() === "y") ||
+          //   ((event.metaKey || event.ctrlKey) && event.shiftKey && event.key.toLowerCase() === "z")
+          // ) {
+          //   // redo
+          //   if (this.undoRedoService.canRedo()) {
+          //     this.undoRedoService.redoAction();
+          //   }
+          // }
           // below for future hotkeys
         }
         this._onProcessKeyboardActionObservable.complete();

--- a/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -186,7 +186,9 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
           if ((event.metaKey || event.ctrlKey) && !event.shiftKey && event.key.toLowerCase() === "z") {
             // UNDO
             if (this.undoRedoService.canUndo()) {
-              this.undoRedoService.undoAction();
+              // Temporarily disabling undo-redo because of a bug that can cause invalid workflow structures.
+              // TODO: enable after fixing the bug.
+              // this.undoRedoService.undoAction();
             }
           } else if (
             ((event.metaKey || event.ctrlKey) && !event.shiftKey && event.key.toLowerCase() === "y") ||
@@ -194,7 +196,7 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
           ) {
             // redo
             if (this.undoRedoService.canRedo()) {
-              this.undoRedoService.redoAction();
+              // this.undoRedoService.redoAction();
             }
           }
           // below for future hotkeys


### PR DESCRIPTION
We observed in #3553 that undo/redo can occasionally cause a workflow state on the frontend to be invalid. As we need to spend more time to investigate the issue, we decide to temporarily disable undo/redo until we fix the issue.