### PR TITLE
fix: Hub page now only shows public workflows/datasets instead of all accessible workflows/datasets

### DIFF
--- a/core/gui/src/app/hub/component/hub-search-result/hub-search-result.component.ts
+++ b/core/gui/src/app/hub/component/hub-search-result/hub-search-result.component.ts
@@ -78,7 +78,6 @@ export class HubSearchResultComponent implements OnInit, AfterViewInit {
       .userChanged()
       .pipe(untilDestroyed(this))
       .subscribe(() => {
-        this.isLogin = this.userService.isLogin();
         this.currentUid = this.userService.getCurrentUser()?.uid;
       });
   }


### PR DESCRIPTION
## Problem
Previously, the Hub page was displaying all workflows/datasets that the current user has access to, including:
- User's own private workflows/datasets
- Private workflows/datasets shared with the user
- Workflows/datasets accessible through projects
- Public workflows/datasets

This behavior was confusing because Hub should only show public workflows/datasets.

