### PR TITLE
chore: bump version to v1.1.0-incubating

### DIFF
--- a/bin/k8s/values.yaml
+++ b/bin/k8s/values.yaml
@@ -113,7 +113,7 @@ texeraImages:
 # Example data loader configuration
 exampleDataLoader:
   enabled: true
-  image: apache/texera-example-data-loader:latest
+  image: apache/texera-example-data-loader:1.1.0-incubating
   username: texera
   password: texera
   datasetDir: datasets
@@ -122,7 +122,7 @@ exampleDataLoader:
 webserver:
   name: webserver
   numOfPods: 1  # Number of pods for the Texera deployment
-  imageName: apache/texera-dashboard-service:latest # image name of the texera
+  imageName: apache/texera-dashboard-service:1.1.0-incubating # image name of the texera
   service:
     type: ClusterIP
     port: 8080
@@ -131,7 +131,7 @@ workflowComputingUnitManager:
   name: workflow-computing-unit-manager
   numOfPods: 1
   serviceAccountName: workflow-computing-unit-manager-service-account
-  imageName: apache/texera-workflow-computing-unit-managing-service:latest
+  imageName: apache/texera-workflow-computing-unit-managing-service:1.1.0-incubating
   service:
     type: ClusterIP
     port: 8888
@@ -139,7 +139,7 @@ workflowComputingUnitManager:
 workflowCompilingService:
   name: workflow-compiling-service
   numOfPods: 1
-  imageName: apache/texera-workflow-compiling-service:latest
+  imageName: apache/texera-workflow-compiling-service:1.1.0-incubating
   service:
     type: ClusterIP
     port: 9090
@@ -147,7 +147,7 @@ workflowCompilingService:
 fileService:
   name: file-service
   numOfPods: 1
-  imageName: apache/texera-file-service:latest
+  imageName: apache/texera-file-service:1.1.0-incubating
   service:
     type: ClusterIP
     port: 9092
@@ -155,7 +155,7 @@ fileService:
 configService:
   name: config-service
   numOfPods: 1
-  imageName: apache/texera-config-service:latest
+  imageName: apache/texera-config-service:1.1.0-incubating
   service:
     type: ClusterIP
     port: 9094
@@ -163,7 +163,7 @@ configService:
 accessControlService:
   name: access-control-service
   numOfPods: 1
-  imageName: apache/texera-access-control-service:latest
+  imageName: apache/texera-access-control-service:1.1.0-incubating
   service:
     type: ClusterIP
     port: 9096
@@ -193,7 +193,7 @@ workflowComputingUnitPool:
     cpu: 100
     memory: 100Gi
     nvidiaGpu: 5
-  imageName: apache/texera-workflow-execution-coordinator:latest
+  imageName: apache/texera-workflow-execution-coordinator:1.1.0-incubating
   service:
     port: 8085
     targetPort: 8085

--- a/bin/single-node/docker-compose.yml
+++ b/bin/single-node/docker-compose.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: texera-single-node-release-1-0-0
+name: texera-single-node-release-1-1-0-incubating
 services:
   # Part1: Specification of the storage services used by Texera
   # MinIO is an S3-compatible object storage used to store datasets and files.
@@ -78,7 +78,7 @@ services:
   # Part2: Specification of Texera's micro-services
   # FileService provides endpoints for Texera's dataset management
   file-service:
-    image: apache/texera-file-service:latest
+    image: apache/texera-file-service:1.1.0-incubating
     container_name: texera-file-service
     restart: always
     depends_on:
@@ -96,7 +96,7 @@ services:
 
   # ConfigService provides endpoints for configuration management
   config-service:
-    image: apache/texera-config-service:latest
+    image: apache/texera-config-service:1.1.0-incubating
     container_name: texera-config-service
     restart: always
     depends_on:
@@ -112,7 +112,7 @@ services:
 
   # AccessControlService handles user permissions and access control
   access-control-service:
-    image: apache/texera-access-control-service:latest
+    image: apache/texera-access-control-service:1.1.0-incubating
     container_name: texera-access-control-service
     restart: always
     depends_on:
@@ -128,7 +128,7 @@ services:
 
   # WorkflowComputingUnitManagingService provides endpoints for managing computing units
   workflow-computing-unit-managing-service:
-    image: apache/texera-workflow-computing-unit-managing-service:latest
+    image: apache/texera-workflow-computing-unit-managing-service:1.1.0-incubating
     container_name: texera-workflow-computing-unit-managing-service
     restart: always
     depends_on:
@@ -144,7 +144,7 @@ services:
 
   # WorkflowCompilingService provides endpoints for sanity check and schema propagation while workflows are being edited
   workflow-compiling-service:
-    image: apache/texera-workflow-compiling-service:latest
+    image: apache/texera-workflow-compiling-service:1.1.0-incubating
     container_name: texera-workflow-compiling-service
     restart: always
     depends_on:
@@ -160,8 +160,8 @@ services:
 
   # ComputingUnitMaster provides endpoints for executing workflows and interactions during executions.
   computing-unit-master:
-    # to enable R operators, change the image tag to single-node-release-1-0-0-R
-    image: apache/texera-workflow-execution-coordinator:latest
+    # to enable R operators, change the image tag to single-node-release-1-1-0-incubating-R
+    image: apache/texera-workflow-execution-coordinator:1.1.0-incubating
     container_name: texera-computing-unit-master
     restart: always
     depends_on:
@@ -174,7 +174,7 @@ services:
 
   # TexeraWebApplication provides endpoints for hub resource management.
   texera-web-application:
-    image: apache/texera-dashboard-service:latest
+    image: apache/texera-dashboard-service:1.1.0-incubating
     container_name: texera-web-application
     restart: always
     depends_on:
@@ -213,7 +213,7 @@ services:
 
 networks:
   default:
-    name: texera-single-node-release-1-0-0
+    name: texera-single-node-release-1-1-0-incubating
 
 # persistent volumes
 volumes:

--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,7 @@ lazy val TexeraProject = (project in file("."))
   )
   .settings(
     name := "texera",
-    version := "1.0.0",
+    version := "1.1.0-incubating",
     organization := "org.apache",
     scalaVersion := "2.13.12",
     publishMavenStyle := true


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR bumps the project version from `1.0.0` to `1.1.0-incubating` across all relevant configuration files:

- **`build.sbt`**: Updated `version := "1.0.0"` to `version := "1.1.0-incubating"`
- **`bin/single-node/docker-compose.yml`**:
  - Updated project name from `texera-single-node-release-1-0-0` to `texera-single-node-release-1-1-0-incubating`
  - Updated network name from `texera-single-node-release-1-0-0` to `texera-single-node-release-1-1-0-incubating`
  - Updated all 7 Texera service image tags from `:latest` to `:1.1.0-incubating`
  - Updated the R operator comment reference
- **`bin/k8s/values.yaml`**: Updated all 8 Texera service image tags from `:latest` to `:1.1.0-incubating`

### Any related issues, documentation, discussions?

Closes #4082

### How was this PR tested?

This is a configuration-only change.

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Claude Code (Claude Opus 4.5)