### PR TITLE
chore(ci): rename CI names for `test-ci` rules

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -89,14 +89,14 @@ github:
         strict: true
         # contexts are the names of checks that must pass
         contexts:
-          - gui (ubuntu-latest, 18)
-          - gui (windows-latest, 18)
-          - gui (macos-latest, 18)
-          - core (ubuntu-22.04, 11)
-          - python_udf (ubuntu-latest, 3.9)
-          - python_udf (ubuntu-latest, 3.10)
-          - python_udf (ubuntu-latest, 3.11)
-          - python_udf (ubuntu-latest, 3.12)
+          - frontend (ubuntu-latest, 18)
+          - frontend (windows-latest, 18)
+          - frontend (macos-latest, 18)
+          - scala (ubuntu-22.04, 11)
+          - python (ubuntu-latest, 3.9)
+          - python (ubuntu-latest, 3.10)
+          - python (ubuntu-latest, 3.11)
+          - python (ubuntu-latest, 3.12)
           - Check License Headers
           - Validate PR title
       required_pull_request_reviews:


### PR DESCRIPTION
### What changes were proposed in this PR?
This PR changes the desired CI rule names against `test-ci` branch to test. This change has to be pushed to `main` to take effect. Will update `test-ci`'s GitHub Action workflow separately (using #3936).

### Any related issues, documentation, discussions?
related to #3939.

### How was this PR tested?
Manual tests.

### Was this PR authored or co-authored using generative AI tooling?
No.