### PR TITLE
chore: Drop support for python 3.9

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -71,7 +71,6 @@ github:
           - frontend (windows-latest, 18)
           - frontend (macos-latest, 18)
           - scala (ubuntu-22.04, 11)
-          - python (ubuntu-latest, 3.9)
           - python (ubuntu-latest, 3.10)
           - python (ubuntu-latest, 3.11)
           - python (ubuntu-latest, 3.12)

--- a/.github/workflows/github-action-build.yml
+++ b/.github/workflows/github-action-build.yml
@@ -128,7 +128,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12' ]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Texera


### PR DESCRIPTION
### What changes were proposed in this PR?
This PR officially removes Python **3.9** support from Texera.  
The changes include:
- Updating all GitHub Actions workflows to drop Python 3.9 test and build matrix entries.
- Removing Python 3.9 from required CI checks.

### Any related issues, documentation, discussions?
resolves #4061.
JIRA ticket [INFRA-27417](https://issues.apache.org/jira/browse/INFRA-27417).

### How was this PR tested?
N/A

### Was this PR authored or co-authored using generative AI tooling?
No