### PR TITLE
fix: support more java.time inputs in timestamp parsing

### DIFF
--- a/common/workflow-core/src/main/scala/org/apache/texera/amber/core/tuple/AttributeTypeUtils.scala
+++ b/common/workflow-core/src/main/scala/org/apache/texera/amber/core/tuple/AttributeTypeUtils.scala
@@ -201,15 +201,15 @@ object AttributeTypeUtils extends Serializable {
   def parseTimestamp(fieldValue: Any): Timestamp = {
     val attempt: Try[Timestamp] = Try {
       fieldValue match {
-        case str: String                   => new Timestamp(DateParserUtils.parseDate(str.trim).getTime)
-        case long: java.lang.Long          => new Timestamp(long)
-        case timestamp: Timestamp          => timestamp
-        case date: java.util.Date          => new Timestamp(date.getTime)
-        case localDateTime: java.time.LocalDateTime  => Timestamp.valueOf(localDateTime)
-        case instant: java.time.Instant       => Timestamp.from(instant)
+        case str: String                              => new Timestamp(DateParserUtils.parseDate(str.trim).getTime)
+        case long: java.lang.Long                     => new Timestamp(long)
+        case timestamp: Timestamp                     => timestamp
+        case date: java.util.Date                     => new Timestamp(date.getTime)
+        case localDateTime: java.time.LocalDateTime   => Timestamp.valueOf(localDateTime)
+        case instant: java.time.Instant               => Timestamp.from(instant)
         case offsetDateTime: java.time.OffsetDateTime => Timestamp.from(offsetDateTime.toInstant)
-        case zonedDateTime: java.time.ZonedDateTime  => Timestamp.from(zonedDateTime.toInstant)
-        case localDate: java.time.LocalDate       => Timestamp.valueOf(localDate.atStartOfDay())
+        case zonedDateTime: java.time.ZonedDateTime   => Timestamp.from(zonedDateTime.toInstant)
+        case localDate: java.time.LocalDate           => Timestamp.valueOf(localDate.atStartOfDay())
         // Integer, Double, Boolean, Binary are considered to be illegal here.
         case _ =>
           throw new AttributeTypeException(

--- a/common/workflow-core/src/test/scala/org/apache/texera/amber/core/tuple/AttributeTypeUtilsSpec.scala
+++ b/common/workflow-core/src/test/scala/org/apache/texera/amber/core/tuple/AttributeTypeUtilsSpec.scala
@@ -183,7 +183,8 @@ class AttributeTypeUtilsSpec extends AnyFunSuite {
     )
 
     val localDateTime = LocalDateTime.of(2023, 11, 13, 10, 15, 30)
-    val timestampFromLocalDateTime = parseField(localDateTime, AttributeType.TIMESTAMP).asInstanceOf[Timestamp]
+    val timestampFromLocalDateTime =
+      parseField(localDateTime, AttributeType.TIMESTAMP).asInstanceOf[Timestamp]
     assert(timestampFromLocalDateTime == Timestamp.valueOf(localDateTime))
 
     val instant = Instant.parse("2023-11-13T10:15:30Z")
@@ -191,15 +192,19 @@ class AttributeTypeUtilsSpec extends AnyFunSuite {
     assert(timestampFromInstant == Timestamp.from(instant))
 
     val offsetDateTime = OffsetDateTime.parse("2023-11-13T12:15:30+02:00")
-    val timestampFromOffsetDateTime = parseField(offsetDateTime, AttributeType.TIMESTAMP).asInstanceOf[Timestamp]
+    val timestampFromOffsetDateTime =
+      parseField(offsetDateTime, AttributeType.TIMESTAMP).asInstanceOf[Timestamp]
     assert(timestampFromOffsetDateTime == Timestamp.from(offsetDateTime.toInstant))
 
-    val zonedDateTime = ZonedDateTime.of(2023, 11, 13, 2, 15, 30, 0, ZoneId.of("America/Los_Angeles"))
-    val timestampFromZonedDateTime = parseField(zonedDateTime, AttributeType.TIMESTAMP).asInstanceOf[Timestamp]
+    val zonedDateTime =
+      ZonedDateTime.of(2023, 11, 13, 2, 15, 30, 0, ZoneId.of("America/Los_Angeles"))
+    val timestampFromZonedDateTime =
+      parseField(zonedDateTime, AttributeType.TIMESTAMP).asInstanceOf[Timestamp]
     assert(timestampFromZonedDateTime == Timestamp.from(zonedDateTime.toInstant))
 
     val localDate = LocalDate.of(2023, 11, 13)
-    val timestampFromLocalDate = parseField(localDate, AttributeType.TIMESTAMP).asInstanceOf[Timestamp]
+    val timestampFromLocalDate =
+      parseField(localDate, AttributeType.TIMESTAMP).asInstanceOf[Timestamp]
     assert(timestampFromLocalDate == Timestamp.valueOf(localDate.atStartOfDay()))
 
     val utilDate = new java.util.Date(1699820130000L)


### PR DESCRIPTION
### What changes were proposed in this PR?

* Added support in `parseTimestamp(fieldValue: Any)` for additional `java.time` input types:

  * `LocalDateTime` → `Timestamp.valueOf(ldt)`
  * `Instant` → `Timestamp.from(inst)`
  * `OffsetDateTime` → `Timestamp.from(odt.toInstant)`
  * `ZonedDateTime` → `Timestamp.from(zdt.toInstant)`
  * `LocalDate` → `Timestamp.valueOf(ld.atStartOfDay())`

### Any related issues, documentation, discussions?

* Closes #4106

### How was this PR tested?

* Added unit tests covering the new `java.time` cases for timestamp parsing:

  * Positive cases for `LocalDateTime`, `Instant`, `OffsetDateTime`, `ZonedDateTime`, and `LocalDate`
  * Negative case verifying unsupported/invalid inputs throw `AttributeTypeException`

### Was this PR authored or co-authored using generative AI tooling?

No