### PR TITLE
fix: Clear Python executable path in udf.conf

### DIFF
--- a/core/config/src/main/resources/udf.conf
+++ b/core/config/src/main/resources/udf.conf
@@ -17,7 +17,7 @@
 
 python {
     # python3 executable path
-    path = "C:\\Users\\linxi\\AppData\\Local\\Programs\\Python\\Python312\\python.exe"
+    path = ""
     path = ${?UDF_PYTHON_PATH}
 
     log {


### PR DESCRIPTION
The Python executable path was mistakenly committed in PR #3848.

fix #3850
