### PR TITLE
fix(gui): Text Wrapping in Comments

### DIFF
--- a/core/gui/src/app/workspace/component/workflow-editor/comment-box-modal/nz-modal-comment-box.component.scss
+++ b/core/gui/src/app/workspace/component/workflow-editor/comment-box-modal/nz-modal-comment-box.component.scss
@@ -24,8 +24,11 @@
   width: 100%;
 
   p {
-    word-break: break-all;
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+    word-break: normal;
     white-space: normal;
+    hyphens: auto;
   }
 }
 


### PR DESCRIPTION
### Purpose
This PR fixes an issue with text wrapping in workflow comments, where words would be broken up between sentences reducing readability

closes #3595

### Changes
- Editited css in `nz-modal-comment-box.component.scss` to fix wrapping

### Before:
<img width="565" height="434" alt="Screenshot (229)" src="https://github.com/user-attachments/assets/e05d44b5-c11d-45a8-88ed-a60d5bd48776" />

### After:
<img width="530" height="433" alt="Screenshot (230)" src="https://github.com/user-attachments/assets/970a8aa7-54d6-41ba-a774-0fb47b93db52" />

