### PR TITLE
chore: Remove publish section with whoami from .asf.yaml

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -78,6 +78,3 @@ notifications:
   pullrequests:         dev@texera.apache.org
   discussions:          dev@texera.apache.org
   jobs:                 commits@texera.apache.org
-
-publish:
-  whoami: asf-site


### PR DESCRIPTION
### What changes were proposed in this PR?
Revert the change made in PR #3785 since we plan to use a separate [repo](https://github.com/apache/incubator-texera-site) to host the website.


### Was this PR authored or co-authored using generative AI tooling?
No