### PR TITLE
chore: Move `transformer` to `operator-requirements.txt`

### DIFF
--- a/amber/operator-requirements.txt
+++ b/amber/operator-requirements.txt
@@ -22,5 +22,4 @@ pillow==10.2.0
 pybase64==1.3.2
 torch==2.8.0
 scikit-learn==1.5.0
-psutil==5.9.0
 transformers==4.53.0

--- a/amber/requirements.txt
+++ b/amber/requirements.txt
@@ -42,6 +42,7 @@ python-lsp-server[all]==1.12.0
 python-lsp-server[websockets]==1.12.0
 bidict==0.22.0
 cached_property==1.5.2
+psutil==5.9.0
 tzlocal==2.1
 pyiceberg==0.8.1
 readerwriterlock==1.0.9


### PR DESCRIPTION
### What changes were proposed in this PR?
Move dependency `transformer` from `requirements.txt` to `operator-requirements.txt`.

### Any related issues, documentation, discussions?
The dependency were introduced #2600 for supporting hugging face operators. It should not have been a dependency for pyamber, but the specific operator.
- #2600

This blocks #4088 

### How was this PR tested?
Existing tests.

### Was this PR authored or co-authored using generative AI tooling?
No