### PR TITLE
chore(ci): explicitly declare main branch's CI rules

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -83,6 +83,28 @@ github:
         required_approving_review_count: 1
       required_linear_history: true
 
+    test-ci:
+      required_status_checks:
+        # strict means "Require branches to be up to date before merging".
+        strict: true
+        # contexts are the names of checks that must pass
+        contexts:
+          - gui (ubuntu-latest, 18)
+          - gui (windows-latest, 18)
+          - gui (macos-latest, 18)
+          - core (ubuntu-22.04, 11)
+          - python_udf (ubuntu-latest, 3.9)
+          - python_udf (ubuntu-latest, 3.10)
+          - python_udf (ubuntu-latest, 3.11)
+          - python_udf (ubuntu-latest, 3.12)
+          - Check License Headers
+          - Validate PR title
+      required_pull_request_reviews:
+        dismiss_stale_reviews: false
+        require_code_owner_reviews: false
+        required_approving_review_count: 1
+      required_linear_history: true
+
 notifications:
   commits:              commits@texera.apache.org
   issues:               dev@texera.apache.org


### PR DESCRIPTION
### What changes were proposed in this PR?
This PR explicitly declares the CI rules on `main` branch.

### Any related issues, documentation, discussions?
resolves #3934 

### How was this PR tested?
Tested with `test-ci` branch before. Now merging rules to `main`.

### Was this PR authored or co-authored using generative AI tooling?
No. 
