### PR TITLE
fix: use `TEXERA_HOME` for jooq

### DIFF
--- a/common/dao/src/main/scala/org/apache/texera/dao/JooqCodeGenerator.scala
+++ b/common/dao/src/main/scala/org/apache/texera/dao/JooqCodeGenerator.scala
@@ -33,7 +33,11 @@ object JooqCodeGenerator {
     val jooqXmlPath: Path = Path
       .of(sys.env.getOrElse("TEXERA_HOME", "."))
       .resolve("common")
-      .resolve("dao").resolve("src").resolve("main").resolve("resources").resolve("jooq-conf.xml")
+      .resolve("dao")
+      .resolve("src")
+      .resolve("main")
+      .resolve("resources")
+      .resolve("jooq-conf.xml")
     val jooqConfig: Configuration = GenerationTool.load(Files.newInputStream(jooqXmlPath))
 
     // Load storage.conf from the specified path


### PR DESCRIPTION
This PR lets jooq use `TEXERA_HOME` to find configurations.