### PR TITLE
feat: add AWS S3 support, data stored as a whole in one place

### DIFF
--- a/deployment/k8s/texera-helmchart/values.yaml
+++ b/deployment/k8s/texera-helmchart/values.yaml
@@ -81,7 +81,7 @@ minio:
     existingClaim: "minio-data-pvc"
 
 
-##### COMMENT THE FOLLOWING BLCOK OUT IF YOU WANT TO USE LOCAL MINIO #####
+##### COMMENT THE FOLLOWING BLOCK OUT IF YOU WANT TO USE LOCAL MINIO #####
 lakefs:
   secrets:
     authEncryptSecretKey: random_string_for_lakefs


### PR DESCRIPTION
**Overview**
This PR is in response of #3626, which address the need to use AWS S3 for storage as a replacement of minio.  

**Technical Details**
This PR creates texera env variables for AWS S3 so that all the texera-related services can use those variables directly as a replacement of minio.  

**Usage**
This PR adds the new AWS S3 feature while keeping the old minio feature. If you want to use S3 for storage, just change the content only in /deployment/k8s/texera-helmchart/values.yaml as prmpted. You should comment/uncomment a total of four places based on your need to use minio/S3.   

**Limitations & Looking Ahead**
Currently our Lakefs settings only accept configuration as plain text, no if-else statement or anchors is allowed. It cannot directly accept env variables, either. So we have to provide two copies of the same credential. One is for the overall Texera config and another is for Lakefs. Future work can focus on optimizing Lakefs config mechanism so that it can accept variables. Then we can have only one copy of S3 credentials. Also, establishing one flag to enable/disable S3 is a good choice. Currently we switch between local minio and S3 by commenting out one of them.   

**Demo Video**

https://github.com/user-attachments/assets/40a6adbc-4496-452a-9a89-7feb079f4252


