### PR TITLE
fix: Dataset share panel 404 error by correcting API endpoint URL

### DIFF
--- a/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
+++ b/core/gui/src/app/dashboard/service/user/dataset/dataset.service.ts
@@ -44,7 +44,7 @@ export const DATASET_VERSION_LATEST_URL = DATASET_VERSION_BASE_URL + "/latest";
 export const DEFAULT_DATASET_NAME = "Untitled dataset";
 export const DATASET_PUBLIC_VERSION_BASE_URL = "publicVersion";
 export const DATASET_PUBLIC_VERSION_RETRIEVE_LIST_URL = DATASET_PUBLIC_VERSION_BASE_URL + "/list";
-export const DATASET_GET_OWNERS_URL = DATASET_BASE_URL + "/datasetUserAccess";
+export const DATASET_GET_OWNERS_URL = DATASET_BASE_URL + "/user-dataset-owners";
 
 export interface MultipartUploadProgress {
   filePath: string;


### PR DESCRIPTION
## Problem
The dataset share panel was failing to open with a 404 error

The frontend was calling an incorrect API endpoint that doesn't exist on the backend.