### PR TITLE
chore(dep): Bump `pandas` version to 2.2.3

### DIFF
--- a/amber/requirements.txt
+++ b/amber/requirements.txt
@@ -17,7 +17,7 @@
 
 wheel==0.41.2
 numpy==1.26.4
-pandas==2.2.2
+pandas==2.2.3
 flake8==7.1.1
 Flake8-pyproject==1.2.3
 black==24.3.0


### PR DESCRIPTION
### What changes were proposed in this PR?
Bump `pandas` version to 2.2.3 to be [compatible with Python 3.13](https://pandas.pydata.org/pandas-docs/stable/whatsnew/v2.2.3.html#pandas-2-2-3-is-now-compatible-with-python-3-13).

### Any related issues, documentation, discussions?

Resolves #4095 

### How was this PR tested?
CI

### Was this PR authored or co-authored using generative AI tooling?
No
