### PR TITLE
chore(dep): bump typing_extensions to 4.14.1

### DIFF
--- a/amber/requirements.txt
+++ b/amber/requirements.txt
@@ -31,7 +31,7 @@ betterproto==2.0.0b7
 typing==3.7.4.3
 pampy==0.3.0
 overrides==7.4.0
-typing_extensions==4.10.0
+typing_extensions==4.14.1
 pytest-reraise==2.1.2
 dataclasses==0.6
 Deprecated==1.2.14


### PR DESCRIPTION
### What changes were proposed in this PR?

This PR bumps `typing_extensions` in `amber/requirements.txt` from `4.10.0` to `4.14.1`.

The goal is to unblock Python 3.13 dependency resolution in CI. With the older pin, the dependency solver could fall back to an older `pydantic` / `pydantic-core` path that fails under Python 3.13. Updating `typing_extensions` allows resolution to proceed to a newer `pydantic-core` build with a `cp313` wheel.

### Any related issues, documentation, discussions?

Closes #4298
Related to #4079

### How was this PR tested?

Verified dependency resolution locally with:

```bash
python3 -m pip install --dry-run -r amber/requirements.txt -r amber/operator-requirements.txt | rg "pydantic(|-core|_core)|typing-extensions|typing_extensions|pyiceberg" -i
```

This resolved to `pydantic-core==2.41.5` instead of the older failing path.

Also verified a Python 3.13 Linux wheel exists for that version with:

```bash
python3 -m pip download --only-binary=:all: --no-deps --platform manylinux2014_x86_64 --python-version 3.13 --implementation cp --abi cp313 pydantic-core==2.41.5
```

### Was this PR authored or co-authored using generative AI tooling?

Generated-by: Codex GPT-5
