### PR TITLE
fix: old workflows failing to run after input port field rename

### DIFF
--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/PortDescriptor.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/PortDescriptor.scala
@@ -22,7 +22,9 @@ package org.apache.texera.amber.operator
 import com.fasterxml.jackson.annotation.{JsonIgnoreProperties, JsonProperty}
 import org.apache.texera.amber.core.workflow.PartitionInfo
 
-@JsonIgnoreProperties(Array("allowMultiInputs")) //TODO: for backward compatibility, remove later
+@JsonIgnoreProperties(
+  Array("allowMultiInputs")
+) // TODO: temporary backward compatibility for workflows persisted before PR #4379.
 case class PortDescription(
     portID: String,
     displayName: String,

--- a/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/PortDescriptor.scala
+++ b/common/workflow-operator/src/main/scala/org/apache/texera/amber/operator/PortDescriptor.scala
@@ -19,9 +19,10 @@
 
 package org.apache.texera.amber.operator
 
-import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.{JsonIgnoreProperties, JsonProperty}
 import org.apache.texera.amber.core.workflow.PartitionInfo
 
+@JsonIgnoreProperties(Array("allowMultiInputs")) //TODO: for backward compatibility, remove later
 case class PortDescription(
     portID: String,
     displayName: String,

--- a/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -421,7 +421,8 @@ export class ExecuteWorkflowService {
       ...op.operatorProperties,
       operatorID: op.operatorID,
       operatorType: op.operatorType,
-      inputPorts: op.inputPorts.map(({ allowMultiInputs, ...port }: any) => port),
+      inputPorts: op.inputPorts
+        .map(({ allowMultiInputs, ...port }: any) => port), //TODO: for backward compatibility, remove later
       outputPorts: op.outputPorts,
     }));
 

--- a/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -421,8 +421,7 @@ export class ExecuteWorkflowService {
       ...op.operatorProperties,
       operatorID: op.operatorID,
       operatorType: op.operatorType,
-      inputPorts: op.inputPorts
-        .map(({ allowMultiInputs, ...port }: any) => port), //TODO: for backward compatibility, remove later
+      inputPorts: op.inputPorts.map(({ allowMultiInputs, ...port }: any) => port), //TODO: for backward compatibility, remove later
       outputPorts: op.outputPorts,
     }));
 

--- a/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -421,7 +421,7 @@ export class ExecuteWorkflowService {
       ...op.operatorProperties,
       operatorID: op.operatorID,
       operatorType: op.operatorType,
-      inputPorts: op.inputPorts.map(({ allowMultiInputs, ...port }: any) => port), //TODO: for backward compatibility, remove later
+      inputPorts: op.inputPorts,
       outputPorts: op.outputPorts,
     }));
 

--- a/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
+++ b/frontend/src/app/workspace/service/execute-workflow/execute-workflow.service.ts
@@ -421,7 +421,7 @@ export class ExecuteWorkflowService {
       ...op.operatorProperties,
       operatorID: op.operatorID,
       operatorType: op.operatorType,
-      inputPorts: op.inputPorts,
+      inputPorts: op.inputPorts.map(({ allowMultiInputs, ...port }: any) => port),
       outputPorts: op.outputPorts,
     }));
 


### PR DESCRIPTION

### What changes were proposed in this PR?
This PR adds a backward-compatibility fix for older saved workflows that still contain the legacy allowMultiInputs field in serialized input port definitions.

After the input port model was changed to use disallowMultiInputs, older workflow JSON in the database could no longer be deserialized correctly and workflow execution failed with an UnrecognizedPropertyException. This PR updates backend deserialization for PortDescription to ignore the obsolete allowMultiInputs field so those existing workflows can still run without requiring migration or manual cleanup.

We can remove this change later.

### Any related issues, documentation, discussions?
Closes #4378

### How was this PR tested?
Tested with the workflow generated by an older version of Texera (before PR #4342).


### Was this PR authored or co-authored using generative AI tooling?
No.