### PR TITLE
chore(gui): fix admin dashboard columns

### DIFF
--- a/core/gui/src/app/dashboard/component/admin/user/admin-user.component.html
+++ b/core/gui/src/app/dashboard/component/admin/user/admin-user.component.html
@@ -79,8 +79,8 @@
             nzType="search"></span>
         </nz-filter-trigger>
       </th>
-      <th>Action</th>
       <th
+        nzWidth="200px"
         [nzFilterFn]="filterByRole"
         [nzSortDirections]="['ascend', 'descend']"
         [nzFilters]="[
@@ -89,7 +89,7 @@
       { text: 'ADMIN', value: 'ADMIN'},
       { text: 'RESTRICTED', value: 'RESTRICTED'}]"
         [nzSortFn]="sortByRole">
-        Role
+        Action/Role
       </th>
       <th>Quota</th>
     </tr>


### PR DESCRIPTION
This PR improves the design of columns in Users Tab under Admin page. The Action and Role columns are combined into one column and the buttons for quota now lies correctly under the Quota column. This also fixes the width of the Action/Role column to minimize the amount of empty space.

Changed File:
- core/gui/src/app/dashboard/component/admin/user/admin-user.component.html

Current Columns:
<img width="820" height="326" alt="image" src="https://github.com/user-attachments/assets/ca1c7d06-51eb-4046-90f1-f00270d0d6e0" />

New Columns:
<img width="407" height="199" alt="image" src="https://github.com/user-attachments/assets/7d2b5b68-e70b-40d1-b192-14824a833612" />

Closes Issue #3590 