### PR TITLE
feat: double click on operator displays result panel.

### DIFF
--- a/core/gui/src/app/workspace/component/result-panel/result-panel.component.ts
+++ b/core/gui/src/app/workspace/component/result-panel/result-panel.component.ts
@@ -92,8 +92,7 @@ export class ResultPanelComponent implements OnInit, OnDestroy {
     private resizeService: PanelResizeService,
     private panelService: PanelService
   ) {
-    const width = localStorage.getItem("result-panel-width");
-    if (width) this.width = Number(width);
+    this.width = 0;
     this.height = Number(localStorage.getItem("result-panel-height")) || this.height;
     this.resizeService.changePanelSize(this.width, this.height);
   }

--- a/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -451,18 +451,22 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
 
   private handleHighlightMouseDBClickInput(): void {
     // on user mouse double-clicks a comment box, open that comment box
+    // on user mouse double-clicks an operator, highlight it and open result panel
     fromJointPaperEvent(this.paper, "cell:pointerdblclick")
       .pipe(untilDestroyed(this))
       .subscribe(event => {
-        const clickedCommentBox = event[0].model;
-        if (
-          clickedCommentBox.isElement() &&
-          this.workflowActionService.getTexeraGraph().hasCommentBox(clickedCommentBox.id.toString())
-        ) {
+        const clickedElement = event[0].model;
+        if (clickedElement.isElement()) {
+          const elementID = clickedElement.id.toString();
           this.wrapper.setMultiSelectMode(<boolean>event[1].shiftKey);
-          const elementID = event[0].model.id.toString();
+          
+          // Handle comment box double-click
           if (this.workflowActionService.getTexeraGraph().hasCommentBox(elementID)) {
             this.openCommentBox(elementID);
+          }
+          // Handle operator double-click
+          else if (this.workflowActionService.getTexeraGraph().hasOperator(elementID)) {
+            this.workflowActionService.openResultPanel();
           }
         }
       });
@@ -786,7 +790,6 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
 
         this.currentOpenedOperatorID = operatorID;
         this.jointUIService.unfoldOperatorDetails(this.paper, operatorID);
-        this.workflowActionService.openResultPanel();
       });
 
     fromJointPaperEvent(this.paper, "element:contextmenu")
@@ -800,7 +803,6 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
 
         this.currentOpenedOperatorID = operatorID;
         this.jointUIService.unfoldOperatorDetails(this.paper, operatorID);
-        this.workflowActionService.openResultPanel();
       });
 
     fromJointPaperEvent(this.paper, "blank:pointerdown")

--- a/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -459,7 +459,7 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
         if (clickedElement.isElement()) {
           const elementID = clickedElement.id.toString();
           this.wrapper.setMultiSelectMode(<boolean>event[1].shiftKey);
-          
+
           // Handle comment box double-click
           if (this.workflowActionService.getTexeraGraph().hasCommentBox(elementID)) {
             this.openCommentBox(elementID);

--- a/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
+++ b/core/gui/src/app/workspace/component/workflow-editor/workflow-editor.component.ts
@@ -460,12 +460,9 @@ export class WorkflowEditorComponent implements AfterViewInit, OnDestroy {
           const elementID = clickedElement.id.toString();
           this.wrapper.setMultiSelectMode(<boolean>event[1].shiftKey);
 
-          // Handle comment box double-click
           if (this.workflowActionService.getTexeraGraph().hasCommentBox(elementID)) {
             this.openCommentBox(elementID);
-          }
-          // Handle operator double-click
-          else if (this.workflowActionService.getTexeraGraph().hasOperator(elementID)) {
+          } else if (this.workflowActionService.getTexeraGraph().hasOperator(elementID)) {
             this.workflowActionService.openResultPanel();
           }
         }


### PR DESCRIPTION
**Feature:**
- Double click on operator displays the result panel instead of single click.
- Result panel is closed by default when a workflow is opened.
Closes #3580 


https://github.com/user-attachments/assets/0498cb3d-2a92-4085-a942-7f2d39c6e197
