### PR TITLE
fix: use `TEXEAR_HOME` or the current directory as the default working directory

### DIFF
--- a/computing-unit-managing-service/src/main/scala/org/apache/texera/service/ComputingUnitManagingService.scala
+++ b/computing-unit-managing-service/src/main/scala/org/apache/texera/service/ComputingUnitManagingService.scala
@@ -24,7 +24,6 @@ import io.dropwizard.auth.AuthDynamicFeature
 import io.dropwizard.core.Application
 import io.dropwizard.core.setup.{Bootstrap, Environment}
 import org.apache.amber.config.StorageConfig
-import org.apache.amber.util.PathUtils.workflowComputingUnitManagingServicePath
 import org.apache.texera.auth.{JwtAuthFilter, SessionUser}
 import org.apache.texera.dao.SqlServer
 import org.apache.texera.service.resource.{
@@ -32,6 +31,8 @@ import org.apache.texera.service.resource.{
   ComputingUnitManagingResource,
   HealthCheckResource
 }
+
+import java.nio.file.Path
 
 class ComputingUnitManagingService extends Application[ComputingUnitManagingServiceConfiguration] {
 
@@ -68,8 +69,11 @@ class ComputingUnitManagingService extends Application[ComputingUnitManagingServ
 }
 
 object ComputingUnitManagingService {
+
   def main(args: Array[String]): Unit = {
-    val configFilePath = workflowComputingUnitManagingServicePath
+    val configFilePath = Path
+      .of(sys.env.getOrElse("TEXERA_HOME", "."))
+      .resolve("computing-unit-managing-service")
       .resolve("src")
       .resolve("main")
       .resolve("resources")

--- a/core/config/src/main/scala/org/apache/amber/util/PathUtils.scala
+++ b/core/config/src/main/scala/org/apache/amber/util/PathUtils.scala
@@ -58,9 +58,6 @@ object PathUtils {
 
   lazy val fileServicePath: Path = corePath.resolve("file-service")
 
-  lazy val workflowComputingUnitManagingServicePath: Path =
-    corePath.resolve("computing-unit-managing-service")
-
   lazy val configServicePath: Path = corePath.resolve("config-service")
 
   lazy val accessControlServicePath: Path = corePath.resolve("access-control-service")


### PR DESCRIPTION
In our current implementation, we used the  `core` folder as the root of all services. When looking for the configuration of a service, we search from the `core` folder. This logic relies heavily on the `core` folder. This PR changes the behavior:
1. We use `TEXERA_HOME` env variable to find the root of the Texera repo. All services/configures/files should be searched starting from this dir.
2. When omitted, we use the current directory as the default working directory.

fixes #3871