### PR TITLE
fix: improve email notification subject

### DIFF
--- a/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
+++ b/core/amber/src/main/scala/edu/uci/ics/texera/web/resource/EmailTemplate.scala
@@ -28,9 +28,8 @@ import edu.uci.ics.texera.config.UserSystemConfig
   */
 object EmailTemplate {
 
-  private val deployment: String = {
+  private val deployment: String =
     UserSystemConfig.appDomain.map(_.replaceFirst("^https?://", "")).getOrElse("")
-  }
 
   /**
     * Creates an email message for user registration notifications.


### PR DESCRIPTION
**Description:**
This PR fixes the previous implementation of enriching email subjects #3548 that aims to add the domain name in email subjects.

**Problem:**
The previous implementation used `ConfigFactory.load()` which reads from `application.conf` by default, but the `user-sys.domain` configuration is defined in `user-system.conf`, causing the domain retrieval to always fail and return empty strings.

Documentation: https://lightbend.github.io/config/latest/api/com/typesafe/config/ConfigFactory.html

**Solution:**
Replaced the incorrect domain retrieval with `UserSystemConfig` which properly reads from `user-system.conf`.

Closes #3720 

**Email Subject Updates:**
```
"New Account Request Pending Approval" -> "New Account Request Pending Approval for [server-name]"
"Account Request Received"             -> "Account Request Received for [server-name]"
"Your Role Has Been Updated"           -> "Your Role Has Been Updated for [server-name]"
```

**Example:**
<img width="1484" height="710" alt="Screenshot 2025-09-11 at 2 16 26 PM" src="https://github.com/user-attachments/assets/21f4d9cd-8642-407c-914d-51c91d6858bd" />