### PR TITLE
chore: Redirect GitHub discussion notifications to dev email list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -86,5 +86,5 @@ notifications:
   commits:              commits@texera.apache.org
   issues:               notifications@texera.apache.org
   pullrequests:         notifications@texera.apache.org
-  discussions:          notifications@texera.apache.org
+  discussions:          dev@texera.apache.org
   jobs:                 commits@texera.apache.org


### PR DESCRIPTION
### What changes were proposed in this PR?
Redirect email notifications of GitHub Discussions to dev@texera.apache.org

### Any related issues, documentation, discussions?
resolves #4159

### How was this PR tested?
N/A

### Was this PR authored or co-authored using generative AI tooling?
No.