### PR TITLE
chore: update Docker image references to Apache registry

### DIFF
--- a/bin/single-node/docker-compose.yml
+++ b/bin/single-node/docker-compose.yml
@@ -78,7 +78,7 @@ services:
   # Part2: Specification of Texera's micro-services
   # FileService provides endpoints for Texera's dataset management
   file-service:
-    image: texera/file-service:single-node-release-1-0-0
+    image: apache/texera-file-service:latest
     container_name: texera-file-service
     restart: always
     depends_on:
@@ -96,7 +96,7 @@ services:
 
   # WorkflowCompilingService provides endpoints for sanity check and schema propagation while workflows are being edited
   workflow-compiling-service:
-    image: texera/workflow-compiling-service:single-node-release-1-0-0
+    image: apache/texera-workflow-compiling-service:latest
     container_name: texera-workflow-compiling-service
     restart: always
     depends_on:
@@ -113,7 +113,7 @@ services:
   # ComputingUnitMaster provides endpoints for executing workflows and interactions during executions.
   computing-unit-master:
     # to enable R operators, change the image tag to single-node-release-1-0-0-R
-    image: texera/computing-unit-master:single-node-release-1-0-0
+    image: apache/texera-workflow-execution-coordinator:latest
     container_name: texera-computing-unit-master
     restart: always
     depends_on:
@@ -126,7 +126,7 @@ services:
 
   # TexeraWebApplication provides endpoints for hub resource management.
   texera-web-application:
-    image: texera/texera-web-application:single-node-release-1-0-0
+    image: apache/texera-dashboard-service:latest
     container_name: texera-web-application
     restart: always
     depends_on:
@@ -147,7 +147,7 @@ services:
       retries: 10
 
   texera-example-data-loader:
-    image: texera/texera-example-data-loader:single-node-release-1-0-0
+    image: apache/texera-example-data-loader:latest
     container_name: texera-example-data-loader
     depends_on:
       texera-web-application:


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR updates all Texera service images in the single-node `docker-compose.yml` to use the Apache registry with `latest` tags, aligning with the naming convention established in the CI/CD workflow (#4055).

The following image references have been updated:
- `texera/file-service:single-node-release-1-0-0` → `apache/texera-file-service:latest`
- `texera/workflow-compiling-service:single-node-release-1-0-0` → `apache/texera-workflow-compiling-service:latest`
- `texera/computing-unit-master:single-node-release-1-0-0` → `apache/texera-workflow-execution-coordinator:latest`
- `texera/texera-web-application:single-node-release-1-0-0` → `apache/texera-dashboard-service:latest`
- `texera/texera-example-data-loader:single-node-release-1-0-0` → `apache/texera-example-data-loader:latest`

This change ensures that the docker-compose configuration uses the correct image names and registry that are now being built and pushed by the GitHub Actions workflow.

### Any related issues, documentation, discussions?

Related to #4055 which introduced the GitHub Actions workflow for building and pushing images to the Apache registry.

### How was this PR tested?

This PR only updates image references in the docker-compose.yml configuration file. No code changes were made.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude (Anthropic)